### PR TITLE
Remove buffered write of BLOBS some and ASI optimized

### DIFF
--- a/3rdparty/indi-asi/99-asi.rules
+++ b/3rdparty/indi-asi/99-asi.rules
@@ -1,3 +1,4 @@
+ACTION=="add", ATTR{idVendor}=="03c3", RUN+="/bin/sh -c '/bin/echo 200 >/sys/module/usbcore/parameters/usbfs_memory_mb'"
 ATTR{product}=="ASI120MM" ATTR{idVendor}=="03c3" ATTR{idProduct}=="120a" GROUP="users", MODE="0666"
 ATTR{product}=="ASI120MC" ATTR{idVendor}=="03c3" ATTR{idProduct}=="120b" GROUP="users", MODE="0666"
 ATTR{product}=="ASI120MC" ATTR{idVendor}=="03c3" ATTR{idProduct}=="120b" GROUP="users", MODE="0666"

--- a/libindi/indidriver.c
+++ b/libindi/indidriver.c
@@ -1448,18 +1448,20 @@ void IUSaveConfigBLOB (FILE *fp, const IBLOBVectorProperty *bvp)
         fprintf (fp, "    name='%s'\n", bp->name);
         fprintf (fp, "    size='%d'\n", bp->size);
         fprintf (fp, "    format='%s'>\n", bp->format);
+        fflush(fp); // need to flush - blob will be written unbuffered
 
         encblob = malloc (4*bp->bloblen/3+4);
         l = to64frombits(encblob, bp->blob, bp->bloblen);
-		size_t written = 0;
-		size_t towrite = l;
-		while (written < l) {
-			size_t wr = fwrite(encblob + written, 1, towrite, fp);
-			if (wr > 0) {
-				towrite -= wr;
-				written += wr;
-			}
-		}
+        int fh = fileno(fp);
+        size_t written = 0;
+        size_t towrite = l;
+        while (written < l) {
+            size_t wr = write(fh, encblob + written, towrite);
+            if (wr > 0) {
+                towrite -= wr;
+                written += wr;
+            }
+        }
         free (encblob);
 
         fprintf (fp, "  </oneBLOB>\n");
@@ -1946,18 +1948,19 @@ IDSetBLOB (const IBLOBVectorProperty *bvp, const char *fmt, ...)
             printf ("    name='%s'\n", bp->name);
             printf ("    size='%d'\n", bp->size);
             printf ("    format='%s'>\n", bp->format);
+            fflush(stdout); // need to flush - blob will be written unbuffered
 
             encblob = malloc (4*bp->bloblen/3+4);
             l = to64frombits(encblob, bp->blob, bp->bloblen);
-			size_t written = 0;
-			size_t towrite = l;
-			while (written < l) {
-				size_t wr = fwrite(encblob + written, 1, towrite, stdout);
-				if (wr > 0) {
-					towrite -= wr;
-					written += wr;
-				}
-			}
+            size_t written = 0;
+            size_t towrite = l;
+            while (written < l) {
+                size_t wr = write(1, encblob + written, towrite);
+                if (wr > 0) {
+                    towrite -= wr;
+                    written += wr;
+                }
+            }
             free (encblob);
 
             printf ("  </oneBLOB>\n");


### PR DESCRIPTION
* remove buffered write of BLOBS  - did not test the performance compared to buffered version, but fwrite() does an extra copy into the stdio buffer which written at a later time with write() syscall,  so using only write() should be faster - removed one unnecessary copy.

* indi_asi_ccd: increase usbfs_memory_mb to 200mb so that ASI1600 can work with other cameras on the same Linux host, new SDK is on the way in a day or two. ZWO guys did a good job on this.