### PR TITLE
Attempt to fix V4L2 exposure issue for devices not providing manual/auto control

### DIFF
--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -838,7 +838,7 @@ bool V4L2_Driver::setShutter(double duration)
 
 bool V4L2_Driver::setManualExposure(double duration)
 {
-    if (AbsExposureN)
+    if (nullptr == AbsExposureN)
     {
         DEBUGF(INDI::Logger::DBG_ERROR, "Failed exposing, the absolute exposure duration control is undefined", "");
         return false;

--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -2589,8 +2589,12 @@ int V4L2_Base::setINTControl(unsigned int ctrl_id, double new_value, char *errms
     if ((queryctrl.flags & V4L2_CTRL_FLAG_READ_ONLY) || (queryctrl.flags & V4L2_CTRL_FLAG_GRABBED) ||
         (queryctrl.flags & V4L2_CTRL_FLAG_INACTIVE) || (queryctrl.flags & V4L2_CTRL_FLAG_VOLATILE))
     {
-        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG, "Can not set control %.*s (%d)", (int)sizeof(queryctrl.name),
-                     queryctrl.name, queryctrl.flags);
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_WARNING, "Setting INT control %.*s will fail, currently %s%s%s%s",
+                     (int)sizeof(queryctrl.name), queryctrl.name,
+                     queryctrl.flags&V4L2_CTRL_FLAG_READ_ONLY?"read only ":"",
+                     queryctrl.flags&V4L2_CTRL_FLAG_GRABBED?"grabbed ":"",
+                     queryctrl.flags&V4L2_CTRL_FLAG_INACTIVE?"inactive ":"",
+                     queryctrl.flags&V4L2_CTRL_FLAG_VOLATILE?"volatile":"");
         return 0;
     }
 
@@ -2601,7 +2605,11 @@ int V4L2_Base::setINTControl(unsigned int ctrl_id, double new_value, char *errms
     control.id    = ctrl_id;
     control.value = (int)new_value;
     if (-1 == XIOCTL(fd, VIDIOC_S_CTRL, &control))
+    {
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_ERROR, "Setting INT control %.*s failed (%s)",
+               (int)sizeof(queryctrl.name), queryctrl.name, errmsg);
         return errno_exit("VIDIOC_S_CTRL", errmsg);
+    }
     return 0;
 }
 
@@ -2617,8 +2625,12 @@ int V4L2_Base::setOPTControl(unsigned int ctrl_id, unsigned int new_value, char 
     if ((queryctrl.flags & V4L2_CTRL_FLAG_READ_ONLY) || (queryctrl.flags & V4L2_CTRL_FLAG_GRABBED) ||
         (queryctrl.flags & V4L2_CTRL_FLAG_INACTIVE) || (queryctrl.flags & V4L2_CTRL_FLAG_VOLATILE))
     {
-        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG, "Can not set control %.*s (%d)", (int)sizeof(queryctrl.name),
-                     queryctrl.name, queryctrl.flags);
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG, "Setting OPT control %.*s will fail, currently %s%s%s%s",
+                     (int)sizeof(queryctrl.name), queryctrl.name,
+                     queryctrl.flags&V4L2_CTRL_FLAG_READ_ONLY?"read only ":"",
+                     queryctrl.flags&V4L2_CTRL_FLAG_GRABBED?"grabbed ":"",
+                     queryctrl.flags&V4L2_CTRL_FLAG_INACTIVE?"inactive ":"",
+                     queryctrl.flags&V4L2_CTRL_FLAG_VOLATILE?"volatile":"");
         return 0;
     }
 
@@ -2629,7 +2641,11 @@ int V4L2_Base::setOPTControl(unsigned int ctrl_id, unsigned int new_value, char 
     control.id    = ctrl_id;
     control.value = new_value;
     if (-1 == XIOCTL(fd, VIDIOC_S_CTRL, &control))
+    {
+        DEBUGFDEVICE(deviceName, INDI::Logger::DBG_ERROR, "Setting INT control %.*s failed (%s)",
+               (int)sizeof(queryctrl.name), queryctrl.name, errmsg);
         return errno_exit("VIDIOC_S_CTRL", errmsg);
+    }
     return 0;
 }
 


### PR DESCRIPTION
This is what the PR displays in the debug console (reversed here for clarity):
```
2017-07-12T17:42:07: Found 4 V4L2 adjustments 
2017-07-12T17:42:07: - Brightness 
2017-07-12T17:42:07: - Gamma 
2017-07-12T17:42:07: - Gain 
2017-07-12T17:42:07: - Exposure (Absolute) (used for absolute exposure duration) 
2017-07-12T17:42:07: Found 1 V4L2 options 
2017-07-12T17:42:07: - Exposure, Auto (used for manual/auto exposure control) 
```
This to understand which control is used in the context of the recent issues with exposure.