### PR TITLE
fix device group

### DIFF
--- a/3rdparty/indi-aagcloudwatcher/indi_aagcloudwatcher.xml.cmake
+++ b/3rdparty/indi-aagcloudwatcher/indi_aagcloudwatcher.xml.cmake
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <driversList>
-<devGroup group="MeteoStations">
+<devGroup group="Weather">
         <device label="AAG Cloud Watcher">
                 <driver name="AAG Cloud Watcher">indi_aagcloudwatcher</driver>
                 <version>@AAG_VERSION_MAJOR@.@AAG_VERSION_MINOR@</version>


### PR DESCRIPTION
I did it. First contribution.
aag cloudwatcher device will appear again in the list of weather device.