### PR TITLE
Fix compile error when building only the indi client

### DIFF
--- a/libindi/libs/indicom.c
+++ b/libindi/libs/indicom.c
@@ -81,7 +81,7 @@
 
 int tty_debug = 0;
 
-#ifndef _WIN32
+#if defined(HAVE_LIBNOVA)
 int extractISOTime(const char *timestr, struct ln_date *iso_date)
 {
     struct tm utm;


### PR DESCRIPTION
Linux and OSX builds fail when configured to build only the client library

> cmake -DINDI_BUILD_SERVER=OFF -DINDI_BUILD_DRIVERS=OFF -DINDI_BUILD_CLIENT=ON -DINDI_BUILD_QT5_CLIENT=OFF
