### PR TITLE
Make the image download in QHY driver async

### DIFF
--- a/3rdparty/indi-qhy/qhy_ccd.cpp
+++ b/3rdparty/indi-qhy/qhy_ccd.cpp
@@ -1064,7 +1064,11 @@ int QHYCCD::grabImage()
   if (ExposureRequest > POLLMS * 5)
       DEBUG(INDI::Logger::DBG_SESSION, "Download complete.");
 
+  PrimaryCCD.setExposureLeft(0);
+
   ExposureComplete(&PrimaryCCD);
+
+  InExposure = false;
 
   return 0;
 }
@@ -1074,6 +1078,10 @@ void QHYCCD::TimerHit()
   if (isConnected() == false)
     return;
 
+   if (!InExposure && asyncCapture.get())
+   {
+     asyncCapture.reset();
+   }
    if (InExposure)
    {
        long timeleft = calcTimeLeft();
@@ -1088,24 +1096,16 @@ void QHYCCD::TimerHit()
            }
            else
            {
-               if (timeleft > 0.07)
-               {
-                   //  use an even tighter timer
-                   SetTimer(50);
-               }
-               else
+               SetTimer(100);
+               if (!asyncCapture.get())
                {
                    /* We're done exposing */
                    DEBUG(INDI::Logger::DBG_DEBUG, "Exposure done, downloading image...");
                    // Don't spam the session log unless it is a long exposure > 5 seconds
                    if (ExposureRequest > POLLMS * 5)
                        DEBUG(INDI::Logger::DBG_SESSION, "Exposure done, downloading image...");
-
-                   PrimaryCCD.setExposureLeft(0);
-                   InExposure = false;
-                   /* grab and save image */
-                   grabImage();
-
+                   /* Grab and save image asynchronuously */
+                   asyncCapture.reset(new std::future<int>(std::async(launch::async, &QHYCCD::grabImage, this)));
                }
            }
        }

--- a/3rdparty/indi-qhy/qhy_ccd.h
+++ b/3rdparty/indi-qhy/qhy_ccd.h
@@ -29,6 +29,9 @@
 #include "qhyccd.h"
 #include "log4z.h"
 
+#include <future>
+#include <memory>
+
 using namespace std;
 
 #define DEVICE struct usb_device *
@@ -169,6 +172,7 @@ private:
 #endif
   pthread_t primary_thread;
   bool terminateThread;
+  std::unique_ptr<std::future<int>> asyncCapture;
 
   friend void ::ISGetProperties(const char *dev);
   friend void ::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int num);


### PR DESCRIPTION
The grabImage() function was called in TimerHit() function which may not return shortly and I experienced stability issues with the communication from a Raspberry Pi indiserver to my Virtuoso mount. This change makes the image download async and it does not block the TimerHit() function.

Please review this PR carefully because it is a change to a basic function of this driver. I used this change so far in my setup and I did not experience any side-effects. Don't merge immediately.