### PR TITLE
QHY driver added to OSX bundle again

### DIFF
--- a/3rdparty/indi-qhy/qhy_ccd.h
+++ b/3rdparty/indi-qhy/qhy_ccd.h
@@ -26,8 +26,8 @@
 #include <indifilterinterface.h>
 #include <iostream>
 
-#include <qhyccd.h>
-#include <log4z.h>
+#include "qhyccd.h"
+#include "log4z.h"
 
 using namespace std;
 
@@ -85,10 +85,12 @@ protected:
   virtual bool SetFilterNames();
   virtual bool GetFilterNames(const char *groupName);
 
+#ifndef OSX_EMBEDED_MODE
   // Streaming
   virtual bool StartStreaming();
   virtual bool StopStreaming();
-
+#endif
+  
   ISwitch                CoolerS[2];
   ISwitchVectorProperty CoolerSP;
 
@@ -155,7 +157,9 @@ private:
   int timerID;
 
   // Thread conditions
+#ifndef OSX_EMBEDED_MODE
   int streamPredicate;
+#endif
   pthread_t primary_thread;
   bool terminateThread;
 

--- a/macosx/INDI Server/INDI Server.xcodeproj/project.pbxproj
+++ b/macosx/INDI Server/INDI Server.xcodeproj/project.pbxproj
@@ -46,6 +46,156 @@
 		592F6CB91BADD70F00D93DE9 /* lx200apdriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 592F6CB81BADD70F00D93DE9 /* lx200apdriver.cpp */; };
 		592F6CBA1BADD78800D93DE9 /* lx200fs2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9D75D5971A8D1787008AA08A /* lx200fs2.cpp */; };
 		592F6CEE1BADDE8400D93DE9 /* lx200driver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 592F6CB41BADD6A600D93DE9 /* lx200driver.cpp */; };
+		593445BF1CF8EF62008AD945 /* libcfitsio.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DDA43181A8CC5F90004AA95 /* libcfitsio.dylib */; };
+		593445C01CF8EF62008AD945 /* libusb.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DDA438B1A8CCD030004AA95 /* libusb.dylib */; };
+		593445C11CF8EF62008AD945 /* libindi.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DDA43A91A8CD3190004AA95 /* libindi.dylib */; };
+		593445CD1CF8EFC8008AD945 /* qhy_ccd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593445C91CF8EFC8008AD945 /* qhy_ccd.cpp */; };
+		593445CE1CF8EFC8008AD945 /* qhy_fw.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593445CB1CF8EFC8008AD945 /* qhy_fw.cpp */; };
+		593445CF1CF8EFCE008AD945 /* indi_qhy.xml in Resources */ = {isa = PBXBuildFile; fileRef = 593445C81CF8EFC8008AD945 /* indi_qhy.xml */; };
+		593445D21CF8F008008AD945 /* indi_qhy_ccd in Copy Files (33 items) (53 items) */ = {isa = PBXBuildFile; fileRef = 593445C51CF8EF62008AD945 /* indi_qhy_ccd */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		593446031CF8F029008AD945 /* IC90A.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445D41CF8F029008AD945 /* IC90A.HEX */; };
+		593446041CF8F029008AD945 /* IC8300.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445D51CF8F029008AD945 /* IC8300.HEX */; };
+		593446051CF8F029008AD945 /* IC16200A.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445D61CF8F029008AD945 /* IC16200A.HEX */; };
+		593446061CF8F029008AD945 /* IC16803.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445D71CF8F029008AD945 /* IC16803.HEX */; };
+		593446071CF8F029008AD945 /* IMG0H.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445D81CF8F029008AD945 /* IMG0H.HEX */; };
+		593446081CF8F029008AD945 /* IMG2P.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445D91CF8F029008AD945 /* IMG2P.HEX */; };
+		593446091CF8F029008AD945 /* IMG2S.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445DA1CF8F029008AD945 /* IMG2S.HEX */; };
+		5934460A1CF8F029008AD945 /* IMG50.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445DB1CF8F029008AD945 /* IMG50.HEX */; };
+		5934460B1CF8F029008AD945 /* miniCam5.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445DC1CF8F029008AD945 /* miniCam5.HEX */; };
+		5934460C1CF8F029008AD945 /* POLEMASTER.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445DD1CF8F029008AD945 /* POLEMASTER.HEX */; };
+		5934460D1CF8F029008AD945 /* QHY2.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445DE1CF8F029008AD945 /* QHY2.HEX */; };
+		5934460E1CF8F029008AD945 /* QHY2E.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445DF1CF8F029008AD945 /* QHY2E.HEX */; };
+		5934460F1CF8F029008AD945 /* QHY2PRO.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445E01CF8F029008AD945 /* QHY2PRO.HEX */; };
+		593446101CF8F029008AD945 /* QHY5.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445E11CF8F029008AD945 /* QHY5.HEX */; };
+		593446111CF8F029008AD945 /* QHY5II.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445E21CF8F029008AD945 /* QHY5II.HEX */; };
+		593446121CF8F029008AD945 /* QHY5III174.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445E31CF8F029008AD945 /* QHY5III174.img */; };
+		593446131CF8F029008AD945 /* QHY5III178.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445E41CF8F029008AD945 /* QHY5III178.img */; };
+		593446141CF8F029008AD945 /* QHY5III185.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445E51CF8F029008AD945 /* QHY5III185.img */; };
+		593446151CF8F029008AD945 /* QHY5III224.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445E61CF8F029008AD945 /* QHY5III224.img */; };
+		593446161CF8F029008AD945 /* QHY5III290.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445E71CF8F029008AD945 /* QHY5III290.img */; };
+		593446171CF8F029008AD945 /* QHY5LOADER.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445E81CF8F029008AD945 /* QHY5LOADER.HEX */; };
+		593446181CF8F029008AD945 /* QHY6.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445E91CF8F029008AD945 /* QHY6.HEX */; };
+		593446191CF8F029008AD945 /* QHY7.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445EA1CF8F029008AD945 /* QHY7.HEX */; };
+		5934461A1CF8F029008AD945 /* QHY8.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445EB1CF8F029008AD945 /* QHY8.HEX */; };
+		5934461B1CF8F029008AD945 /* QHY8L.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445EC1CF8F029008AD945 /* QHY8L.HEX */; };
+		5934461C1CF8F029008AD945 /* QHY8M.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445ED1CF8F029008AD945 /* QHY8M.HEX */; };
+		5934461D1CF8F029008AD945 /* QHY8PRO.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445EE1CF8F029008AD945 /* QHY8PRO.HEX */; };
+		5934461E1CF8F029008AD945 /* QHY9S.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445EF1CF8F029008AD945 /* QHY9S.HEX */; };
+		5934461F1CF8F029008AD945 /* QHY10.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F01CF8F029008AD945 /* QHY10.HEX */; };
+		593446201CF8F029008AD945 /* QHY11.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F11CF8F029008AD945 /* QHY11.HEX */; };
+		593446211CF8F029008AD945 /* QHY12.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F21CF8F029008AD945 /* QHY12.HEX */; };
+		593446221CF8F029008AD945 /* QHY15.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F31CF8F029008AD945 /* QHY15.HEX */; };
+		593446231CF8F029008AD945 /* QHY16.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F41CF8F029008AD945 /* QHY16.HEX */; };
+		593446241CF8F029008AD945 /* QHY20.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F51CF8F029008AD945 /* QHY20.HEX */; };
+		593446251CF8F029008AD945 /* QHY21.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F61CF8F029008AD945 /* QHY21.HEX */; };
+		593446261CF8F029008AD945 /* QHY22.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F71CF8F029008AD945 /* QHY22.HEX */; };
+		593446271CF8F029008AD945 /* QHY23.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F81CF8F029008AD945 /* QHY23.HEX */; };
+		593446281CF8F029008AD945 /* QHY27.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445F91CF8F029008AD945 /* QHY27.HEX */; };
+		593446291CF8F029008AD945 /* QHY28.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445FA1CF8F029008AD945 /* QHY28.HEX */; };
+		5934462A1CF8F029008AD945 /* QHY29.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593445FB1CF8F029008AD945 /* QHY29.HEX */; };
+		5934462B1CF8F029008AD945 /* QHY163.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445FC1CF8F029008AD945 /* QHY163.img */; };
+		5934462C1CF8F029008AD945 /* QHY174.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445FD1CF8F029008AD945 /* QHY174.img */; };
+		5934462D1CF8F029008AD945 /* QHY178.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445FE1CF8F029008AD945 /* QHY178.img */; };
+		5934462E1CF8F029008AD945 /* QHY224.img in Resources */ = {isa = PBXBuildFile; fileRef = 593445FF1CF8F029008AD945 /* QHY224.img */; };
+		5934462F1CF8F029008AD945 /* QHY290.img in Resources */ = {isa = PBXBuildFile; fileRef = 593446001CF8F029008AD945 /* QHY290.img */; };
+		593446301CF8F029008AD945 /* QHY16000.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593446011CF8F029008AD945 /* QHY16000.HEX */; };
+		593446311CF8F029008AD945 /* QHY160002AD.HEX in Resources */ = {isa = PBXBuildFile; fileRef = 593446021CF8F029008AD945 /* QHY160002AD.HEX */; };
+		593447B11CF8F2BB008AD945 /* cjson.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593446F41CF8F2BB008AD945 /* cjson.cpp */; };
+		593447B21CF8F2BB008AD945 /* cmosdll.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593446F61CF8F2BB008AD945 /* cmosdll.cpp */; };
+		593447B31CF8F2BB008AD945 /* dithercontrol.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593446F81CF8F2BB008AD945 /* dithercontrol.cpp */; };
+		593447B41CF8F2BB008AD945 /* download_fx2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593446FA1CF8F2BB008AD945 /* download_fx2.cpp */; };
+		593447B51CF8F2BB008AD945 /* download_fx3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593446FB1CF8F2BB008AD945 /* download_fx3.cpp */; };
+		593447B61CF8F2BB008AD945 /* ic8300.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593446FC1CF8F2BB008AD945 /* ic8300.cpp */; };
+		593447B71CF8F2BB008AD945 /* ic16803.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593446FE1CF8F2BB008AD945 /* ic16803.cpp */; };
+		593447B81CF8F2BB008AD945 /* img0h.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447001CF8F2BB008AD945 /* img0h.cpp */; };
+		593447B91CF8F2BB008AD945 /* img2p.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447021CF8F2BB008AD945 /* img2p.cpp */; };
+		593447BA1CF8F2BB008AD945 /* img132e.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447041CF8F2BB008AD945 /* img132e.cpp */; };
+		593447BB1CF8F2BB008AD945 /* log4z.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447061CF8F2BB008AD945 /* log4z.cpp */; };
+		593447BC1CF8F2BB008AD945 /* minicam5f_m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447081CF8F2BB008AD945 /* minicam5f_m.cpp */; };
+		593447BD1CF8F2BB008AD945 /* minicam5s_c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934470A1CF8F2BB008AD945 /* minicam5s_c.cpp */; };
+		593447BE1CF8F2BB008AD945 /* minicam5s_m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934470C1CF8F2BB008AD945 /* minicam5s_m.cpp */; };
+		593447BF1CF8F2BB008AD945 /* polemaster.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934470E1CF8F2BB008AD945 /* polemaster.cpp */; };
+		593447C01CF8F2BB008AD945 /* qhy2pro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447101CF8F2BB008AD945 /* qhy2pro.cpp */; };
+		593447C11CF8F2BB008AD945 /* qhy5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447121CF8F2BB008AD945 /* qhy5.cpp */; };
+		593447C21CF8F2BB008AD945 /* qhy5hii.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447141CF8F2BB008AD945 /* qhy5hii.cpp */; };
+		593447C31CF8F2BB008AD945 /* qhy5ii.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447161CF8F2BB008AD945 /* qhy5ii.cpp */; };
+		593447C41CF8F2BB008AD945 /* qhy5iibase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447181CF8F2BB008AD945 /* qhy5iibase.cpp */; };
+		593447C51CF8F2BB008AD945 /* qhy5iii163base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934471A1CF8F2BB008AD945 /* qhy5iii163base.cpp */; };
+		593447C61CF8F2BB008AD945 /* qhy5iii165base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934471C1CF8F2BB008AD945 /* qhy5iii165base.cpp */; };
+		593447C71CF8F2BB008AD945 /* qhy5iii174base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934471E1CF8F2BB008AD945 /* qhy5iii174base.cpp */; };
+		593447C81CF8F2BB008AD945 /* qhy5iii174c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447201CF8F2BB008AD945 /* qhy5iii174c.cpp */; };
+		593447C91CF8F2BB008AD945 /* qhy5iii174m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447221CF8F2BB008AD945 /* qhy5iii174m.cpp */; };
+		593447CA1CF8F2BB008AD945 /* qhy5iii178base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447241CF8F2BB008AD945 /* qhy5iii178base.cpp */; };
+		593447CB1CF8F2BB008AD945 /* qhy5iii178c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447261CF8F2BB008AD945 /* qhy5iii178c.cpp */; };
+		593447CC1CF8F2BB008AD945 /* qhy5iii178m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447281CF8F2BB008AD945 /* qhy5iii178m.cpp */; };
+		593447CD1CF8F2BB008AD945 /* qhy5iii183base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934472A1CF8F2BB008AD945 /* qhy5iii183base.cpp */; };
+		593447CE1CF8F2BB008AD945 /* qhy5iii185base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934472C1CF8F2BB008AD945 /* qhy5iii185base.cpp */; };
+		593447CF1CF8F2BB008AD945 /* qhy5iii185c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934472E1CF8F2BB008AD945 /* qhy5iii185c.cpp */; };
+		593447D01CF8F2BB008AD945 /* qhy5iii224base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447301CF8F2BB008AD945 /* qhy5iii224base.cpp */; };
+		593447D11CF8F2BB008AD945 /* qhy5iii224c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447321CF8F2BB008AD945 /* qhy5iii224c.cpp */; };
+		593447D21CF8F2BB008AD945 /* qhy5iii236c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447341CF8F2BB008AD945 /* qhy5iii236c.cpp */; };
+		593447D31CF8F2BB008AD945 /* qhy5iii290base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447361CF8F2BB008AD945 /* qhy5iii290base.cpp */; };
+		593447D41CF8F2BB008AD945 /* qhy5iii290c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447381CF8F2BB008AD945 /* qhy5iii290c.cpp */; };
+		593447D51CF8F2BB008AD945 /* qhy5iii290m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934473A1CF8F2BB008AD945 /* qhy5iii290m.cpp */; };
+		593447D61CF8F2BB008AD945 /* qhy5iii367base.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934473C1CF8F2BB008AD945 /* qhy5iii367base.cpp */; };
+		593447D71CF8F2BB008AD945 /* qhy5iiibase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934473E1CF8F2BB008AD945 /* qhy5iiibase.cpp */; };
+		593447D81CF8F2BB008AD945 /* qhy5iiicoolbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447401CF8F2BB008AD945 /* qhy5iiicoolbase.cpp */; };
+		593447D91CF8F2BB008AD945 /* qhy5iiig400m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447421CF8F2BB008AD945 /* qhy5iiig400m.cpp */; };
+		593447DA1CF8F2BB008AD945 /* qhy5lii_c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447441CF8F2BB008AD945 /* qhy5lii_c.cpp */; };
+		593447DB1CF8F2BB008AD945 /* qhy5lii_m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447461CF8F2BB008AD945 /* qhy5lii_m.cpp */; };
+		593447DC1CF8F2BB008AD945 /* qhy5liibase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447481CF8F2BB008AD945 /* qhy5liibase.cpp */; };
+		593447DD1CF8F2BB008AD945 /* qhy5pii_c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934474A1CF8F2BB008AD945 /* qhy5pii_c.cpp */; };
+		593447DE1CF8F2BB008AD945 /* qhy5pii_m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934474C1CF8F2BB008AD945 /* qhy5pii_m.cpp */; };
+		593447DF1CF8F2BB008AD945 /* qhy5rii_m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934474E1CF8F2BB008AD945 /* qhy5rii_m.cpp */; };
+		593447E01CF8F2BB008AD945 /* qhy5tii_c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447501CF8F2BB008AD945 /* qhy5tii_c.cpp */; };
+		593447E11CF8F2BB008AD945 /* qhy6.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447521CF8F2BB008AD945 /* qhy6.cpp */; };
+		593447E21CF8F2BB008AD945 /* qhy7.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447541CF8F2BB008AD945 /* qhy7.cpp */; };
+		593447E31CF8F2BB008AD945 /* qhy8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447561CF8F2BB008AD945 /* qhy8.cpp */; };
+		593447E41CF8F2BB008AD945 /* qhy8l.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447581CF8F2BB008AD945 /* qhy8l.cpp */; };
+		593447E51CF8F2BB008AD945 /* qhy8pro.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934475A1CF8F2BB008AD945 /* qhy8pro.cpp */; };
+		593447E61CF8F2BB008AD945 /* qhy9s.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934475C1CF8F2BB008AD945 /* qhy9s.cpp */; };
+		593447E71CF8F2BB008AD945 /* qhy9t.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934475E1CF8F2BB008AD945 /* qhy9t.cpp */; };
+		593447E81CF8F2BB008AD945 /* qhy10.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447601CF8F2BB008AD945 /* qhy10.cpp */; };
+		593447E91CF8F2BB008AD945 /* qhy11.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447621CF8F2BB008AD945 /* qhy11.cpp */; };
+		593447EA1CF8F2BB008AD945 /* qhy12.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447641CF8F2BB008AD945 /* qhy12.cpp */; };
+		593447EB1CF8F2BB008AD945 /* qhy15.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447661CF8F2BB008AD945 /* qhy15.cpp */; };
+		593447EC1CF8F2BB008AD945 /* qhy16.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447681CF8F2BB008AD945 /* qhy16.cpp */; };
+		593447ED1CF8F2BB008AD945 /* qhy21.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934476A1CF8F2BB008AD945 /* qhy21.cpp */; };
+		593447EE1CF8F2BB008AD945 /* qhy22.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934476C1CF8F2BB008AD945 /* qhy22.cpp */; };
+		593447EF1CF8F2BB008AD945 /* qhy23.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934476E1CF8F2BB008AD945 /* qhy23.cpp */; };
+		593447F01CF8F2BB008AD945 /* qhy27.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447701CF8F2BB008AD945 /* qhy27.cpp */; };
+		593447F11CF8F2BB008AD945 /* qhy28.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447721CF8F2BB008AD945 /* qhy28.cpp */; };
+		593447F21CF8F2BB008AD945 /* qhy29.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447741CF8F2BB008AD945 /* qhy29.cpp */; };
+		593447F31CF8F2BB008AD945 /* qhy45gx.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447761CF8F2BB008AD945 /* qhy45gx.cpp */; };
+		593447F41CF8F2BB008AD945 /* qhy90a.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447781CF8F2BB008AD945 /* qhy90a.cpp */; };
+		593447F51CF8F2BB008AD945 /* qhy163c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934477A1CF8F2BB008AD945 /* qhy163c.cpp */; };
+		593447F61CF8F2BB008AD945 /* qhy163m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934477C1CF8F2BB008AD945 /* qhy163m.cpp */; };
+		593447F71CF8F2BB008AD945 /* qhy165c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934477E1CF8F2BB008AD945 /* qhy165c.cpp */; };
+		593447F81CF8F2BB008AD945 /* qhy174c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447801CF8F2BB008AD945 /* qhy174c.cpp */; };
+		593447F91CF8F2BB008AD945 /* qhy174m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447821CF8F2BB008AD945 /* qhy174m.cpp */; };
+		593447FA1CF8F2BB008AD945 /* qhy178c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447841CF8F2BB008AD945 /* qhy178c.cpp */; };
+		593447FB1CF8F2BB008AD945 /* qhy178m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447861CF8F2BB008AD945 /* qhy178m.cpp */; };
+		593447FC1CF8F2BB008AD945 /* qhy183c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447881CF8F2BB008AD945 /* qhy183c.cpp */; };
+		593447FD1CF8F2BB008AD945 /* qhy224c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934478A1CF8F2BB008AD945 /* qhy224c.cpp */; };
+		593447FE1CF8F2BB008AD945 /* qhy290c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934478C1CF8F2BB008AD945 /* qhy290c.cpp */; };
+		593447FF1CF8F2BB008AD945 /* qhy290m.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934478E1CF8F2BB008AD945 /* qhy290m.cpp */; };
+		593448001CF8F2BB008AD945 /* qhy367c.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447901CF8F2BB008AD945 /* qhy367c.cpp */; };
+		593448011CF8F2BB008AD945 /* qhy695a.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447921CF8F2BB008AD945 /* qhy695a.cpp */; };
+		593448021CF8F2BB008AD945 /* qhy814g.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447941CF8F2BB008AD945 /* qhy814g.cpp */; };
+		593448031CF8F2BB008AD945 /* qhy08050g.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447961CF8F2BB008AD945 /* qhy08050g.cpp */; };
+		593448041CF8F2BB008AD945 /* qhy16000.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447981CF8F2BB008AD945 /* qhy16000.cpp */; };
+		593448051CF8F2BB008AD945 /* qhy16000g.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934479A1CF8F2BB008AD945 /* qhy16000g.cpp */; };
+		593448061CF8F2BB008AD945 /* qhy16200a.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934479C1CF8F2BB008AD945 /* qhy16200a.cpp */; };
+		593448071CF8F2BB008AD945 /* qhy160002ad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5934479E1CF8F2BB008AD945 /* qhy160002ad.cpp */; };
+		593448081CF8F2BB008AD945 /* qhyabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447A01CF8F2BB008AD945 /* qhyabase.cpp */; };
+		593448091CF8F2BB008AD945 /* qhybase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447A21CF8F2BB008AD945 /* qhybase.cpp */; };
+		5934480A1CF8F2BB008AD945 /* qhycam.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447A41CF8F2BB008AD945 /* qhycam.cpp */; };
+		5934480B1CF8F2BB008AD945 /* qhyccd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447A61CF8F2BB008AD945 /* qhyccd.cpp */; };
+		5934480C1CF8F2BB008AD945 /* qhyccdimgprocess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447A81CF8F2BB008AD945 /* qhyccdimgprocess.cpp */; };
+		5934480D1CF8F2BB008AD945 /* qhyicbase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447A91CF8F2BB008AD945 /* qhyicbase.cpp */; };
+		5934480E1CF8F2BB008AD945 /* solar800g.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447AB1CF8F2BB008AD945 /* solar800g.cpp */; };
+		5934480F1CF8F2BB008AD945 /* solar1600.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447AD1CF8F2BB008AD945 /* solar1600.cpp */; };
+		593448101CF8F2BB008AD945 /* unlockimagequeue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 593447AF1CF8F2BB008AD945 /* unlockimagequeue.cpp */; };
 		5944982C1C135B3600E0E281 /* lx200pulsar2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5944982B1C135B3600E0E281 /* lx200pulsar2.cpp */; };
 		594498351C135D8000E0E281 /* libindi.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DDA43A91A8CD3190004AA95 /* libindi.dylib */; };
 		594498361C135D8000E0E281 /* libnova.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DDA422C1A8CB6920004AA95 /* libnova.dylib */; };
@@ -666,6 +816,41 @@
 			proxyType = 1;
 			remoteGlobalIDString = 5924ACE91C8B44FD00750816;
 			remoteInfo = indi_nextarevo;
+		};
+		593445B31CF8EF62008AD945 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 594D0B2B188300ED00B50F4E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9DDA43171A8CC5F90004AA95;
+			remoteInfo = cfitsio;
+		};
+		593445B51CF8EF62008AD945 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 594D0B2B188300ED00B50F4E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9DDA438A1A8CCD030004AA95;
+			remoteInfo = usb;
+		};
+		593445B71CF8EF62008AD945 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 594D0B2B188300ED00B50F4E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9DDA422B1A8CB6920004AA95;
+			remoteInfo = nova;
+		};
+		593445B91CF8EF62008AD945 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 594D0B2B188300ED00B50F4E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9DDA43A81A8CD3190004AA95;
+			remoteInfo = indi;
+		};
+		593445D01CF8EFFC008AD945 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 594D0B2B188300ED00B50F4E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 593445B11CF8EF62008AD945;
+			remoteInfo = indi_qhy_ccd;
 		};
 		5944982F1C135D8000E0E281 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -2233,6 +2418,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 6;
 			files = (
+				593445D21CF8F008008AD945 /* indi_qhy_ccd in Copy Files (33 items) (53 items) */,
 				59563CCC1CF20A3800DE1A54 /* indi_ssag_ccd in Copy Files (33 items) (53 items) */,
 				59C3D6811CF07E7200974D80 /* indi_nstep_focus in Copy Files (33 items) (53 items) */,
 				598786B81CE735FF00DF2294 /* indi_fli_ccd in Copy Files (33 items) (53 items) */,
@@ -2512,6 +2698,249 @@
 		592F6CB61BADD6D100D93DE9 /* lx200gemini.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lx200gemini.cpp; sourceTree = "<group>"; };
 		592F6CB81BADD70F00D93DE9 /* lx200apdriver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lx200apdriver.cpp; sourceTree = "<group>"; };
 		592FECEF1BADFB6000F645F3 /* atiktest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = atiktest.cpp; sourceTree = "<group>"; };
+		593445C51CF8EF62008AD945 /* indi_qhy_ccd */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = indi_qhy_ccd; sourceTree = BUILT_PRODUCTS_DIR; };
+		593445C71CF8EFC8008AD945 /* config.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; };
+		593445C81CF8EFC8008AD945 /* indi_qhy.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = indi_qhy.xml; sourceTree = "<group>"; };
+		593445C91CF8EFC8008AD945 /* qhy_ccd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy_ccd.cpp; sourceTree = "<group>"; };
+		593445CA1CF8EFC8008AD945 /* qhy_ccd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy_ccd.h; sourceTree = "<group>"; };
+		593445CB1CF8EFC8008AD945 /* qhy_fw.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy_fw.cpp; sourceTree = "<group>"; };
+		593445CC1CF8EFC8008AD945 /* qhy_fw.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy_fw.h; sourceTree = "<group>"; };
+		593445D41CF8F029008AD945 /* IC90A.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IC90A.HEX; sourceTree = "<group>"; };
+		593445D51CF8F029008AD945 /* IC8300.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IC8300.HEX; sourceTree = "<group>"; };
+		593445D61CF8F029008AD945 /* IC16200A.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IC16200A.HEX; sourceTree = "<group>"; };
+		593445D71CF8F029008AD945 /* IC16803.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IC16803.HEX; sourceTree = "<group>"; };
+		593445D81CF8F029008AD945 /* IMG0H.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IMG0H.HEX; sourceTree = "<group>"; };
+		593445D91CF8F029008AD945 /* IMG2P.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IMG2P.HEX; sourceTree = "<group>"; };
+		593445DA1CF8F029008AD945 /* IMG2S.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IMG2S.HEX; sourceTree = "<group>"; };
+		593445DB1CF8F029008AD945 /* IMG50.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = IMG50.HEX; sourceTree = "<group>"; };
+		593445DC1CF8F029008AD945 /* miniCam5.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = miniCam5.HEX; sourceTree = "<group>"; };
+		593445DD1CF8F029008AD945 /* POLEMASTER.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = POLEMASTER.HEX; sourceTree = "<group>"; };
+		593445DE1CF8F029008AD945 /* QHY2.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY2.HEX; sourceTree = "<group>"; };
+		593445DF1CF8F029008AD945 /* QHY2E.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY2E.HEX; sourceTree = "<group>"; };
+		593445E01CF8F029008AD945 /* QHY2PRO.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY2PRO.HEX; sourceTree = "<group>"; };
+		593445E11CF8F029008AD945 /* QHY5.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY5.HEX; sourceTree = "<group>"; };
+		593445E21CF8F029008AD945 /* QHY5II.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY5II.HEX; sourceTree = "<group>"; };
+		593445E31CF8F029008AD945 /* QHY5III174.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY5III174.img; sourceTree = "<group>"; };
+		593445E41CF8F029008AD945 /* QHY5III178.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY5III178.img; sourceTree = "<group>"; };
+		593445E51CF8F029008AD945 /* QHY5III185.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY5III185.img; sourceTree = "<group>"; };
+		593445E61CF8F029008AD945 /* QHY5III224.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY5III224.img; sourceTree = "<group>"; };
+		593445E71CF8F029008AD945 /* QHY5III290.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY5III290.img; sourceTree = "<group>"; };
+		593445E81CF8F029008AD945 /* QHY5LOADER.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY5LOADER.HEX; sourceTree = "<group>"; };
+		593445E91CF8F029008AD945 /* QHY6.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY6.HEX; sourceTree = "<group>"; };
+		593445EA1CF8F029008AD945 /* QHY7.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY7.HEX; sourceTree = "<group>"; };
+		593445EB1CF8F029008AD945 /* QHY8.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY8.HEX; sourceTree = "<group>"; };
+		593445EC1CF8F029008AD945 /* QHY8L.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY8L.HEX; sourceTree = "<group>"; };
+		593445ED1CF8F029008AD945 /* QHY8M.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY8M.HEX; sourceTree = "<group>"; };
+		593445EE1CF8F029008AD945 /* QHY8PRO.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY8PRO.HEX; sourceTree = "<group>"; };
+		593445EF1CF8F029008AD945 /* QHY9S.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY9S.HEX; sourceTree = "<group>"; };
+		593445F01CF8F029008AD945 /* QHY10.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY10.HEX; sourceTree = "<group>"; };
+		593445F11CF8F029008AD945 /* QHY11.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY11.HEX; sourceTree = "<group>"; };
+		593445F21CF8F029008AD945 /* QHY12.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY12.HEX; sourceTree = "<group>"; };
+		593445F31CF8F029008AD945 /* QHY15.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY15.HEX; sourceTree = "<group>"; };
+		593445F41CF8F029008AD945 /* QHY16.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY16.HEX; sourceTree = "<group>"; };
+		593445F51CF8F029008AD945 /* QHY20.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY20.HEX; sourceTree = "<group>"; };
+		593445F61CF8F029008AD945 /* QHY21.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY21.HEX; sourceTree = "<group>"; };
+		593445F71CF8F029008AD945 /* QHY22.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY22.HEX; sourceTree = "<group>"; };
+		593445F81CF8F029008AD945 /* QHY23.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY23.HEX; sourceTree = "<group>"; };
+		593445F91CF8F029008AD945 /* QHY27.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY27.HEX; sourceTree = "<group>"; };
+		593445FA1CF8F029008AD945 /* QHY28.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY28.HEX; sourceTree = "<group>"; };
+		593445FB1CF8F029008AD945 /* QHY29.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY29.HEX; sourceTree = "<group>"; };
+		593445FC1CF8F029008AD945 /* QHY163.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY163.img; sourceTree = "<group>"; };
+		593445FD1CF8F029008AD945 /* QHY174.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY174.img; sourceTree = "<group>"; };
+		593445FE1CF8F029008AD945 /* QHY178.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY178.img; sourceTree = "<group>"; };
+		593445FF1CF8F029008AD945 /* QHY224.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY224.img; sourceTree = "<group>"; };
+		593446001CF8F029008AD945 /* QHY290.img */ = {isa = PBXFileReference; lastKnownFileType = file; path = QHY290.img; sourceTree = "<group>"; };
+		593446011CF8F029008AD945 /* QHY16000.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY16000.HEX; sourceTree = "<group>"; };
+		593446021CF8F029008AD945 /* QHY160002AD.HEX */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = QHY160002AD.HEX; sourceTree = "<group>"; };
+		593446F41CF8F2BB008AD945 /* cjson.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cjson.cpp; sourceTree = "<group>"; };
+		593446F51CF8F2BB008AD945 /* cjson.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cjson.h; sourceTree = "<group>"; };
+		593446F61CF8F2BB008AD945 /* cmosdll.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cmosdll.cpp; sourceTree = "<group>"; };
+		593446F71CF8F2BB008AD945 /* cmosdll.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cmosdll.h; sourceTree = "<group>"; };
+		593446F81CF8F2BB008AD945 /* dithercontrol.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = dithercontrol.cpp; sourceTree = "<group>"; };
+		593446F91CF8F2BB008AD945 /* dithercontrol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = dithercontrol.h; sourceTree = "<group>"; };
+		593446FA1CF8F2BB008AD945 /* download_fx2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = download_fx2.cpp; sourceTree = "<group>"; };
+		593446FB1CF8F2BB008AD945 /* download_fx3.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = download_fx3.cpp; sourceTree = "<group>"; };
+		593446FC1CF8F2BB008AD945 /* ic8300.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ic8300.cpp; sourceTree = "<group>"; };
+		593446FD1CF8F2BB008AD945 /* ic8300.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ic8300.h; sourceTree = "<group>"; };
+		593446FE1CF8F2BB008AD945 /* ic16803.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ic16803.cpp; sourceTree = "<group>"; };
+		593446FF1CF8F2BB008AD945 /* ic16803.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ic16803.h; sourceTree = "<group>"; };
+		593447001CF8F2BB008AD945 /* img0h.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = img0h.cpp; sourceTree = "<group>"; };
+		593447011CF8F2BB008AD945 /* img0h.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = img0h.h; sourceTree = "<group>"; };
+		593447021CF8F2BB008AD945 /* img2p.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = img2p.cpp; sourceTree = "<group>"; };
+		593447031CF8F2BB008AD945 /* img2p.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = img2p.h; sourceTree = "<group>"; };
+		593447041CF8F2BB008AD945 /* img132e.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = img132e.cpp; sourceTree = "<group>"; };
+		593447051CF8F2BB008AD945 /* img132e.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = img132e.h; sourceTree = "<group>"; };
+		593447061CF8F2BB008AD945 /* log4z.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = log4z.cpp; sourceTree = "<group>"; };
+		593447071CF8F2BB008AD945 /* log4z.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = log4z.h; sourceTree = "<group>"; };
+		593447081CF8F2BB008AD945 /* minicam5f_m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = minicam5f_m.cpp; sourceTree = "<group>"; };
+		593447091CF8F2BB008AD945 /* minicam5f_m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = minicam5f_m.h; sourceTree = "<group>"; };
+		5934470A1CF8F2BB008AD945 /* minicam5s_c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = minicam5s_c.cpp; sourceTree = "<group>"; };
+		5934470B1CF8F2BB008AD945 /* minicam5s_c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = minicam5s_c.h; sourceTree = "<group>"; };
+		5934470C1CF8F2BB008AD945 /* minicam5s_m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = minicam5s_m.cpp; sourceTree = "<group>"; };
+		5934470D1CF8F2BB008AD945 /* minicam5s_m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = minicam5s_m.h; sourceTree = "<group>"; };
+		5934470E1CF8F2BB008AD945 /* polemaster.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = polemaster.cpp; sourceTree = "<group>"; };
+		5934470F1CF8F2BB008AD945 /* polemaster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = polemaster.h; sourceTree = "<group>"; };
+		593447101CF8F2BB008AD945 /* qhy2pro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy2pro.cpp; sourceTree = "<group>"; };
+		593447111CF8F2BB008AD945 /* qhy2pro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy2pro.h; sourceTree = "<group>"; };
+		593447121CF8F2BB008AD945 /* qhy5.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5.cpp; sourceTree = "<group>"; };
+		593447131CF8F2BB008AD945 /* qhy5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5.h; sourceTree = "<group>"; };
+		593447141CF8F2BB008AD945 /* qhy5hii.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5hii.cpp; sourceTree = "<group>"; };
+		593447151CF8F2BB008AD945 /* qhy5hii.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5hii.h; sourceTree = "<group>"; };
+		593447161CF8F2BB008AD945 /* qhy5ii.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5ii.cpp; sourceTree = "<group>"; };
+		593447171CF8F2BB008AD945 /* qhy5ii.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5ii.h; sourceTree = "<group>"; };
+		593447181CF8F2BB008AD945 /* qhy5iibase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iibase.cpp; sourceTree = "<group>"; };
+		593447191CF8F2BB008AD945 /* qhy5iibase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iibase.h; sourceTree = "<group>"; };
+		5934471A1CF8F2BB008AD945 /* qhy5iii163base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii163base.cpp; sourceTree = "<group>"; };
+		5934471B1CF8F2BB008AD945 /* qhy5iii163base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii163base.h; sourceTree = "<group>"; };
+		5934471C1CF8F2BB008AD945 /* qhy5iii165base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii165base.cpp; sourceTree = "<group>"; };
+		5934471D1CF8F2BB008AD945 /* qhy5iii165base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii165base.h; sourceTree = "<group>"; };
+		5934471E1CF8F2BB008AD945 /* qhy5iii174base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii174base.cpp; sourceTree = "<group>"; };
+		5934471F1CF8F2BB008AD945 /* qhy5iii174base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii174base.h; sourceTree = "<group>"; };
+		593447201CF8F2BB008AD945 /* qhy5iii174c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii174c.cpp; sourceTree = "<group>"; };
+		593447211CF8F2BB008AD945 /* qhy5iii174c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii174c.h; sourceTree = "<group>"; };
+		593447221CF8F2BB008AD945 /* qhy5iii174m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii174m.cpp; sourceTree = "<group>"; };
+		593447231CF8F2BB008AD945 /* qhy5iii174m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii174m.h; sourceTree = "<group>"; };
+		593447241CF8F2BB008AD945 /* qhy5iii178base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii178base.cpp; sourceTree = "<group>"; };
+		593447251CF8F2BB008AD945 /* qhy5iii178base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii178base.h; sourceTree = "<group>"; };
+		593447261CF8F2BB008AD945 /* qhy5iii178c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii178c.cpp; sourceTree = "<group>"; };
+		593447271CF8F2BB008AD945 /* qhy5iii178c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii178c.h; sourceTree = "<group>"; };
+		593447281CF8F2BB008AD945 /* qhy5iii178m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii178m.cpp; sourceTree = "<group>"; };
+		593447291CF8F2BB008AD945 /* qhy5iii178m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii178m.h; sourceTree = "<group>"; };
+		5934472A1CF8F2BB008AD945 /* qhy5iii183base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii183base.cpp; sourceTree = "<group>"; };
+		5934472B1CF8F2BB008AD945 /* qhy5iii183base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii183base.h; sourceTree = "<group>"; };
+		5934472C1CF8F2BB008AD945 /* qhy5iii185base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii185base.cpp; sourceTree = "<group>"; };
+		5934472D1CF8F2BB008AD945 /* qhy5iii185base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii185base.h; sourceTree = "<group>"; };
+		5934472E1CF8F2BB008AD945 /* qhy5iii185c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii185c.cpp; sourceTree = "<group>"; };
+		5934472F1CF8F2BB008AD945 /* qhy5iii185c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii185c.h; sourceTree = "<group>"; };
+		593447301CF8F2BB008AD945 /* qhy5iii224base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii224base.cpp; sourceTree = "<group>"; };
+		593447311CF8F2BB008AD945 /* qhy5iii224base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii224base.h; sourceTree = "<group>"; };
+		593447321CF8F2BB008AD945 /* qhy5iii224c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii224c.cpp; sourceTree = "<group>"; };
+		593447331CF8F2BB008AD945 /* qhy5iii224c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii224c.h; sourceTree = "<group>"; };
+		593447341CF8F2BB008AD945 /* qhy5iii236c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii236c.cpp; sourceTree = "<group>"; };
+		593447351CF8F2BB008AD945 /* qhy5iii236c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii236c.h; sourceTree = "<group>"; };
+		593447361CF8F2BB008AD945 /* qhy5iii290base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii290base.cpp; sourceTree = "<group>"; };
+		593447371CF8F2BB008AD945 /* qhy5iii290base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii290base.h; sourceTree = "<group>"; };
+		593447381CF8F2BB008AD945 /* qhy5iii290c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii290c.cpp; sourceTree = "<group>"; };
+		593447391CF8F2BB008AD945 /* qhy5iii290c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii290c.h; sourceTree = "<group>"; };
+		5934473A1CF8F2BB008AD945 /* qhy5iii290m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii290m.cpp; sourceTree = "<group>"; };
+		5934473B1CF8F2BB008AD945 /* qhy5iii290m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii290m.h; sourceTree = "<group>"; };
+		5934473C1CF8F2BB008AD945 /* qhy5iii367base.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iii367base.cpp; sourceTree = "<group>"; };
+		5934473D1CF8F2BB008AD945 /* qhy5iii367base.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iii367base.h; sourceTree = "<group>"; };
+		5934473E1CF8F2BB008AD945 /* qhy5iiibase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iiibase.cpp; sourceTree = "<group>"; };
+		5934473F1CF8F2BB008AD945 /* qhy5iiibase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iiibase.h; sourceTree = "<group>"; };
+		593447401CF8F2BB008AD945 /* qhy5iiicoolbase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iiicoolbase.cpp; sourceTree = "<group>"; };
+		593447411CF8F2BB008AD945 /* qhy5iiicoolbase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iiicoolbase.h; sourceTree = "<group>"; };
+		593447421CF8F2BB008AD945 /* qhy5iiig400m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5iiig400m.cpp; sourceTree = "<group>"; };
+		593447431CF8F2BB008AD945 /* qhy5iiig400m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5iiig400m.h; sourceTree = "<group>"; };
+		593447441CF8F2BB008AD945 /* qhy5lii_c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5lii_c.cpp; sourceTree = "<group>"; };
+		593447451CF8F2BB008AD945 /* qhy5lii_c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5lii_c.h; sourceTree = "<group>"; };
+		593447461CF8F2BB008AD945 /* qhy5lii_m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5lii_m.cpp; sourceTree = "<group>"; };
+		593447471CF8F2BB008AD945 /* qhy5lii_m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5lii_m.h; sourceTree = "<group>"; };
+		593447481CF8F2BB008AD945 /* qhy5liibase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5liibase.cpp; sourceTree = "<group>"; };
+		593447491CF8F2BB008AD945 /* qhy5liibase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5liibase.h; sourceTree = "<group>"; };
+		5934474A1CF8F2BB008AD945 /* qhy5pii_c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5pii_c.cpp; sourceTree = "<group>"; };
+		5934474B1CF8F2BB008AD945 /* qhy5pii_c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5pii_c.h; sourceTree = "<group>"; };
+		5934474C1CF8F2BB008AD945 /* qhy5pii_m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5pii_m.cpp; sourceTree = "<group>"; };
+		5934474D1CF8F2BB008AD945 /* qhy5pii_m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5pii_m.h; sourceTree = "<group>"; };
+		5934474E1CF8F2BB008AD945 /* qhy5rii_m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5rii_m.cpp; sourceTree = "<group>"; };
+		5934474F1CF8F2BB008AD945 /* qhy5rii_m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5rii_m.h; sourceTree = "<group>"; };
+		593447501CF8F2BB008AD945 /* qhy5tii_c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy5tii_c.cpp; sourceTree = "<group>"; };
+		593447511CF8F2BB008AD945 /* qhy5tii_c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy5tii_c.h; sourceTree = "<group>"; };
+		593447521CF8F2BB008AD945 /* qhy6.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy6.cpp; sourceTree = "<group>"; };
+		593447531CF8F2BB008AD945 /* qhy6.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy6.h; sourceTree = "<group>"; };
+		593447541CF8F2BB008AD945 /* qhy7.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy7.cpp; sourceTree = "<group>"; };
+		593447551CF8F2BB008AD945 /* qhy7.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy7.h; sourceTree = "<group>"; };
+		593447561CF8F2BB008AD945 /* qhy8.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy8.cpp; sourceTree = "<group>"; };
+		593447571CF8F2BB008AD945 /* qhy8.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy8.h; sourceTree = "<group>"; };
+		593447581CF8F2BB008AD945 /* qhy8l.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy8l.cpp; sourceTree = "<group>"; };
+		593447591CF8F2BB008AD945 /* qhy8l.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy8l.h; sourceTree = "<group>"; };
+		5934475A1CF8F2BB008AD945 /* qhy8pro.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy8pro.cpp; sourceTree = "<group>"; };
+		5934475B1CF8F2BB008AD945 /* qhy8pro.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy8pro.h; sourceTree = "<group>"; };
+		5934475C1CF8F2BB008AD945 /* qhy9s.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy9s.cpp; sourceTree = "<group>"; };
+		5934475D1CF8F2BB008AD945 /* qhy9s.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy9s.h; sourceTree = "<group>"; };
+		5934475E1CF8F2BB008AD945 /* qhy9t.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy9t.cpp; sourceTree = "<group>"; };
+		5934475F1CF8F2BB008AD945 /* qhy9t.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy9t.h; sourceTree = "<group>"; };
+		593447601CF8F2BB008AD945 /* qhy10.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy10.cpp; sourceTree = "<group>"; };
+		593447611CF8F2BB008AD945 /* qhy10.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy10.h; sourceTree = "<group>"; };
+		593447621CF8F2BB008AD945 /* qhy11.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy11.cpp; sourceTree = "<group>"; };
+		593447631CF8F2BB008AD945 /* qhy11.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy11.h; sourceTree = "<group>"; };
+		593447641CF8F2BB008AD945 /* qhy12.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy12.cpp; sourceTree = "<group>"; };
+		593447651CF8F2BB008AD945 /* qhy12.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy12.h; sourceTree = "<group>"; };
+		593447661CF8F2BB008AD945 /* qhy15.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy15.cpp; sourceTree = "<group>"; };
+		593447671CF8F2BB008AD945 /* qhy15.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy15.h; sourceTree = "<group>"; };
+		593447681CF8F2BB008AD945 /* qhy16.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy16.cpp; sourceTree = "<group>"; };
+		593447691CF8F2BB008AD945 /* qhy16.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy16.h; sourceTree = "<group>"; };
+		5934476A1CF8F2BB008AD945 /* qhy21.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy21.cpp; sourceTree = "<group>"; };
+		5934476B1CF8F2BB008AD945 /* qhy21.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy21.h; sourceTree = "<group>"; };
+		5934476C1CF8F2BB008AD945 /* qhy22.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy22.cpp; sourceTree = "<group>"; };
+		5934476D1CF8F2BB008AD945 /* qhy22.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy22.h; sourceTree = "<group>"; };
+		5934476E1CF8F2BB008AD945 /* qhy23.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy23.cpp; sourceTree = "<group>"; };
+		5934476F1CF8F2BB008AD945 /* qhy23.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy23.h; sourceTree = "<group>"; };
+		593447701CF8F2BB008AD945 /* qhy27.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy27.cpp; sourceTree = "<group>"; };
+		593447711CF8F2BB008AD945 /* qhy27.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy27.h; sourceTree = "<group>"; };
+		593447721CF8F2BB008AD945 /* qhy28.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy28.cpp; sourceTree = "<group>"; };
+		593447731CF8F2BB008AD945 /* qhy28.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy28.h; sourceTree = "<group>"; };
+		593447741CF8F2BB008AD945 /* qhy29.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy29.cpp; sourceTree = "<group>"; };
+		593447751CF8F2BB008AD945 /* qhy29.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy29.h; sourceTree = "<group>"; };
+		593447761CF8F2BB008AD945 /* qhy45gx.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy45gx.cpp; sourceTree = "<group>"; };
+		593447771CF8F2BB008AD945 /* qhy45gx.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy45gx.h; sourceTree = "<group>"; };
+		593447781CF8F2BB008AD945 /* qhy90a.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy90a.cpp; sourceTree = "<group>"; };
+		593447791CF8F2BB008AD945 /* qhy90a.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy90a.h; sourceTree = "<group>"; };
+		5934477A1CF8F2BB008AD945 /* qhy163c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy163c.cpp; sourceTree = "<group>"; };
+		5934477B1CF8F2BB008AD945 /* qhy163c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy163c.h; sourceTree = "<group>"; };
+		5934477C1CF8F2BB008AD945 /* qhy163m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy163m.cpp; sourceTree = "<group>"; };
+		5934477D1CF8F2BB008AD945 /* qhy163m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy163m.h; sourceTree = "<group>"; };
+		5934477E1CF8F2BB008AD945 /* qhy165c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy165c.cpp; sourceTree = "<group>"; };
+		5934477F1CF8F2BB008AD945 /* qhy165c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy165c.h; sourceTree = "<group>"; };
+		593447801CF8F2BB008AD945 /* qhy174c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy174c.cpp; sourceTree = "<group>"; };
+		593447811CF8F2BB008AD945 /* qhy174c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy174c.h; sourceTree = "<group>"; };
+		593447821CF8F2BB008AD945 /* qhy174m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy174m.cpp; sourceTree = "<group>"; };
+		593447831CF8F2BB008AD945 /* qhy174m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy174m.h; sourceTree = "<group>"; };
+		593447841CF8F2BB008AD945 /* qhy178c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy178c.cpp; sourceTree = "<group>"; };
+		593447851CF8F2BB008AD945 /* qhy178c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy178c.h; sourceTree = "<group>"; };
+		593447861CF8F2BB008AD945 /* qhy178m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy178m.cpp; sourceTree = "<group>"; };
+		593447871CF8F2BB008AD945 /* qhy178m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy178m.h; sourceTree = "<group>"; };
+		593447881CF8F2BB008AD945 /* qhy183c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy183c.cpp; sourceTree = "<group>"; };
+		593447891CF8F2BB008AD945 /* qhy183c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy183c.h; sourceTree = "<group>"; };
+		5934478A1CF8F2BB008AD945 /* qhy224c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy224c.cpp; sourceTree = "<group>"; };
+		5934478B1CF8F2BB008AD945 /* qhy224c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy224c.h; sourceTree = "<group>"; };
+		5934478C1CF8F2BB008AD945 /* qhy290c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy290c.cpp; sourceTree = "<group>"; };
+		5934478D1CF8F2BB008AD945 /* qhy290c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy290c.h; sourceTree = "<group>"; };
+		5934478E1CF8F2BB008AD945 /* qhy290m.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy290m.cpp; sourceTree = "<group>"; };
+		5934478F1CF8F2BB008AD945 /* qhy290m.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy290m.h; sourceTree = "<group>"; };
+		593447901CF8F2BB008AD945 /* qhy367c.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy367c.cpp; sourceTree = "<group>"; };
+		593447911CF8F2BB008AD945 /* qhy367c.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy367c.h; sourceTree = "<group>"; };
+		593447921CF8F2BB008AD945 /* qhy695a.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy695a.cpp; sourceTree = "<group>"; };
+		593447931CF8F2BB008AD945 /* qhy695a.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy695a.h; sourceTree = "<group>"; };
+		593447941CF8F2BB008AD945 /* qhy814g.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy814g.cpp; sourceTree = "<group>"; };
+		593447951CF8F2BB008AD945 /* qhy814g.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy814g.h; sourceTree = "<group>"; };
+		593447961CF8F2BB008AD945 /* qhy08050g.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy08050g.cpp; sourceTree = "<group>"; };
+		593447971CF8F2BB008AD945 /* qhy08050g.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy08050g.h; sourceTree = "<group>"; };
+		593447981CF8F2BB008AD945 /* qhy16000.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy16000.cpp; sourceTree = "<group>"; };
+		593447991CF8F2BB008AD945 /* qhy16000.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy16000.h; sourceTree = "<group>"; };
+		5934479A1CF8F2BB008AD945 /* qhy16000g.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy16000g.cpp; sourceTree = "<group>"; };
+		5934479B1CF8F2BB008AD945 /* qhy16000g.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy16000g.h; sourceTree = "<group>"; };
+		5934479C1CF8F2BB008AD945 /* qhy16200a.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy16200a.cpp; sourceTree = "<group>"; };
+		5934479D1CF8F2BB008AD945 /* qhy16200a.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy16200a.h; sourceTree = "<group>"; };
+		5934479E1CF8F2BB008AD945 /* qhy160002ad.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhy160002ad.cpp; sourceTree = "<group>"; };
+		5934479F1CF8F2BB008AD945 /* qhy160002ad.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhy160002ad.h; sourceTree = "<group>"; };
+		593447A01CF8F2BB008AD945 /* qhyabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhyabase.cpp; sourceTree = "<group>"; };
+		593447A11CF8F2BB008AD945 /* qhyabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhyabase.h; sourceTree = "<group>"; };
+		593447A21CF8F2BB008AD945 /* qhybase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhybase.cpp; sourceTree = "<group>"; };
+		593447A31CF8F2BB008AD945 /* qhybase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhybase.h; sourceTree = "<group>"; };
+		593447A41CF8F2BB008AD945 /* qhycam.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhycam.cpp; sourceTree = "<group>"; };
+		593447A51CF8F2BB008AD945 /* qhycam.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhycam.h; sourceTree = "<group>"; };
+		593447A61CF8F2BB008AD945 /* qhyccd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhyccd.cpp; sourceTree = "<group>"; };
+		593447A71CF8F2BB008AD945 /* qhyccd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhyccd.h; sourceTree = "<group>"; };
+		593447A81CF8F2BB008AD945 /* qhyccdimgprocess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhyccdimgprocess.cpp; sourceTree = "<group>"; };
+		593447A91CF8F2BB008AD945 /* qhyicbase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = qhyicbase.cpp; sourceTree = "<group>"; };
+		593447AA1CF8F2BB008AD945 /* qhyicbase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qhyicbase.h; sourceTree = "<group>"; };
+		593447AB1CF8F2BB008AD945 /* solar800g.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = solar800g.cpp; sourceTree = "<group>"; };
+		593447AC1CF8F2BB008AD945 /* solar800g.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = solar800g.h; sourceTree = "<group>"; };
+		593447AD1CF8F2BB008AD945 /* solar1600.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = solar1600.cpp; sourceTree = "<group>"; };
+		593447AE1CF8F2BB008AD945 /* solar1600.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = solar1600.h; sourceTree = "<group>"; };
+		593447AF1CF8F2BB008AD945 /* unlockimagequeue.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = unlockimagequeue.cpp; sourceTree = "<group>"; };
+		593447B01CF8F2BB008AD945 /* unlockimagequeue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unlockimagequeue.h; sourceTree = "<group>"; };
 		5944982A1C135A2000E0E281 /* atikconfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = atikconfig.h; sourceTree = "<group>"; };
 		5944982B1C135B3600E0E281 /* lx200pulsar2.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = lx200pulsar2.cpp; sourceTree = "<group>"; };
 		5944983B1C135D8000E0E281 /* indi_lynx_focus */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = indi_lynx_focus; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3034,6 +3463,16 @@
 			files = (
 				5924ACF11C8B44FD00750816 /* libindi.dylib in Frameworks */,
 				5924ACF21C8B44FD00750816 /* libnova.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		593445BE1CF8EF62008AD945 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				593445BF1CF8EF62008AD945 /* libcfitsio.dylib in Frameworks */,
+				593445C01CF8EF62008AD945 /* libusb.dylib in Frameworks */,
+				593445C11CF8EF62008AD945 /* libindi.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3642,6 +4081,273 @@
 			path = "indi-nexstarevo";
 			sourceTree = "<group>";
 		};
+		593445C61CF8EF8F008AD945 /* indi-qhy */ = {
+			isa = PBXGroup;
+			children = (
+				593446321CF8F02D008AD945 /* libqhy */,
+				593445D31CF8F00C008AD945 /* firmware */,
+				593445C71CF8EFC8008AD945 /* config.h */,
+				593445C81CF8EFC8008AD945 /* indi_qhy.xml */,
+				593445C91CF8EFC8008AD945 /* qhy_ccd.cpp */,
+				593445CA1CF8EFC8008AD945 /* qhy_ccd.h */,
+				593445CB1CF8EFC8008AD945 /* qhy_fw.cpp */,
+				593445CC1CF8EFC8008AD945 /* qhy_fw.h */,
+			);
+			path = "indi-qhy";
+			sourceTree = "<group>";
+		};
+		593445D31CF8F00C008AD945 /* firmware */ = {
+			isa = PBXGroup;
+			children = (
+				593445D41CF8F029008AD945 /* IC90A.HEX */,
+				593445D51CF8F029008AD945 /* IC8300.HEX */,
+				593445D61CF8F029008AD945 /* IC16200A.HEX */,
+				593445D71CF8F029008AD945 /* IC16803.HEX */,
+				593445D81CF8F029008AD945 /* IMG0H.HEX */,
+				593445D91CF8F029008AD945 /* IMG2P.HEX */,
+				593445DA1CF8F029008AD945 /* IMG2S.HEX */,
+				593445DB1CF8F029008AD945 /* IMG50.HEX */,
+				593445DC1CF8F029008AD945 /* miniCam5.HEX */,
+				593445DD1CF8F029008AD945 /* POLEMASTER.HEX */,
+				593445DE1CF8F029008AD945 /* QHY2.HEX */,
+				593445DF1CF8F029008AD945 /* QHY2E.HEX */,
+				593445E01CF8F029008AD945 /* QHY2PRO.HEX */,
+				593445E11CF8F029008AD945 /* QHY5.HEX */,
+				593445E21CF8F029008AD945 /* QHY5II.HEX */,
+				593445E31CF8F029008AD945 /* QHY5III174.img */,
+				593445E41CF8F029008AD945 /* QHY5III178.img */,
+				593445E51CF8F029008AD945 /* QHY5III185.img */,
+				593445E61CF8F029008AD945 /* QHY5III224.img */,
+				593445E71CF8F029008AD945 /* QHY5III290.img */,
+				593445E81CF8F029008AD945 /* QHY5LOADER.HEX */,
+				593445E91CF8F029008AD945 /* QHY6.HEX */,
+				593445EA1CF8F029008AD945 /* QHY7.HEX */,
+				593445EB1CF8F029008AD945 /* QHY8.HEX */,
+				593445EC1CF8F029008AD945 /* QHY8L.HEX */,
+				593445ED1CF8F029008AD945 /* QHY8M.HEX */,
+				593445EE1CF8F029008AD945 /* QHY8PRO.HEX */,
+				593445EF1CF8F029008AD945 /* QHY9S.HEX */,
+				593445F01CF8F029008AD945 /* QHY10.HEX */,
+				593445F11CF8F029008AD945 /* QHY11.HEX */,
+				593445F21CF8F029008AD945 /* QHY12.HEX */,
+				593445F31CF8F029008AD945 /* QHY15.HEX */,
+				593445F41CF8F029008AD945 /* QHY16.HEX */,
+				593445F51CF8F029008AD945 /* QHY20.HEX */,
+				593445F61CF8F029008AD945 /* QHY21.HEX */,
+				593445F71CF8F029008AD945 /* QHY22.HEX */,
+				593445F81CF8F029008AD945 /* QHY23.HEX */,
+				593445F91CF8F029008AD945 /* QHY27.HEX */,
+				593445FA1CF8F029008AD945 /* QHY28.HEX */,
+				593445FB1CF8F029008AD945 /* QHY29.HEX */,
+				593445FC1CF8F029008AD945 /* QHY163.img */,
+				593445FD1CF8F029008AD945 /* QHY174.img */,
+				593445FE1CF8F029008AD945 /* QHY178.img */,
+				593445FF1CF8F029008AD945 /* QHY224.img */,
+				593446001CF8F029008AD945 /* QHY290.img */,
+				593446011CF8F029008AD945 /* QHY16000.HEX */,
+				593446021CF8F029008AD945 /* QHY160002AD.HEX */,
+			);
+			name = firmware;
+			path = ../../../QHYCCD_SDK_CrossPlatform/firmware;
+			sourceTree = "<group>";
+		};
+		593446321CF8F02D008AD945 /* libqhy */ = {
+			isa = PBXGroup;
+			children = (
+				593446F41CF8F2BB008AD945 /* cjson.cpp */,
+				593446F51CF8F2BB008AD945 /* cjson.h */,
+				593446F61CF8F2BB008AD945 /* cmosdll.cpp */,
+				593446F71CF8F2BB008AD945 /* cmosdll.h */,
+				593446F81CF8F2BB008AD945 /* dithercontrol.cpp */,
+				593446F91CF8F2BB008AD945 /* dithercontrol.h */,
+				593446FA1CF8F2BB008AD945 /* download_fx2.cpp */,
+				593446FB1CF8F2BB008AD945 /* download_fx3.cpp */,
+				593446FC1CF8F2BB008AD945 /* ic8300.cpp */,
+				593446FD1CF8F2BB008AD945 /* ic8300.h */,
+				593446FE1CF8F2BB008AD945 /* ic16803.cpp */,
+				593446FF1CF8F2BB008AD945 /* ic16803.h */,
+				593447001CF8F2BB008AD945 /* img0h.cpp */,
+				593447011CF8F2BB008AD945 /* img0h.h */,
+				593447021CF8F2BB008AD945 /* img2p.cpp */,
+				593447031CF8F2BB008AD945 /* img2p.h */,
+				593447041CF8F2BB008AD945 /* img132e.cpp */,
+				593447051CF8F2BB008AD945 /* img132e.h */,
+				593447061CF8F2BB008AD945 /* log4z.cpp */,
+				593447071CF8F2BB008AD945 /* log4z.h */,
+				593447081CF8F2BB008AD945 /* minicam5f_m.cpp */,
+				593447091CF8F2BB008AD945 /* minicam5f_m.h */,
+				5934470A1CF8F2BB008AD945 /* minicam5s_c.cpp */,
+				5934470B1CF8F2BB008AD945 /* minicam5s_c.h */,
+				5934470C1CF8F2BB008AD945 /* minicam5s_m.cpp */,
+				5934470D1CF8F2BB008AD945 /* minicam5s_m.h */,
+				5934470E1CF8F2BB008AD945 /* polemaster.cpp */,
+				5934470F1CF8F2BB008AD945 /* polemaster.h */,
+				593447101CF8F2BB008AD945 /* qhy2pro.cpp */,
+				593447111CF8F2BB008AD945 /* qhy2pro.h */,
+				593447121CF8F2BB008AD945 /* qhy5.cpp */,
+				593447131CF8F2BB008AD945 /* qhy5.h */,
+				593447141CF8F2BB008AD945 /* qhy5hii.cpp */,
+				593447151CF8F2BB008AD945 /* qhy5hii.h */,
+				593447161CF8F2BB008AD945 /* qhy5ii.cpp */,
+				593447171CF8F2BB008AD945 /* qhy5ii.h */,
+				593447181CF8F2BB008AD945 /* qhy5iibase.cpp */,
+				593447191CF8F2BB008AD945 /* qhy5iibase.h */,
+				5934471A1CF8F2BB008AD945 /* qhy5iii163base.cpp */,
+				5934471B1CF8F2BB008AD945 /* qhy5iii163base.h */,
+				5934471C1CF8F2BB008AD945 /* qhy5iii165base.cpp */,
+				5934471D1CF8F2BB008AD945 /* qhy5iii165base.h */,
+				5934471E1CF8F2BB008AD945 /* qhy5iii174base.cpp */,
+				5934471F1CF8F2BB008AD945 /* qhy5iii174base.h */,
+				593447201CF8F2BB008AD945 /* qhy5iii174c.cpp */,
+				593447211CF8F2BB008AD945 /* qhy5iii174c.h */,
+				593447221CF8F2BB008AD945 /* qhy5iii174m.cpp */,
+				593447231CF8F2BB008AD945 /* qhy5iii174m.h */,
+				593447241CF8F2BB008AD945 /* qhy5iii178base.cpp */,
+				593447251CF8F2BB008AD945 /* qhy5iii178base.h */,
+				593447261CF8F2BB008AD945 /* qhy5iii178c.cpp */,
+				593447271CF8F2BB008AD945 /* qhy5iii178c.h */,
+				593447281CF8F2BB008AD945 /* qhy5iii178m.cpp */,
+				593447291CF8F2BB008AD945 /* qhy5iii178m.h */,
+				5934472A1CF8F2BB008AD945 /* qhy5iii183base.cpp */,
+				5934472B1CF8F2BB008AD945 /* qhy5iii183base.h */,
+				5934472C1CF8F2BB008AD945 /* qhy5iii185base.cpp */,
+				5934472D1CF8F2BB008AD945 /* qhy5iii185base.h */,
+				5934472E1CF8F2BB008AD945 /* qhy5iii185c.cpp */,
+				5934472F1CF8F2BB008AD945 /* qhy5iii185c.h */,
+				593447301CF8F2BB008AD945 /* qhy5iii224base.cpp */,
+				593447311CF8F2BB008AD945 /* qhy5iii224base.h */,
+				593447321CF8F2BB008AD945 /* qhy5iii224c.cpp */,
+				593447331CF8F2BB008AD945 /* qhy5iii224c.h */,
+				593447341CF8F2BB008AD945 /* qhy5iii236c.cpp */,
+				593447351CF8F2BB008AD945 /* qhy5iii236c.h */,
+				593447361CF8F2BB008AD945 /* qhy5iii290base.cpp */,
+				593447371CF8F2BB008AD945 /* qhy5iii290base.h */,
+				593447381CF8F2BB008AD945 /* qhy5iii290c.cpp */,
+				593447391CF8F2BB008AD945 /* qhy5iii290c.h */,
+				5934473A1CF8F2BB008AD945 /* qhy5iii290m.cpp */,
+				5934473B1CF8F2BB008AD945 /* qhy5iii290m.h */,
+				5934473C1CF8F2BB008AD945 /* qhy5iii367base.cpp */,
+				5934473D1CF8F2BB008AD945 /* qhy5iii367base.h */,
+				5934473E1CF8F2BB008AD945 /* qhy5iiibase.cpp */,
+				5934473F1CF8F2BB008AD945 /* qhy5iiibase.h */,
+				593447401CF8F2BB008AD945 /* qhy5iiicoolbase.cpp */,
+				593447411CF8F2BB008AD945 /* qhy5iiicoolbase.h */,
+				593447421CF8F2BB008AD945 /* qhy5iiig400m.cpp */,
+				593447431CF8F2BB008AD945 /* qhy5iiig400m.h */,
+				593447441CF8F2BB008AD945 /* qhy5lii_c.cpp */,
+				593447451CF8F2BB008AD945 /* qhy5lii_c.h */,
+				593447461CF8F2BB008AD945 /* qhy5lii_m.cpp */,
+				593447471CF8F2BB008AD945 /* qhy5lii_m.h */,
+				593447481CF8F2BB008AD945 /* qhy5liibase.cpp */,
+				593447491CF8F2BB008AD945 /* qhy5liibase.h */,
+				5934474A1CF8F2BB008AD945 /* qhy5pii_c.cpp */,
+				5934474B1CF8F2BB008AD945 /* qhy5pii_c.h */,
+				5934474C1CF8F2BB008AD945 /* qhy5pii_m.cpp */,
+				5934474D1CF8F2BB008AD945 /* qhy5pii_m.h */,
+				5934474E1CF8F2BB008AD945 /* qhy5rii_m.cpp */,
+				5934474F1CF8F2BB008AD945 /* qhy5rii_m.h */,
+				593447501CF8F2BB008AD945 /* qhy5tii_c.cpp */,
+				593447511CF8F2BB008AD945 /* qhy5tii_c.h */,
+				593447521CF8F2BB008AD945 /* qhy6.cpp */,
+				593447531CF8F2BB008AD945 /* qhy6.h */,
+				593447541CF8F2BB008AD945 /* qhy7.cpp */,
+				593447551CF8F2BB008AD945 /* qhy7.h */,
+				593447561CF8F2BB008AD945 /* qhy8.cpp */,
+				593447571CF8F2BB008AD945 /* qhy8.h */,
+				593447581CF8F2BB008AD945 /* qhy8l.cpp */,
+				593447591CF8F2BB008AD945 /* qhy8l.h */,
+				5934475A1CF8F2BB008AD945 /* qhy8pro.cpp */,
+				5934475B1CF8F2BB008AD945 /* qhy8pro.h */,
+				5934475C1CF8F2BB008AD945 /* qhy9s.cpp */,
+				5934475D1CF8F2BB008AD945 /* qhy9s.h */,
+				5934475E1CF8F2BB008AD945 /* qhy9t.cpp */,
+				5934475F1CF8F2BB008AD945 /* qhy9t.h */,
+				593447601CF8F2BB008AD945 /* qhy10.cpp */,
+				593447611CF8F2BB008AD945 /* qhy10.h */,
+				593447621CF8F2BB008AD945 /* qhy11.cpp */,
+				593447631CF8F2BB008AD945 /* qhy11.h */,
+				593447641CF8F2BB008AD945 /* qhy12.cpp */,
+				593447651CF8F2BB008AD945 /* qhy12.h */,
+				593447661CF8F2BB008AD945 /* qhy15.cpp */,
+				593447671CF8F2BB008AD945 /* qhy15.h */,
+				593447681CF8F2BB008AD945 /* qhy16.cpp */,
+				593447691CF8F2BB008AD945 /* qhy16.h */,
+				5934476A1CF8F2BB008AD945 /* qhy21.cpp */,
+				5934476B1CF8F2BB008AD945 /* qhy21.h */,
+				5934476C1CF8F2BB008AD945 /* qhy22.cpp */,
+				5934476D1CF8F2BB008AD945 /* qhy22.h */,
+				5934476E1CF8F2BB008AD945 /* qhy23.cpp */,
+				5934476F1CF8F2BB008AD945 /* qhy23.h */,
+				593447701CF8F2BB008AD945 /* qhy27.cpp */,
+				593447711CF8F2BB008AD945 /* qhy27.h */,
+				593447721CF8F2BB008AD945 /* qhy28.cpp */,
+				593447731CF8F2BB008AD945 /* qhy28.h */,
+				593447741CF8F2BB008AD945 /* qhy29.cpp */,
+				593447751CF8F2BB008AD945 /* qhy29.h */,
+				593447761CF8F2BB008AD945 /* qhy45gx.cpp */,
+				593447771CF8F2BB008AD945 /* qhy45gx.h */,
+				593447781CF8F2BB008AD945 /* qhy90a.cpp */,
+				593447791CF8F2BB008AD945 /* qhy90a.h */,
+				5934477A1CF8F2BB008AD945 /* qhy163c.cpp */,
+				5934477B1CF8F2BB008AD945 /* qhy163c.h */,
+				5934477C1CF8F2BB008AD945 /* qhy163m.cpp */,
+				5934477D1CF8F2BB008AD945 /* qhy163m.h */,
+				5934477E1CF8F2BB008AD945 /* qhy165c.cpp */,
+				5934477F1CF8F2BB008AD945 /* qhy165c.h */,
+				593447801CF8F2BB008AD945 /* qhy174c.cpp */,
+				593447811CF8F2BB008AD945 /* qhy174c.h */,
+				593447821CF8F2BB008AD945 /* qhy174m.cpp */,
+				593447831CF8F2BB008AD945 /* qhy174m.h */,
+				593447841CF8F2BB008AD945 /* qhy178c.cpp */,
+				593447851CF8F2BB008AD945 /* qhy178c.h */,
+				593447861CF8F2BB008AD945 /* qhy178m.cpp */,
+				593447871CF8F2BB008AD945 /* qhy178m.h */,
+				593447881CF8F2BB008AD945 /* qhy183c.cpp */,
+				593447891CF8F2BB008AD945 /* qhy183c.h */,
+				5934478A1CF8F2BB008AD945 /* qhy224c.cpp */,
+				5934478B1CF8F2BB008AD945 /* qhy224c.h */,
+				5934478C1CF8F2BB008AD945 /* qhy290c.cpp */,
+				5934478D1CF8F2BB008AD945 /* qhy290c.h */,
+				5934478E1CF8F2BB008AD945 /* qhy290m.cpp */,
+				5934478F1CF8F2BB008AD945 /* qhy290m.h */,
+				593447901CF8F2BB008AD945 /* qhy367c.cpp */,
+				593447911CF8F2BB008AD945 /* qhy367c.h */,
+				593447921CF8F2BB008AD945 /* qhy695a.cpp */,
+				593447931CF8F2BB008AD945 /* qhy695a.h */,
+				593447941CF8F2BB008AD945 /* qhy814g.cpp */,
+				593447951CF8F2BB008AD945 /* qhy814g.h */,
+				593447961CF8F2BB008AD945 /* qhy08050g.cpp */,
+				593447971CF8F2BB008AD945 /* qhy08050g.h */,
+				593447981CF8F2BB008AD945 /* qhy16000.cpp */,
+				593447991CF8F2BB008AD945 /* qhy16000.h */,
+				5934479A1CF8F2BB008AD945 /* qhy16000g.cpp */,
+				5934479B1CF8F2BB008AD945 /* qhy16000g.h */,
+				5934479C1CF8F2BB008AD945 /* qhy16200a.cpp */,
+				5934479D1CF8F2BB008AD945 /* qhy16200a.h */,
+				5934479E1CF8F2BB008AD945 /* qhy160002ad.cpp */,
+				5934479F1CF8F2BB008AD945 /* qhy160002ad.h */,
+				593447A01CF8F2BB008AD945 /* qhyabase.cpp */,
+				593447A11CF8F2BB008AD945 /* qhyabase.h */,
+				593447A21CF8F2BB008AD945 /* qhybase.cpp */,
+				593447A31CF8F2BB008AD945 /* qhybase.h */,
+				593447A41CF8F2BB008AD945 /* qhycam.cpp */,
+				593447A51CF8F2BB008AD945 /* qhycam.h */,
+				593447A61CF8F2BB008AD945 /* qhyccd.cpp */,
+				593447A71CF8F2BB008AD945 /* qhyccd.h */,
+				593447A81CF8F2BB008AD945 /* qhyccdimgprocess.cpp */,
+				593447A91CF8F2BB008AD945 /* qhyicbase.cpp */,
+				593447AA1CF8F2BB008AD945 /* qhyicbase.h */,
+				593447AB1CF8F2BB008AD945 /* solar800g.cpp */,
+				593447AC1CF8F2BB008AD945 /* solar800g.h */,
+				593447AD1CF8F2BB008AD945 /* solar1600.cpp */,
+				593447AE1CF8F2BB008AD945 /* solar1600.h */,
+				593447AF1CF8F2BB008AD945 /* unlockimagequeue.cpp */,
+				593447B01CF8F2BB008AD945 /* unlockimagequeue.h */,
+			);
+			name = libqhy;
+			path = ../../../QHYCCD_SDK_CrossPlatform/src;
+			sourceTree = "<group>";
+		};
 		594498D31C13625700E0E281 /* weather */ = {
 			isa = PBXGroup;
 			children = (
@@ -3768,6 +4474,7 @@
 				5987860B1CE71FB900DF2294 /* indi_fli_focus */,
 				59C3D67F1CF07D8C00974D80 /* indi_nstep_focus */,
 				59563CC11CF1E8D200DE1A54 /* indi_ssag_ccd */,
+				593445C51CF8EF62008AD945 /* indi_qhy_ccd */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -3884,6 +4591,7 @@
 		59567C081A8D325E0057A35A /* 3rd */ = {
 			isa = PBXGroup;
 			children = (
+				593445C61CF8EF8F008AD945 /* indi-qhy */,
 				59563C9B1CF1E8A000DE1A54 /* indi-ssag */,
 				598785BE1CE71F1A00DF2294 /* indi-fli */,
 				5924ACE81C8B44AB00750816 /* indi-nexstarevo */,
@@ -4619,6 +5327,26 @@
 			productReference = 5924ACF71C8B44FD00750816 /* indi_nexstarevo_telescope */;
 			productType = "com.apple.product-type.tool";
 		};
+		593445B11CF8EF62008AD945 /* indi_qhy_ccd */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 593445C21CF8EF62008AD945 /* Build configuration list for PBXNativeTarget "indi_qhy_ccd" */;
+			buildPhases = (
+				593445BA1CF8EF62008AD945 /* Sources */,
+				593445BE1CF8EF62008AD945 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				593445B21CF8EF62008AD945 /* PBXTargetDependency */,
+				593445B41CF8EF62008AD945 /* PBXTargetDependency */,
+				593445B61CF8EF62008AD945 /* PBXTargetDependency */,
+				593445B81CF8EF62008AD945 /* PBXTargetDependency */,
+			);
+			name = indi_qhy_ccd;
+			productName = indi_lxbasic;
+			productReference = 593445C51CF8EF62008AD945 /* indi_qhy_ccd */;
+			productType = "com.apple.product-type.tool";
+		};
 		5944982D1C135D8000E0E281 /* indi_lynx_focus */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 594498381C135D8000E0E281 /* Build configuration list for PBXNativeTarget "indi_lynx_focus" */;
@@ -4844,6 +5572,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				593445D11CF8EFFC008AD945 /* PBXTargetDependency */,
 				59563CCB1CF20A2A00DE1A54 /* PBXTargetDependency */,
 				59C3D6831CF07E7B00974D80 /* PBXTargetDependency */,
 				598786BC1CE7361000DF2294 /* PBXTargetDependency */,
@@ -5950,6 +6679,7 @@
 				598785E81CE71FAF00DF2294 /* indi_fli_wheel */,
 				598785FA1CE71FB900DF2294 /* indi_fli_focus */,
 				59563CA11CF1E8D200DE1A54 /* indi_ssag_ccd */,
+				593445B11CF8EF62008AD945 /* indi_qhy_ccd */,
 			);
 		};
 /* End PBXProject section */
@@ -5960,32 +6690,80 @@
 			buildActionMask = 2147483647;
 			files = (
 				59563CC91CF209F600DE1A54 /* indi_ssag.xml in Resources */,
+				593446031CF8F029008AD945 /* IC90A.HEX in Resources */,
+				5934461E1CF8F029008AD945 /* QHY9S.HEX in Resources */,
+				5934460F1CF8F029008AD945 /* QHY2PRO.HEX in Resources */,
+				5934461B1CF8F029008AD945 /* QHY8L.HEX in Resources */,
+				5934462A1CF8F029008AD945 /* QHY29.HEX in Resources */,
+				593446181CF8F029008AD945 /* QHY6.HEX in Resources */,
 				591C90EA1C13746D00FCE596 /* indi_sbig.xml in Resources */,
 				594499611C136CE300E0E281 /* indi_asiccd.xml in Resources */,
+				593446211CF8F029008AD945 /* QHY12.HEX in Resources */,
+				593446171CF8F029008AD945 /* QHY5LOADER.HEX in Resources */,
 				59567C5C1A8D34E90057A35A /* indi_aagcloudwatcher_sk.xml in Resources */,
+				5934462F1CF8F029008AD945 /* QHY290.img in Resources */,
+				5934460E1CF8F029008AD945 /* QHY2E.HEX in Resources */,
 				5924ACFF1C8B458500750816 /* indi_nexstarevo.xml in Resources */,
 				59567CB21A8D3D3B0057A35A /* indi_spectracyber.xml in Resources */,
+				593446091CF8F029008AD945 /* IMG2S.HEX in Resources */,
+				593446291CF8F029008AD945 /* QHY28.HEX in Resources */,
 				59567C981A8D3B900057A35A /* indi_eqmod_scope_limits_sk.xml in Resources */,
+				593446311CF8F029008AD945 /* QHY160002AD.HEX in Resources */,
 				9D0B2A8D1A8D21B300ED17BF /* indi_tcfs_sk.xml in Resources */,
+				593446301CF8F029008AD945 /* QHY16000.HEX in Resources */,
+				593446081CF8F029008AD945 /* IMG2P.HEX in Resources */,
+				593446241CF8F029008AD945 /* QHY20.HEX in Resources */,
 				598786161CE7204B00DF2294 /* indi_fli.xml in Resources */,
 				59567C5D1A8D34E90057A35A /* indi_aagcloudwatcher.xml in Resources */,
 				59567C971A8D3B900057A35A /* indi_eqmod.xml in Resources */,
+				593446061CF8F029008AD945 /* IC16803.HEX in Resources */,
+				593446071CF8F029008AD945 /* IMG0H.HEX in Resources */,
 				596EBB59188AC60700190323 /* InfoPlist.strings in Resources */,
 				59C11FC319B50AEE00B21125 /* AppIcon.icns in Resources */,
 				59567CAB1A8D3CC20057A35A /* AlignData.xml in Resources */,
+				5934462C1CF8F029008AD945 /* QHY174.img in Resources */,
 				596556E91C4A4A0B0044680B /* indi_qsi.xml in Resources */,
+				5934462E1CF8F029008AD945 /* QHY224.img in Resources */,
+				593446161CF8F029008AD945 /* QHY5III290.img in Resources */,
 				59567CAC1A8D3CC20057A35A /* indi_align_sk.xml in Resources */,
+				593446201CF8F029008AD945 /* QHY11.HEX in Resources */,
 				596EBB58188AC60700190323 /* Credits.rtf in Resources */,
+				593446151CF8F029008AD945 /* QHY5III224.img in Resources */,
+				593446221CF8F029008AD945 /* QHY15.HEX in Resources */,
+				5934460A1CF8F029008AD945 /* IMG50.HEX in Resources */,
+				593446281CF8F029008AD945 /* QHY27.HEX in Resources */,
+				5934460B1CF8F029008AD945 /* miniCam5.HEX in Resources */,
 				59567C991A8D3B900057A35A /* indi_eqmod_simulator_sk.xml in Resources */,
+				593446131CF8F029008AD945 /* QHY5III178.img in Resources */,
 				9DDA440C1A8D00E10004AA95 /* drivers.xml in Resources */,
+				5934461F1CF8F029008AD945 /* QHY10.HEX in Resources */,
+				593446041CF8F029008AD945 /* IC8300.HEX in Resources */,
 				59567C5B1A8D34E40057A35A /* indi_sx.xml in Resources */,
 				59567C961A8D3B900057A35A /* indi_eqmod_sk.xml in Resources */,
 				59567CF61A8D40BC0057A35A /* indi_shoestring.xml in Resources */,
+				593446101CF8F029008AD945 /* QHY5.HEX in Resources */,
+				5934462B1CF8F029008AD945 /* QHY163.img in Resources */,
+				5934462D1CF8F029008AD945 /* QHY178.img in Resources */,
+				593446231CF8F029008AD945 /* QHY16.HEX in Resources */,
+				593446271CF8F029008AD945 /* QHY23.HEX in Resources */,
 				59567CF21A8D409E0057A35A /* indi_usbfocus.xml in Resources */,
 				59567CB11A8D3D3B0057A35A /* indi_spectracyber_sk.xml in Resources */,
+				593446121CF8F029008AD945 /* QHY5III174.img in Resources */,
+				593446191CF8F029008AD945 /* QHY7.HEX in Resources */,
+				593446261CF8F029008AD945 /* QHY22.HEX in Resources */,
+				5934460D1CF8F029008AD945 /* QHY2.HEX in Resources */,
+				5934461D1CF8F029008AD945 /* QHY8PRO.HEX in Resources */,
+				593446111CF8F029008AD945 /* QHY5II.HEX in Resources */,
+				593446051CF8F029008AD945 /* IC16200A.HEX in Resources */,
+				593445CF1CF8EFCE008AD945 /* indi_qhy.xml in Resources */,
+				593446141CF8F029008AD945 /* QHY5III185.img in Resources */,
 				59567CFD1A8D41000057A35A /* indi_atik.xml in Resources */,
+				5934460C1CF8F029008AD945 /* POLEMASTER.HEX in Resources */,
+				5934461A1CF8F029008AD945 /* QHY8.HEX in Resources */,
 				5979B2F9188ACE7200360C07 /* MainMenu.xib in Resources */,
 				59567CB51A8D3D500057A35A /* indi_maxdomeii.xml in Resources */,
+				5934461C1CF8F029008AD945 /* QHY8M.HEX in Resources */,
+				593446251CF8F029008AD945 /* QHY21.HEX in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6023,6 +6801,111 @@
 			files = (
 				5924ACFE1C8B455C00750816 /* nexstarevo.cpp in Sources */,
 				5924ACFD1C8B455C00750816 /* NexStarAUXScope.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		593445BA1CF8EF62008AD945 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				593447D01CF8F2BB008AD945 /* qhy5iii224base.cpp in Sources */,
+				593447BA1CF8F2BB008AD945 /* img132e.cpp in Sources */,
+				593448061CF8F2BB008AD945 /* qhy16200a.cpp in Sources */,
+				593447BC1CF8F2BB008AD945 /* minicam5f_m.cpp in Sources */,
+				593447F11CF8F2BB008AD945 /* qhy28.cpp in Sources */,
+				593447ED1CF8F2BB008AD945 /* qhy21.cpp in Sources */,
+				593447FD1CF8F2BB008AD945 /* qhy224c.cpp in Sources */,
+				593447BE1CF8F2BB008AD945 /* minicam5s_m.cpp in Sources */,
+				593447B11CF8F2BB008AD945 /* cjson.cpp in Sources */,
+				593447BF1CF8F2BB008AD945 /* polemaster.cpp in Sources */,
+				593447B81CF8F2BB008AD945 /* img0h.cpp in Sources */,
+				593447E31CF8F2BB008AD945 /* qhy8.cpp in Sources */,
+				593447E61CF8F2BB008AD945 /* qhy9s.cpp in Sources */,
+				593448041CF8F2BB008AD945 /* qhy16000.cpp in Sources */,
+				593447F31CF8F2BB008AD945 /* qhy45gx.cpp in Sources */,
+				593448001CF8F2BB008AD945 /* qhy367c.cpp in Sources */,
+				593445CD1CF8EFC8008AD945 /* qhy_ccd.cpp in Sources */,
+				593447D61CF8F2BB008AD945 /* qhy5iii367base.cpp in Sources */,
+				593447E81CF8F2BB008AD945 /* qhy10.cpp in Sources */,
+				593447B61CF8F2BB008AD945 /* ic8300.cpp in Sources */,
+				593447CA1CF8F2BB008AD945 /* qhy5iii178base.cpp in Sources */,
+				5934480F1CF8F2BB008AD945 /* solar1600.cpp in Sources */,
+				593447E41CF8F2BB008AD945 /* qhy8l.cpp in Sources */,
+				593447C31CF8F2BB008AD945 /* qhy5ii.cpp in Sources */,
+				593447B91CF8F2BB008AD945 /* img2p.cpp in Sources */,
+				593448021CF8F2BB008AD945 /* qhy814g.cpp in Sources */,
+				593447C21CF8F2BB008AD945 /* qhy5hii.cpp in Sources */,
+				5934480A1CF8F2BB008AD945 /* qhycam.cpp in Sources */,
+				593447E11CF8F2BB008AD945 /* qhy6.cpp in Sources */,
+				593447BB1CF8F2BB008AD945 /* log4z.cpp in Sources */,
+				593447C61CF8F2BB008AD945 /* qhy5iii165base.cpp in Sources */,
+				593447DF1CF8F2BB008AD945 /* qhy5rii_m.cpp in Sources */,
+				593447D11CF8F2BB008AD945 /* qhy5iii224c.cpp in Sources */,
+				593447DA1CF8F2BB008AD945 /* qhy5lii_c.cpp in Sources */,
+				593447CB1CF8F2BB008AD945 /* qhy5iii178c.cpp in Sources */,
+				5934480D1CF8F2BB008AD945 /* qhyicbase.cpp in Sources */,
+				593447D81CF8F2BB008AD945 /* qhy5iiicoolbase.cpp in Sources */,
+				593447F91CF8F2BB008AD945 /* qhy174m.cpp in Sources */,
+				593447F61CF8F2BB008AD945 /* qhy163m.cpp in Sources */,
+				593447EB1CF8F2BB008AD945 /* qhy15.cpp in Sources */,
+				593447DC1CF8F2BB008AD945 /* qhy5liibase.cpp in Sources */,
+				593447BD1CF8F2BB008AD945 /* minicam5s_c.cpp in Sources */,
+				593447CD1CF8F2BB008AD945 /* qhy5iii183base.cpp in Sources */,
+				5934480C1CF8F2BB008AD945 /* qhyccdimgprocess.cpp in Sources */,
+				593447C41CF8F2BB008AD945 /* qhy5iibase.cpp in Sources */,
+				593447C91CF8F2BB008AD945 /* qhy5iii174m.cpp in Sources */,
+				593447FF1CF8F2BB008AD945 /* qhy290m.cpp in Sources */,
+				593447B51CF8F2BB008AD945 /* download_fx3.cpp in Sources */,
+				593447F21CF8F2BB008AD945 /* qhy29.cpp in Sources */,
+				593447B41CF8F2BB008AD945 /* download_fx2.cpp in Sources */,
+				593447CF1CF8F2BB008AD945 /* qhy5iii185c.cpp in Sources */,
+				593447FC1CF8F2BB008AD945 /* qhy183c.cpp in Sources */,
+				593448031CF8F2BB008AD945 /* qhy08050g.cpp in Sources */,
+				593447D51CF8F2BB008AD945 /* qhy5iii290m.cpp in Sources */,
+				593447FE1CF8F2BB008AD945 /* qhy290c.cpp in Sources */,
+				593447D41CF8F2BB008AD945 /* qhy5iii290c.cpp in Sources */,
+				593447D21CF8F2BB008AD945 /* qhy5iii236c.cpp in Sources */,
+				593448101CF8F2BB008AD945 /* unlockimagequeue.cpp in Sources */,
+				593447D31CF8F2BB008AD945 /* qhy5iii290base.cpp in Sources */,
+				593447FA1CF8F2BB008AD945 /* qhy178c.cpp in Sources */,
+				593448071CF8F2BB008AD945 /* qhy160002ad.cpp in Sources */,
+				593447F71CF8F2BB008AD945 /* qhy165c.cpp in Sources */,
+				593447C81CF8F2BB008AD945 /* qhy5iii174c.cpp in Sources */,
+				593447EA1CF8F2BB008AD945 /* qhy12.cpp in Sources */,
+				5934480B1CF8F2BB008AD945 /* qhyccd.cpp in Sources */,
+				593447E91CF8F2BB008AD945 /* qhy11.cpp in Sources */,
+				593447E51CF8F2BB008AD945 /* qhy8pro.cpp in Sources */,
+				593447CC1CF8F2BB008AD945 /* qhy5iii178m.cpp in Sources */,
+				593447F01CF8F2BB008AD945 /* qhy27.cpp in Sources */,
+				593447DB1CF8F2BB008AD945 /* qhy5lii_m.cpp in Sources */,
+				593447DE1CF8F2BB008AD945 /* qhy5pii_m.cpp in Sources */,
+				593448081CF8F2BB008AD945 /* qhyabase.cpp in Sources */,
+				593447E01CF8F2BB008AD945 /* qhy5tii_c.cpp in Sources */,
+				593447EE1CF8F2BB008AD945 /* qhy22.cpp in Sources */,
+				593447C11CF8F2BB008AD945 /* qhy5.cpp in Sources */,
+				593447C51CF8F2BB008AD945 /* qhy5iii163base.cpp in Sources */,
+				593447C71CF8F2BB008AD945 /* qhy5iii174base.cpp in Sources */,
+				593448051CF8F2BB008AD945 /* qhy16000g.cpp in Sources */,
+				593447F51CF8F2BB008AD945 /* qhy163c.cpp in Sources */,
+				593447B31CF8F2BB008AD945 /* dithercontrol.cpp in Sources */,
+				593447B71CF8F2BB008AD945 /* ic16803.cpp in Sources */,
+				593447E71CF8F2BB008AD945 /* qhy9t.cpp in Sources */,
+				593447D71CF8F2BB008AD945 /* qhy5iiibase.cpp in Sources */,
+				593447C01CF8F2BB008AD945 /* qhy2pro.cpp in Sources */,
+				593447B21CF8F2BB008AD945 /* cmosdll.cpp in Sources */,
+				593447DD1CF8F2BB008AD945 /* qhy5pii_c.cpp in Sources */,
+				593447CE1CF8F2BB008AD945 /* qhy5iii185base.cpp in Sources */,
+				593447FB1CF8F2BB008AD945 /* qhy178m.cpp in Sources */,
+				593448011CF8F2BB008AD945 /* qhy695a.cpp in Sources */,
+				593447F81CF8F2BB008AD945 /* qhy174c.cpp in Sources */,
+				593445CE1CF8EFC8008AD945 /* qhy_fw.cpp in Sources */,
+				593447F41CF8F2BB008AD945 /* qhy90a.cpp in Sources */,
+				593447E21CF8F2BB008AD945 /* qhy7.cpp in Sources */,
+				593447EF1CF8F2BB008AD945 /* qhy23.cpp in Sources */,
+				593447D91CF8F2BB008AD945 /* qhy5iiig400m.cpp in Sources */,
+				593447EC1CF8F2BB008AD945 /* qhy16.cpp in Sources */,
+				5934480E1CF8F2BB008AD945 /* solar800g.cpp in Sources */,
+				593448091CF8F2BB008AD945 /* qhybase.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -6849,6 +7732,31 @@
 			isa = PBXTargetDependency;
 			target = 5924ACE91C8B44FD00750816 /* indi_nexstarevo_telescope */;
 			targetProxy = 5924AD001C8B459A00750816 /* PBXContainerItemProxy */;
+		};
+		593445B21CF8EF62008AD945 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9DDA43171A8CC5F90004AA95 /* cfitsio */;
+			targetProxy = 593445B31CF8EF62008AD945 /* PBXContainerItemProxy */;
+		};
+		593445B41CF8EF62008AD945 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9DDA438A1A8CCD030004AA95 /* usb */;
+			targetProxy = 593445B51CF8EF62008AD945 /* PBXContainerItemProxy */;
+		};
+		593445B61CF8EF62008AD945 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9DDA422B1A8CB6920004AA95 /* nova */;
+			targetProxy = 593445B71CF8EF62008AD945 /* PBXContainerItemProxy */;
+		};
+		593445B81CF8EF62008AD945 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9DDA43A81A8CD3190004AA95 /* indi */;
+			targetProxy = 593445B91CF8EF62008AD945 /* PBXContainerItemProxy */;
+		};
+		593445D11CF8EFFC008AD945 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 593445B11CF8EF62008AD945 /* indi_qhy_ccd */;
+			targetProxy = 593445D01CF8EFFC008AD945 /* PBXContainerItemProxy */;
 		};
 		5944982E1C135D8000E0E281 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -7898,6 +8806,74 @@
 			};
 			name = Release;
 		};
+		593445C31CF8EF62008AD945 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+					USELIBFTD2XX,
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"../../../libnova-0.15.0/src",
+					"../../../libnova-0.15.0/src/libnova",
+					"../../../libusb-1.0.19/libusb",
+					../../../cfitsio,
+					../../libindi/libs/indibase,
+					../../libindi/libs,
+					../../libindi,
+					/usr/local/include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		593445C41CF8EF62008AD945 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					USELIBFTD2XX,
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"../../../libnova-0.15.0/src",
+					"../../../libnova-0.15.0/src/libnova",
+					"../../../libusb-1.0.19/libusb",
+					../../../cfitsio,
+					../../libindi/libs/indibase,
+					../../libindi/libs,
+					../../libindi,
+					/usr/local/include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		594498391C135D8000E0E281 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -8672,9 +9648,6 @@
 					../../libindi/libs/indibase,
 					../../libindi/libs,
 					../../libindi,
-					"../../../libfli-1.104",
-					"../../../libfli-1.104/unix",
-					"../../../libfli-1.104/unix/osx",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -8708,9 +9681,6 @@
 					../../libindi/libs/indibase,
 					../../libindi/libs,
 					../../libindi,
-					"../../../libfli-1.104",
-					"../../../libfli-1.104/unix",
-					"../../../libfli-1.104/unix/osx",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -11409,6 +12379,15 @@
 			buildConfigurations = (
 				5924ACF51C8B44FD00750816 /* Debug */,
 				5924ACF61C8B44FD00750816 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		593445C21CF8EF62008AD945 /* Build configuration list for PBXNativeTarget "indi_qhy_ccd" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				593445C31CF8EF62008AD945 /* Debug */,
+				593445C41CF8EF62008AD945 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Changes to QHY driver necessary to build it on OSX with libqhy 1.6.