### PR TITLE
Removed code that set tracking state to SCOPE_IDLE after sync event.

### DIFF
--- a/libindi/drivers/telescope/ieqpro.cpp
+++ b/libindi/drivers/telescope/ieqpro.cpp
@@ -600,7 +600,6 @@ bool IEQPro::Sync(double ra, double dec)
         DEBUG(INDI::Logger::DBG_ERROR, "Failed to sync.");
     }
 
-    TrackState = SCOPE_IDLE;
     EqNP.s     = IPS_OK;
 
     currentRA  = ra;

--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -718,7 +718,6 @@ bool LX200AstroPhysics::Sync(double ra, double dec)
     DEBUGF(INDI::Logger::DBG_DEBUG, "%s Synchronization successful %s", (syncType == USE_REGULAR_SYNC ? "CM" : "CMR"), syncString);
     DEBUG(INDI::Logger::DBG_SESSION, "Synchronization successful.");
 
-    TrackState = SCOPE_IDLE;
     EqNP.s     = IPS_OK;
 
     NewRaDec(currentRA, currentDEC);

--- a/libindi/drivers/telescope/lx200basic.cpp
+++ b/libindi/drivers/telescope/lx200basic.cpp
@@ -346,7 +346,6 @@ bool LX200Basic::Sync(double ra, double dec)
 
     DEBUG(INDI::Logger::DBG_SESSION, "Synchronization successful.");
 
-    TrackState = SCOPE_IDLE;
     EqNP.s     = IPS_OK;
 
     NewRaDec(currentRA, currentDEC);

--- a/libindi/drivers/telescope/lx200generic.cpp
+++ b/libindi/drivers/telescope/lx200generic.cpp
@@ -612,7 +612,6 @@ bool LX200Generic::Sync(double ra, double dec)
 
     DEBUG(INDI::Logger::DBG_SESSION, "Synchronization successful.");
 
-    TrackState = SCOPE_IDLE;
     EqNP.s     = IPS_OK;
 
     NewRaDec(currentRA, currentDEC);

--- a/libindi/drivers/telescope/lx200gotonova.cpp
+++ b/libindi/drivers/telescope/lx200gotonova.cpp
@@ -381,7 +381,6 @@ bool LX200GotoNova::Sync(double ra, double dec)
     DEBUGF(INDI::Logger::DBG_DEBUG, "%s Synchronization successful %s", (syncType == USE_REGULAR_SYNC ? "CM" : "CMR"), syncString);
     DEBUG(INDI::Logger::DBG_SESSION, "Synchronization successful.");
 
-    TrackState = SCOPE_IDLE;
     EqNP.s     = IPS_OK;
 
     NewRaDec(currentRA, currentDEC);

--- a/libindi/drivers/telescope/lx200pulsar2.cpp
+++ b/libindi/drivers/telescope/lx200pulsar2.cpp
@@ -1301,7 +1301,6 @@ bool LX200Pulsar2::Sync(double ra, double dec)
         currentRA  = ra;
         currentDEC = dec;
         DEBUG(INDI::Logger::DBG_SESSION, "Synchronization successful.");
-        TrackState = SCOPE_IDLE;
         EqNP.s     = IPS_OK;
         NewRaDec(currentRA, currentDEC);
     }


### PR DESCRIPTION
These drivers set the tracking state to SCOPE_IDLE after a synchronize event.  I don't see why this was done since all a sync does is adjust the stored position of the mount and shouldn't cause any change in motor state.

I thought I'd bring this up - perhaps we can have the authors of these drivers review?