### PR TITLE
ASI: fix triple calling of ASIStartExposure()

### DIFF
--- a/3rdparty/indi-asi/asi_ccd.cpp
+++ b/3rdparty/indi-asi/asi_ccd.cpp
@@ -826,6 +826,7 @@ bool ASICCD::StartExposure(float duration)
           usleep(100000);
           continue;
     }
+    break;
   }
 
   if (errCode != ASI_SUCCESS)


### PR DESCRIPTION
Regardless of the status returned by the ASIStartExposure() it was called 3 times in a row.