### PR TITLE
Small bug fix in roll off simulator

### DIFF
--- a/libindi/drivers/dome/roll_off.cpp
+++ b/libindi/drivers/dome/roll_off.cpp
@@ -263,7 +263,7 @@ IPState RollOff::Move(DomeDirection dir, DomeMotionCommand operation)
 IPState RollOff::Park()
 {    
     IPState rc = INDI::Dome::Move(DOME_CCW, MOTION_START);
-    if (!rc==IPS_ALERT)
+    if (rc==IPS_BUSY)
     {
         DEBUG(INDI::Logger::DBG_SESSION, "Roll off is parking...");
         return IPS_BUSY;
@@ -275,7 +275,7 @@ IPState RollOff::Park()
 IPState RollOff::UnPark()
 {
     IPState rc = INDI::Dome::Move(DOME_CW, MOTION_START);
-    if (!rc==IPS_ALERT)
+    if (rc==IPS_BUSY)
     {       
            DEBUG(INDI::Logger::DBG_SESSION, "Roll off is unparking...");
            return IPS_BUSY;


### PR DESCRIPTION
This fixes a small bug in the roll off simulator which prevented it being used in the 'Observatory startup procedure' of ekos scheduler. 
During the startup procedure, on unpark, it temporarly changed to IPS_ALERT which triggered an error in the scheduler which causes it to stop the schedule.