### PR TITLE
Add udev rules for the ssag so it has correct permissions without lib…

### DIFF
--- a/3rdparty/indi-ssag/95-ssag.rules
+++ b/3rdparty/indi-ssag/95-ssag.rules
@@ -1,0 +1,6 @@
+#Unintialized ssag
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1856", ATTRS{idProduct}=="0011", MODE="0666"
+#ssag after firmware load
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1856", ATTRS{idProduct}=="0012", MODE="0666"
+
+

--- a/3rdparty/indi-ssag/CMakeLists.txt
+++ b/3rdparty/indi-ssag/CMakeLists.txt
@@ -11,6 +11,8 @@ find_package(USB-1 REQUIRED)
 #find_package(Threads REQUIRED)
 #find_package(CFITSIO REQUIRED)
 
+set(UDEVRULES_INSTALL_DIR "/lib/udev/rules.d" CACHE STRING "Base directory for udev rules")
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/indi_ssag.xml ${CMAKE_CURRENT_BINARY_DIR}/indi_ssag.xml )
 
 include_directories( ${CMAKE_CURRENT_BINARY_DIR})
@@ -40,4 +42,5 @@ endif (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm*")
 install(TARGETS indi_ssag_ccd RUNTIME DESTINATION bin )
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/indi_ssag.xml DESTINATION ${INDI_DATA_DIR})
+install(FILES 95-ssag.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 


### PR DESCRIPTION
…qhy installed

This commit just adds udev rules for the ssag, so it gets permissions correctly set on a system that does not already have libqhy installed with it's udev rules.  This allows use of indi-ssag without installing the qhy stuff.