### PR TITLE
Fix BLOB size passed when block is compressed

### DIFF
--- a/libindi/drivers/auxiliary/astrometrydriver.cpp
+++ b/libindi/drivers/auxiliary/astrometrydriver.cpp
@@ -273,7 +273,7 @@ bool AstrometryDriver::ISSnoopDevice (XMLEle *root)
 {
      if(SolverS[0].s == ISS_ON && IUSnoopBLOB(root,&CCDDataBP)==0)
      {
-        processBLOB(reinterpret_cast<uint8_t*>(CCDDataB[0].blob), static_cast<uint32_t>(CCDDataB[0].size));
+        processBLOB(reinterpret_cast<uint8_t*>(CCDDataB[0].blob), static_cast<uint32_t>(CCDDataB[0].bloblen));
         return true;
      }
 
@@ -292,6 +292,7 @@ bool AstrometryDriver::processBLOB(const uint8_t *data, const uint32_t size)
     FILE *fp = NULL;
     char imageFileName[MAXRBUF];
 
+    DEBUGF(INDI::Logger::DBG_SESSION, "Processing %d-byte blob at %p", size, data);
     strncpy(imageFileName, "/tmp/ccdsolver.fits", MAXRBUF);
 
     fp = fopen(imageFileName, "w");

--- a/libindi/indidriver.c
+++ b/libindi/indidriver.c
@@ -829,6 +829,8 @@ IUSnoopBLOB (XMLEle *root, IBLOBVectorProperty *bvp)
                 from64tobits_fast(bp->blob, pcdataXMLEle(ep), enclen);
                 strncpy(bp->format, valuXMLAtt(fa), MAXINDIFORMAT);
                 bp->size = atoi(valuXMLAtt(sa));
+		bp->bloblen = atoi(valuXMLAtt(ec));
+		/* fprintf(stderr,"Snooping blob %d bytes %d compressed bytes\n",bp->size,bp->bloblen); */
             }
         }
     }
@@ -1171,7 +1173,8 @@ dispatch (XMLEle *root, char msg[])
                 XMLAtt *na = findXMLAtt (ep, "name");
                 XMLAtt *fa = findXMLAtt (ep, "format");
                 XMLAtt *sa = findXMLAtt (ep, "size");
-                if (na && fa && sa) {
+                XMLAtt *ea = findXMLAtt (ep, "enclen");
+                if (na && fa && ea && sa) {
                     if (n >= maxn) {
                         int newsz = (maxn=n+1)*sizeof(char *);
                         blobs = (char **) realloc (blobs, newsz);
@@ -1186,7 +1189,8 @@ dispatch (XMLEle *root, char msg[])
                     blobsizes[n] = from64tobits_fast(blobs[n], pcdataXMLEle(ep), bloblen);
                     names[n] = valuXMLAtt(na);
                     formats[n] = valuXMLAtt(fa);
-                    sizes[n] = atoi(valuXMLAtt(sa));
+                    sizes[n] = atoi(valuXMLAtt(ea));
+		    IDMessage(dev, "%s: newBLOBVector fetching %d bytes, real size %d", name, sizes[n], atoi(valuXMLAtt(sa)));
                     n++;
                 }
             }


### PR DESCRIPTION
BLOB length `bloblen` must be coherent with the actual length of the block, while `size` should report the actual size of the raw data.
Make Astrometry driver use field `bloblen` to avoid a crash reading invalid memory.