### PR TITLE
Fix the confusing log messages I added in the last commit

### DIFF
--- a/libindi/drivers/dome/roll_off.cpp
+++ b/libindi/drivers/dome/roll_off.cpp
@@ -184,9 +184,9 @@ bool RollOff::ISNewSwitch (const char *dev, const char *name, ISState *states, c
             ParkableWhenScopeUnparkedSP.s = IPS_OK;
 
             if (ParkableWhenScopeUnparkedS[0].s == ISS_ON)
-                DEBUG(INDI::Logger::DBG_WARNING, "Scope park aware is disabled. Roof can close when scope unparked or unknown. Only enable this option is parking the dome at any time will not cause damage to any equipment.");
+                DEBUG(INDI::Logger::DBG_WARNING, "Scope park aware is enabled. Roof will not close when a snooped unparked telescope exists");
             else
-                DEBUG(INDI::Logger::DBG_SESSION, "Scope park aware is enabled. Roof will not close when a snooped unparked telescope exists");
+                DEBUG(INDI::Logger::DBG_SESSION, "Scope park aware is disabled. Roof can close when scope unparked or unknown. Only enable this option is parking the dome at any time will not cause damage to any equipment.");
 
             IDSetSwitch(&ParkableWhenScopeUnparkedSP, NULL);
 

--- a/libindi/drivers/dome/roll_off.cpp
+++ b/libindi/drivers/dome/roll_off.cpp
@@ -184,9 +184,9 @@ bool RollOff::ISNewSwitch (const char *dev, const char *name, ISState *states, c
             ParkableWhenScopeUnparkedSP.s = IPS_OK;
 
             if (ParkableWhenScopeUnparkedS[0].s == ISS_ON)
-                DEBUG(INDI::Logger::DBG_WARNING, "Warning: Roof is parkable when telescope state is unparked or unknown. Only enable this option is parking the dome at any time will not cause damange to any equipment.");
+                DEBUG(INDI::Logger::DBG_WARNING, "Scope park aware is disabled. Roof can close when scope unparked or unknown. Only enable this option is parking the dome at any time will not cause damage to any equipment.");
             else
-                DEBUG(INDI::Logger::DBG_SESSION, "Scope park aware is disabled. Roof can close when scope unparked or unknown");
+                DEBUG(INDI::Logger::DBG_SESSION, "Scope park aware is enabled. Roof will not close when a snooped unparked telescope exists");
 
             IDSetSwitch(&ParkableWhenScopeUnparkedSP, NULL);
 


### PR DESCRIPTION
Sorry the logging messages when the park-aware button was used were both incorrect and confusing. Hope this improves it a bit....
See related discussion here http://www.indilib.org/forum/ekos/1598-feedback-for-the-new-feature-scope-park-aware.html