### PR TITLE
Fix geographic coordinate comparison

### DIFF
--- a/3rdparty/indi-eqmod/align/pointset.cpp
+++ b/3rdparty/indi-eqmod/align/pointset.cpp
@@ -369,17 +369,17 @@ char *PointSet::WriteDataFile(const char *filename)
         wordfree(&wexp);
         return (char *)("Badly formed filename");
     }
+    if (lnalignpos)
+    { // Why this ?
+        if ((fabs(lnalignpos->lng - IUFindNumber(telescope->getNumber("GEOGRAPHIC_COORD"), "LONG")->value)>1E-4) ||
+            (fabs(lnalignpos->lat - IUFindNumber(telescope->getNumber("GEOGRAPHIC_COORD"), "LAT")->value)>1E-4))
+            return (char *)("Can not mix alignment data from different sites (lng. and/or lat. differs)");
+    }
     //if (filename == NULL) return;
     if (!(fp = fopen(wexp.we_wordv[0], "w")))
     {
         wordfree(&wexp);
         return strerror(errno);
-    }
-    if (lnalignpos)
-    { // Why this ?
-        if ((lnalignpos->lng != IUFindNumber(telescope->getNumber("GEOGRAPHIC_COORD"), "LONG")->value) ||
-            (lnalignpos->lat != IUFindNumber(telescope->getNumber("GEOGRAPHIC_COORD"), "LAT")->value))
-            return (char *)("Can not mix alignment data from different sites (lng. and/or lat. differs)");
     }
     root = toXML();
 


### PR DESCRIPTION
At the moment if you load an AlignData.xml file, you can never save it again because of the rounding error in the floating point comparison.
Worst the file is cleared because it is opened for write before this test.

This patch fix the problem by comparing the coordinates to 1E-4 (10 meters) and opening the file after the test.