### PR TITLE
Bugfix  v4l2 compressed formats

### DIFF
--- a/libindi/drivers/video/v4l2driver.h
+++ b/libindi/drivers/video/v4l2driver.h
@@ -177,6 +177,7 @@ class V4L2_Driver: public INDI::CCD
    virtual void getBasicData(void);
    void allocateBuffers();
    void releaseBuffers();
+   void updateFrameSize();
    
    /* Shutter control */
    bool setShutter(double duration);

--- a/libindi/libs/indibase/indiccd.cpp
+++ b/libindi/libs/indibase/indiccd.cpp
@@ -81,6 +81,8 @@ CCDChip::CCDChip()
     RawFrame= (uint8_t *) malloc(sizeof(uint8_t)); // Seed for realloc
     RawFrameSize=0;
 
+    SubX = SubY = 0;
+    SubW = SubH = 1;
     BPP = 8;
     BinX = BinY = 1;
     NAxis = 2;

--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -200,7 +200,16 @@ bool V4L2_Base::is_compressed() const
 {
     /* See note at top of this file */
 #if ( LINUX_VERSION_CODE >= KERNEL_VERSION(3,17,0) )
-    return fmt.fmt.pix.flags & V4L2_FMT_FLAG_COMPRESSED;
+    switch(fmt.fmt.pix.pixelformat)
+    {
+        case V4L2_PIX_FMT_MJPEG:
+            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"%s: format %c%c%c%c patched to be considered compressed",__FUNCTION__,fmt.fmt.pix.pixelformat,fmt.fmt.pix.pixelformat>>8,fmt.fmt.pix.pixelformat>>16,fmt.fmt.pix.pixelformat>>24);
+            return true;
+
+        default:
+            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"%s: format %c%c%c%c has compressed flag %d",__FUNCTION__,fmt.fmt.pix.pixelformat,fmt.fmt.pix.pixelformat>>8,fmt.fmt.pix.pixelformat>>16,fmt.fmt.pix.pixelformat>>24,fmt.fmt.pix.flags & V4L2_FMT_FLAG_COMPRESSED);
+            return fmt.fmt.pix.flags & V4L2_FMT_FLAG_COMPRESSED;
+    }
 #else
     switch(fmt.fmt.pix.pixelformat)
     {

--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -575,7 +575,7 @@ int V4L2_Base::read_frame(char * errmsg)
                     struct timeval epochtime = {0};
                     /*gettimeofday(&epochtime, NULL); uncomment this to get the timestamp from epoch start */
 
-                    float const secs = ( epochtime.tv_sec - uptime.tv_sec + buf.timestamp.tv_sec ) + (epochtime.tv_usec - uptime.tv_nsec/1000.0f + buf.timestamp.tv_usec)/1000.0f;
+                    float const secs = ( epochtime.tv_sec - uptime.tv_sec + buf.timestamp.tv_sec ) + (epochtime.tv_usec - uptime.tv_nsec/1000.0f + buf.timestamp.tv_usec)/1000000.0f;
 
                     if( V4L2_BUF_FLAG_TSTAMP_SRC_SOE == ( buf.flags & V4L2_BUF_FLAG_TSTAMP_SRC_MASK ) )
                     {

--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -285,8 +285,11 @@ V4L2_Base::ioctl_set_format(struct v4l2_format new_fmt, char * errmsg)
     {
         close_device();
 
-        if( !open_device(path, errmsg) )
+        if( open_device(path, errmsg) )
+        {
+            DEBUGFDEVICE(deviceName,INDI::Logger::DBG_DEBUG,"%s: failed reopening device %s (%s)",__FUNCTION__,path,errmsg);
             return -1;
+        }
     }
 
     /* Trying format with VIDIOC_TRY_FMT has no interesting advantage here */
@@ -1317,7 +1320,7 @@ int V4L2_Base::open_device(const char * devpath, char * errmsg)
     }
 
     streamedonce=false;
-
+    snprintf(errmsg,ERRMSGSIZ,"%s\n",strerror(0));
     return 0;
 }
 


### PR DESCRIPTION
This should fix switching frame characteristics with a V4L2 CCD driver.

Tested switching back and forth fields (MJPEG) type, frame sizes and streaming robustness.
Streaming robustness is a bit feeble for now as it is the recorder which selects frame while the V4L2 driver remains at full rate. Most often KStars breaks because of the data rate.

The crash was caused by an invalid buffer copied, a bit difficult to reproduce in the debugger. Use "set disable-randomization off" in gdb to get in a situation closer to the normal use.

MJPEG is reported as not compressed by the kernel, so this is now patched in is_compressed(). If there are other useful formats like this observed in such situation, feel free to add a case to the switch.

There as also a problem when reopening the device after streaming, which is needed for some cameras before switching frame characteristics.

Also in this pull request: fixed calculation of exposure duration, which is not used currently, but could be to drop invalid frames.

I did not put a WIP on letting Ekos know about the exposure progress, more tests needed.