### PR TITLE
Make minimum exposure time 0.0001 seconds

### DIFF
--- a/3rdparty/indi-qhy/qhy_ccd.cpp
+++ b/3rdparty/indi-qhy/qhy_ccd.cpp
@@ -38,7 +38,7 @@
 
 #define POLLMS                  1000        /* Polling time (ms) */
 #define TEMP_THRESHOLD          0.2         /* Differential temperature threshold (C)*/
-#define MINIMUM_CCD_EXPOSURE    0.001       /* 0.001 seconds minimum exposure */
+#define MINIMUM_CCD_EXPOSURE    0.0001       /* 0.001 seconds minimum exposure */
 #define MAX_DEVICES             4           /* Max device cameraCount */
 
 //NB Disable for real driver


### PR DESCRIPTION
In relation with this post : http://indilib.org/forum/ccds-dslrs/2475-qhy5-ii-minimum-exposure-time.html

A lot of qhy camera have a minimum exposure time below the millisecond :
QHY5III174                      Exposure Time   5us-900sec
QHY5III178                      Exposure Time   9us-1200sec
QHY5III224                      Exposure Time   7us-429sec
QHY5III290                      Exposure Time   5us-600sec
QHY5III185C                   Exposure Time   15us-900sec
QHY16200A/IC16200A   Exposure Time   1ms-10000sec
QHY8L/8PRO                  Exposure time   /
QHY695A/IC695A           Exposure time   1ms-10000sec
QHY10                            Exposure time   /
QHY90A                          Exposure time   1ms-10000sec
QHY12                            Exposure time   /
IC8300                            Exposure time   /
QHY9                              Exposure time   /
 
