### PR TITLE
Initial support for GigE machine vision cameras.

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -46,6 +46,7 @@ option(WITH_ASICAM "Install ZWO Optics ASI Driver" On)
 option(WITH_DSI "Install Meade DSI Driver" On)
 #option(WITH_QHY "Install QHY Driver" Off)
 option(WITH_GPSD "Install GPSD Driver" On)
+option(WITH_GIGE "Install GiGE machine vision Driver" On)
 
 if (WITH_QHY)
 add_subdirectory(indi-qhy)
@@ -92,6 +93,10 @@ endif (WITH_NSE)
 if (WITH_GPSD)
 add_subdirectory(indi-gpsd)
 endif (WITH_GPSD)
+
+if (WITH_GIGE)
+add_subdirectory(indi-gige)
+endif (WITH_GIGE)
 
 if (WITH_APOGEE)
 find_package(APOGEE)

--- a/3rdparty/indi-gige/AUTHORS
+++ b/3rdparty/indi-gige/AUTHORS
@@ -1,0 +1,1 @@
+Hendrik Beijeman  (hbeyeman@gmail.com) http://phym.nl

--- a/3rdparty/indi-gige/CMakeLists.txt
+++ b/3rdparty/indi-gige/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 2.4.7)
+PROJECT(indi_gige CXX C)
+
+LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake_modules/")
+include(GNUInstallDirs)
+
+find_package(CFITSIO REQUIRED)
+find_package(INDI REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(GLIB2 REQUIRED)
+find_package(ARAVIS REQUIRED)
+
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )
+
+include_directories( ${CMAKE_CURRENT_BINARY_DIR})
+include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
+include_directories( ${INDI_INCLUDE_DIR})
+include_directories( ${CFITSIO_INCLUDE_DIR})
+include_directories( ${GLIB2_INCLUDE_DIRS})
+include_directories( ${Arv_INCLUDE_DIRS})
+
+############# GENERIC CCD ###############
+if (CFITSIO_FOUND)
+
+    set(GIGE_SRCS
+	${CMAKE_CURRENT_SOURCE_DIR}/src/indi_gige.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ArvGeneric.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ArvFactory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/BlackFly.cpp
+)
+
+add_executable(indi_gige_ccd ${GIGE_SRCS})
+
+#target_link_libraries(indi_gige_ccd ${INDI_DRIVER_LIBRARIES} ${CFITSIO_LIBRARIES} m ${ZLIB_LIBRARY} ${GLIB2_LIBRARY} ${ARV_LIBRARY})
+target_link_libraries(indi_gige_ccd ${INDI_DRIVER_LIBRARIES} ${GLIB2_LIBRARIES} ${Arv_LIBRARIES} ${CFITSIO_LIBRARIES} m gobject-2.0 ${ZLIB_LIBRARY})
+
+install(TARGETS indi_gige_ccd RUNTIME DESTINATION bin)
+
+endif (CFITSIO_FOUND)
+
+install(FILES indi_gige_ccd.xml DESTINATION ${INDI_DATA_DIR})

--- a/3rdparty/indi-gige/INSTALL
+++ b/3rdparty/indi-gige/INSTALL
@@ -1,0 +1,35 @@
+INSTALL indi-gige-ccd
+=====================
+
+* indi-gige-ccd
+    You must have CMake >= 2.4.7 in order to build this package.
+
+    To build only the indi-gige package, do the following:
+
+$ cd 3rdparty
+
+$ mkdir build
+
+$ cd build
+
+$ cmake -DCMAKE_INSTALL_PREFIX=/usr -DWITH_APOGEE:BOOL=OFF -DWITH_ASICAM:BOOL=OFF -DWITH_DSI:BOOL=OFF 
+        -DWITH_FISH^CMP:BOOL=OFF -DWITH_FLI:BOOL=OFF -DWITH_GPHOTO:BOOL=OFF -DWITH_QSI:BOOL=OFF
+        -DWITH_SBIG:BOOL=OFF -DWITH_GPSD:BOOL=OFF ../ 
+
+$ make 
+
+$ sudo make install
+
+    By this point, you'll have the indi-gige-ccd driver installed.
+
+INSTALL aravis
+==============
+
+Clone from github, https://github.com/AravisProject/aravis
+Follow the project aravis instructions, you need the library only.
+If you don't want or need the viewer, you can skip it (and the gstreamer dependencies):
+
+$ ./configure --disable-viewer
+
+...
+

--- a/3rdparty/indi-gige/README
+++ b/3rdparty/indi-gige/README
@@ -1,0 +1,96 @@
+GigE CCD Driver
+===============
+
+This package provides basic support for most GigE machine vision cameras through Project Aravis.
+
+
+Requirtments
+============
+
++ INDI >= v1.2.0 (https://github.com/indilib/indi)
+
+	You need to install both indi and indi-devel to build this package.
+	
++ cfitsio
+
+	cfitsio-devel is required to compile support for FITS.
+	
++ aravis >= v0.6
+
+	aravis is required, see https://github.com/AravisProject/aravis
+
+* glib-2.0, gobject-2.0
+    
+    Required through aravis
+	
+
+Installation
+============
+
+	See INSTALL
+	
+Use Notes
+=========
+    
+    Machine vision GigE cameras are designed towards throughput, and hence provide emphasis
+    on high-speed video streaming. The main design goal for this driver is to use these
+    cameras as primary imager or for guiding. Therefore, the main goal of this driver is
+    not to provide high-speed video streams, but to control these cameras more or less as
+    a generic CCD camera with a manual trigger and manual exposure controls.
+
+    Many of the pre-processing features found on many of these cameras have therefore been
+    not exposed. 
+	
+    
+    To run the driver from the command line:
+	
+	$ indiserver indi_gige_ccd
+	
+
+GigE machine vision overview
+============================
+
+    Gigabit Ethernet machine vision cameras can be controlled in two ways:
+        (1) Genicam standard, which accesses the camera's onboard XML file
+        (2) CSR (Control Register) based:
+            (2a) IIDC standard set
+            (2b) Vendor specific set
+
+    Project Aravis only uses genicam standard. For some features you need to
+    access the CSR directly. These can easily be queried with arv-tool-0.6  that come
+    with aravis, i.e.
+        $ arv-tool-0.6 control R[0xF0F00A00] R[0xF0F00A04] R[0xF0F00A08] R[0xF0F00A10] R[0xF0F00A14]
+
+            Point Grey Research-16048874
+            R[0xf0f00a00] = 0x08000600
+            R[0xf0f00a04] = 0x00040002
+            R[0xf0f00a08] = 0x00000000
+            R[0xf0f00a10] = 0x0a000000
+            R[0xf0f00a14] = 0x84780000
+
+    and refer to the camera register manual. 
+
+    For Grey Point blackfly cameras you can sometimes set raw mode and disable framerate through CSR only.
+    This is done by subclassing the AvrGeneric class, see BlackFly.cpp for reference.
+
+    If you are unsure, use the vendor's capture tool, and use wireshark to dump the traffic to the camera.
+    This way, you can quickly and easily deduce what each register is used for, and how settings are
+    programmed for your specific camera.
+
+Known issues
+============
+    
+    (1) Currently, only a single camera is supported, although with GigE cameras you can have
+    as many as you like in your network. Aravis library fully supports many cameras at once.
+    It is rather easy to make this change, if you need it. Simply adapt the source code in
+    indi_gige.cpp and ArvFactory.cpp to provide the necessary iteration. 
+
+    (2) Sometimes, with larger exposure times (>= 5s), the first frame is dropped. This
+    will generate a black frame. Subsequent frames are OK. I have no idea why, it seems
+    related to my particular camera behavior. 
+
+    (3) Probably only BLACKFLY cameras work, because AFAIK all machine vision cameras work 
+    with exposure times slaved to the framerate. If you want to access longer exposure times,
+    you need to disable automatic frame rate control. Unfortunately, how to do this is 
+    camera-specific.
+

--- a/3rdparty/indi-gige/config.h.cmake
+++ b/3rdparty/indi-gige/config.h.cmake
@@ -1,0 +1,14 @@
+/* Define to 1 if you have the <linux/videodev2.h> header file. */
+#cmakedefine HAVE_LINUX_VIDEODEV2_H 1
+
+/* The symbol timezone is an int, not a function */
+#define TIMEZONE_IS_INT 1
+
+/* Define if you have termios.h */
+#cmakedefine   HAVE_TERMIOS_H 1
+
+/* Define if you have fitsio.h */
+#cmakedefine   HAVE_CFITSIO_H 1
+
+/* Define if you have libnova.h */
+#cmakedefine   HAVE_NOVA_H 1

--- a/3rdparty/indi-gige/indi_gige_ccd.xml
+++ b/3rdparty/indi-gige/indi_gige_ccd.xml
@@ -1,0 +1,7 @@
+<devGroup group="CCDs">
+        <device label="GigE CCD" mdpd="true">
+                <driver name="GigE CCD">indi_gige_ccd</driver>
+		<version>0.1</version>
+	</device>
+</devGroup>
+

--- a/3rdparty/indi-gige/src/ArvFactory.cpp
+++ b/3rdparty/indi-gige/src/ArvFactory.cpp
@@ -1,0 +1,45 @@
+/*
+ GigE interface wrapper on araviss
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "ArvGeneric.h"
+#include "BlackFly.h"
+
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <string.h>
+
+#define BLACKFLY_MODEL  "BFLY-PGE-31S4M"
+
+arv::ArvCamera* ArvFactory::find_first_available(void)
+{
+	::ArvCamera* camera = arv_camera_new(NULL);
+    const char* model_name = arv_camera_get_model_name(camera);
+
+    if ((camera == NULL) || (model_name == NULL))
+        return NULL;
+
+    if (memmem(model_name, strlen(model_name), BLACKFLY_MODEL, strlen(BLACKFLY_MODEL))) {
+        printf("Creating BlackFly...\n");
+        return new BlackFly((void*)camera);
+    } else {
+        printf("Creating Generic...\n");
+        return new ArvGeneric((void*)camera);
+    }
+}
+        

--- a/3rdparty/indi-gige/src/ArvGeneric.cpp
+++ b/3rdparty/indi-gige/src/ArvGeneric.cpp
@@ -1,0 +1,321 @@
+/*
+ GigE interface wrapper on araviss
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "ArvGeneric.h"
+
+using namespace arv;
+
+const char* ArvGeneric::_str_val(const char* s) { return (s ? s : "None"); }
+const char* ArvGeneric::vendor_name()                       { return this->_str_val(this->cam.vendor_name); }
+const char* ArvGeneric::model_name()                        { return this->_str_val(this->cam.model_name); }
+const char* ArvGeneric::device_id()                         { return this->_str_val(this->cam.device_id); }
+min_max_property<int> ArvGeneric::get_bin_x()               { return min_max_property<int>(this->cam.bin_x); }
+min_max_property<int> ArvGeneric::get_bin_y()              { return min_max_property<int>(this->cam.bin_y); }
+min_max_property<int> ArvGeneric::get_x_offset()           { return min_max_property<int>(this->cam.x_offset); }
+min_max_property<int> ArvGeneric::get_y_offset()           { return min_max_property<int>(this->cam.y_offset); }
+min_max_property<int> ArvGeneric::get_width()              { return min_max_property<int>(this->cam.width); }
+min_max_property<int> ArvGeneric::get_height()             { return min_max_property<int>(this->cam.height); }
+min_max_property<int> ArvGeneric::get_bpp()                 { return min_max_property<int>(16,16,16); }
+min_max_property<double> ArvGeneric::get_pixel_pitch()      { return min_max_property<double>(this->cam.pixel_pitch); }
+min_max_property<double> ArvGeneric::get_exposure()         { return min_max_property<double>(this->cam.exposure); }
+min_max_property<double> ArvGeneric::get_gain()             { return min_max_property<double>(this->cam.gain); }
+min_max_property<double> ArvGeneric::get_frame_rate()       { return min_max_property<double>(this->cam.frame_rate); }
+
+template<typename T> bool ArvGeneric::_get_bounds(void (*fn_arv_bounds)(::ArvCamera*, T* min, T* max), min_max_property<T>* prop)
+{
+    T min,max;
+    fn_arv_bounds(this->camera, &min, &max);
+    prop->update(min,max);
+}
+
+bool ArvGeneric::is_exposing() { return this->stream_active; }
+bool ArvGeneric::is_connected() { return (this->camera ? true : false); }
+bool ArvGeneric::_stream_active() { return this->stream_active; }
+
+ArvGeneric::ArvGeneric(void* camera_device)
+    : ArvCamera(camera_device)
+{
+    this->_init();
+    this->camera = (::ArvCamera*)camera_device;
+    this->dev = arv_camera_get_device(this->camera);
+        
+    this->cam.model_name = arv_camera_get_model_name(this->camera);
+    this->cam.vendor_name = arv_camera_get_vendor_name(this->camera);
+    this->cam.device_id = arv_camera_get_device_id(this->camera);
+}
+
+ArvGeneric::~ArvGeneric()
+{
+    if (this->is_connected()) {
+        this->disconnect();
+    }
+    this->_init();
+}
+
+bool ArvGeneric::connect()
+{
+    /* (Re-)connect by means of the device-id */
+    if (!this->camera){
+        this->camera = ::arv_camera_new(this->cam.device_id);
+        if (!this->camera)
+            return false;
+
+        this->dev = arv_camera_get_device(this->camera);
+        this->cam.model_name = arv_camera_get_model_name(this->camera);
+        this->cam.vendor_name = arv_camera_get_vendor_name(this->camera);
+        this->cam.device_id = arv_camera_get_device_id(this->camera);
+    }
+    return true;
+}
+
+bool ArvGeneric::_configure(void)
+{
+    this->_set_initial_config();
+    return this->_get_initial_config();
+}
+
+void ArvGeneric::_init()
+{
+    this->camera = NULL;
+    this->buffer = NULL;
+    this->stream = NULL;
+    this->stream_active = false;
+    
+    /* Don't clear device_id, its needed to re-attach with connect() */
+}
+
+bool ArvGeneric::disconnect()
+{
+    if(this->is_connected()) {
+        this->_test_exposure_and_abort();
+        g_clear_object(&this->camera);
+    }
+    this->_init();
+}
+
+bool ArvGeneric::_set_initial_config()
+{
+    /* Configure "manual" mode
+     *      (1) disable auto exposure
+     *      (2) disable auto framerate (to enable maximum possible exposure time)
+     *      (3) set binning to 1x1
+     *      (4) set software trigger */
+    arv_camera_set_binning(camera, 1,1);
+    arv_camera_set_gain_auto(camera, ARV_AUTO_OFF);
+    arv_camera_set_exposure_time_auto(camera, ARV_AUTO_OFF);
+    arv_camera_set_trigger (camera, "Software");
+    return true;
+}
+
+bool ArvGeneric::_get_initial_config()
+{
+    this->_get_bounds<gint>(arv_camera_get_x_binning_bounds, &this->cam.bin_x);
+    this->_get_bounds<gint>(arv_camera_get_y_binning_bounds, &this->cam.bin_y);
+    this->_get_bounds<gint>(arv_camera_get_x_offset_bounds, &this->cam.x_offset);
+    this->_get_bounds<gint>(arv_camera_get_y_offset_bounds, &this->cam.y_offset);
+    this->_get_bounds<gint>(arv_camera_get_width_bounds, &this->cam.width);
+    this->_get_bounds<gint>(arv_camera_get_height_bounds, &this->cam.height);
+    this->_get_bounds<double>(arv_camera_get_frame_rate_bounds, &this->cam.frame_rate);
+    this->_get_bounds<double>(arv_camera_get_exposure_time_bounds, &this->cam.exposure);
+    this->_get_bounds<double>(arv_camera_get_gain_bounds, &this->cam.gain);
+
+    this->cam.vendor_name = arv_camera_get_vendor_name(camera);
+    this->cam.model_name = arv_camera_get_model_name (camera);
+    this->cam.device_id = arv_camera_get_device_id (camera);
+
+    /* No GVCP call for this..., specialize if necessary */
+    this->cam.pixel_pitch.set_single(1.0);
+
+    return true;
+}
+        
+int ArvGeneric::get_frame_byte_size()
+{
+    return arv_camera_get_payload(this->camera);
+}
+
+void ArvGeneric::set_geometry(int const x, int const y, int const w, int const h)
+{
+    this->cam.x_offset.set(x);
+    this->cam.y_offset.set(y);
+    this->cam.width.set(w);
+    this->cam.height.set(h);
+
+    arv_camera_set_region(
+            this->camera,
+            this->cam.x_offset.val(),
+            this->cam.y_offset.val(),
+            this->cam.width.val(),
+            this->cam.height.val());
+}
+
+void ArvGeneric::update_geometry(void)
+{
+    gint x,y,w,h,binx,biny;
+
+    arv_camera_get_region(this->camera, &x, &y, &w, &h);
+    arv_camera_get_binning(this->camera, &binx, &biny);
+    
+    this->cam.x_offset.set(x);
+    this->cam.y_offset.set(y);
+    this->cam.width.set(w);
+    this->cam.height.set(h);
+    this->cam.bin_x.set(binx);
+    this->cam.bin_y.set(biny);
+}
+        
+void ArvGeneric::set_bin(int const bin_x, int const bin_y)
+{
+    this->cam.bin_x.set(bin_x);
+    this->cam.bin_y.set(bin_y);
+
+    arv_camera_set_binning(this->camera, this->cam.bin_x.val(), this->cam.bin_y.val());    
+}
+
+void ArvGeneric::_test_exposure_and_abort(void)
+{
+    if (this->_stream_active())
+        this->exposure_abort();
+}
+
+
+template<typename T> void ArvGeneric::_set_cam_exposure_property(void (*arv_set)(::ArvCamera*,T), min_max_property<T>* prop, T const new_val)
+{
+    this->_test_exposure_and_abort();
+    prop->set(new_val);
+    arv_set(this->camera, prop->val());
+}
+
+void ArvGeneric::set_gain(double const val) { this->_set_cam_exposure_property(arv_camera_set_gain, &this->cam.gain, val); }
+void ArvGeneric::set_exposure_time(double const val) { this->_set_cam_exposure_property(arv_camera_set_exposure_time, &this->cam.exposure, val); }
+
+::ArvBuffer* ArvGeneric::_buffer_create(void)
+{
+    
+    ::ArvBuffer* buffer;
+
+    /* Ensure no buffers in stream */
+    while (1) {
+        buffer = arv_stream_try_pop_buffer(this->stream);
+        if (buffer)
+            g_clear_object(&buffer);
+        else
+            break;
+    }
+	
+    gint const payload = arv_camera_get_payload(this->camera);
+	buffer = arv_buffer_new(payload, NULL);
+	arv_stream_push_buffer(this->stream, buffer); 
+    return buffer;
+}
+
+
+::ArvStream* ArvGeneric::_stream_create(void)
+{
+	::ArvStream* stream = arv_camera_create_stream(this->camera, NULL, NULL);
+    return stream;
+}
+
+
+void ArvGeneric::_stream_start()
+{
+    this->stream_active = true;
+
+	/* Start the acquisition stream */
+    arv_camera_set_acquisition_mode(this->camera, ARV_ACQUISITION_MODE_SINGLE_FRAME);
+	arv_camera_start_acquisition(this->camera);
+}
+
+void ArvGeneric::_stream_stop()
+{
+	/* stop the acquisition stream */
+	arv_camera_stop_acquisition(this->camera);
+	g_object_unref(this->stream);
+
+    this->stream_active = false;
+}
+
+void ArvGeneric::_trigger_exposure()
+{
+    /* Trigger for an exposure */
+    arv_camera_software_trigger(this->camera);
+}
+
+void ArvGeneric::exposure_start(void)
+{
+    this->_test_exposure_and_abort();
+    this->stream = this->_stream_create();
+    this->buffer = this->_buffer_create();
+
+    this->_stream_start();
+    this->_trigger_exposure();
+}
+
+void ArvGeneric::exposure_abort(void)
+{
+    if (this->_stream_active()) {
+        arv_camera_abort_acquisition(this->camera);
+        this->_stream_stop();
+    }
+}
+
+void ArvGeneric::_get_image(void (*fn_image_callback)(void* const, uint8_t const * const, size_t), void* const usr_ptr)
+{
+    ArvBuffer* const popped_buf  = arv_stream_timeout_pop_buffer(this->stream, 100000);
+    if ((popped_buf != NULL) && (popped_buf == this->buffer) && 
+            arv_buffer_get_status(this->buffer) == ARV_BUFFER_STATUS_SUCCESS)
+    {
+        if (fn_image_callback != NULL) {
+            size_t size;
+            uint8_t const * const data = (uint8_t const*const)arv_buffer_get_data(this->buffer, &size);
+            fn_image_callback(usr_ptr, data, size);
+        }
+    } else {
+        //TODO: failure...
+    }
+}
+
+ARV_EXPOSURE_STATUS ArvGeneric::exposure_poll(void (*fn_image_callback)(void* const, uint8_t const * const, size_t), void* const usr_ptr)
+{
+    if (!this->_stream_active())
+        return ARV_EXPOSURE_UNKNOWN;
+
+    ::ArvBufferStatus const status = arv_buffer_get_status(this->buffer);
+    switch (status) {
+        case ARV_BUFFER_STATUS_CLEARED:
+            return ARV_EXPOSURE_BUSY;
+        case ARV_BUFFER_STATUS_FILLING:
+            return ARV_EXPOSURE_FILLING;
+        case ARV_BUFFER_STATUS_UNKNOWN:
+            return ARV_EXPOSURE_UNKNOWN;
+        case ARV_BUFFER_STATUS_SUCCESS:
+            this->_get_image(fn_image_callback, usr_ptr);
+            this->_stream_stop();
+            return ARV_EXPOSURE_FINISHED;
+        case ARV_BUFFER_STATUS_TIMEOUT:
+        case ARV_BUFFER_STATUS_MISSING_PACKETS:
+        case ARV_BUFFER_STATUS_WRONG_PACKET_ID:
+        case ARV_BUFFER_STATUS_SIZE_MISMATCH:
+        case ARV_BUFFER_STATUS_ABORTED:
+            this->_stream_stop();
+            return ARV_EXPOSURE_FAILED;
+        default:
+            return ARV_EXPOSURE_UNKNOWN;
+    }
+}
+

--- a/3rdparty/indi-gige/src/ArvGeneric.h
+++ b/3rdparty/indi-gige/src/ArvGeneric.h
@@ -1,0 +1,119 @@
+/*
+ GigE interface wrapper on araviss
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CPP_ARV_GENERIC_H
+#define CPP_ARV_GENERIC_H
+
+extern "C" {
+#include <stddef.h>
+#include <stdio.h>
+#include <arv.h>
+}
+
+#include "ArvInterface.h"
+
+using namespace arv;
+
+
+class ArvGeneric : public arv::ArvCamera
+{
+    public:
+        ArvGeneric(void* camera_device);
+        ~ArvGeneric();
+
+        bool is_connected();
+        bool is_exposing();
+        bool connect();
+        bool disconnect();        
+        const char* vendor_name();
+        const char* model_name();
+        const char* device_id();
+        int get_frame_byte_size();
+        min_max_property<int> get_bin_x();
+        min_max_property<int> get_bin_y();
+        min_max_property<int> get_x_offset();
+        min_max_property<int> get_y_offset();
+        min_max_property<int> get_width();
+        min_max_property<int> get_height();
+        min_max_property<int> get_bpp();
+        min_max_property<double> get_pixel_pitch();
+        min_max_property<double> get_exposure();
+        min_max_property<double> get_gain();
+        min_max_property<double> get_frame_rate();
+        
+        void set_bin(int const bin_x, int const bin_y);
+        void set_geometry(int const x, int const y, int const w, int const h);
+        void update_geometry(void);
+        void set_exposure_time(double const val);
+        void set_gain(double const val);
+
+        void exposure_start(void);
+        void exposure_abort(void);
+        ARV_EXPOSURE_STATUS exposure_poll(void (*fn_image_callback)(void* const, uint8_t const * const, size_t), void* const usr_ptr); 
+
+    protected:
+        void _init(void);
+        bool _configure(void);
+        void _test_exposure_and_abort(void);
+        template<typename T> bool _get_bounds(void (*fn_arv_bounds)(::ArvCamera*, T* min, T* max), min_max_property<T>* prop);
+        template<typename T> void _set_cam_exposure_property(void (*arv_set)(::ArvCamera*,T), min_max_property<T>* prop, T const new_val);
+
+        const char* _str_val(const char* s);
+        bool _get_initial_config();
+        bool _set_initial_config();
+        void _get_image(void (*fn_image_callback)(void* const, uint8_t const * const, size_t), void* const usr_ptr);
+
+        /* aravis library state variables */
+        ::ArvCamera* camera;
+        ::ArvDevice* dev;
+        ::ArvStream* stream;
+        ::ArvBuffer* buffer;
+       
+        /* streaming, capturing functions */ 
+        ::ArvStream* _stream_create(void);
+        ::ArvBuffer* _buffer_create(void);
+        bool _stream_active();
+        void _stream_start();
+        void _stream_stop();
+        void _trigger_exposure();
+
+        bool stream_active;
+
+        /* Camera properties */
+        struct {
+            min_max_property<gint> bin_x;
+            min_max_property<gint> bin_y;
+            min_max_property<gint> x_offset;
+            min_max_property<gint> y_offset;
+            min_max_property<gint> width;
+            min_max_property<gint> height;
+
+            min_max_property<double> pixel_pitch;
+
+            min_max_property<double> exposure;
+            min_max_property<double> gain;
+            min_max_property<double> frame_rate;
+
+            const char* vendor_name;
+            const char* model_name;
+            const char* device_id;
+        } cam;
+};
+
+
+#endif /*CPP_ARV_CAMERA_H*/

--- a/3rdparty/indi-gige/src/ArvInterface.h
+++ b/3rdparty/indi-gige/src/ArvInterface.h
@@ -1,0 +1,124 @@
+/*
+ GigE interface wrapper on aravis
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CPP_ARV_IFACE_H
+#define CPP_ARV_IFACE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+namespace arv {
+
+    
+typedef enum {
+    ARV_EXPOSURE_UNKNOWN = -1,      //!< Unknown status?
+    ARV_EXPOSURE_FINISHED = 0,      //!< Exposure has finished, image returned
+    ARV_EXPOSURE_BUSY,              //!< Exposure is still ungoing
+    ARV_EXPOSURE_FILLING,           //!< Exposure is finished, being transferred on the lower layer
+    ARV_EXPOSURE_FAILED,            //!< Exposure has finished, with an error, no image returned.
+
+} ARV_EXPOSURE_STATUS;
+
+template<class T> class min_max_property
+{
+    public:
+        min_max_property() {}
+        min_max_property(T const min, T const max, T const val)
+        {
+            this->_min = min;
+            this->_max = max;
+            this->_val = val;
+        }
+
+        void update(T const min, T const max)
+        {
+            this->_min = min;
+            this->_max = max;
+        }
+
+        void set(T const new_val) {
+            if (new_val > this->_max)
+                this->_val = this->_max;
+            else if (new_val < this->_min)
+                this->_val = this->_min;
+            else
+                this->_val = new_val;
+        }
+        void set_single(T const single_val) {
+            this->_min = this->_max = this->_val = single_val;
+        }
+
+        T val() { return this->_val; }
+        T min() { return this->_min; }
+        T max() { return this->_max; }
+
+    private:
+        T _min, _max, _val;
+};
+
+class ArvCamera
+{
+    public:
+        ArvCamera(void* camera_device) {}
+        virtual bool connect() = 0;
+        virtual bool disconnect() = 0;
+        virtual bool is_connected() = 0;
+        virtual bool is_exposing() = 0;
+
+        /* Get properties */
+        virtual const char* vendor_name() = 0;
+        virtual const char* model_name() = 0;
+        virtual const char* device_id() = 0;
+        virtual int get_frame_byte_size() = 0;
+        virtual min_max_property<int> get_bin_x() = 0;
+        virtual min_max_property<int> get_bin_y() = 0;
+        virtual min_max_property<int> get_x_offset() = 0;
+        virtual min_max_property<int> get_y_offset() = 0;
+        virtual min_max_property<int> get_width() = 0;
+        virtual min_max_property<int> get_height() = 0;
+        virtual min_max_property<int> get_bpp() = 0;
+        virtual min_max_property<double> get_pixel_pitch() = 0;
+        virtual min_max_property<double> get_exposure() = 0;
+        virtual min_max_property<double> get_gain() = 0;
+        virtual min_max_property<double> get_frame_rate() = 0;
+
+        /* Set geometry */
+        virtual void set_bin(int const bin_x, int const bin_y) = 0;
+        virtual void set_geometry(int const x, int const y, int const w, int const h) = 0;
+        virtual void update_geometry(void) = 0;
+
+        /* Set exposure */
+        virtual void set_exposure_time(double const val) = 0;
+        virtual void set_gain(double const val) = 0;
+
+        virtual void exposure_start(void) = 0;
+        virtual void exposure_abort(void) = 0;
+        virtual ARV_EXPOSURE_STATUS exposure_poll(void (*fn_image_callback)(void* const, uint8_t const * const, size_t), void* const) = 0; 
+};
+
+class ArvFactory
+{
+    public:
+        static ArvCamera* find_first_available(void);
+
+        //TODO: add iterative support to add all discovered cameras
+};
+
+} /* Namepsace */
+
+#endif

--- a/3rdparty/indi-gige/src/BlackFly.cpp
+++ b/3rdparty/indi-gige/src/BlackFly.cpp
@@ -1,0 +1,142 @@
+/*
+ GigE interface wrapper on araviss
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "ArvGeneric.h"
+#include "BlackFly.h"
+
+using namespace arv;
+
+BlackFly::BlackFly(void* camera_device)
+    : ArvGeneric(camera_device)
+{
+    printf("%s\n", __PRETTY_FUNCTION__);
+}
+
+bool BlackFly::_custom_settings()
+{
+    printf("%s\n", __PRETTY_FUNCTION__);
+    ::ArvDevice* dev = this->dev;
+#define WRITE_REGISTER(reg, val)                                        \
+    {                                                                   \
+        error = NULL;                                                   \
+        result = arv_device_write_register(dev, (reg),(val), &error);   \
+        if ((result != 1) || (error != NULL)) {                         \
+            goto error;                                                 \
+        }                                                               \
+    }                                   
+
+    gboolean result;
+    guint32 val;
+    GError *error = NULL;
+
+    int i;
+    for(i=0; i<4; i++) {
+        WRITE_REGISTER(0xF0F00614UL, 0x00000000UL); /* Set Isochronous transfer off */    
+        WRITE_REGISTER(0xF0F00608UL, 0xE0000000UL); /* Set Current video format 7 */
+        WRITE_REGISTER(0xF0F00604UL, 0x00000000UL); /* Set Current video mode 0  */
+
+        WRITE_REGISTER(0xF0F00630UL, 0x00800000UL); /* Little Endian, please! */
+
+        WRITE_REGISTER(0xF0F00A08UL, 0x00000000UL); /* Mode0 IMAGE_POSITION (max)*/
+        WRITE_REGISTER(0xF0F00A0CUL, 0x08000600UL); /* Mode0 IMAGE_SIZE     (max) */
+        WRITE_REGISTER(0xF0F00A10UL, 0x0a000000UL); /* Mode0 IMAGE_FORMAT, configure RAW16   */
+        WRITE_REGISTER(0xF0F00A7CUL, 0x40000000UL); /* Mode0 IMAGE_POSITION/COLOR_CODING_ID */
+        WRITE_REGISTER(0xF0F00A44UL, 0x34540000UL); /* Mode0 BYTE_PER_PACKET */
+
+        /* Disable auto-frame-rate */
+        WRITE_REGISTER(0xF0F0081CUL, 0xC2000FFFUL); /* FRAME_RATE, No AUTO, OFF */
+
+    }
+
+    return true;
+
+error:
+    return false;
+}
+
+bool BlackFly::connect(void)
+{
+    printf("%s\n", __PRETTY_FUNCTION__);
+    bool const ret = ArvGeneric::connect();
+    if (ret) {
+        this->_configure();
+    }
+    return ret;
+}
+
+void BlackFly::_fixup(void)
+{
+    ::ArvDevice* dev = this->dev;
+#define WRITE_REGISTER(reg, val)                                        \
+    {                                                                   \
+        error = NULL;                                                   \
+        result = arv_device_write_register(dev, (reg),(val), &error);   \
+        if ((result != 1) || (error != NULL)) {                         \
+            goto error;                                                 \
+        }                                                               \
+    }                                   
+
+    gboolean result;
+    guint32 val;
+    GError *error = NULL;
+
+    int i;
+    for(i=0; i<4; i++) {
+        WRITE_REGISTER(0xF0F00614UL, 0x00000000UL); /* Isochronous transfer off */    
+        WRITE_REGISTER(0xF0F00630UL, 0x00800000UL); /* Little Endian, please! */
+    }
+error:
+    return;
+
+}
+
+void BlackFly::exposure_start(void)
+{
+    printf("%s\n", __PRETTY_FUNCTION__);
+    /* At some point in stream start, the endianness gets reset by the camera itself... why? genicam? */
+    this->_fixup();
+    ArvGeneric::exposure_start();
+}
+
+bool BlackFly::_configure(void)
+{
+    printf("%s\n", __PRETTY_FUNCTION__);
+    this->_set_initial_config();
+    return this->_get_initial_config();
+}
+
+bool BlackFly::_get_initial_config(void)
+{
+    printf("%s\n", __PRETTY_FUNCTION__);
+    ArvGeneric::_get_initial_config();
+
+    /* Pitch can only be found in the datasheet, so hardcode ours here */
+    this->cam.pixel_pitch.set_single(3.45);
+
+    /* Probably can find this somewhere in genicam, too, but it depends on framerate
+     * and the maximum exposure is consequently not published */
+    this->cam.exposure.update(5000,11900000);
+}
+
+bool BlackFly::_set_initial_config(void)
+{
+    printf("%s\n", __PRETTY_FUNCTION__);
+    ArvGeneric::_set_initial_config();
+    this->_custom_settings();
+}
+

--- a/3rdparty/indi-gige/src/BlackFly.h
+++ b/3rdparty/indi-gige/src/BlackFly.h
@@ -1,0 +1,39 @@
+/*
+ GigE interface wrapper on araviss
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef CPP_ARV_BLACKFLY_H
+#define CPP_ARV_BLACKFLY_H
+
+class BlackFly : public ArvGeneric
+{
+    public:
+        BlackFly(void* camera_device);
+        bool connect();
+        void exposure_start(void);
+
+    protected:
+        bool _configure(void);
+        bool _get_initial_config();
+        bool _set_initial_config();
+
+    private:
+        bool _custom_settings();
+        void _fixup();
+};
+
+#endif

--- a/3rdparty/indi-gige/src/config.h
+++ b/3rdparty/indi-gige/src/config.h
@@ -1,0 +1,14 @@
+/* Define to 1 if you have the <linux/videodev2.h> header file. */
+/* #undef HAVE_LINUX_VIDEODEV2_H */
+
+/* The symbol timezone is an int, not a function */
+#define TIMEZONE_IS_INT 1
+
+/* Define if you have termios.h */
+/* #undef HAVE_TERMIOS_H */
+
+/* Define if you have fitsio.h */
+/* #undef HAVE_CFITSIO_H */
+
+/* Define if you have libnova.h */
+/* #undef HAVE_NOVA_H */

--- a/3rdparty/indi-gige/src/indi_gige.cpp
+++ b/3rdparty/indi-gige/src/indi_gige.cpp
@@ -1,0 +1,402 @@
+/*
+ GigE interface for INDI based on aravis
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <time.h>
+#include <list>
+#include <sys/time.h>
+
+#include "indidevapi.h"
+#include "eventloop.h"
+
+#include "indi_gige.h"
+
+#define TIME_VAL_INIT(x)            ({ (x)->tv_sec = 0; (x)->tv_usec = 0; })
+#define TIME_VAL_ISSET(x)           ( ((x)->tv_sec != 0) && ((x)->tv_usec != 0) )
+#define TIME_VAL_US(x)              ( ((x)->tv_sec)*1000000+((x)->tv_usec) )
+#define TIME_VAL_GET(x)             ( gettimeofday(x, NULL) )
+
+#define TIMER_TRANSFER_TIMEOUT_US   (5000000UL)     /* Allow for relatively large link-layer delays */
+#define TIMER_EXPOSURE_TIMEOUT_US   (200000UL)      /* GigE cameras are very precise, so set 100ms time-out */
+
+#define TIMER_US_TO_MS (1000)
+#define TIMER_US_TO_S (1000000)
+#define TIMER_TICK_MS  (100)
+#define CAPS        (CCD_CAN_ABORT | CCD_CAN_BIN | CCD_CAN_SUBFRAME)
+       
+#define FOR_EVERY_CAMERA    \
+{\
+    std::list<GigECCD*>::iterator camera;\
+    for (camera=cameras.begin(); camera != cameras.end(); ++camera)
+
+static std::list<GigECCD*> cameras;
+
+static void cleanup()
+{
+    FOR_EVERY_CAMERA {
+        delete (*camera);
+    }}
+}
+
+void ISInit()
+{
+    static bool has_init = false;
+    if (!has_init) {
+        has_init = true;
+
+        arv::ArvCamera* camera = arv::ArvFactory::find_first_available();
+        GigECCD* indi_camera = new GigECCD(camera);
+        cameras.push_back(indi_camera);
+    }
+    atexit(cleanup);
+}
+
+void ISGetProperties(const char *dev)
+{
+    ISInit();
+    FOR_EVERY_CAMERA {
+        if (dev == NULL || !strcmp(dev, (*camera)->name)) {
+            (*camera)->ISGetProperties(dev);
+            //??????????????????
+            if (dev != NULL)
+                break;
+        }
+    }}
+}
+
+void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int num)
+{
+    ISInit();
+    FOR_EVERY_CAMERA {
+        if (dev == NULL || !strcmp(dev, (*camera)->name)) {
+            (*camera)->ISNewSwitch(dev, name, states, names, num);
+            if (dev != NULL)
+                break;
+        }
+    }}
+}
+
+void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int num)
+{
+    ISInit();
+    FOR_EVERY_CAMERA {
+        if (dev == NULL || !strcmp(dev, (*camera)->name)) {
+            (*camera)->ISNewText(dev, name, texts, names, num);
+            if (dev != NULL)
+                break;
+        }
+    }}
+}
+
+void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int num)
+{
+    ISInit();
+    FOR_EVERY_CAMERA {
+        if (dev == NULL || !strcmp(dev, (*camera)->name)) {
+            (*camera)->ISNewNumber(dev, name, values, names, num);
+            if (dev != NULL)
+                break;
+        }
+    }}
+}
+
+void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[], char *names[], int n) {
+  INDI_UNUSED(dev);
+  INDI_UNUSED(name);
+  INDI_UNUSED(sizes);
+  INDI_UNUSED(blobsizes);
+  INDI_UNUSED(blobs);
+  INDI_UNUSED(formats);
+  INDI_UNUSED(names);
+  INDI_UNUSED(n);
+}
+
+void ISSnoopDevice(XMLEle *root)
+{
+    ISInit();
+    
+    FOR_EVERY_CAMERA {
+        (*camera)->ISSnoopDevice(root);
+    }}
+
+}
+
+const char *GigECCD::getDefaultName() { return this->name; }
+
+GigECCD::GigECCD(arv::ArvCamera* camera)
+{
+    this->camera = camera;
+    snprintf(this->name, sizeof(this->name), "%s", this->camera->model_name());
+    setDeviceName(this->name);
+}
+
+GigECCD::~GigECCD()
+{
+
+}
+
+
+bool GigECCD::initProperties()
+{
+    INDI::CCD::initProperties();
+    this->SetCCDCapability((CAPS));
+    this->addConfigurationControl();
+    this->addDebugControl();
+    return true;
+}
+
+bool GigECCD::_update_geometry(void)
+{
+    /* Get actual values */
+    this->camera->update_geometry(); 
+
+    /* Sync these with INDI */
+    PrimaryCCD.setBin(this->camera->get_bin_x().val(), this->camera->get_bin_y().val());
+    PrimaryCCD.setFrame(
+            this->camera->get_x_offset().val(),
+            this->camera->get_y_offset().val(),
+            this->camera->get_width().val(),
+            this->camera->get_height().val());
+
+    /* Sanity checks, reserve buffers */
+    int const width = this->camera->get_width().val();
+    int const height = this->camera->get_height().val(); 
+    int const frame_byte_size = this->camera->get_frame_byte_size();
+    int const indi_bufsize = PrimaryCCD.getSubW() * PrimaryCCD.getSubH() * PrimaryCCD.getBPP() / 8;
+
+    if (indi_bufsize != frame_byte_size) {
+        DEBUGF(INDI::Logger::DBG_ERROR, "Unexpected INDI image buffer size, has %i bytes, camera has %i", indi_bufsize, frame_byte_size);
+        PrimaryCCD.setFrameBufferSize(0);
+    } else {
+        DEBUGF(INDI::Logger::DBG_SESSION, "Reserving INDI image buffer size %i bytes", indi_bufsize);
+        PrimaryCCD.setFrameBufferSize(frame_byte_size);
+    }
+}
+
+void GigECCD::_update_indi_properties(void)
+{
+    DEBUG(INDI::Logger::DBG_SESSION, "update_indi_properties()");
+    IUFillNumber(&this->indiprop_gain[0], "Range", "", "%g",
+            (double)this->camera->get_gain().min(),
+            (double)this->camera->get_gain().max(),
+            1.,
+            (double)this->camera->get_gain().val());
+    IUFillNumberVector(&this->indiprop_gain_prop, this->indiprop_gain, 1, getDeviceName(), "Gain", "", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
+
+    IUFillText(&indiprop_info[0], "Vendor Name", "", this->camera->vendor_name());
+    IUFillText(&indiprop_info[1], "Model Name", "", this->camera->model_name());
+    IUFillText(&indiprop_info[2], "Device ID", "", this->camera->device_id());
+    IUFillTextVector(&indiprop_info_prop, indiprop_info, 3, getDeviceName(), "Camera Info", "", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    
+    defineText(&indiprop_info_prop);
+    defineNumber(&this->indiprop_gain_prop);
+}
+
+void GigECCD::_delete_indi_properties(void)
+{
+    this->deleteProperty(this->indiprop_gain_prop.name);
+    this->deleteProperty(this->indiprop_info_prop.name);
+}
+
+//Initial call
+bool GigECCD::updateProperties()
+{
+    INDI::CCD::updateProperties();
+
+    if (this->camera->is_connected()) {
+        this->_update_indi_properties();
+        this->SetCCDParams(
+            this->camera->get_width().max(),
+            this->camera->get_height().max(),
+            this->camera->get_bpp().val(),
+            this->camera->get_pixel_pitch().val(),
+            this->camera->get_pixel_pitch().val());
+
+        (void)this->_update_geometry();
+        this->timer_id = this->SetTimer(TIMER_TICK_MS);
+    } else {
+        rmTimer(this->timer_id);
+        this->_delete_indi_properties();
+    }
+
+    return true;
+}
+
+bool GigECCD::Connect()
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "%s", __PRETTY_FUNCTION__);
+    return camera->connect();
+}
+
+bool GigECCD::Disconnect()
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "%s", __PRETTY_FUNCTION__);
+#if 0
+    //TODO: re-iterate and acquire proper camera from AvrFactory (based on ID?)
+    return camera->disconnect();
+#endif
+    return true;
+}
+
+bool GigECCD::StartExposure(float duration)
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "%s exposure_time=%.4f", __PRETTY_FUNCTION__, duration);
+    /* Driver will clamp to lowest possible exposure */
+    if (PrimaryCCD.getFrameType() == CCDChip::BIAS_FRAME)
+        duration = 0;
+
+    camera->set_exposure_time((double)(duration)*1000000.0);
+    
+    TIME_VAL_INIT(&this->exposure_transfer_time);
+    TIME_VAL_GET(&this->exposure_start_time);
+
+    camera->exposure_start();
+    return camera->is_exposing();
+}
+
+bool GigECCD::AbortExposure()
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "%s", __PRETTY_FUNCTION__);
+    camera->exposure_abort();
+    return true;
+}
+        
+void GigECCD::_update_image(uint8_t const * const data, size_t size)
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "Receiving %i bytes image", size);
+
+    size_t const frame_buf_size = PrimaryCCD.getFrameBufferSize();
+
+    if ((size == frame_buf_size) && (data != NULL)) {
+        uint8_t *const image = PrimaryCCD.getFrameBuffer();
+        memcpy(image, (void*const)data, frame_buf_size);
+        this->ExposureComplete(&PrimaryCCD);
+    } else {
+        DEBUGF(INDI::Logger::DBG_ERROR, "Unexpected failure during image download. Framebuf has %i bytes, got %i", frame_buf_size, size);
+        this->_handle_failed();
+    }
+}
+
+void GigECCD::_receive_image_hook(void* const class_ptr, uint8_t const *const data, size_t size)
+{
+    GigECCD* const cls = static_cast<GigECCD* const>(class_ptr);
+    cls->_update_image(data, size);
+}
+        
+void GigECCD::_handle_failed(void)
+{
+    DEBUG(INDI::Logger::DBG_ERROR, "Failure occurred, filling image with black");
+
+    camera->exposure_abort();
+    
+    PrimaryCCD.setExposureLeft(0);
+
+    /* Fill with black */
+    uint8_t *const image = PrimaryCCD.getFrameBuffer();
+    memset(image, 0, PrimaryCCD.getFrameBufferSize());
+
+    this->ExposureComplete(&PrimaryCCD);
+}
+
+void GigECCD::_handle_timeout(struct timeval* const tv, uint32_t timeout_us)
+{
+    if (!TIME_VAL_ISSET(tv))
+        TIME_VAL_GET(tv);
+    
+    struct timeval now;
+    TIME_VAL_GET(&now);
+    
+    uint32_t const elapsed = ((TIME_VAL_US(&now)) - (TIME_VAL_US(tv)));
+    uint32_t const exposure_time = (uint32_t)this->camera->get_exposure().val();
+    uint32_t const time_left = exposure_time - elapsed;
+
+    if (elapsed >= exposure_time)
+        PrimaryCCD.setExposureLeft(0);
+    else
+        PrimaryCCD.setExposureLeft((float)time_left/(float)TIMER_US_TO_S);
+
+    if (elapsed > timeout_us)
+        this->_handle_failed();
+}
+
+void GigECCD::TimerHit()
+{
+    this->timer_id = this->SetTimer(TIMER_TICK_MS);
+    if (!this->camera->is_connected() || !this->camera->is_exposing())
+        return;
+
+    arv::ARV_EXPOSURE_STATUS const status = camera->exposure_poll(this->_receive_image_hook, this);
+    switch (status) {
+        case arv::ARV_EXPOSURE_FINISHED:
+            /* Nothing to do, ArvCamera automatically unsets is_exposing */
+            break;
+        case arv::ARV_EXPOSURE_UNKNOWN:
+        case arv::ARV_EXPOSURE_FAILED:
+            this->_handle_failed();
+            break;
+        case arv::ARV_EXPOSURE_FILLING:
+            this->_handle_timeout(&this->exposure_transfer_time, TIMER_TRANSFER_TIMEOUT_US);
+            break;
+        case arv::ARV_EXPOSURE_BUSY:
+            this->_handle_timeout(&this->exposure_start_time, ((uint32_t)this->camera->get_exposure().val()+TIMER_EXPOSURE_TIMEOUT_US));
+            break;
+    }
+}
+
+bool GigECCD::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
+{
+    if (!strcmp(dev, this->getDeviceName())) {
+        if (!strcmp(name, this->indiprop_gain_prop.name)) {
+            IUUpdateNumber(&this->indiprop_gain_prop, values, names, n);
+            this->camera->set_gain(this->indiprop_gain[0].value);
+            this->indiprop_gain_prop.s = IPS_OK;
+            
+            /* Get-back from camera system */
+            double actual_value = this->camera->get_gain().val();
+            IUUpdateNumber(&this->indiprop_gain_prop, &actual_value, names, n);
+            IDSetNumber(&this->indiprop_gain_prop, NULL);
+            return true;
+        }
+    }
+
+    return INDI::CCD::ISNewNumber(dev, name, values, names, n);
+}
+
+bool GigECCD::UpdateCCDFrame(int x, int y, int w, int h)
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "%s x=%i y=%i w=%i h=%i", __PRETTY_FUNCTION__, x,y,w,h);
+
+    this->camera->set_geometry(x,y,w,h);
+    return this->_update_geometry();
+}
+
+bool GigECCD::UpdateCCDBin(int binx, int biny)
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "%s binx=%i biny=%i", __PRETTY_FUNCTION__, binx, biny);
+    camera->set_bin(binx, biny);
+    return UpdateCCDFrame(PrimaryCCD.getSubX(), PrimaryCCD.getSubY(), PrimaryCCD.getSubW(), PrimaryCCD.getSubH());
+}
+
+bool GigECCD::UpdateCCDFrameType(CCDChip::CCD_FRAME fType)
+{
+    DEBUGF(INDI::Logger::DBG_SESSION, "%s", __PRETTY_FUNCTION__);
+    PrimaryCCD.setFrameType(fType);
+    return true;
+}
+

--- a/3rdparty/indi-gige/src/indi_gige.h
+++ b/3rdparty/indi-gige/src/indi_gige.h
@@ -1,0 +1,87 @@
+/*
+ GigE interface for INDI based on aravis
+ Copyright (C) 2016 Hendrik Beijeman (hbeyeman@gmail.com)
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef GENERIC_CCD_H
+#define GENERIC_CCD_H
+
+#include <indiccd.h>
+#include <iostream>
+
+#include "ArvInterface.h"
+
+using namespace std;
+
+class GigECCD: public INDI::CCD
+{
+    public:
+
+        GigECCD(arv::ArvCamera* camera);
+        virtual ~GigECCD();
+
+        const char *getDefaultName();
+
+        bool initProperties();
+        bool updateProperties();
+
+        bool Connect();
+        bool Disconnect();
+
+        bool StartExposure(float duration);
+        bool AbortExposure();
+
+    protected:
+
+        void TimerHit();
+        virtual bool UpdateCCDFrame(int x, int y, int w, int h);
+        virtual bool UpdateCCDBin(int binx, int biny);
+        virtual bool UpdateCCDFrameType(CCDChip::CCD_FRAME fType);
+
+    private:
+        void _delete_indi_properties(void);
+        void _update_indi_properties(void);
+        bool _update_geometry(void);
+        void _update_image(uint8_t const * const data, size_t size);
+        static void _receive_image_hook(void* const class_ptr, uint8_t const *const data, size_t size);
+
+        void _handle_failed(void);
+        void _handle_timeout(struct timeval* const tv, uint32_t timeout_us);
+
+        arv::ArvCamera*  camera;
+        char             name[32];
+        int              timer_id;
+        struct timeval   exposure_start_time;
+        struct timeval   exposure_transfer_time;
+
+        /* Indi properties */
+
+        INumber indiprop_gain[1];
+        INumberVectorProperty indiprop_gain_prop;
+        IText indiprop_info[3];
+        ITextVectorProperty indiprop_info_prop;
+  
+        virtual bool ISNewNumber (const char *dev, const char *name, double values[], char *names[], int n);
+
+        friend void ::ISGetProperties(const char *dev);
+        friend void ::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int num);
+        friend void ::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int num);
+        friend void ::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int num);
+        friend void ::ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[], char *names[], int n);
+};
+
+#endif // GENERIC_CCD_H

--- a/cmake_modules/FindARAVIS.cmake
+++ b/cmake_modules/FindARAVIS.cmake
@@ -1,0 +1,43 @@
+# - Find the native sqlite3 includes and library
+#
+# This module defines
+#  ARV_INCLUDE_DIR, where to find libgphoto2 header files
+#  ARV_LIBRARIES, the libraries to link against to use libgphoto2
+#  ARV_FOUND, If false, do not try to use libgphoto2.
+#  ARV_VERSION_STRING, e.g. 2.4.14
+#  ARV_VERSION_MAJOR, e.g. 2
+#  ARV_VERSION_MINOR, e.g. 4
+#  ARV_VERSION_PATCH, e.g. 14
+#
+# also defined, but not for general use are
+#  ARV_LIBRARY, where to find the sqlite3 library.
+
+
+#=============================================================================
+# Copyright 2010 henrik andersson
+#=============================================================================
+
+SET(ARV_FIND_REQUIRED ${Arv_FIND_REQUIRED})
+
+find_path(ARV_INCLUDE_DIR aravis-0.6/arv.h)
+mark_as_advanced(ARV_INCLUDE_DIR)
+
+set(ARV_NAMES ${ARV_NAMES} aravis-0.6)
+find_library(ARV_LIBRARY NAMES ${ARV_NAMES} )
+mark_as_advanced(ARV_LIBRARY)
+
+set(ARV_VERSION_MAJOR "0")
+set(ARV_VERSION_MINOR "6")
+set(ARV_VERSION_STRING "${ARV_VERSION_MAJOR}.${ARV_VERSION_MINOR}")
+
+# handle the QUIETLY and REQUIRED arguments and set ARV_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ARV DEFAULT_MSG ARV_LIBRARY ARV_INCLUDE_DIR)
+
+IF(ARV_FOUND)
+    #SET(Arv_LIBRARIES ${ARV_LIBRARY})
+    SET(Arv_LIBRARIES "aravis-0.6")
+    SET(Arv_INCLUDE_DIRS "${ARV_INCLUDE_DIR}/aravis-0.6")
+    MESSAGE (STATUS "Found aravis: ${Arv_LIBRARIES} ${Arv_INCLUDE_DIRS}")
+ENDIF(ARV_FOUND)

--- a/cmake_modules/FindGLIB2.cmake
+++ b/cmake_modules/FindGLIB2.cmake
@@ -1,0 +1,218 @@
+# - Try to find GLib2
+# Once done this will define
+#
+#  GLIB2_FOUND - system has GLib2
+#  GLIB2_INCLUDE_DIRS - the GLib2 include directory
+#  GLIB2_LIBRARIES - Link these to use GLib2
+#
+#  HAVE_GLIB_GREGEX_H  glib has gregex.h header and 
+#                      supports g_regex_match_simple
+#
+#  Copyright (c) 2006 Andreas Schneider <mail@cynapses.org>
+#  Copyright (c) 2006 Philippe Bernery <philippe.bernery@gmail.com>
+#  Copyright (c) 2007 Daniel Gollub <dgollub@suse.de>
+#  Copyright (c) 2007 Alban Browaeys <prahal@yahoo.com>
+#  Copyright (c) 2008 Michael Bell <michael.bell@web.de>
+#  Copyright (c) 2008 Bjoern Ricks <bjoern.ricks@googlemail.com>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+#  For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+#
+
+
+IF (GLIB2_LIBRARIES AND GLIB2_INCLUDE_DIRS )
+  # in cache already
+  SET(GLIB2_FOUND TRUE)
+ELSE (GLIB2_LIBRARIES AND GLIB2_INCLUDE_DIRS )
+
+  INCLUDE(FindPkgConfig)
+
+  ## Glib
+  IF ( GLIB2_FIND_REQUIRED )
+    SET( _pkgconfig_REQUIRED "REQUIRED" )
+  ELSE ( GLIB2_FIND_REQUIRED )
+    SET( _pkgconfig_REQUIRED "" )
+  ENDIF ( GLIB2_FIND_REQUIRED )
+
+  IF ( GLIB2_MIN_VERSION )
+    PKG_SEARCH_MODULE( GLIB2 ${_pkgconfig_REQUIRED} glib-2.0>=${GLIB2_MIN_VERSION} )
+  ELSE ( GLIB2_MIN_VERSION )
+    PKG_SEARCH_MODULE( GLIB2 ${_pkgconfig_REQUIRED} glib-2.0 )
+  ENDIF ( GLIB2_MIN_VERSION )
+  IF ( PKG_CONFIG_FOUND )
+    IF ( GLIB2_FOUND )
+      SET ( GLIB2_CORE_FOUND TRUE )
+    ELSE ( GLIB2_FOUND )
+      SET ( GLIB2_CORE_FOUND FALSE )
+    ENDIF ( GLIB2_FOUND )
+  ENDIF ( PKG_CONFIG_FOUND )
+
+  # Look for glib2 include dir and libraries w/o pkgconfig
+  IF ( NOT GLIB2_FOUND AND NOT PKG_CONFIG_FOUND )
+    FIND_PATH(
+      _glibconfig_include_DIR
+    NAMES
+      glibconfig.h
+    PATHS
+      /opt/gnome/lib64
+      /opt/gnome/lib
+      /opt/lib/
+      /opt/local/lib
+      /sw/lib/
+      /usr/lib64
+      /usr/lib
+      /usr/local/include
+      ${CMAKE_LIBRARY_PATH}
+    PATH_SUFFIXES
+      glib-2.0/include
+    )
+
+    FIND_PATH(
+      _glib2_include_DIR
+    NAMES
+      glib.h
+    PATHS
+      /opt/gnome/include
+      /opt/local/include
+      /sw/include
+      /usr/include
+      /usr/local/include
+    PATH_SUFFIXES
+      glib-2.0
+    )
+
+    #MESSAGE(STATUS "Glib headers: ${_glib2_include_DIR}")
+
+    FIND_LIBRARY(
+      _glib2_link_DIR
+    NAMES
+      glib-2.0
+      glib
+    PATHS
+      /opt/gnome/lib
+      /opt/local/lib
+      /sw/lib
+      /usr/lib
+      /usr/local/lib
+    )
+    IF ( _glib2_include_DIR AND _glib2_link_DIR )
+        SET ( _glib2_FOUND TRUE )
+    ENDIF ( _glib2_include_DIR AND _glib2_link_DIR )
+
+
+    IF ( _glib2_FOUND )
+        SET ( GLIB2_INCLUDE_DIRS ${_glib2_include_DIR} ${_glibconfig_include_DIR} )
+        SET ( GLIB2_LIBRARIES ${_glib2_link_DIR} )
+        SET ( GLIB2_CORE_FOUND TRUE )
+    ELSE ( _glib2_FOUND )
+        SET ( GLIB2_CORE_FOUND FALSE )
+    ENDIF ( _glib2_FOUND )
+
+    # Handle dependencies
+    # libintl
+    IF ( NOT LIBINTL_FOUND )
+      FIND_PATH(LIBINTL_INCLUDE_DIR
+      NAMES
+        libintl.h
+      PATHS
+        /opt/gnome/include
+        /opt/local/include
+        /sw/include
+        /usr/include
+        /usr/local/include
+      )
+
+      FIND_LIBRARY(LIBINTL_LIBRARY
+      NAMES
+        intl
+      PATHS
+        /opt/gnome/lib
+        /opt/local/lib
+        /sw/lib
+        /usr/local/lib
+        /usr/lib
+      )
+
+      IF (LIBINTL_LIBRARY AND LIBINTL_INCLUDE_DIR)
+        SET (LIBINTL_FOUND TRUE)
+      ENDIF (LIBINTL_LIBRARY AND LIBINTL_INCLUDE_DIR)
+    ENDIF ( NOT LIBINTL_FOUND )
+
+    # libiconv
+    IF ( NOT LIBICONV_FOUND )
+      FIND_PATH(LIBICONV_INCLUDE_DIR
+      NAMES
+        iconv.h
+      PATHS
+        /opt/gnome/include
+        /opt/local/include
+        /opt/local/include
+        /sw/include
+        /sw/include
+        /usr/local/include
+        /usr/include
+      PATH_SUFFIXES
+        glib-2.0
+      )
+
+      FIND_LIBRARY(LIBICONV_LIBRARY
+      NAMES
+        iconv
+      PATHS
+        /opt/gnome/lib
+        /opt/local/lib
+        /sw/lib
+        /usr/lib
+        /usr/local/lib
+      )
+
+      IF (LIBICONV_LIBRARY AND LIBICONV_INCLUDE_DIR)
+        SET (LIBICONV_FOUND TRUE)
+      ENDIF (LIBICONV_LIBRARY AND LIBICONV_INCLUDE_DIR)
+    ENDIF ( NOT LIBICONV_FOUND )
+
+    IF (LIBINTL_FOUND)
+      SET (GLIB2_LIBRARIES ${GLIB2_LIBRARIES} ${LIBINTL_LIBRARY})
+      SET (GLIB2_INCLUDE_DIRS ${GLIB2_INCLUDE_DIRS} ${LIBINTL_INCLUDE_DIR})
+    ENDIF (LIBINTL_FOUND)
+
+    IF (LIBICONV_FOUND)
+      SET (GLIB2_LIBRARIES ${GLIB2_LIBRARIES} ${LIBICONV_LIBRARY})
+      SET (GLIB2_INCLUDE_DIRS ${GLIB2_INCLUDE_DIRS} ${LIBICONV_INCLUDE_DIR})
+    ENDIF (LIBICONV_FOUND)
+
+  ENDIF ( NOT GLIB2_FOUND AND NOT PKG_CONFIG_FOUND )
+  ##
+
+  IF (GLIB2_CORE_FOUND AND GLIB2_INCLUDE_DIRS AND GLIB2_LIBRARIES)
+    SET (GLIB2_FOUND TRUE)
+  ENDIF (GLIB2_CORE_FOUND AND GLIB2_INCLUDE_DIRS AND GLIB2_LIBRARIES)
+
+  IF (GLIB2_FOUND)
+    IF (NOT GLIB2_FIND_QUIETLY)
+      MESSAGE (STATUS "Found GLib2: ${GLIB2_LIBRARIES} ${GLIB2_INCLUDE_DIRS}")
+    ENDIF (NOT GLIB2_FIND_QUIETLY)
+  ELSE (GLIB2_FOUND)
+    IF (GLIB2_FIND_REQUIRED)
+      MESSAGE (SEND_ERROR "Could not find GLib2")
+    ENDIF (GLIB2_FIND_REQUIRED)
+  ENDIF (GLIB2_FOUND)
+
+  # show the GLIB2_INCLUDE_DIRS and GLIB2_LIBRARIES variables only in the advanced view
+  MARK_AS_ADVANCED(GLIB2_INCLUDE_DIRS GLIB2_LIBRARIES)
+  MARK_AS_ADVANCED(LIBICONV_INCLUDE_DIR LIBICONV_LIBRARY)
+  MARK_AS_ADVANCED(LIBINTL_INCLUDE_DIR LIBINTL_LIBRARY)
+
+ENDIF (GLIB2_LIBRARIES AND GLIB2_INCLUDE_DIRS)
+
+IF ( GLIB2_FOUND )
+	# Check if system has a newer version of glib
+	# which supports g_regex_match_simple
+	INCLUDE( CheckIncludeFiles )
+	SET( CMAKE_REQUIRED_INCLUDES ${GLIB2_INCLUDE_DIRS} )
+	CHECK_INCLUDE_FILES ( glib/gregex.h HAVE_GLIB_GREGEX_H )
+	# Reset CMAKE_REQUIRED_INCLUDES
+	SET( CMAKE_REQUIRED_INCLUDES "" )
+ENDIF( GLIB2_FOUND )
+


### PR DESCRIPTION
This commit enables initial support for Point Grey machine vision
cameras, and in general, for any camera supported through Project
Aravis.

These cameras are mainly geared towards high speed video streams, and do
not typically support very high exposure times. This driver attempts to
operate the camera in the most manual mode possible. Because most
cameras slave the programmable exposure time to the configured
framerate, which cannot be set lower than 1.0 FPS, out of the box these
cameras do not support longer exposure times, unless the frame rate is
manually disabled.

Unfortunately, this is a vendor-specific operation, here implemented for
the "BlackFly" family from Point Grey.
However, typically, it is not so difficult to set disable the frame
rate. Look in arvcamera.c (in Project Aravis) or BlackFly.cpp for clues
if you want to adapt this for your own camera.

Tested with kstars/EKOS and PHD2, with a BlackFly BFLY-PGE-31S4M camera.