### PR TITLE
Fixes #137 - compile issue in V4L2 client with 3.x kernels.

### DIFF
--- a/libindi/libs/webcam/v4l2_base.h
+++ b/libindi/libs/webcam/v4l2_base.h
@@ -172,11 +172,7 @@ class V4L2_Base
   struct v4l2_querymenu querymenu;
   bool has_ext_pix_format;
 
-  // N.B. This is disabled under Raspbian as of 2017-01-04 since the V4L2 headers lack the V4L2_PIX_FMT_FLAG
-  // Once Raspbian is updated to a more recent Linux kernel, it should be supported again.
-  #ifdef V4L2_PIX_FMT_FLAG_PREMUL_ALPHA
-  bool is_compressed() const { return fmt.fmt.pix.flags & V4L2_FMT_FLAG_COMPRESSED; }
-  #endif
+  bool is_compressed() const;
 
   WPF *callback;
   void *uptr;


### PR DESCRIPTION
Make sure source compatibility is preserved with 3.x kernels:
- Field 'flags' is available in the V4L2 API starting kernel 3.17,
- Timestamps were introduced in the V4L2 API starting kernel 3.15,
- DMABUF was introduced in the V4L2 API starting kernel 3.8.

Tested with kernel headers 3.6, 3.8, 3.9, 3.16, 3.17, 3.19, 4.4.