### PR TITLE
Fix for missing FILE_PATH property in gphoto ccd

### DIFF
--- a/3rdparty/indi-gphoto/gphoto_ccd.cpp
+++ b/3rdparty/indi-gphoto/gphoto_ccd.cpp
@@ -663,6 +663,10 @@ bool GPhotoCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
             if (!sim)
                 gphoto_set_upload_settings(gphotodrv, IUFindOnSwitchIndex(&UploadSP));
+
+            // Default behavior required (enable path property)
+            INDI::CCD::ISNewSwitch(dev, name, states, names, n);
+
             return true;
         }
 


### PR DESCRIPTION
The property FILE_PATH failled to appear in gphoto when Upload was set to Local or Both.
As a result, a notification was received by clients for a unknown property.