### PR TITLE
Remove sign from LX200 set longitude command

### DIFF
--- a/libindi/drivers/telescope/lx200driver.cpp
+++ b/libindi/drivers/telescope/lx200driver.cpp
@@ -887,7 +887,7 @@ int setSiteLongitude(int fd, double Long)
 
    getSexComponents(Long, &d, &m, &s);
 
-   snprintf(temp_string, sizeof( temp_string ), ":Sg%+03d:%02d#", d, m);	//azwing must be with sign
+   snprintf(temp_string, sizeof( temp_string ), ":Sg%03d:%02d#", d, m);
 
    return (setStandardProcedure(fd, temp_string));
 }


### PR DESCRIPTION
This change reverts a recent change made for OnStep support. The OnStep firmware was recently changed to support the standard LX200 set longitude command (:SgDDD:MM#). The previous sign change may have broken support for other LX200-protocol mounts that use this code (though I don't have any of these devices to test with).

Adding @azwing in case he has input.