### PR TITLE
Fix constant string conversion to non-const char*

### DIFF
--- a/3rdparty/indi-gphoto/gphoto_driver.cpp
+++ b/3rdparty/indi-gphoto/gphoto_driver.cpp
@@ -232,7 +232,7 @@ out:
     return NULL;
 }
 
-void show_widget(gphoto_widget *widget, char *prefix) {
+void show_widget(gphoto_widget *widget, const char *prefix) {
     int i;
     struct tm *tm;
     switch(widget->type) {

--- a/3rdparty/indi-sbig/sbig_ccd.cpp
+++ b/3rdparty/indi-sbig/sbig_ccd.cpp
@@ -1526,7 +1526,7 @@ int	SBIGCCD::BitIo(BitIOParams *biop, BitIOResults *bior) {
   return res;
 }
 
-char *SBIGCCD::GetCameraName() {
+const char *SBIGCCD::GetCameraName() {
   if (isSimulation()) {
     return "Simulated camera";
   }
@@ -1544,7 +1544,7 @@ char *SBIGCCD::GetCameraName() {
   return gccdir.name;
 }
 
-char *SBIGCCD::GetCameraID() {
+const char *SBIGCCD::GetCameraID() {
   if (isSimulation()) {
     return "Simulated ID";
   }
@@ -2033,7 +2033,7 @@ int SBIGCCD::CFWConnect() {
     }
   }
   if (res == CE_NO_ERROR) {
-    char *name = "Unknown filterwheel";
+    const char *name = "Unknown filterwheel";
     char fw[64] = "Unknown ID";
     bool	bClear = true;
     int model = CFWr.cfwModel;

--- a/3rdparty/indi-sbig/sbig_ccd.h
+++ b/3rdparty/indi-sbig/sbig_ccd.h
@@ -309,8 +309,8 @@ private:
 
   // High level functions:
   bool CheckLink();
-  char *GetCameraName();
-  char *GetCameraID();
+  const char *GetCameraName();
+  const char *GetCameraID();
   int getCCDSizeInfo(int ccd, int rm, int &frmW, int &frmH, double &pixW, double &pixH);
   bool IsFanControlAvailable();
 


### PR DESCRIPTION
Just a few small contributions to remove some compiler warnings.
I don't have hardware to test these changes, but thought we could discuss them here.