### PR TITLE
Add libcfitsio3 to dependencies to let it build on trusty

### DIFF
--- a/debian/libindi/control
+++ b/debian/libindi/control
@@ -5,7 +5,7 @@ Maintainer: Jasem Mutlaq <mutlaqja@ikarustech.com>
 Build-Depends: debhelper (>= 8.1.3~),
  cdbs,
  cmake (>= 2.4.7),
- libcfitsio-dev,
+ libcfitsio-dev|libcfitsio3-dev,
  libnova-dev,
  libusb-1.0-0-dev,
  zlib1g-dev,


### PR DESCRIPTION
This enables (AFAIK) to build libindi on trusty and harms nothing (trusty just do not have generic libfitsio).