### PR TITLE
indi_fli_ccd: fix cooler to work with PL9000

### DIFF
--- a/3rdparty/libfli/libfli-camera-usb.c
+++ b/3rdparty/libfli/libfli-camera-usb.c
@@ -2403,12 +2403,13 @@ long fli_camera_usb_get_cooler_power(flidev_t dev, double *power)
 		{
 			short pwm;
 
-			if (DEVICE->devinfo.fwrev == 0x0100)
-			{
-				r = -EFAULT;
-			}
-			else
-			{
+			// Commented this block as it prevents PL9000 form working
+			//if (DEVICE->devinfo.fwrev == 0x0100)
+			//{
+			///	r = -EFAULT;
+			//}
+			//else
+			//{
 
 				rlen = 14; wlen = 2;
 				IOWRITE_U16(buf, 0, PROLINE_COMMAND_GET_TEMPERATURE);
@@ -2416,7 +2417,7 @@ long fli_camera_usb_get_cooler_power(flidev_t dev, double *power)
 
 				IOREAD_U16(buf, 4, pwm);
 				*power = (double) pwm;
-			}
+			//}
 		}
 		break;
 


### PR DESCRIPTION
Proline PL09000 camera resulted in this and the cooler did not work:

2016-12-30T20:29:17: FLIGetCoolerPower() failed. Bad address. 
2016-12-30T20:29:16: FLIGetCoolerPower() failed. Bad address. 
2016-12-30T20:29:15: FLIGetCoolerPower() failed. Bad address. 

Now it shows correct cooler power and temperature