### PR TITLE
use setFocuserConnection() instead unregister fonction

### DIFF
--- a/libindi/drivers/focuser/focuslynx.cpp
+++ b/libindi/drivers/focuser/focuslynx.cpp
@@ -108,8 +108,13 @@ FocusLynxF1::FocusLynxF1(const char *target)
    * F1 or F2 to set the target of the created instance
    */
   setFocusTarget(target);
-  // explain in connect() function Only set on the Fx constructor, not on the F2 one
+
+  // Till now only Serial connection is coding, would change in future
+  setFocuserConnection(CONNECTION_SERIAL);
+
+  // explain in connect() function Only set on the F1 constructor, not on the F2 one
   PortFD = 0;
+
   DBG_FOCUS = INDI::Logger::getInstance().addDebugLevel("Focus F1 Verbose", "FOCUS F1");
 }
 
@@ -153,9 +158,6 @@ bool FocusLynxF1::initProperties()
   IUFillText(&WifiT[7], "Security key", "", "");
   IUFillText(&WifiT[8], "Wep key", "", "");
   IUFillTextVector(&WifiTP, WifiT, 9, getDeviceName(), "WIFI-INFO", "Wifi", HUB_SETTINGS_TAB, IP_RO, 0, IPS_IDLE); 
-  
-  // FIXME
-  //IUSaveText(&PortT[0], "/dev/ttyUSB1");
 
   return true;
 }
@@ -197,10 +199,10 @@ bool FocusLynxF1::Connect()
      * other value = descriptor number
      */
     PortFD = -1;
-    else if ((connectrc = tty_connect(serialConnection->port(), 115200, 8, 0, 1, &PortFD)) != TTY_OK)
+    else if ((connectrc = tty_connect(serialConnection->port(), serialConnection->baud(), 8, 0, 1, &PortFD)) != TTY_OK)
     {
       tty_error_msg(connectrc, errorMsg, MAXRBUF);   
-      DEBUGF(INDI::Logger::DBG_SESSION, "Failed to connect to port %s. Error: %s", serialConnection->port(), errorMsg);
+      DEBUGF(INDI::Logger::DBG_SESSION, "Failed to connect to port %s, rate %s. Error: %s", serialConnection->port(), serialConnection->baud(), errorMsg);
       PortFD = 0;
       return false;
     }
@@ -822,6 +824,10 @@ int FocusLynxF1::getVersion(int *major, int *minor, int *sub)
 FocusLynxF2::FocusLynxF2(const char *target)
 {
   setFocusTarget(target);
+
+  // When second focuser no direct communication set to the hub
+  setFocuserConnection(CONNECTION_NONE);
+
   DBG_FOCUS = INDI::Logger::getInstance().addDebugLevel("Focus F2 Verbose", "FOCUS F2");
 }
 /************************************************************************************

--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -109,18 +109,12 @@ FocusLynxBase::~FocusLynxBase()
 * ***********************************************************************************/
 bool FocusLynxBase::initProperties()
 {
+
+
   INDI::Focuser::initProperties();
 
-  /* Added by Philippe Besson, the 29th of Mars 2017
-   To remove Serial and tcp properties for the second focuser
-   To avoid final user confusions. */
-  if (!strcmp(getFocusTarget(), "F2"))
-  {
-    unRegisterConnection(serialConnection);
-    unRegisterConnection(tcpConnection);
-  }
-
   // Focuser temperature
+
   IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
   IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 


### PR DESCRIPTION
 to set correctly communication channel with the HUB.
As coding related to TCP is not done yet, set only SERIAL one for now.