### PR TITLE
libusb paths for osx w/homebrew

### DIFF
--- a/cmake_modules/FindUSB-1.cmake
+++ b/cmake_modules/FindUSB-1.cmake
@@ -54,6 +54,7 @@ else (LIBUSB_1_LIBRARIES AND LIBUSB_1_INCLUDE_DIRS)
       /usr/include
       /usr/include/libusb-1.0
       /usr/local/include
+      /usr/local/include/libusb-1.0
       /opt/local/include
       /sw/include
   )


### PR DESCRIPTION
I'm working on building indi/kstars on OSX and ran into a problem with libusb when installed with homebrew. This patch adds an additional header search path for cmake and allows indi to build on OSX.