### PR TITLE
More robust handling of reading pier side from mount

### DIFF
--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -968,8 +968,10 @@ void LX200AstroPhysics::syncSideOfPier()
 
     if (!strcmp(response, "East"))
         setPierSide(INDI::Telescope::PIER_EAST);
-    else
+    else if (!strcmp(response, "West"))
         setPierSide(INDI::Telescope::PIER_WEST);
+    else
+        DEBUGF(INDI::Logger::DBG_ERROR, "Invalid pier side response from device-> %s", response);
 
 }
 


### PR DESCRIPTION
This change will make sure a data communication error will not cause the pier side to be set erroneously.

The error is reported to the debug log.