### PR TITLE
Fixing DMX21/V4L2 corrupted frames

### DIFF
--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -707,8 +707,11 @@ bool V4L2_Driver::StartExposure(float duration)
 {
     if (is_exposing)
     {
-        DEBUG(INDI::Logger::DBG_ERROR, "Can not start new exposure while exposing.");
-        return false;
+        /* Clicking the "Expose" set button while an exposure is running arrives here.
+         * But if we reply false, PrimaryCCD won't be exposing anymore and we won't be able to stop the exposure in V4L2_Base, which will loop forever.
+         * So instead of returning an error, tell the caller we're busy until the end of this exposure. */
+        DEBUG(INDI::Logger::DBG_ERROR, "Can not start new exposure, please wait for the end of exposure.");
+        return true;
     }
 
     V4LFrame->expose = duration;
@@ -1124,12 +1127,22 @@ void V4L2_Driver::newFrame()
       //if (!is_streaming && !is_recording) stop_capturing();
       if (streamer->isBusy() == false)
           stop_capturing();
+      else IDLog("%s: streamer is busy, continue capturing\n",__FUNCTION__);
 
       DEBUGF(INDI::Logger::DBG_SESSION, "Capture of one frame (%d stacked frames) took %ld.%06ld seconds.", subframeCount, current_exposure.tv_sec, current_exposure.tv_usec);
       ExposureComplete(&PrimaryCCD);
       //PrimaryCCD.setFrameBufferSize(frameBytes);
     }
     is_exposing=false;
+  }
+  else
+  {
+      /* If we arrive here, PrimaryCCD is not exposing anymore, we can't forward the frame and we can't be aborted neither, thus abort the exposure right now.
+       * That issue can be reproduced when clicking the "Set" button on the "Main Control" tab while an exposure is running.
+       * Note that the patch in StartExposure returning busy instead of error prevents the flow from coming here, so now it's only a safeguard. */
+      IDLog("%s: frame received while not exposing, force-aborting capture\n",__FUNCTION__);
+      AbortExposure();
+      is_exposing = false;
   }
 }
 

--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -785,7 +785,9 @@ bool V4L2_Driver::setManualExposure(double duration)
   }
   
   /* N.B. Check how this differs from one camera to another. This is just a proof of concept for now */
-  if (duration * 10000 != AbsExposureN->value) {
+  /* With DMx 21A04.AS, exposing twice with the same duration causes an incomplete frame to pop in the buffer list
+   * This can be worked around by verifying the buffer size, but it won't work for anything else than Y8/Y16, so set exposure unconditionally */
+  /*if (duration * 10000 != AbsExposureN->value)*/ {
     double curVal = AbsExposureN->value;
     AbsExposureN->value = duration * 10000;
     ctrl_id = *((unsigned int *)  AbsExposureN->aux0);

--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -47,6 +47,39 @@
 
 #define CLEAR(x) memset (&(x), 0, sizeof (x))
 
+#define DBG_STR_PIX "%c%c%c%c"
+#define DBG_PIX(pf) ((pf)>>0)&0xFF, ((pf)>>8)&0xFF, ((pf)>>16)&0xFF, ((pf)>>24)&0xFF
+
+#define DBG_STR_FMT "%ux%u " DBG_STR_PIX " %scompressed (%ssupported)"
+#define DBG_FMT(f) (f).fmt.pix.width, (f).fmt.pix.height, \
+    DBG_PIX((f).fmt.pix.pixelformat), \
+    ((f).fmt.pix.flags & V4L2_FMT_FLAG_COMPRESSED)?"":"un", \
+    (decoder->issupportedformat((f).fmt.pix.pixelformat)?"":"un")
+
+#define DBG_STR_BUF "#%d ...%c .%c%c%c %c%c.%c .%c%c%c %c%c%c%c % 7d bytes %4.4s seq %d:%d stamp %ld.%06ld"
+#define DBG_BUF(b) (b).index, \
+    /* 0x00010000 */((b).flags & V4L2_BUF_FLAG_TSTAMP_SRC_SOE)?'S':'E', \
+    /* 0x00004000 */((b).flags & V4L2_BUF_FLAG_TIMESTAMP_COPY)?'c':'.', \
+    /* 0x00002000 */((b).flags & V4L2_BUF_FLAG_TIMESTAMP_MONOTONIC)?'m':'.', \
+    /* 0x00001000 */((b).flags & V4L2_BUF_FLAG_NO_CACHE_CLEAN)?'C':'.', \
+    /* 0x00000800 */((b).flags & V4L2_BUF_FLAG_NO_CACHE_INVALIDATE)?'I':'.', \
+    /* 0x00000400 */((b).flags & V4L2_BUF_FLAG_PREPARED)?'p':'.', \
+    /* 0x00000100 */((b).flags & V4L2_BUF_FLAG_TIMECODE)?'T':'.', \
+    /* 0x00000040 */((b).flags & V4L2_BUF_FLAG_ERROR)?'E':'.', \
+    /* 0x00000020 */((b).flags & V4L2_BUF_FLAG_BFRAME)?'B':'.', \
+    /* 0x00000010 */((b).flags & V4L2_BUF_FLAG_PFRAME)?'P':'.', \
+    /* 0x00000008 */((b).flags & V4L2_BUF_FLAG_KEYFRAME)?'K':'.', \
+    /* 0x00000004 */((b).flags & V4L2_BUF_FLAG_DONE)?'d':'.', \
+    /* 0x00000002 */((b).flags & V4L2_BUF_FLAG_QUEUED)?'q':'.', \
+    /* 0x00000001 */((b).flags & V4L2_BUF_FLAG_MAPPED)?'m':'.', \
+    (b).bytesused, \
+    ((b).memory == V4L2_MEMORY_MMAP)?"mmap": \
+        ((b).memory == V4L2_MEMORY_USERPTR)?"uptr": \
+        ((b).memory == V4L2_MEMORY_DMABUF)?"dma": \
+        ((b).memory == V4L2_MEMORY_OVERLAY)?"over":"", \
+    (b).sequence, (b).field, \
+    (b).timestamp.tv_sec, (b).timestamp.tv_usec
+
 using namespace std;
 
 /*char *entityXML(char *src) {

--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -118,10 +118,17 @@ V4L2_Base::V4L2_Base()
    cancrop=true;
    cansetrate=true;
    streamedonce=false;   
+
    v4l2_decode=new V4L2_Decode();
    decoder=v4l2_decode->getDefaultDecoder();
    decoder->init();
    dodecode=true;
+
+   v4l2_record=new V4L2_Record();
+   recorder=v4l2_record->getDefaultRecorder();
+   recorder->init();
+   dorecord = false;
+
    bpp=8; 
    has_ext_pix_format=false;
    const std::vector<unsigned int> &vsuppformats=decoder->getsupportedformats();
@@ -130,11 +137,23 @@ V4L2_Base::V4L2_Base()
      IDLog("%c%c%c%c ", (*it >> 0), (*it >> 8), (*it >>16), (*it >> 24));
    IDLog("\n");
    //DEBUGF(INDI::Logger::DBG_SESSION,"Default decoder: %s", decoder->getName());
+
+   getframerate = NULL;
+   setframerate = NULL;
+
+   reallocate_buffers = false;
+   path = NULL;
+   uptr = NULL;
+
+   lxstate = LX_ACTIVE;
+   streamactive = false;
+   cropset = false;
 }
 
 V4L2_Base::~V4L2_Base()
 {
-
+    delete v4l2_decode;
+    delete v4l2_record;
 }
 
 /** @internal Helper for ioctl calls, with logging facility.

--- a/libindi/libs/webcam/v4l2_base.h
+++ b/libindi/libs/webcam/v4l2_base.h
@@ -193,6 +193,7 @@ class V4L2_Base
   V4L2_Decoder *decoder;
   bool dodecode;
 
+  V4L2_Record *v4l2_record;
   V4L2_Recorder *recorder;
   bool dorecord;
 

--- a/libindi/libs/webcam/v4l2_base.h
+++ b/libindi/libs/webcam/v4l2_base.h
@@ -130,7 +130,7 @@ class V4L2_Base
 
   protected:
 
-  int xioctl(int fd, int request, void *arg);
+  int xioctl(int fd, int request, void *arg, char const * const request_str);
   int read_frame(char *errsg);
   int uninit_device(char *errmsg);
   int open_device(const char *devpath, char *errmsg);

--- a/libindi/libs/webcam/v4l2_base.h
+++ b/libindi/libs/webcam/v4l2_base.h
@@ -131,6 +131,8 @@ class V4L2_Base
   protected:
 
   int xioctl(int fd, int request, void *arg, char const * const request_str);
+  int ioctl_set_format(struct v4l2_format new_fmt, char * errmsg);
+
   int read_frame(char *errsg);
   int uninit_device(char *errmsg);
   int open_device(const char *devpath, char *errmsg);

--- a/libindi/libs/webcam/v4l2_base.h
+++ b/libindi/libs/webcam/v4l2_base.h
@@ -171,6 +171,7 @@ class V4L2_Base
   struct v4l2_queryctrl queryctrl;
   struct v4l2_querymenu querymenu;
   bool has_ext_pix_format;
+  bool is_compressed() const { return fmt.fmt.pix.flags & V4L2_FMT_FLAG_COMPRESSED; };
 
   WPF *callback;
   void *uptr;


### PR DESCRIPTION
Worked in the V4L2 driver around the problem of corrupted frames on my DMX21.
I tested with a few other webcams, but of course this would need more test samples.
I tried very hard to conform strictly to the V4L2 spec in my changes. There are portions of the code (which I didn't touch) indicating much fiddling with buggy drivers :) I don't think I broke anything there, but well, as long as the problematic device isn't tested...
There's much to do here to clarify the code, perhaps I'll return to this soon.
I have another rework for cropping, but the feature isn't much used probably so that can wait.