### PR TITLE
ultra precision goto

### DIFF
--- a/libindi/drivers/telescope/lx200_10micron.cpp
+++ b/libindi/drivers/telescope/lx200_10micron.cpp
@@ -228,7 +228,7 @@ bool LX200_10MICRON::ReadScopeStatus()
         if (isParked() == false)
             SetParked(true);
         break;
-    case GSTAT_STOPPING:
+    case GSTAT_SLEWING_OR_STOPPING:
         TrackState = SCOPE_SLEWING;
         break;
     case GSTAT_NOT_TRACKING_AND_NOT_MOVING:
@@ -261,9 +261,11 @@ bool LX200_10MICRON::ReadScopeStatus()
     return true;
 }
 
-// Called by updateProperties, Note: the LX200Generic version may set us back to LOW precision mode so we override here
+// Called by updateProperties
 void LX200_10MICRON::getBasicData(void)
 {
+    checkLX200Format(fd);
+
     getMountInfo();
 }
 

--- a/libindi/drivers/telescope/lx200_10micron.h
+++ b/libindi/drivers/telescope/lx200_10micron.h
@@ -30,7 +30,7 @@ typedef enum {
     GSTAT_UNPARKING                   =  3,
     GSTAT_SLEWING_TO_HOME             =  4,
     GSTAT_PARKED                      =  5,
-    GSTAT_STOPPING                    =  6,
+    GSTAT_SLEWING_OR_STOPPING         =  6,
     GSTAT_NOT_TRACKING_AND_NOT_MOVING =  7,
     GSTAT_MOTORS_TOO_COLD             =  8,
     GSTAT_TRACKING_OUTSIDE_LIMITS     =  9,

--- a/libindi/drivers/telescope/lx200driver.cpp
+++ b/libindi/drivers/telescope/lx200driver.cpp
@@ -151,8 +151,10 @@ int SendPulseCmd(int fd, int direction, int duration_msec);
 /**************************************************************************
  Other Commands
  **************************************************************************/
- /* Ensures LX200 RA/DEC format is long */
+/* Determines LX200 RA/DEC format, tries to set to long if found short */
 int checkLX200Format(int fd);
+/* return the controller_format enum value */
+int getLX200Format(void);
 /* Select a site from the LX200 controller */
 int selectSite(int fd, int siteNum);
 /* Select a catalog object */
@@ -736,56 +738,77 @@ int setMaxSlewRate(int fd, int slewRate)
 
 int setObjectRA(int fd, double ra)
 {
+    DEBUGFDEVICE(lx200Name, DBG_SCOPE, "<%s>", __FUNCTION__);
 
- DEBUGFDEVICE(lx200Name, DBG_SCOPE, "<%s>", __FUNCTION__);
+    int h, m, s;
+    char temp_string[22];
 
- int h, m, s, frac_m;
- char temp_string[16];
+    switch(controller_format) {
+    case LX200_LONG_FORMAT:
+        getSexComponents(ra, &h, &m, &s);
+        snprintf(temp_string, sizeof( temp_string ), ":Sr %02d:%02d:%02d#", h, m, s);
+    break;
+    case LX200_LONGER_FORMAT:
+        double d_s;
+        getSexComponentsIID(ra, &h, &m, &d_s);
+        snprintf(temp_string, sizeof( temp_string ), ":Sr %02d:%02d:%05.02f#", h, m, d_s);
+    break;
+    case LX200_SHORT_FORMAT:
+        int frac_m;
+        getSexComponents(ra, &h, &m, &s);
+        frac_m = (s / 60.0) * 10.;
+        snprintf(temp_string, sizeof( temp_string ), ":Sr %02d:%02d.%01d#", h, m, frac_m);
+    break;
+    default:
+        DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Unknown controller_format <%d>", controller_format);
+        return -1;
+    break;
+    }
 
- getSexComponents(ra, &h, &m, &s);
-
- frac_m = (s / 60.0) * 10.;
-
- if (controller_format == LX200_LONG_FORMAT)
-    snprintf(temp_string, sizeof( temp_string ), ":Sr %02d:%02d:%02d#", h, m, s);
- else
-    snprintf(temp_string, sizeof( temp_string ), ":Sr %02d:%02d.%01d#", h, m, frac_m);
-
- return (setStandardProcedure(fd, temp_string));
+    return (setStandardProcedure(fd, temp_string));
 }
 
 
 int setObjectDEC(int fd, double dec)
 {
-  DEBUGFDEVICE(lx200Name, DBG_SCOPE, "<%s>", __FUNCTION__);
+    DEBUGFDEVICE(lx200Name, DBG_SCOPE, "<%s>", __FUNCTION__);
 
-  int d, m, s;
-  char temp_string[16];
+    int d, m, s;
+    char temp_string[22];
 
-  getSexComponents(dec, &d, &m, &s);
-
-  switch(controller_format)
-  {
- 
-    case LX200_SHORT_FORMAT:
-    /* case with negative zero */
-    if (!d && dec < 0)
-        snprintf(temp_string, sizeof( temp_string ), ":Sd -%02d*%02d#", d, m);
-    else	
-        snprintf(temp_string, sizeof( temp_string ), ":Sd %+03d*%02d#", d, m);
-    break;
-
+    switch(controller_format) {
     case LX200_LONG_FORMAT:
-    /* case with negative zero */
-    if (!d && dec < 0)
-        snprintf(temp_string, sizeof( temp_string ), ":Sd -%02d:%02d:%02d#", d, m, s);
-    else	
-        snprintf(temp_string, sizeof( temp_string ), ":Sd %+03d:%02d:%02d#", d, m, s);
+        getSexComponents(dec, &d, &m, &s);
+        /* case with negative zero */
+        if (!d && dec < 0)
+            snprintf(temp_string, sizeof( temp_string ), ":Sd -%02d:%02d:%02d#", d, m, s);
+        else
+            snprintf(temp_string, sizeof( temp_string ), ":Sd %+03d:%02d:%02d#", d, m, s);
     break;
-  }
+    case LX200_LONGER_FORMAT:
+        double d_s;
+        getSexComponentsIID(dec, &d, &m, &d_s);
+        /* case with negative zero */
+        if (!d && dec < 0)
+            snprintf(temp_string, sizeof( temp_string ), ":Sd -%02d:%02d:%05.02f#", d, m, d_s);
+        else
+            snprintf(temp_string, sizeof( temp_string ), ":Sd %+03d:%02d:%05.02f#", d, m, d_s);
+    break;
+    case LX200_SHORT_FORMAT:
+        getSexComponents(dec, &d, &m, &s);
+        /* case with negative zero */
+        if (!d && dec < 0)
+            snprintf(temp_string, sizeof( temp_string ), ":Sd -%02d*%02d#", d, m);
+        else
+            snprintf(temp_string, sizeof( temp_string ), ":Sd %+03d*%02d#", d, m);
+    break;
+    default:
+        DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Unknown controller_format <%d>", controller_format);
+        return -1;
+    break;
+    }
   
-  return (setStandardProcedure(fd, temp_string));
-
+    return (setStandardProcedure(fd, temp_string));
 }
 
 int setCommandXYZ(int fd, int x, int y, int z, const char *cmd)
@@ -1350,6 +1373,11 @@ int selectSubCatalog(int fd, int catalog, int subCatalog)
   return (setStandardProcedure(fd, temp_string));
 }
 
+int getLX200Format(void)
+{
+	return controller_format;
+}
+
 int checkLX200Format(int fd)
 {
   char temp_string[16];
@@ -1360,14 +1388,14 @@ int checkLX200Format(int fd)
   DEBUGFDEVICE(lx200Name, DBG_SCOPE, "CMD <%s>", ":GR#");
 
   if ( (error_type = tty_write_string(fd, ":GR#", &nbytes_write)) != TTY_OK)
-    	   return error_type;
+      return error_type;
 
   error_type = tty_read_section(fd, temp_string, '#', LX200_TIMEOUT, &nbytes_read);
   
   if (nbytes_read < 1)
   {
       DEBUGFDEVICE(lx200Name, DBG_SCOPE, "RES ERROR <%d>", error_type);
-   return error_type;
+      return error_type;
   }
    
   temp_string[nbytes_read - 1] = '\0';
@@ -1380,6 +1408,12 @@ int checkLX200Format(int fd)
       DEBUGDEVICE(lx200Name, DBG_SCOPE, "Detected low precision format, attempting to switch to high precision.");
       if ( (error_type = tty_write_string(fd, ":U#", &nbytes_write)) != TTY_OK)
           return error_type;
+  }
+  else if (temp_string[8] == '.')
+  {
+      controller_format = LX200_LONGER_FORMAT;
+      DEBUGDEVICE(lx200Name, DBG_SCOPE, "Coordinate format is ultra high precision.");
+      return 0;
   }
   else
   {

--- a/libindi/drivers/telescope/lx200driver.h
+++ b/libindi/drivers/telescope/lx200driver.h
@@ -27,8 +27,8 @@ enum TSlew { LX200_SLEW_MAX, LX200_SLEW_FIND, LX200_SLEW_CENTER, LX200_SLEW_GUID
 enum TAlign {  LX200_ALIGN_POLAR, LX200_ALIGN_ALTAZ, LX200_ALIGN_LAND };
   /* Directions */
 enum TDirection { LX200_NORTH, LX200_WEST, LX200_EAST, LX200_SOUTH, LX200_ALL};
-  /* Formats of Right ascention and Declenation */
-enum TFormat { LX200_SHORT_FORMAT, LX200_LONG_FORMAT};
+  /* Formats of Right Ascension and Declination */
+enum TFormat { LX200_SHORT_FORMAT, LX200_LONG_FORMAT, LX200_LONGER_FORMAT };
   /* Time Format */
 enum TTimeFormat { LX200_24, LX200_AM, LX200_PM};
   /* Focus operation */
@@ -230,8 +230,10 @@ int SendPulseCmd(int fd, int direction, int duration_msec);
 /**************************************************************************
  Other Commands
  **************************************************************************/
- /* Ensures LX200 RA/DEC format is long */
+/* Determines LX200 RA/DEC format, tries to set to long if found short */
 int checkLX200Format(int fd);
+/* return the controller_format enum value */
+int getLX200Format(void);
 /* Select a site from the LX200 controller */
 int selectSite(int fd, int siteNum);
 /* Select a catalog object */

--- a/libindi/drivers/telescope/lx200generic.cpp
+++ b/libindi/drivers/telescope/lx200generic.cpp
@@ -491,9 +491,20 @@ bool LX200Generic::Goto(double r,double d)
     targetRA=r;
     targetDEC=d;
     char RAStr[64], DecStr[64];
+    int fracbase = 0;
 
-    fs_sexa(RAStr, targetRA, 2, 3600);
-    fs_sexa(DecStr, targetDEC, 2, 3600);
+    switch (getLX200Format()) {
+    case LX200_LONGER_FORMAT:
+        fracbase = 360000;
+    break;
+    case LX200_LONG_FORMAT:
+    case LX200_SHORT_FORMAT:
+    default:
+        fracbase = 3600;
+    break;
+    }
+    fs_sexa(RAStr, targetRA, 2, fracbase);
+    fs_sexa(DecStr, targetDEC, 2, fracbase);
 
     // If moving, let's stop it first.
     if (EqNP.s == IPS_BUSY)

--- a/libindi/libs/indicom.c
+++ b/libindi/libs/indicom.c
@@ -214,6 +214,17 @@ void getSexComponents(double value, int *d, int *m, int *s)
    *d *= -1;
 }
 
+void getSexComponentsIID(double value, int *d, int *m, double *s)
+{
+
+  *d = (int32_t) fabs(value);
+  *m = (int32_t) ((fabs(value) - *d) * 60.0);
+  *s = (double) (((fabs(value) - *d) * 60.0 - *m) *60.0);
+
+  if (value < 0)
+   *d *= -1;
+}
+
 /* fill buf with properly formatted INumber string. return length */
 int
 numberFormat (char *buf, const char *format, double value)

--- a/libindi/libs/indicom.h
+++ b/libindi/libs/indicom.h
@@ -182,6 +182,7 @@ int extractISOTime(const char *timestr, struct ln_date *iso_date);
 #endif
 
 void getSexComponents(double value, int *d, int *m, int *s);
+void getSexComponentsIID(double value, int *d, int *m, double *s);
 
 /** \brief Fill buffer with properly formatted INumber string.
     \param buf to store the formatted string.


### PR DESCRIPTION
For example as tested on a GM2000HPS : 
```
SCOPE   64.116921 sec   : <setObjectRA>
SCOPE   64.116961 sec   : CMD <:Sr 00:10:03.24#>
SCOPE   64.161167 sec   : CMD <:Sr 00:10:03.24#> successful.
SCOPE   64.161200 sec   : <setObjectDEC>
SCOPE   64.161218 sec   : CMD <:Sd +59:14:45.60#>
SCOPE   64.237205 sec   : CMD <:Sd +59:14:45.60#> successful.
SCOPE   64.237257 sec   : <Slew>
SCOPE   64.237263 sec   : CMD <:MS#>
SCOPE   64.361598 sec   : RES <0>
INFO    64.361628 sec   : Slewing to RA:  0:10:03.24 - DEC: 59:14:45.60
```