### PR TITLE
[inovaplx] changed min/max exposure setting and gain/blacklevel tab

### DIFF
--- a/3rdparty/indi-inovaplx/inovaplx_ccd.cpp
+++ b/3rdparty/indi-inovaplx/inovaplx_ccd.cpp
@@ -155,10 +155,10 @@ bool INovaCCD::initProperties()
 
     IUFillNumber(&CameraPropertiesN[CCD_GAIN_N], "CCD_GAIN_VALUE", "Gain", "%4.0f", 0, 1023, 1, 255);
     IUFillNumber(&CameraPropertiesN[CCD_BLACKLEVEL_N], "CCD_BLACKLEVEL_VALUE", "Black Level", "%3.0f", 0, 255, 1, 0);
-    IUFillNumberVector(&CameraPropertiesNP, CameraPropertiesN, 2, getDeviceName(), "CCD_PROPERTIES", "Control", IMAGE_SETTINGS_TAB, IP_RW, 60, IPS_IDLE);
+    IUFillNumberVector(&CameraPropertiesNP, CameraPropertiesN, 2, getDeviceName(), "CCD_PROPERTIES", "Control", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     // Set minimum exposure speed to 0.001 seconds
-    PrimaryCCD.setMinMaxStep("CCD_EXPOSURE", "CCD_EXPOSURE_VALUE", 0.001, 3600, 1, false);
+    PrimaryCCD.setMinMaxStep("CCD_EXPOSURE", "CCD_EXPOSURE_VALUE", 0.0001, 1000, 1, false);
 
     return true;
 


### PR DESCRIPTION
I changed the minimum and maximum exposure settings with real ones in inovaplx. These settings apply to all i.Nova cameras of the PLx series. (not all the cameras of this series exceed 1000s exposure, but can reach sub-ms exposure for solar observation)