### PR TITLE
Fix status messages and SoftPEC implementation in skywatcherAPIMount driver

### DIFF
--- a/libindi/drivers/telescope/skywatcherAPIMount.h
+++ b/libindi/drivers/telescope/skywatcherAPIMount.h
@@ -94,6 +94,15 @@ private:
     ISwitch SlewModes[2];
     ISwitchVectorProperty SlewModesSP;
 
+    // A switch for SoftPEC modes
+    enum { SOFTPEC_ENABLED, SOFTPEC_DISABLED };
+    ISwitch SoftPECModes[2];
+    ISwitchVectorProperty SoftPECModesSP;
+
+    // SoftPEC value for tracking mode
+    INumber SoftPecN;
+    INumberVectorProperty SoftPecNP;
+
     // A switch for park movement directions (clockwise/counterclockwise)
     ISwitch ParkMovementDirection[2];
     ISwitchVectorProperty ParkMovementDirectionSP;
@@ -120,6 +129,8 @@ private:
     ln_equ_posn CurrentTrackingTarget;
     long OldTrackingTarget[2];
     struct ln_hrz_posn CurrentAltAz;
+    bool ResetTrackingSeconds;
+    int TrackingSecs;
 
 #ifdef USE_INITIAL_JULIAN_DATE
     double InitialJulianDate;


### PR DESCRIPTION
First commit:
The driver flooded the KStars status bar with tracking messsages. Now it is rewritten to give reasonable information over time.

Second commit:
I noticed that the Virtuoso mount has a constant drift on the Alt axis downwards in tracking mode and it makes impossible to keep the target in the FOV with telescope+CCD configuration. This mount does not have PEC implementation thus I checked the drift and it was about 0.009 degree/minute. I added support for this static compensation in the driver and works very well. I named SoftPEC (software PEC). I will document it after merge on the wiki.