### PR TITLE
Add include path for libusb installed from macports

### DIFF
--- a/cmake_modules/FindUSB-1.cmake
+++ b/cmake_modules/FindUSB-1.cmake
@@ -56,6 +56,7 @@ else (LIBUSB_1_LIBRARIES AND LIBUSB_1_INCLUDE_DIRS)
       /usr/local/include
       /usr/local/include/libusb-1.0
       /opt/local/include
+      /opt/local/include/libusb-1.0
       /sw/include
   )
 


### PR DESCRIPTION
MacPorts installs the libusb-1.0 headers to /opt/local/include/libusb-1.0/ by default. This path was missing in the include directory search paths.