### PR TITLE
Feature  v4l2ccd exposure left

### DIFF
--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -57,7 +57,7 @@ void V4L2_Driver::updateFrameSize()
         frameBytes = PrimaryCCD.getSubW() * PrimaryCCD.getSubH() * (PrimaryCCD.getBPP() / 8 + (PrimaryCCD.getBPP()%8?1:0)) * 3;
 
     PrimaryCCD.setFrameBufferSize(frameBytes);
-    DEBUGF(INDI::Logger::DBG_SESSION,"%s: frame bytes %d",__FUNCTION__,PrimaryCCD.getFrameBufferSize());
+    DEBUGF(INDI::Logger::DBG_DEBUG,"%s: frame bytes %d",__FUNCTION__,PrimaryCCD.getFrameBufferSize());
 }
 
 bool V4L2_Driver::initProperties()

--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -710,7 +710,7 @@ bool V4L2_Driver::StartExposure(float duration)
         /* Clicking the "Expose" set button while an exposure is running arrives here.
          * But if we reply false, PrimaryCCD won't be exposing anymore and we won't be able to stop the exposure in V4L2_Base, which will loop forever.
          * So instead of returning an error, tell the caller we're busy until the end of this exposure. */
-        DEBUGF(INDI::Logger::DBG_ERROR, "Can not start new exposure, please wait for the end of the current %f-second exposure.",V4LFrame->expose);
+        DEBUGF(INDI::Logger::DBG_ERROR, "Can not start new exposure, please wait for the end of the current exposure (%.1f seconds left).",exposureLeft);
         return true;
     }
 

--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -31,7 +31,6 @@ V4L2_Driver::V4L2_Driver()
   divider = 128.;    
   
   is_capturing = false;
-  is_exposing = false;
 
   Options=NULL;
   v4loptions=0; 
@@ -41,7 +40,8 @@ V4L2_Driver::V4L2_Driver()
   stackMode=STACK_NONE;
 
   lx=new Lx();
-
+  lxtimer = -1;
+  stdtimer = -1;
 }
 
 V4L2_Driver::~V4L2_Driver()
@@ -127,7 +127,7 @@ bool V4L2_Driver::initProperties()
   if (!lx->initProperties(this))
     DEBUG(INDI::Logger::DBG_WARNING, "Can not init Long Exposure");
 
-  SetCCDCapability(CCD_CAN_BIN | CCD_CAN_SUBFRAME | CCD_HAS_STREAMING);
+  SetCCDCapability(CCD_CAN_BIN | CCD_CAN_SUBFRAME | CCD_HAS_STREAMING | CCD_CAN_ABORT);
 
   strncpy(v4l_base->deviceName, getDeviceName(), MAXINDIDEVICE);
 
@@ -696,61 +696,89 @@ bool V4L2_Driver::ISNewNumber (const char *dev, const char *name, double values[
       IDSetNumber(&ImageAdjustNP, NULL);
       return true;
     }
-      
-  
 
   return INDI::CCD::ISNewNumber(dev, name, values, names, n);
-  	
 }
 
 bool V4L2_Driver::StartExposure(float duration)
 {
-    if (is_exposing)
+    /* Clicking the "Expose" set button while an exposure is running arrives here.
+     * Now that V4L2 CCD has the option to abort, this will properly abort the exposure.
+     * If CAN_ABORT is not set, we have to tell the caller we're busy until the end of this exposure.
+     * If we don't, PrimaryCCD will stop exposing nonetheless and we won't be able to restart an exposure.
+     */
     {
-        /* Clicking the "Expose" set button while an exposure is running arrives here.
-         * But if we reply false, PrimaryCCD won't be exposing anymore and we won't be able to stop the exposure in V4L2_Base, which will loop forever.
-         * So instead of returning an error, tell the caller we're busy until the end of this exposure. */
-        DEBUGF(INDI::Logger::DBG_ERROR, "Can not start new exposure, please wait for the end of the current exposure (%.1f seconds left).",exposureLeft);
-        return true;
+        if(streamer->isBusy())
+        {
+            DEBUG(INDI::Logger::DBG_ERROR, "Cannot start new exposure while streamer is busy, stop streaming first");
+            return !(GetCCDCapability() & CCD_CAN_ABORT);
+        }
+
+        if (is_capturing)
+        {
+            DEBUGF(INDI::Logger::DBG_ERROR, "Cannot start new exposure until the current one completes (%.3f seconds left).",exposureLeft);
+            return !(GetCCDCapability() & CCD_CAN_ABORT);
+        }
     }
 
-    V4LFrame->expose = duration;
-    setShutter(V4LFrame->expose);
+    if(setShutter(duration))
+    {
+        V4LFrame->expose = duration;
+        PrimaryCCD.setExposureDuration(duration);
+        this->exposureLeft = duration;
 
-    PrimaryCCD.setExposureDuration(duration);
+        if (!lx->isenabled() || lx->getLxmode() == LXSERIAL )
+            start_capturing(false);
 
-     if (!(lx->isenabled()) || (lx->getLxmode() == LXSERIAL ))
-        start_capturing();
+        /* Update exposure duration in client */
+        /* FIXME: exposure update timer has period hardcoded 1 second */
+        if(is_capturing && 1.0f < duration)
+        {
+            if(-1 != stdtimer)
+                IERmTimer(stdtimer);
+            stdtimer = IEAddTimer(1000, (IE_TCF *)stdtimerCallback, this);
+        }
+        else stdtimer = -1;
+    }
 
-     is_exposing=true;
-
-     return true;
+    return is_capturing;
 }
 
 bool V4L2_Driver::setShutter(double duration)
 {
-  bool rc=true;
-  gettimeofday(&capture_start, NULL);
-  if (lx->isenabled()) 
+    if (lx->isenabled())
     {
-      DEBUGF(INDI::Logger::DBG_SESSION, "Using long exposure mode for %g sec frame.", duration);
-      rc=startlongexposure(duration);
-      if (rc == false)
-	DEBUG(INDI::Logger::DBG_WARNING, "Unable to start long exposure, falling back to auto exposure.");
+        DEBUGF(INDI::Logger::DBG_SESSION, "Using long exposure mode for %.3f sec frame.", duration);
+        if(!startlongexposure(duration))
+        {
+            DEBUGF(INDI::Logger::DBG_WARNING, "Unable to start %.3f-second long exposure, falling back to auto exposure", duration);
+            return false;
+        }
     }
-  else if (AbsExposureN && ManualExposureSP && (AbsExposureN->max >= (duration * 10000)))
+    else if (AbsExposureN && ManualExposureSP && (AbsExposureN->max >= (duration * 10000)) && (AbsExposureN->min <= (duration*10000)))
     {
-      DEBUGF(INDI::Logger::DBG_SESSION, "Using device manual exposure (max %f, required %f).", AbsExposureN->max, (duration * 10000));
-      rc = setManualExposure(duration);
-      if (rc == false)
-	DEBUG(INDI::Logger::DBG_WARNING, "Unable to set manual exposure, falling back to auto exposure.");
+        // INT control for manual exposure duration is an integer - log is cheating a bit
+        DEBUGF(INDI::Logger::DBG_SESSION, "Using device %d-tick manual exposure for %.3f-second exposure", (int)(duration*10000), duration);
+        if(!setManualExposure(duration))
+        {
+            DEBUGF(INDI::Logger::DBG_WARNING, "Unable to set %.3f-second manual exposure, falling back to auto exposure", duration);
+            return false;
+        }
+
+        timerclear(&exposure_duration);
+        exposure_duration.tv_sec = (long) duration ;
+        exposure_duration.tv_usec = (long) ((duration - (double) exposure_duration.tv_sec) * 1000000.0) ;
     }
-  timerclear(&exposure_duration);
-  exposure_duration.tv_sec = (long) duration ;
-  exposure_duration.tv_usec = (long) ((duration - (double) exposure_duration.tv_sec) * 1000000.0) ;
-  frameCount=0;
-  subframeCount=0;
-  return rc;
+    else
+    {
+        DEBUGF(INDI::Logger::DBG_WARNING, "Failed %.3f-second manual exposure, out of device tick bounds [%d,%d]", duration, (int)AbsExposureN->min, (int)AbsExposureN->max);
+        return false;
+    }
+
+    gettimeofday(&capture_start, NULL);
+    frameCount=0;
+    subframeCount=0;
+    return true;
 }
 
 bool V4L2_Driver::setManualExposure(double duration)
@@ -805,13 +833,6 @@ bool V4L2_Driver::setManualExposure(double duration)
     IDSetNumber(&ImageAdjustNP, NULL);
   }
 
-  /* Update exposure duration in client - hardcoded 1 second */
-  if(1.0f < duration)
-  {
-    this->exposureLeft = duration;
-    IEAddTimer(1000, (IE_TCF *)stdtimerCallback, this);
-  }
-  
   return true;
 }
 
@@ -822,22 +843,60 @@ void V4L2_Driver::stdtimerCallback(void *userpointer)
     //DEBUGF(INDI::Logger::DBG_SESSION,"Exposure running, %f seconds left...",p->exposureLeft);
     p->PrimaryCCD.setExposureLeft(p->exposureLeft);
     if(1.0f < p->exposureLeft)
-        IEAddTimer(1000, (IE_TCF *)stdtimerCallback, userpointer);
+        p->stdtimer = IEAddTimer(1000, (IE_TCF *)stdtimerCallback, userpointer);
+    else p->stdtimer = -1;
 }
 
-void V4L2_Driver::start_capturing() {
-  char errmsg[ERRMSGSIZ];
-  if (is_capturing) return;
-  v4l_base->start_capturing(errmsg);
-  is_capturing = true;
-  //timer_gettime(fpstimer, &tframe1);  
+bool V4L2_Driver::start_capturing(bool do_stream)
+{
+    if(streamer->isBusy())
+    {
+        DEBUG(INDI::Logger::DBG_WARNING, "Cannot start exposure while streaming is in progress");
+        return false;
+    }
+
+    if(is_capturing)
+    {
+        DEBUGF(INDI::Logger::DBG_WARNING, "Cannot start exposure while another is in progress (%.3f seconds left)", exposureLeft);
+        return false;
+    }
+
+    char errmsg[ERRMSGSIZ];
+    if(v4l_base->start_capturing(errmsg))
+    {
+        DEBUGF(INDI::Logger::DBG_WARNING, "V4L2 base failed starting capture (%s)", errmsg);
+        return false;
+    }
+
+    if(do_stream)
+        v4l_base->doRecord(streamer->isDirectRecording());
+
+    is_capturing = true;
+    return true;
 }
 
-void V4L2_Driver::stop_capturing() {
-  char errmsg[ERRMSGSIZ];
-  if (!is_capturing) return;
-  v4l_base->stop_capturing(errmsg);
-  is_capturing = false;
+bool V4L2_Driver::stop_capturing()
+{
+    if(!is_capturing)
+    {
+        DEBUG(INDI::Logger::DBG_WARNING, "No exposure or streaming in progress");
+        return true;
+    }
+
+    if(!streamer->isBusy() && 0.0f < exposureLeft)
+        DEBUGF(INDI::Logger::DBG_WARNING, "Stopping running exposure %.3f seconds before completion",exposureLeft);
+
+    //if(streamer->isDirectRecording())
+    v4l_base->doRecord(false);
+
+    char errmsg[ERRMSGSIZ];
+    if(v4l_base->stop_capturing(errmsg))
+    {
+        DEBUGF(INDI::Logger::DBG_WARNING, "V4L2 base failed stopping capture (%s)", errmsg);
+    }
+
+    is_capturing = false;
+    return true;
 }
 
 
@@ -862,7 +921,7 @@ void V4L2_Driver::lxtimerCallback(void *userpointer)
   }
   IERmTimer(p->lxtimer);
   if( !p->v4l_base->isstreamactive() )
-	p->start_capturing(); // jump to new/updateFrame
+	p->start_capturing(false); // jump to new/updateFrame
         //p->v4l_base->start_capturing(errmsg); // jump to new/updateFrame
 }
 
@@ -1167,7 +1226,6 @@ void V4L2_Driver::newFrame()
       ExposureComplete(&PrimaryCCD);
       //PrimaryCCD.setFrameBufferSize(frameBytes);
     }
-    is_exposing=false;
   }
   else
   {
@@ -1176,20 +1234,25 @@ void V4L2_Driver::newFrame()
        * Note that the patch in StartExposure returning busy instead of error prevents the flow from coming here, so now it's only a safeguard. */
       IDLog("%s: frame received while not exposing, force-aborting capture\n",__FUNCTION__);
       AbortExposure();
-      is_exposing = false;
   }
 }
 
 bool V4L2_Driver::AbortExposure()
 {
-  char errmsg[ERRMSGSIZ];
-  if (lx->isenabled())
-    lx->stopLx();
-  else
-    //if (!is_streaming && !is_recording)
-    if (streamer->isBusy() == false)
-        stop_capturing();
-  return true;
+    if (lx->isenabled())
+    {
+        lx->stopLx();
+        return true;
+    }
+    else if (!streamer->isBusy())
+    {
+        if(-1 != stdtimer)
+            IERmTimer(stdtimer);
+        return stop_capturing();
+    }
+
+    DEBUG(INDI::Logger::DBG_WARNING, "Cannot abort exposure while video streamer is busy, stop streaming first");
+    return false;
 }
 
 bool V4L2_Driver::Connect()
@@ -1360,27 +1423,20 @@ bool V4L2_Driver::StartStreaming()
         return false;
     }
 
-    if (!is_capturing)
-    {
-        start_capturing();
-        //v4l_base->setDropFrameCount(streamer->getFramesToDrop());
-        v4l_base->doRecord(streamer->isDirectRecording());
-        return true;
-    }
-
-    return false;
+    /* Callee will take care of checking states */
+    return start_capturing(true);
 }
 
 bool V4L2_Driver::StopStreaming()
 {
-    if (is_exposing)
+    if(!streamer->isBusy() /*&& is_capturing*/)
+    {
+        /* Strange situation indeed, but it's theoretically possible to try to stop streaming while exposing - safeguard actually */
+        DEBUGF(INDI::Logger::DBG_WARNING, "Cannot stop streaming, exposure running (%.1f seconds remaining)", exposureLeft);
         return false;
+    }
 
-    if (streamer->isDirectRecording())
-        v4l_base->doRecord(false);
-
-    stop_capturing();
-    return true;
+    return stop_capturing();
 }
 
 bool V4L2_Driver::saveConfigItems(FILE *fp)

--- a/libindi/drivers/video/v4l2driver.h
+++ b/libindi/drivers/video/v4l2driver.h
@@ -189,8 +189,8 @@ class V4L2_Driver: public INDI::CCD
    static void stdtimerCallback(void *userpointer);
 
    /* start/stop functions */
-   void start_capturing();
-   void stop_capturing();
+   bool start_capturing(bool do_stream);
+   bool stop_capturing();
 
    virtual void updateV4L2Controls();   
    
@@ -216,6 +216,7 @@ class V4L2_Driver: public INDI::CCD
    //Long Exposure
    Lx *lx;
    int lxtimer;
+   int stdtimer;
 
    short lxstate;
 

--- a/libindi/drivers/video/v4l2driver.h
+++ b/libindi/drivers/video/v4l2driver.h
@@ -87,6 +87,8 @@ class V4L2_Driver: public INDI::CCD
     void stackFrame();
     void newFrame();
     
+    float exposureLeft;
+
    protected:
 
     virtual bool Connect();
@@ -184,6 +186,7 @@ class V4L2_Driver: public INDI::CCD
    bool setManualExposure(double duration);
    bool startlongexposure(double timeinsec);
    static void lxtimerCallback(void *userpointer);
+   static void stdtimerCallback(void *userpointer);
 
    /* start/stop functions */
    void start_capturing();

--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -966,8 +966,8 @@ int V4L2_Base::check_device(char * errmsg)
 
     DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Driver %s (version %u.%u.%u)", cap.driver, (cap.version >> 16) & 0xFF,
                  (cap.version >> 8) & 0xFF, (cap.version & 0xFF));
-    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"  card; \t%s", cap.card);
-    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"  bus; \t%s", cap.bus_info);
+    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"  card: %s", cap.card);
+    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"  bus:  %s", cap.bus_info);
 
     setframerate=&V4L2_Base::stdsetframerate;
     getframerate=&V4L2_Base::stdgetframerate;
@@ -975,7 +975,7 @@ int V4L2_Base::check_device(char * errmsg)
     if (!(strcmp((const char *)cap.driver, "pwc")))
     {
         unsigned int qual=3;
-        //pwc driver soes not allow to get current fps with VIDIOCPWC
+        //pwc driver does not allow to get current fps with VIDIOCPWC
         //frameRate.numerator=1; // using default module load fps
         //frameRate.denominator=10;
         //if (ioctl(fd, VIDIOCPWCSLED, &qual)) {
@@ -1053,21 +1053,20 @@ int V4L2_Base::check_device(char * errmsg)
 
     /* Select video input, video standard and tune here. */
 
-    DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Available Inputs:");
-    for (input_avail.index=0; ioctl(fd, VIDIOC_ENUMINPUT, &input_avail) != -1; input_avail.index ++)
-    {
-        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t%d. %s (type %s)", input_avail.index, input_avail.name,
-                     (input_avail.type==V4L2_INPUT_TYPE_TUNER?"Tuner/RF Demodulator":"Composite/S-Video"));
-    }
-    if (errno != EINVAL)
-        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\tProblem enumerating inputs");
     if (-1 == ioctl (fd, VIDIOC_G_INPUT, &input.index))
     {
         perror ("VIDIOC_G_INPUT");
         exit (EXIT_FAILURE);
     }
-    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Current Video input: %d", input.index);
 
+    DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Enumerating available Inputs:");
+    for (input_avail.index=0; ioctl(fd, VIDIOC_ENUMINPUT, &input_avail) != -1; input_avail.index ++)
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"%2d. %s (type %s)%s", input_avail.index, input_avail.name,
+                     (input_avail.type==V4L2_INPUT_TYPE_TUNER?"Tuner/RF Demodulator":"Composite/S-Video",input.index==input_avail.index?" current":""));
+    if (errno != EINVAL)
+        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"(problem enumerating inputs)");
+
+    /* Cropping */
     cropcap.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
     cancrop=true;
     if (-1 == XIOCTL(fd, VIDIOC_CROPCAP, &cropcap))
@@ -1079,13 +1078,13 @@ int V4L2_Base::check_device(char * errmsg)
     }
     if (cancrop)
     {
-        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Crop capabilities: bounds = (top=%d, left=%d, width=%d, height=%d)", cropcap.bounds.top,
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG," Crop capabilities: bounds  = (top=%d, left=%d, width=%d, height=%d)", cropcap.bounds.top,
                      cropcap.bounds.left, cropcap.bounds.width, cropcap.bounds.height);
-        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Crop capabilities: defrect = (top=%d, left=%d, width=%d, height=%d)", cropcap.defrect.top,
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG," Crop capabilities: defrect = (top=%d, left=%d, width=%d, height=%d)", cropcap.defrect.top,
                      cropcap.defrect.left, cropcap.defrect.width, cropcap.defrect.height);
-        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Crop capabilities: pixelaspect = %d / %d", cropcap.pixelaspect.numerator,
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG," Crop capabilities: pixelaspect = %d / %d", cropcap.pixelaspect.numerator,
                      cropcap.pixelaspect.denominator);
-        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Resetting crop area to default");
+        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Explicitely resetting crop area to default...");
         crop.c.top=cropcap.defrect.top;
         crop.c.left=cropcap.defrect.left;
         crop.c.width=cropcap.defrect.width;
@@ -1111,39 +1110,39 @@ int V4L2_Base::check_device(char * errmsg)
         struct v4l2_fmtdesc fmt_avail;
         fmt_avail.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
         //DEBUG(INDI::Logger::DBG_SESSION,"Available Capture Image formats:");
-        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Available Capture Image formats:");
+        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Enumerating available Capture Image formats:");
         for (fmt_avail.index=0; ioctl(fd, VIDIOC_ENUM_FMT, &fmt_avail) != -1; fmt_avail.index ++)
         {
             //DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,INDI::Logger::DBG_SESSION,"\t%d. %s (%c%c%c%c) %s\n", fmt_avail.index, fmt_avail.description, (fmt_avail.pixelformat)&0xFF, (fmt_avail.pixelformat >> 8)&0xFF,
             //     (fmt_avail.pixelformat >> 16)&0xFF, (fmt_avail.pixelformat >> 24)&0xFF, (decoder->issupportedformat(fmt_avail.pixelformat)?"supported":"UNSUPPORTED"));
-            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t%d. %s (%c%c%c%c) %s", fmt_avail.index, fmt_avail.description, (fmt_avail.pixelformat)&0xFF, (fmt_avail.pixelformat >> 8)&0xFF,
+            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"%2d. Format %s (%c%c%c%c) is %s", fmt_avail.index, fmt_avail.description, (fmt_avail.pixelformat)&0xFF, (fmt_avail.pixelformat >> 8)&0xFF,
                          (fmt_avail.pixelformat >> 16)&0xFF, (fmt_avail.pixelformat >> 24)&0xFF, (decoder->issupportedformat(fmt_avail.pixelformat)?"supported":"UNSUPPORTED"));
             {
                 // Enumerating frame sizes available for this pixel format
                 struct v4l2_frmsizeenum frm_sizeenum;
                 frm_sizeenum.pixel_format=fmt_avail.pixelformat;
-                DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t  Available Frame sizes/rates for this format:");
+                DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"    Enumerating available Frame sizes/rates for this format:");
                 for (frm_sizeenum.index=0; XIOCTL(fd, VIDIOC_ENUM_FRAMESIZES, &frm_sizeenum) != -1; frm_sizeenum.index ++)
                 {
                     switch (frm_sizeenum.type)
                     {
                         case V4L2_FRMSIZE_TYPE_DISCRETE:
-                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t %d. (Discrete)  width %d x height %d\n", frm_sizeenum.index, frm_sizeenum.discrete.width,  frm_sizeenum.discrete.height);
+                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"    %2d. (Discrete)  width %d x height %d\n", frm_sizeenum.index, frm_sizeenum.discrete.width,  frm_sizeenum.discrete.height);
                             break;
                         case V4L2_FRMSIZE_TYPE_STEPWISE:
-                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t  (Stepwise)  min. width %d, max. width %d step width %d", frm_sizeenum.stepwise.min_width,
+                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Stepwise)  min. width %d, max. width %d step width %d", frm_sizeenum.stepwise.min_width,
                                          frm_sizeenum.stepwise.max_width, frm_sizeenum.stepwise.step_width);
-                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t  (Stepwise)  min. height %d, max. height %d step height %d ", frm_sizeenum.stepwise.min_height,
+                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Stepwise)  min. height %d, max. height %d step height %d ", frm_sizeenum.stepwise.min_height,
                                          frm_sizeenum.stepwise.max_height, frm_sizeenum.stepwise.step_height);
                             break;
                         case V4L2_FRMSIZE_TYPE_CONTINUOUS:
-                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t  (Continuous--step=1)  min. width %d, max. width %d", frm_sizeenum.stepwise.min_width,
+                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Continuous--step=1)  min. width %d, max. width %d", frm_sizeenum.stepwise.min_width,
                                          frm_sizeenum.stepwise.max_width);
-                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t  (Continuous--step=1)  min. height %d, max. height %d ", frm_sizeenum.stepwise.min_height,
+                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Continuous--step=1)  min. height %d, max. height %d ", frm_sizeenum.stepwise.min_height,
                                          frm_sizeenum.stepwise.max_height);
                             break;
                         default:
-                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"Unknown Frame size type: %d\n",frm_sizeenum.type);
+                            DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        Unknown Frame size type: %d\n",frm_sizeenum.type);
                             break;
                     }
                     {
@@ -1167,26 +1166,26 @@ int V4L2_Base::check_device(char * errmsg)
                         frmi_valenum.stepwise.max.denominator = 0;
                         frmi_valenum.stepwise.step.numerator =0;
                         frmi_valenum.stepwise.step.denominator = 0;
-                        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t    Frame intervals:");
+                        DEBUGDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        Frame intervals:");
                         for (frmi_valenum.index=0; XIOCTL(fd, VIDIOC_ENUM_FRAMEINTERVALS, &frmi_valenum) != -1; frmi_valenum.index ++)
                         {
                             switch (frmi_valenum.type)
                             {
                                 case V4L2_FRMIVAL_TYPE_DISCRETE:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"%d/%d s, ", frmi_valenum.discrete.numerator,  frmi_valenum.discrete.denominator);
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        %d/%d s", frmi_valenum.discrete.numerator,  frmi_valenum.discrete.denominator);
                                     break;
                                 case V4L2_FRMIVAL_TYPE_STEPWISE:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"(Stepwise)  min. %d/%ds, max. %d / %d s, step %d / %d s", frmi_valenum.stepwise.min.numerator, frmi_valenum.stepwise.min.denominator,
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Stepwise)  min. %d/%ds, max. %d / %d s, step %d / %d s", frmi_valenum.stepwise.min.numerator, frmi_valenum.stepwise.min.denominator,
                                                  frmi_valenum.stepwise.max.numerator, frmi_valenum.stepwise.max.denominator,
                                                  frmi_valenum.stepwise.step.numerator, frmi_valenum.stepwise.step.denominator);
                                     break;
                                 case V4L2_FRMIVAL_TYPE_CONTINUOUS:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"(Continuous)  min. %d / %d s, max. %d / %d s", frmi_valenum.stepwise.min.numerator,
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Continuous)  min. %d / %d s, max. %d / %d s", frmi_valenum.stepwise.min.numerator,
                                                  frmi_valenum.stepwise.min.denominator,
                                                  frmi_valenum.stepwise.max.numerator, frmi_valenum.stepwise.max.denominator);
                                     break;
                                 default:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t    Unknown Frame rate type: %d",frmi_valenum.type);
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        Unknown Frame rate type: %d",frmi_valenum.type);
                                     break;
                             }
                         }
@@ -1196,21 +1195,21 @@ int V4L2_Base::check_device(char * errmsg)
                             switch (frmi_valenum.type)
                             {
                                 case V4L2_FRMIVAL_TYPE_DISCRETE:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"%d/%d s, ", frmi_valenum.discrete.numerator,  frmi_valenum.discrete.denominator);
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        %d/%d s", frmi_valenum.discrete.numerator,  frmi_valenum.discrete.denominator);
                                     break;
                                 case V4L2_FRMIVAL_TYPE_STEPWISE:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"(Stepwise)  min. %d/%ds, max. %d / %d s, step %d / %d s", frmi_valenum.stepwise.min.numerator,
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Stepwise)  min. %d/%ds, max. %d / %d s, step %d / %d s", frmi_valenum.stepwise.min.numerator,
                                                  frmi_valenum.stepwise.min.denominator,
                                                  frmi_valenum.stepwise.max.numerator, frmi_valenum.stepwise.max.denominator,
                                                  frmi_valenum.stepwise.step.numerator, frmi_valenum.stepwise.step.denominator);
                                     break;
                                 case V4L2_FRMIVAL_TYPE_CONTINUOUS:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"(Continuous)  min. %d / %d s, max. %d / %d s", frmi_valenum.stepwise.min.numerator,
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        (Continuous)  min. %d / %d s, max. %d / %d s", frmi_valenum.stepwise.min.numerator,
                                                  frmi_valenum.stepwise.min.denominator,
                                                  frmi_valenum.stepwise.max.numerator, frmi_valenum.stepwise.max.denominator);
                                     break;
                                 default:
-                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"\t    Unknown Frame rate type: %d",frmi_valenum.type);
+                                    DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG,"        Unknown Frame rate type: %d",frmi_valenum.type);
                                     break;
                             }
                         }

--- a/libindi/libs/webcam/v4l2_base.h
+++ b/libindi/libs/webcam/v4l2_base.h
@@ -159,6 +159,8 @@ class V4L2_Base
 
         void findMinMax();
 
+        int enumeratedInputs;
+        int enumeratedCaptureFormats;
 
         /* Frame rate */
         int stdsetframerate(struct v4l2_fract frate, char * errmsg);


### PR DESCRIPTION
This pull request should allow users of USB CCDs to better manage exposures.

- Added exposure left report to client.
- Fixed various start/stop/restart/abort situations which would lock the driver logic up.
- Implemented CCD_CAN_ABORT logic over those fixes.
- A few log changes to make driver behavior clearer.

Basically, it allows the end-user to abort that 20-minute exposure launched by mistake.
It also makes starting and stopping streaming and exposure more robust.