### PR TITLE
Fix repeated keys issue in MGen driver

### DIFF
--- a/3rdparty/indi-mgen/indi_mgenautoguider.xml
+++ b/3rdparty/indi-mgen/indi_mgenautoguider.xml
@@ -3,7 +3,7 @@
 <devGroup group="Aux">
     <device label="Lacerta MGen Autoguider">
         <driver name="MGen Autoguider">indi_mgenautoguider</driver>
-        <version>0.1</version>
+        <version>0.2</version>
     </device>
 </devGroup>
 </driversList>

--- a/3rdparty/indi-mgen/mgenautoguider.cpp
+++ b/3rdparty/indi-mgen/mgenautoguider.cpp
@@ -97,28 +97,40 @@ bool MGenAutoguider::ISNewSwitch(const char *dev, const char *name, ISState *sta
             {
                 IUUpdateSwitch(&ui.remote.property, states, names, n);
                 ISwitch *const key_switch = IUFindOnSwitch(&ui.remote.property);
-                ui.is_enabled = key_switch->aux == nullptr ? false : true;
-                ui.remote.property.s = IPS_OK;
+                if (key_switch)
+                {
+                    ui.is_enabled = key_switch->aux == nullptr ? false : true;
+                    ui.remote.property.s = IPS_OK;
+                }
+                else ui.remote.property.s = IPS_ALERT;
                 IDSetSwitch(&ui.remote.property, NULL);
             }
             if (!strcmp(name, "MGEN_UI_BUTTONS1"))
             {
                 IUUpdateSwitch(&ui.buttons.properties[0], states, names, n);
-                ISwitch *const key_switch         = IUFindOnSwitch(&ui.buttons.properties[0]);
-                MGIO_INSERT_BUTTON::Button button = *(reinterpret_cast<MGIO_INSERT_BUTTON::Button *>(key_switch->aux));
-                MGIO_INSERT_BUTTON(button).ask(*device);
-                key_switch->s              = ISS_OFF;
-                ui.buttons.properties[0].s = IPS_OK;
+                ISwitch *const key_switch = IUFindOnSwitch(&ui.buttons.properties[0]);
+                if (key_switch)
+                {
+                    MGIO_INSERT_BUTTON::Button button = *(reinterpret_cast<MGIO_INSERT_BUTTON::Button *>(key_switch->aux));
+                    MGIO_INSERT_BUTTON(button).ask(*device);
+                    key_switch->s              = ISS_OFF;
+                    ui.buttons.properties[0].s = IPS_OK;
+                }
+                else ui.buttons.properties[0].s = IPS_ALERT;
                 IDSetSwitch(&ui.buttons.properties[0], NULL);
             }
             if (!strcmp(name, "MGEN_UI_BUTTONS2"))
             {
                 IUUpdateSwitch(&ui.buttons.properties[1], states, names, n);
-                ISwitch *const key_switch         = IUFindOnSwitch(&ui.buttons.properties[1]);
-                MGIO_INSERT_BUTTON::Button button = *(reinterpret_cast<MGIO_INSERT_BUTTON::Button *>(key_switch->aux));
-                MGIO_INSERT_BUTTON(button).ask(*device);
-                key_switch->s              = ISS_OFF;
-                ui.buttons.properties[1].s = IPS_OK;
+                ISwitch *const key_switch = IUFindOnSwitch(&ui.buttons.properties[1]);
+                if (key_switch)
+                {
+                    MGIO_INSERT_BUTTON::Button button = *(reinterpret_cast<MGIO_INSERT_BUTTON::Button *>(key_switch->aux));
+                    MGIO_INSERT_BUTTON(button).ask(*device);
+                    key_switch->s              = ISS_OFF;
+                    ui.buttons.properties[1].s = IPS_OK;
+                }
+                else ui.buttons.properties[1].s = IPS_ALERT;
                 IDSetSwitch(&ui.buttons.properties[1], NULL);
             }
         }

--- a/3rdparty/indi-mgen/mgenautoguider.cpp
+++ b/3rdparty/indi-mgen/mgenautoguider.cpp
@@ -93,6 +93,14 @@ bool MGenAutoguider::ISNewSwitch(const char *dev, const char *name, ISState *sta
     {
         if (!strcmp(dev, getDeviceName()))
         {
+            if (!strcmp(name, "MGEN_UI_REMOTE"))
+            {
+                IUUpdateSwitch(&ui.remote.property, states, names, n);
+                ISwitch *const key_switch = IUFindOnSwitch(&ui.remote.property);
+                ui.is_enabled = key_switch->aux == nullptr ? false : true;
+                ui.remote.property.s = IPS_OK;
+                IDSetSwitch(&ui.remote.property, NULL);
+            }
             if (!strcmp(name, "MGEN_UI_BUTTONS1"))
             {
                 IUUpdateSwitch(&ui.buttons.properties[0], states, names, n);
@@ -150,7 +158,7 @@ bool MGenAutoguider::ISNewNumber(char const *dev, char const *name, double value
                 IDSetNumber(&ui.framerate.property, NULL);
                 RemoveTimer(ui.timer);
                 TimerHit();
-                _S("UI refresh rate is now %+02.2 frames per second", ui.framerate.number.value);
+                _S("UI refresh rate is now %+02.2f frames per second", ui.framerate.number.value);
                 return true;
             }
         }
@@ -219,8 +227,14 @@ bool MGenAutoguider::initProperties()
 
     {
         char const TAB[] = "Remote UI";
+        IUFillSwitch(&ui.remote.switches[0], "MGEN_UI_FRAMERATE_ENABLE", "Enable", ISS_OFF);
+        ui.remote.switches[0].aux = (void*)1;
+        IUFillSwitch(&ui.remote.switches[1], "MGEN_UI_FRAMERATE_DISABLE", "Disable", ISS_ON);
+        ui.remote.switches[1].aux = (void*)0;
+        IUFillSwitchVector(&ui.remote.property, &ui.remote.switches[0], 2, getDeviceName(), "MGEN_UI_REMOTE",
+                           "Enable Remote UI", TAB, IP_RW, ISR_1OFMANY, 0, IPS_OK);
         /* FIXME frame rate kills connection quickly, make INDI::CCD blob compressed by default at the expense of server cpu power */
-        IUFillNumber(&ui.framerate.number, "MGEN_UI_FRAMERATE", "Frame rate", "%+02.2f fps", 0, 4, 0.25f, 0.25f);
+        IUFillNumber(&ui.framerate.number, "MGEN_UI_FRAMERATE", "Frame rate", "%+02.2f fps", 0, 4, 0.25f, 0.5f);
         IUFillNumberVector(&ui.framerate.property, &ui.framerate.number, 1, getDeviceName(), "MGEN_UI_OPTIONS", "UI",
                            TAB, IP_RW, 60, IPS_IDLE);
 
@@ -257,6 +271,7 @@ bool MGenAutoguider::updateProperties()
         _D("registering properties", "");
         defineText(&version.firmware.property);
         defineNumber(&voltage.property);
+        defineSwitch(&ui.remote.property);
         defineNumber(&ui.framerate.property);
         defineSwitch(&ui.buttons.properties[0]);
         defineSwitch(&ui.buttons.properties[1]);
@@ -266,6 +281,7 @@ bool MGenAutoguider::updateProperties()
         _D("removing properties", "");
         deleteProperty(version.firmware.property.name);
         deleteProperty(voltage.property.name);
+        deleteProperty(ui.remote.property.name);
         deleteProperty(ui.framerate.property.name);
         deleteProperty(ui.buttons.properties[0].name);
         deleteProperty(ui.buttons.properties[1].name);
@@ -486,7 +502,7 @@ void MGenAutoguider::TimerHit()
             }
 
             /* Update UI frame - I'm trading efficiency for code clarity, sorry for the computation with doubles */
-            if (0 == ui.timestamp.tv_sec || 0 < ui.framerate.number.value)
+            if (ui.is_enabled && (0 == ui.timestamp.tv_sec || 0 < ui.framerate.number.value))
             {
                 double const ui_period = 1.0f / ui.framerate.number.value;
                 double const ui_next =

--- a/3rdparty/indi-mgen/mgenautoguider.h
+++ b/3rdparty/indi-mgen/mgenautoguider.h
@@ -170,7 +170,13 @@ class MGenAutoguider : public INDI::CCD
     struct ui
     {
         int timer;                 /*!< The timer counting for the refresh event updating the remote user interface. */
+        bool is_enabled;           /*!< Whether the remote UI is being transferred to the client. */
         struct timespec timestamp; /*!< The last time this structure was read from the device. */
+        struct remote
+        {
+            ISwitch switches[2]; /*!< Remote UI enable/disable. */
+            ISwitchVectorProperty property; /* Remote UI INDI property. */
+        } remote;
         struct framerate
         {
             INumber number; /*!< Frame rate value, in frames per second - more frames increase risk of disconnection. */
@@ -181,7 +187,7 @@ class MGenAutoguider : public INDI::CCD
             ISwitch switches[6];                 /*!< Button switches for ESC, SET, UP, LEFT, RIGHT and DOWN. */
             ISwitchVectorProperty properties[2]; /*!< Button INDI properties, {ESC,SET} and {UP,LEFT,RIGHT,DOWN}. */
         } buttons;
-        ui(): timer(0), timestamp({ .tv_sec = 0, .tv_nsec = 0 }) {}
+        ui(): timer(0), is_enabled(false), timestamp({ .tv_sec = 0, .tv_nsec = 0 }) {}
     } ui;
 
   protected:

--- a/3rdparty/indi-mgen/mgio_insert_button.h
+++ b/3rdparty/indi-mgen/mgio_insert_button.h
@@ -70,7 +70,8 @@ class MGIO_INSERT_BUTTON : MGC
 
         if (root.lock())
         {
-            _D("sending button %d", query[2]);
+            IOByte const b = query[2];
+            _D("sending button %d", b);
 
             query[2] &= 0x7F;
             root.write(query);
@@ -79,6 +80,8 @@ class MGIO_INSERT_BUTTON : MGC
             query[2] |= 0x80;
             root.write(query);
             root.read(answer);
+
+            _D("button %d sent", b);
 
             root.unlock();
         }

--- a/3rdparty/indi-mgen/mgio_read_display_frame.h
+++ b/3rdparty/indi-mgen/mgio_read_display_frame.h
@@ -114,6 +114,8 @@ class MGIO_READ_DISPLAY_FRAME : MGC
 
         if (root.lock())
         {
+            _D("reading UI frame",0);
+
             for (unsigned int block = 0; block < 8 * 128; block += 128)
             {
                 /* Query is using 10 bits of the address over two bytes, then 1 byte for the count */
@@ -139,6 +141,8 @@ class MGIO_READ_DISPLAY_FRAME : MGC
             /* Device replies with opcode only, and subfunc is done */
             answer.resize(1);
             root.read(answer);
+
+            _D("done reading UI frame",0);
 
             root.unlock();
         }


### PR DESCRIPTION
This fixes #200.

As the remote buttons are a ATMOST1 type, there can happen that one of them is released by the user when clicking before the message is handled by the driver. This is especially visible on a remote server. In that case looking for a "ON" switch while managing inputs caused a null dereference.