### PR TITLE
Fix DEC custom rate scaling and set OK state when tracking is enabled

### DIFF
--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -1036,7 +1036,7 @@ bool LX200AstroPhysics::SetTrackRate(double raRate, double deRate)
     */
 
     double APRARate = (raRate - 15.041067) / 15.041067;
-    double APDERate = deRate;
+    double APDERate = (deRate - 15.041067) / 15.041067;
 
     if (setAPRATrackRate(PortFD, APRARate) < 0 || setAPDETrackRate(PortFD, APDERate) < 0)
         return false;

--- a/libindi/libs/indibase/inditelescope.cpp
+++ b/libindi/libs/indibase/inditelescope.cpp
@@ -1264,6 +1264,7 @@ bool INDI::Telescope::ISNewSwitch(const char *dev, const char *name, ISState *st
 
                 TrackStateS[TRACK_ON].s = (targetState == TRACK_ON) ? ISS_ON : ISS_OFF;
                 TrackStateS[TRACK_OFF].s = (targetState == TRACK_ON) ? ISS_OFF : ISS_ON;
+                TrackStateSP.s = IPS_OK;
             }
             else
             {


### PR DESCRIPTION
DEC rate needs to be scaled to sidereal.
Tracking state switch never set to OK when tracking mode turned on.
