### PR TITLE
Fix gtest on osx

### DIFF
--- a/travis-ci/deps-osx.sh
+++ b/travis-ci/deps-osx.sh
@@ -29,7 +29,8 @@ brew install \
 			wget
 
 if [ ! -z $BUILD_INSTALL_GTEST ]; then
-  /bin/bash install-gtest.sh
+  DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+  /bin/bash ${DIR}/install-gtest.sh
 else
   echo "==> BUILD_INSTALL_GTEST not specified"
 fi


### PR DESCRIPTION
I didn't have BUILD_INSTALL_GTEST defined in my personal TravisCI settings so I missed this one. It now builds correctly but there are no unit tests running on TravisCI or on my local machine.

```
Seans-MBP:test seanhoughton$ ctest -V
UpdateCTestConfiguration  from :/Users/seanhoughton/Code/indi/libindi/test/DartConfiguration.tcl
UpdateCTestConfiguration  from :/Users/seanhoughton/Code/indi/libindi/test/DartConfiguration.tcl
Test project /Users/seanhoughton/Code/indi/libindi/test
Constructing a list of tests
Checking test dependency graph...
Checking test dependency graph end
No tests were found!!!
```
