### PR TITLE
Build alignment module on all platforms

### DIFF
--- a/libindi/CMakeLists.txt
+++ b/libindi/CMakeLists.txt
@@ -290,9 +290,7 @@ install(TARGETS indidriverstatic ARCHIVE DESTINATION ${LIB_DESTINATION})
 ##################################################
 ########### INDI Alignment Subsystem #############
 ##################################################
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/alignment)
-endif()
 
 #####################################
 ######## AGENT GROUP #########


### PR DESCRIPTION
Currently the AlignmentDriver library is only built for "Linux" platforms. However, it's a dependency and must be linked on all platforms causing linker errors. I've removed the platform condition and it builds and links on OSX with no additional changes.