### PR TITLE
Add a feature to the base indidome to know if the telescope is parked

### DIFF
--- a/libindi/drivers/dome/roll_off.cpp
+++ b/libindi/drivers/dome/roll_off.cpp
@@ -222,6 +222,11 @@ IPState RollOff::Move(DomeDirection dir, DomeMotionCommand operation)
             DEBUG(INDI::Logger::DBG_WARNING, "Roof is already fully closed.");
             return IPS_ALERT;
         }
+        else if (dir == DOME_CCW && isTelescopeParked() == false)
+        {
+            DEBUG(INDI::Logger::DBG_WARNING, "Cannot close roof until the telescope is parked.");
+            return IPS_ALERT;
+        }
 
         fullOpenLimitSwitch   = ISS_OFF;
         fullClosedLimitSwitch = ISS_OFF;

--- a/libindi/libs/indibase/indidome.cpp
+++ b/libindi/libs/indibase/indidome.cpp
@@ -49,6 +49,7 @@ INDI::Dome::Dome()
     parkDataType = PARK_NONE;
     Parkdatafile= "~/.indi/ParkData.xml";
     IsParked=false;
+    IsTelescopeParked=false;
     HaveLatLong=false;
     HaveRaDec=false;
 }
@@ -144,6 +145,7 @@ bool INDI::Dome::initProperties()
     controller->initProperties();
 
     IDSnoopDevice(ActiveDeviceT[0].text,"EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceT[0].text,"TELESCOPE_PARK");
     IDSnoopDevice(ActiveDeviceT[0].text,"GEOGRAPHIC_COORD");
 
     IDSnoopDevice(ActiveDeviceT[1].text,"WEATHER_STATUS");
@@ -557,6 +559,7 @@ bool INDI::Dome::ISNewText (const char *dev, const char *name, char *texts[], ch
             IDSetText(&ActiveDeviceTP,NULL);
 
             IDSnoopDevice(ActiveDeviceT[0].text,"EQUATORIAL_EOD_COORD");
+            IDSnoopDevice(ActiveDeviceT[0].text,"TELESCOPE_PARK");
             IDSnoopDevice(ActiveDeviceT[0].text,"TARGET_EOD_COORD");
             IDSnoopDevice(ActiveDeviceT[0].text,"GEOGRAPHIC_COORD");            
             IDSnoopDevice(ActiveDeviceT[1].text,"WEATHER_STATUS");
@@ -575,6 +578,8 @@ bool INDI::Dome::ISSnoopDevice (XMLEle *root)
     XMLEle *ep=NULL;
     const char *propName = findXMLAttValu(root, "name");
 
+    //DEBUGF(INDI::Logger::DBG_DEBUG, "snooped %s", pcdataXMLEle(ep));
+            
     // Check TARGET
     if (!strcmp("TARGET_EOD_COORD", propName))
     {
@@ -697,6 +702,28 @@ bool INDI::Dome::ISSnoopDevice (XMLEle *root)
 
             return true;
         }
+    }
+
+    if (!strcmp("TELESCOPE_PARK", propName))
+    {
+	for (ep = nextXMLEle(root, 1) ; ep != NULL ; ep = nextXMLEle(root, 0))
+        {
+            const char *elemName = findXMLAttValu(ep, "name");
+            if (!strcmp(elemName, "PARK"))
+            {
+                if (!strcmp(pcdataXMLEle(ep), "On"))
+                {
+                    DEBUG(INDI::Logger::DBG_DEBUG, "snooped park state PARKED");
+		    IsTelescopeParked = true;
+                }
+                else
+                {
+                    DEBUG(INDI::Logger::DBG_DEBUG, "snooped park state UNPARKED");
+		    IsTelescopeParked = false;
+                }
+            }
+        }
+        return true;
     }
 
     controller->ISSnoopDevice(root);
@@ -1394,6 +1421,11 @@ void INDI::Dome::SetAxis1Park(double value)
 void INDI::Dome::SetAxis1ParkDefault(double value)
 {
   Axis1DefaultParkPosition=value;
+}
+
+bool INDI::Dome::isTelescopeParked()
+{
+  return IsTelescopeParked;
 }
 
 IPState INDI::Dome::Move(DomeDirection dir, DomeMotionCommand operation)

--- a/libindi/libs/indibase/indidome.h
+++ b/libindi/libs/indibase/indidome.h
@@ -400,6 +400,12 @@ protected:
      */
     virtual void UpdateAutoSync();
 
+    /**
+     * @brief Returns true if the telescope is parked. False if unkown or not parked.
+     *
+     */
+    bool isTelescopeParked();
+
     double Csc(double x);
     double Sec(double x);
 
@@ -473,6 +479,7 @@ private:
 
         IPState mountState;
         IPState weatherState;
+        bool IsTelescopeParked;
 
         bool IsParked;
         const char *ParkDeviceName;


### PR DESCRIPTION
Hi, this is a feature I'd like to have in the base indidome for my roll-off driver.
Basically I'm paranoid about the roof closing and the telescope not being parked. This will be an extra safety check allowing me to use isTelescopeParked() from my driver.
