### PR TITLE
Fixed debug log using AbsExposureN while possibly null.

### DIFF
--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -800,7 +800,7 @@ bool V4L2_Driver::setShutter(double duration)
     }
     else
     {
-        DEBUGF(INDI::Logger::DBG_WARNING, "Failed %.3f-second manual exposure, out of device tick bounds [%d,%d]", duration, (int)AbsExposureN->min, (int)AbsExposureN->max);
+        DEBUGF(INDI::Logger::DBG_WARNING, "Failed %.3f-second manual exposure, out of device tick bounds [%d,%d]", duration, AbsExposureN?(int)AbsExposureN->min:0, AbsExposureN?(int)AbsExposureN->max:0);
         return false;
     }
 


### PR DESCRIPTION
This fixes the current iteration of the crash described #242.
I'll need to clarify why AbsExposureN is null in that context, and what are the consequences.
Basically, in the scenario described, ImageAdjustNP does not contain "Exposure (Absolute)".