### PR TITLE
Add initial support for DSI Color III.

### DIFF
--- a/3rdparty/indi-dsi/CMakeLists.txt
+++ b/3rdparty/indi-dsi/CMakeLists.txt
@@ -10,7 +10,7 @@ set(RULES_INSTALL_DIR "/etc/udev/rules.d")
 set(FIRMWARE_INSTALL_DIR "/lib/firmware")
 
 set (DSI_VERSION_MAJOR 0)
-set (DSI_VERSION_MINOR 1)
+set (DSI_VERSION_MINOR 2)
 
 find_package(CFITSIO REQUIRED)
 find_package(INDI REQUIRED)
@@ -35,6 +35,7 @@ set(indidsi_SRCS
    ${CMAKE_CURRENT_SOURCE_DIR}/DsiProII.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/DsiProIII.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/DsiColorII.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/DsiColorIII.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/DsiTypes.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/Util.cpp
    )

--- a/3rdparty/indi-dsi/DsiColorIII.cpp
+++ b/3rdparty/indi-dsi/DsiColorIII.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2009, Roland Roberts <roland@astrofoto.org>
+ * Copyright (c) 2016, Ben Gilsrud <bgilsrud@gmail.com>
+ *
+ * Modifications and extensions for DSI III support 2015, G. Schmidt (gs)
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#  include "config.h"
+#endif
+
+#include "DsiColorIII.h"
+
+using namespace DSI;
+
+void
+DsiColorIII::initImager(const char *devname)
+{
+
+    command(DeviceCommand::SET_ROW_COUNT_EVEN, read_height_even);
+    command(DeviceCommand::SET_ROW_COUNT_ODD, read_height_odd);
+
+    if (is_high_gain)
+        sendRegister(AdRegister::CONFIGURATION, 0x58);
+    else
+        sendRegister(AdRegister::CONFIGURATION, 0xd8);
+
+    sendRegister(AdRegister::MUX_CONFIG, 0xc0);
+
+    /* Sigh.  "Interestingly," it would appear that you MUST take at least one
+     * throw-away image or else GET_EXP_TIMER_COUNT won't work on "real"
+     * exposures.  Sounds like a firmware bug to me, but not something we can
+     * do anything about.  Although MaximDL uses 4 exposures of 1000 ticks
+     * (100 ms) each, this shorter exposure works just fine.
+     */
+    for (int i = 0; i < 1; i++) {
+        unsigned char *foo = getImage(1);
+	delete [] foo;
+    }
+}
+
+DsiColorIII::DsiColorIII(const char *devname) : Device(devname)
+{
+    // color_type = ColorType.NONE;
+    is_high_gain = false;
+
+    is_color = true; /* This assumes the ICX285AQ is used, which has a standard Bayer matrix */
+
+    /* Turn off test mode so we can actually return an image */
+    test_pattern = false;
+
+    /* The DSI Color III supports binning */
+    is_binnable = true;
+
+    /* The DSI Color III is equipped with a temperature sensor */
+    has_tempsensor = true;
+
+    /* Sony lists the pixel size a 6.45x6.45 microns. */
+
+    aspect_ratio = 1.0;
+
+    read_width       = 1434;
+    read_height_even = 0;
+    read_height_odd  = 1050;
+    read_height      = read_height_even + read_height_odd;
+
+    read_bpp         = 2;
+
+    image_width    = 1360;
+    image_height   = 1024;
+    image_offset_x =  30;
+    image_offset_y =  13; 
+
+
+    timeout_response = 1000;
+    timeout_request  = 1000;
+    timeout_image    = 5000;
+    pixel_size_x   = 6.45;
+    pixel_size_y   = 6.45;
+
+    exposure_time  =  10;
+
+    initImager();
+}
+
+DsiColorIII::~DsiColorIII() {}

--- a/3rdparty/indi-dsi/DsiColorIII.h
+++ b/3rdparty/indi-dsi/DsiColorIII.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2009, Roland Roberts <roland@astrofoto.org>
+ * Copyright (c) 2016, Ben Gilsrud <bgilsrud@gmail.com>
+ *
+ */
+
+#ifndef __DsiColorIII_hh
+#define __DsiColorIII_hh
+
+#include "DsiDevice.h"
+
+namespace DSI {
+
+    class DsiColorIII : public Device {
+
+      private:
+        void initImager(const char *devname = 0);
+
+      public:
+
+        DsiColorIII(const char *devname);
+        ~DsiColorIII();
+    };
+};
+
+#endif /* __DsiColorIII_hh */
+

--- a/3rdparty/indi-dsi/DsiDeviceFactory.cpp
+++ b/3rdparty/indi-dsi/DsiDeviceFactory.cpp
@@ -19,6 +19,7 @@
 #include "DsiProII.h"
 #include "DsiColorII.h"
 #include "DsiProIII.h"
+#include "DsiColorIII.h"
 #include "DsiException.h"
 
 using namespace std;
@@ -56,6 +57,9 @@ DSI::DeviceFactory::getInstance(const char *devname)
 
     if (ccdChipName == "ICX285AL")
         return new DSI::DsiProIII(devname);
+
+    if (ccdChipName == "ICX285AQ")
+        return new DSI::DsiColorIII(devname);
 
     return 0;
 }


### PR DESCRIPTION
This should add support for the DSI Color III. I don't have a DSI Color III to test with, but I have verified that this doesn't break support for my DSI Pro I.