### PR TITLE
Migrate Quantum Filter Wheel to updated connections plugin framework

### DIFF
--- a/libindi/drivers/filter_wheel/quantum_wheel.h
+++ b/libindi/drivers/filter_wheel/quantum_wheel.h
@@ -20,18 +20,18 @@
 #define QFW_H
 
 #include <indifilterwheel.h>
+#include <connectionplugins/connectionserial.h>
 
 class QFW: public INDI::FilterWheel {
 private:
 public:
-	QFW();
+    QFW();
     ~QFW();
 
     void debugTriggered(bool enable);
     void simulationTriggered(bool enable);
 
-    bool Connect();
-    bool Disconnect();
+    bool Handshake();
     const char *getDefaultName();
 
     bool initProperties();
@@ -42,7 +42,6 @@ public:
     bool SelectFilter(int);
     virtual bool SetFilterNames() { return true; }
     bool GetFilterNames(const char *);
-    int fd;
 };
 
 #endif // QFW_H


### PR DESCRIPTION
For some reason I cannot set default port with serialConnection->setDefaultPort("/dev/ttyACM0") but it does not impact driver's functionality. It works as expected.