### PR TITLE
Fix for unrecognized meadedsi camera model (01ed)

### DIFF
--- a/3rdparty/indi-dsi/99-meadedsi.rules
+++ b/3rdparty/indi-dsi/99-meadedsi.rules
@@ -1,6 +1,7 @@
 # 1. Pre-renumeration IDs
 # Meade DSI
 SUBSYSTEM=="usb", ACTION=="add", ATTR{idVendor}=="156c", ATTR{idProduct}=="0100", RUN+="/sbin/fxload -t fx2 -D $tempnode -I /lib/firmware/meade-deepskyimager.hex"
+SUBSYSTEM=="usb", ACTION=="add", ATTR{idVendor}=="156c", ATTR{idProduct}=="01ed", RUN+="/sbin/fxload -t fx2 -D $tempnode -I /lib/firmware/meade-deepskyimager.hex"
 
 # 2. Post-renumeration IDs
 # Meade DSI


### PR DESCRIPTION
It's a fix for ATTR{idProduct}=="01ed". Tested on the camera and it works fine.