### PR TITLE
indi_fli_ccd - bugfixes

### DIFF
--- a/3rdparty/indi-fli/fli_ccd.cpp
+++ b/3rdparty/indi-fli/fli_ccd.cpp
@@ -590,14 +590,17 @@ bool FLICCD::grabImage()
     }
     else
     {
+        bool success = true;
         for (int i=0; i < height ; i++)
         {
             if ( (err = FLIGrabRow(fli_dev, image + (i * row_size), width)))
             {
-                DEBUGF(INDI::Logger::DBG_ERROR, "FLIGrabRow() failed at row %d. %s.", i, strerror((int)-err));
-                return false;
+                /* print this error once but read to the end to flush the array */
+                if (success) DEBUGF(INDI::Logger::DBG_ERROR, "FLIGrabRow() failed at row %d. %s.", i, strerror((int)-err));
+                success = false;
             }
         }
+        if (!success) return false;
     }
 
     DEBUG(INDI::Logger::DBG_SESSION, "Download complete.");
@@ -657,7 +660,7 @@ void FLICCD::TimerHit()
         else
         {
             DEBUGF(INDI::Logger::DBG_DEBUG,"Exposure in progress. Time left: %ld seconds", timeleft/1000);
-            PrimaryCCD.setExposureLeft(timeleft);
+            PrimaryCCD.setExposureLeft(timeleft/1000.0);
         }
       }
     }

--- a/3rdparty/libfli/libfli-camera-usb.c
+++ b/3rdparty/libfli/libfli-camera-usb.c
@@ -951,7 +951,8 @@ long fli_camera_usb_get_temperature(flidev_t dev, double *temperature)
 
 long fli_camera_usb_grab_row(flidev_t dev, void *buff, size_t width)
 {
-  flicamdata_t *cam = DEVICE->device_data;
+	flicamdata_t *cam = DEVICE->device_data;
+	int abort = 0;
 
 	if(width > (size_t) (cam->image_area.lr.x - cam->image_area.ul.x))
 	{
@@ -1055,7 +1056,6 @@ long fli_camera_usb_grab_row(flidev_t dev, void *buff, size_t width)
 		case FLIUSB_PROLINE_ID+1:
 		{
 			long rlen, rtotal;
-			int abort = 0;
 
 			/* First we need to determine if the row is in memory */
 			while ( (cam->grabrowcounttot < cam->grabrowwidth) && (abort == 0) )
@@ -1209,7 +1209,7 @@ long fli_camera_usb_grab_row(flidev_t dev, void *buff, size_t width)
 		case FLIUSB_PROLINE_ID:
 		{
 			long rlen = 0, rtotal = 0;
-			int abort = 0, index = 0;
+			int index = 0;
 
 			/*
 			 * cam->gbuf_siz -- size of the grab buffer (bytes)
@@ -1597,7 +1597,8 @@ long fli_camera_usb_grab_row(flidev_t dev, void *buff, size_t width)
 			debug(FLIDEBUG_WARN, "Hmmm, shouldn't be here, operation on NO camera...");
 			break;
 	}
-
+	/* return IO error if the reading failed */
+	if (abort) return -EIO;
 	return 0;
 }
 


### PR DESCRIPTION
libfli: Make FLIGrabRow() return error on failure it used to return always success.
indi_fli_ccd: handle correctly broken frames.
indi_fli_ccd: fix wrong exposure time left display.