### PR TITLE
LX200: fix check of return value for setMaxSlewRate()

### DIFF
--- a/libindi/drivers/telescope/lx200_OnStep.cpp
+++ b/libindi/drivers/telescope/lx200_OnStep.cpp
@@ -205,7 +205,7 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
 
         if (!strcmp(name, MaxSlewRateNP.name))
         {
-            if (setMaxSlewRate(PortFD, (int)values[0] < 0))
+            if (setMaxSlewRate(PortFD, (int)values[0]) < 0)
             {
                 MaxSlewRateNP.s = IPS_ALERT;
                 IDSetNumber(&MaxSlewRateNP, "Error setting maximum slew rate.");

--- a/libindi/drivers/telescope/lx200classic.cpp
+++ b/libindi/drivers/telescope/lx200classic.cpp
@@ -174,7 +174,7 @@ bool LX200Classic::ISNewNumber(const char *dev, const char *name, double values[
 
         if (!strcmp(name, MaxSlewRateNP.name))
         {
-            if (setMaxSlewRate(PortFD, (int)values[0] < 0))
+            if (setMaxSlewRate(PortFD, (int)values[0]) < 0)
             {
                 MaxSlewRateNP.s = IPS_ALERT;
                 IDSetNumber(&MaxSlewRateNP, "Error setting maximum slew rate.");


### PR DESCRIPTION
On both LX200Classic and OnStep instead of comparing the return value of setMaxSlewRate() for being less than zero we compare instead value[0].

Besides, it seems that the current release of OnStep does not implement this command.