### PR TITLE
Adding USB connectivity to SQM driver

### DIFF
--- a/libindi/drivers/auxiliary/sqm.cpp
+++ b/libindi/drivers/auxiliary/sqm.cpp
@@ -110,7 +110,7 @@ bool SQM::initProperties()
     if (sqmConnection & CONNECTION_SERIAL)
     {
         serialConnection = new Connection::Serial(this);
-//        serialConnection->registerHandshake([&]() { return getDeviceInfo(); });
+        serialConnection->registerHandshake([&]() { return getDeviceInfo(); });
         registerConnection(serialConnection);
     }
 
@@ -217,9 +217,11 @@ bool SQM::getDeviceInfo()
     const char *cmd = "ix";
     char buffer[39]={0};
 
-//    PortFD = tcpConnection->getPortFD();
-    PortFD = serialConnection->getPortFD();
-
+    if (getActiveConnection() == serialConnection) {
+        PortFD = serialConnection->getPortFD();
+    } else if (getActiveConnection() == tcpConnection) {
+        PortFD = tcpConnection->getPortFD();
+    }
     DEBUGF(INDI::Logger::DBG_DEBUG, "CMD: %s", cmd);
 
     ssize_t written = write(PortFD, cmd, 2);
@@ -237,7 +239,7 @@ bool SQM::getDeviceInfo()
         ssize_t response = read(PortFD, buffer + received, 39 - received);
         if (response < 0)
         {
-            DEBUGF(INDI::Logger::DBG_ERROR, "Error getting device info wile reading response : %s", strerror(errno));
+            DEBUGF(INDI::Logger::DBG_ERROR, "Error getting device info while reading response: %s", strerror(errno));
             return false;
         }
 

--- a/libindi/drivers/auxiliary/sqm.cpp
+++ b/libindi/drivers/auxiliary/sqm.cpp
@@ -237,7 +237,7 @@ bool SQM::getDeviceInfo()
         ssize_t response = read(PortFD, buffer + received, 39 - received);
         if (response < 0)
         {
-            DEBUGF(INDI::Logger::DBG_ERROR, "Error getting device info wile reading response: %s", strerror(errno));
+            DEBUGF(INDI::Logger::DBG_ERROR, "Error getting device info wile reading response : %s", strerror(errno));
             return false;
         }
 

--- a/libindi/drivers/auxiliary/sqm.h
+++ b/libindi/drivers/auxiliary/sqm.h
@@ -26,11 +26,6 @@
 
 #include "defaultdevice.h"
 
-namespace Connection
-{
-class TCP;
-}
-
 class SQM : public INDI::DefaultDevice
 {
   public:
@@ -39,6 +34,17 @@ class SQM : public INDI::DefaultDevice
 
     virtual bool initProperties();
     virtual bool updateProperties();
+
+    /**
+     * \struct SqmConnection
+     * \brief Holds the connection mode of the device.
+     */
+    enum
+    {
+        CONNECTION_NONE   = 1 << 0,
+        CONNECTION_SERIAL = 1 << 1,
+        CONNECTION_TCP    = 1 << 2
+    } SqmConnection;
 
   protected:
     const char *getDefaultName();
@@ -56,7 +62,9 @@ class SQM : public INDI::DefaultDevice
     INumberVectorProperty UnitInfoNP;
     INumber UnitInfoN[4];
 
-    Connection::TCP *tcpConnection = NULL;
+    Connection::Serial *serialConnection = NULL;
+    Connection::TCP *tcpConnection       = NULL;
 
     int PortFD = -1;
+    uint8_t sqmConnection = CONNECTION_SERIAL | CONNECTION_TCP;
 };


### PR DESCRIPTION
I've added USB connectivity feature to the SQM driver.
Can you test that I have not broken the TCP connectivity feature as I only have a USB device to test with?
Its working fine with my SQM-LU device.
 