### PR TITLE
Cleaning code and other improvements

### DIFF
--- a/libindi/drivers/focuser/focuslynx.cpp
+++ b/libindi/drivers/focuser/focuslynx.cpp
@@ -84,8 +84,8 @@ void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], 
 
 void ISSnoopDevice(XMLEle *root)
 {
-    // not need to Snoop other devices
-    INDI_UNUSED(root);
+    lynxDriveF1->ISSnoopDevice(root);
+    lynxDriveF2->ISSnoopDevice(root);
 }
 
 /************************************************************************************

--- a/libindi/drivers/focuser/focuslynx.cpp
+++ b/libindi/drivers/focuser/focuslynx.cpp
@@ -786,7 +786,7 @@ bool FocusLynxF1::getHubConfig()
 void FocusLynxF1::setSimulation(bool enable)
 {
     // call by F2 to set the Simulation option
-    INDI:DefaultDevice::setSimulation(enable);
+    INDI::DefaultDevice::setSimulation(enable);
 }
 
 /************************************************************************************
@@ -794,8 +794,8 @@ void FocusLynxF1::setSimulation(bool enable)
 * ***********************************************************************************/
 void FocusLynxF1::setDebug(bool enable)
 {
-  // Call by F2 to set the Debug option
-  INDI::DefaultDevice::setDebug(enable);
+    // Call by F2 to set the Debug option
+    INDI::DefaultDevice::setDebug(enable);
 }
 /************************************************************************************
 *

--- a/libindi/drivers/focuser/focuslynx.cpp
+++ b/libindi/drivers/focuser/focuslynx.cpp
@@ -267,17 +267,6 @@ bool FocusLynxF1::updateProperties()
 /************************************************************************************
  *
 * ***********************************************************************************/
-void FocusLynxF1::ISGetProperties(const char *dev)
-{
-    if (dev != nullptr && strcmp(dev, getDeviceName()) != 0)
-        return;
-
-    FocusLynxBase::ISGetProperties(dev);
-}
-
-/************************************************************************************
- *
-* ***********************************************************************************/
 bool FocusLynxF1::getHubConfig()
 {
     char cmd[32]={0};
@@ -908,20 +897,6 @@ bool FocusLynxF2::RemoteDisconnect()
   DEBUGF(INDI::Logger::DBG_SESSION,"Remote disconnection: %s is offline.", getDeviceName());
   DEBUGF(INDI::Logger::DBG_SESSION, "Value of F2 PortFD = %d", PortFD);
   return true;
-}
-
-/************************************************************************************
- *
-* ***********************************************************************************/
-void FocusLynxF2::ISGetProperties(const char *dev)
-{
-    if (dev != nullptr && strcmp(dev, getDeviceName()) != 0)
-        return;
-
-    FocusLynxBase::ISGetProperties(dev);
-    // Remove the port selector from the main tab of F2. Set only on F1 focuser
-    // FIXME
-    //deleteProperty(PortTP.name);
 }
 
 /************************************************************************************

--- a/libindi/drivers/focuser/focuslynx.cpp
+++ b/libindi/drivers/focuser/focuslynx.cpp
@@ -1,5 +1,5 @@
 /*
-  Focus Lynx/Focus Boss IIINDI driver
+  Focus Lynx/Focus Boss II INDI driver
   Copyright (C) 2015 Jasem Mutlaq (mutlaqja@ikarustech.com)
 
   This library is free software; you can redistribute it and/or
@@ -16,8 +16,6 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
-// using namespace std;
 
 #include "focuslynx.h"
 
@@ -86,9 +84,8 @@ void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], 
 
 void ISSnoopDevice(XMLEle *root)
 {
-    // Also need to check the caller to avoid unsued function ??
-    lynxDriveF1->ISSnoopDevice(root);
-    lynxDriveF2->ISSnoopDevice(root);
+    // not need to Snoop other devices
+    INDI_UNUSED(root);
 }
 
 /************************************************************************************
@@ -108,11 +105,11 @@ FocusLynxF1::FocusLynxF1(const char *target)
      */
     setFocusTarget(target);
 
-    // Till now only Serial connection is coding, would change in future
-    setFocuserConnection(CONNECTION_SERIAL);
+    // Both communication available, Serial and network (tcp/ip)
+    setFocuserConnection(CONNECTION_SERIAL | CONNECTION_TCP);
 
     // explain in connect() function Only set on the F1 constructor, not on the F2 one
-    PortFD = 0;
+    PortFD = -1;
 
     DBG_FOCUS = INDI::Logger::getInstance().addDebugLevel("Focus F1 Verbose", "FOCUS F1");
 }
@@ -136,6 +133,7 @@ bool FocusLynxF1::initProperties()
  */
 {
     FocusLynxBase::initProperties();
+
     // General info
     IUFillText(&HubT[0], "Firmware", "", "");
     IUFillText(&HubT[1], "Sleeping", "", "");
@@ -158,6 +156,12 @@ bool FocusLynxF1::initProperties()
     IUFillText(&WifiT[8], "Wep key", "", "");
     IUFillTextVector(&WifiTP, WifiT, 9, getDeviceName(), "WIFI-INFO", "Wifi", HUB_SETTINGS_TAB, IP_RO, 0, IPS_IDLE);
 
+    serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
+    tcpConnection->setDefaultPort(9760);
+    // To avoid confusion has Debug levels only visible on F2 remove it from F1
+    // Simultation option and Debug option present only on F2
+    deleteProperty("SIMULATION");
+    deleteProperty("DEBUG");
     return true;
 }
 
@@ -176,66 +180,42 @@ bool FocusLynxF1::Connect()
 /* Overide of connect() function
  * different for F1 or F2 focuser
  * F1 connect only himself to the driver and
- * it is the only one who's connect the serail port to establish the physical communication
+ * it is the only one who's connect to the communication port to establish the physical communication
  */
 {
-    int connectrc = 0;
-    char errorMsg[MAXRBUF];
-
     configurationComplete = false;
-
-    int modelIndex = IUFindOnSwitchIndex(&ModelSP);
-    if (modelIndex == 0)
-    {
-        DEBUG(INDI::Logger::DBG_ERROR, "You must select a model before establishing connection");
-        return false;
-    }
-
     if (isSimulation())
-        /* PortFD value used to give the /dev/ttyUSBx descriptor
-         * if -1 = simulation mode
+        /* PortFD value used to give the /dev/ttyUSBx or TCP descriptor
+         * if -1 = no physical port selected or simulation mode
          * if 0 = no descriptor created, F1 not connected (error)
          * other value = descriptor number
          */
         PortFD = -1;
-    else if ((connectrc = tty_connect(serialConnection->port(), serialConnection->baud(), 8, 0, 1, &PortFD)) != TTY_OK)
-    {
-        tty_error_msg(connectrc, errorMsg, MAXRBUF);
-        DEBUGF(INDI::Logger::DBG_SESSION, "Failed to connect to port %s, rate %s. Error: %s", serialConnection->port(),
-               serialConnection->baud(), errorMsg);
-        PortFD = 0;
-        return false;
-    }
+    else
+        if (!INDI::Focuser::Connect())
+            return false;
 
-    if (ack())
-    {
-        DEBUG(INDI::Logger::DBG_SESSION, "FocusLynx is online. Getting focus parameters...");
-        setDeviceType(modelIndex);
-        SetTimer(POLLMS);
-        if (isFromRemote)
-            isFromRemote = false;
-        else
-            lynxDriveF2->RemoteConnect();
-
-        return true;
-    }
-
-    DEBUG(
-        INDI::Logger::DBG_SESSION,
-        "Error retreiving data from FocusLynx, please ensure FocusLynx controller is powered and the port is correct.");
-    return false;
+    return Handshake();
 }
 
 /************************************************************************************
  *
 * ***********************************************************************************/
 bool FocusLynxF1::Disconnect()
-/* If we disconnect F1, the serial socket would be close.
- * Then in this case we have to disconnect the second focuser F2
- */
 {
-    FocusLynxBase::Disconnect();
+    // If we disconnect F1, the socket would be close.
+    INDI::Focuser::Disconnect();
+
+    // Get value of PortFD, should be -1
+    if (getActiveConnection() == serialConnection)
+        PortFD = serialConnection->getPortFD();
+    else
+        if (getActiveConnection() == tcpConnection)
+            PortFD = tcpConnection->getPortFD();
+    // Then we have to disconnect the second focuser F2
     lynxDriveF2->RemoteDisconnect();
+
+    DEBUGF(INDI::Logger::DBG_SESSION, "Value of PortFD = %d", PortFD);
     return true;
 }
 
@@ -243,7 +223,7 @@ bool FocusLynxF1::Disconnect()
  *
 * ***********************************************************************************/
 int FocusLynxF1::getPortFD()
-// Would be used by F2 instance to communicate with teh HUB
+// Would be used by F2 instance to communicate with the HUB
 {
     DEBUGF(INDI::Logger::DBG_SESSION, "F1 PortFD : %d", PortFD);
     return PortFD;
@@ -264,6 +244,7 @@ bool FocusLynxF1::updateProperties()
         defineText(&HubTP);
         defineText(&WiredTP);
         defineText(&WifiTP);
+        defineNumber(&LedNP);
 
         if (getHubConfig())
             DEBUG(INDI::Logger::DBG_SESSION, "HUB paramaters updated.");
@@ -278,8 +259,8 @@ bool FocusLynxF1::updateProperties()
         deleteProperty(HubTP.name);
         deleteProperty(WiredTP.name);
         deleteProperty(WifiTP.name);
+        deleteProperty(LedNP.name);
     }
-
     return true;
 }
 
@@ -311,7 +292,7 @@ bool FocusLynxF1::getHubConfig()
     /* Answer from the HUB
      <FHGETHUBINFO>!
     HUB INFO
-    Hub FVer = 1.0.9
+    Hub FVer = 2.0.4
     Sleeping = 0
     Wired IP = 169.254.190.196
     DHCPisOn = 1
@@ -350,7 +331,7 @@ bool FocusLynxF1::getHubConfig()
         if (isResponseOK() == false)
             return false;
 
-        if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+        if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
         {
             tty_error_msg(errcode, errmsg, MAXRBUF);
             DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -372,10 +353,10 @@ bool FocusLynxF1::getHubConfig()
     // Hub Version
     if (isSimulation())
     {
-        strncpy(response, "Hub FVer = 1.0.9\n", 32);
+        strncpy(response, "Hub FVer = 2.0.4\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -391,7 +372,7 @@ bool FocusLynxF1::getHubConfig()
         IUSaveText(&HubT[0], text);
         IDSetText(&HubTP, nullptr);
 
-        //Save localy the Version of the firmaware's Hub
+        //Save localy the Version of the firmware's Hub
         strncpy(version, text, sizeof(version));
 
         DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
@@ -408,7 +389,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "Sleeping = 0\n", 16);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -424,7 +405,7 @@ bool FocusLynxF1::getHubConfig()
         IUSaveText(&HubT[1], text);
         IDSetText(&HubTP, nullptr);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -438,7 +419,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "Wired IP = 169.168.1.10\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -454,7 +435,7 @@ bool FocusLynxF1::getHubConfig()
         IUSaveText(&WiredT[0], text);
         IDSetText(&WiredTP, nullptr);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -468,7 +449,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "DHCPisOn = 1\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -484,7 +465,7 @@ bool FocusLynxF1::getHubConfig()
         IUSaveText(&WiredT[1], text);
         IDSetText(&WiredTP, nullptr);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -498,7 +479,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF Atchd = 1\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -513,7 +494,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[0], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -527,7 +508,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF Conn  = 1\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -542,7 +523,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[1], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -556,7 +537,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF FVer  = 1.0.0\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -571,7 +552,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[2], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -585,7 +566,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF FV OK = 1\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -600,7 +581,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[3], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -614,7 +595,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF SSID = FocusLynxConfig\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -629,7 +610,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[4], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -643,7 +624,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF IP = 192.168.1.11\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -658,7 +639,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[5], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -672,7 +653,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF SecMd = A\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -687,7 +668,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[6], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -701,7 +682,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF SecKy =\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -716,7 +697,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[7], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -730,7 +711,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "WF WepKI = 0\n", 32);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -745,7 +726,7 @@ bool FocusLynxF1::getHubConfig()
         WifiTP.s = IPS_OK;
         IUSaveText(&WifiT[8], text);
 
-        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  KEy = %s", text, key);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Text =  %s,  Key = %s", text, key);
     }
     else if (rc != 1)
         return false;
@@ -756,7 +737,7 @@ bool FocusLynxF1::getHubConfig()
     // Set the light to ILDE if no module WIFI detected
     if (!strcmp(WifiT[0].text, "0"))
     {
-        DEBUGF(INDI::Logger::DBG_SESSION, "WifiT = %s", WifiT[0].text);
+        DEBUGF(INDI::Logger::DBG_SESSION, "Wifi module = %s", WifiT[0].text);
         WifiTP.s = IPS_IDLE;
     }
     IDSetText(&WifiTP, nullptr);
@@ -767,7 +748,7 @@ bool FocusLynxF1::getHubConfig()
         strncpy(response, "END\n", 16);
         nbytes_read = strlen(response);
     }
-    else if ((errcode = tty_read_section(PortFD, response, 0xA, FOCUSLYNX_TIMEOUT, &nbytes_read)) != TTY_OK)
+    else if ( (errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(errcode, errmsg, MAXRBUF);
         DEBUGF(INDI::Logger::DBG_ERROR, "%s", errmsg);
@@ -784,21 +765,17 @@ bool FocusLynxF1::getHubConfig()
         if (strcmp(response, "END"))
             return false;
     }
-    // End of added code by Philippe Besson
 
     tcflush(PortFD, TCIFLUSH);
 
     configurationComplete = true;
 
-    /* test for fucntion getVersion.
-     * !!TO be removed for released version
-     */
-
     int a, b, c, temp;
     temp = getVersion(&a, &b, &c);
     if (temp != 0)
         DEBUGF(INDI::Logger::DBG_SESSION, "Version major: %d, minor: %d, subversion: %d", a, b, c);
-    DEBUGF(INDI::Logger::DBG_SESSION, "Version major: %d", temp);
+    else
+        DEBUG(INDI::Logger::DBG_SESSION, "Couldn't get version information");
 
     return true;
 }
@@ -806,28 +783,20 @@ bool FocusLynxF1::getHubConfig()
 /************************************************************************************
  *
 * ***********************************************************************************/
-int FocusLynxF1::getVersion(int *major, int *minor, int *sub)
-// This methode have to be overided by child object
-/* For future use of implementation of new firmware 2.0.0
- * and give ability to keep compatible to actual 1.0.9
- * WIll be to avoid calling to new functions
- * Not yet implemented in this version of the driver
- */
+void FocusLynxF1::setSimulation(bool enable)
 {
-    char sMajor[8]={0}, sMinor[8]={0}, sSub[8]={0};
-    int rc = sscanf(version, "%[^.].%[^.].%s", sMajor, sMinor, sSub);
-
-    DEBUGF(INDI::Logger::DBG_DEBUG, "Version major: %s, minor: %s, subversion: %s", sMajor, sMinor, sSub);
-    *major = atoi(sMajor);
-    *minor = atoi(sMinor);
-    *sub   = atoi(sSub);
-
-    if (rc == 3)
-        return *major;
-    else
-        return 0; // 0 Means error in this case
+    // call by F2 to set the Simulation option
+    INDI:DefaultDevice::setSimulation(enable);
 }
 
+/************************************************************************************
+ *
+* ***********************************************************************************/
+void FocusLynxF1::setDebug(bool enable)
+{
+  // Call by F2 to set the Debug option
+  INDI::DefaultDevice::setDebug(enable);
+}
 /************************************************************************************
 *
 *               Second Focuser (F2)
@@ -841,7 +810,7 @@ FocusLynxF2::FocusLynxF2(const char *target)
 {
     setFocusTarget(target);
 
-    // When second focuser no direct communication set to the hub
+    // The second focuser has no direct communication with the hub
     setFocuserConnection(CONNECTION_NONE);
 
     DBG_FOCUS = INDI::Logger::getInstance().addDebugLevel("Focus F2 Verbose", "FOCUS F2");
@@ -851,6 +820,17 @@ FocusLynxF2::FocusLynxF2(const char *target)
 * ***********************************************************************************/
 FocusLynxF2::~FocusLynxF2()
 {
+}
+
+/**************************************************************************************
+*
+***************************************************************************************/
+bool FocusLynxF2::initProperties()
+{
+    FocusLynxBase::initProperties();
+    // Remove from F2 to avoid confusion, already present on F1
+    deleteProperty("DRIVER_INFO");
+    return true;
 }
 
 /************************************************************************************
@@ -867,31 +847,25 @@ const char *FocusLynxF2::getDefaultName()
 bool FocusLynxF2::Connect()
 /* Overide of connect() function
  * different for F2 or F1 focuser
- * F2 don't connect himself to the driver
+ * F2 don't connect himself to the hub
  */
 {
-    // When started by EKOS avoid infinity loop
-    if (isFromRemote)
-        isFromRemote = false;
-    else
-        lynxDriveF1->RemoteConnect();
+    configurationComplete = false;
+
+    if (!lynxDriveF1->isConnected())
+    {
+        if (!lynxDriveF1->Connect())
+        {
+            DEBUG(INDI::Logger::DBG_SESSION, "Focus F1 should be connected before try to connect F2");
+            return false;
+        }
+        lynxDriveF1->setConnected(true, IPS_OK);
+        lynxDriveF1->updateProperties();
+    }
     PortFD = lynxDriveF1->getPortFD(); //Get the socket descriptor open by focuser F1 connect()
     DEBUGF(INDI::Logger::DBG_SESSION, "F2 PortFD : %d", PortFD);
 
-    configurationComplete = false;
-
-    if (PortFD == 0)
-    {
-        DEBUG(INDI::Logger::DBG_SESSION, "Focus F1 should be connected before try to connect F2");
-        return false;
-    }
-
     int modelIndex = IUFindOnSwitchIndex(&ModelSP);
-    if (modelIndex == 0)
-    {
-        DEBUG(INDI::Logger::DBG_ERROR, "You must select a model before establishing connection");
-        return false;
-    }
 
     if (ack())
     {
@@ -901,9 +875,8 @@ bool FocusLynxF2::Connect()
         return true;
     }
 
-    DEBUG(
-        INDI::Logger::DBG_SESSION,
-        "Error retreiving data from FocusLynx, please ensure FocusLynx controller is powered and the port is correct.");
+    DEBUG(INDI::Logger::DBG_SESSION,
+          "Error retreiving data from FocusLynx, please ensure FocusLynx controller is powered and the port is correct.");
     return false;
 }
 
@@ -912,10 +885,29 @@ bool FocusLynxF2::Connect()
 * ***********************************************************************************/
 bool FocusLynxF2::Disconnect()
 {
-    FocusLynxBase::Disconnect();
-    // to be sue that when stoped by EKOS, both Focuser would be disconneted
-    lynxDriveF1->RemoteDisconnect();
+    // If we disconnect F2, No socket to close, set local PortFD to -1
+    PortFD = -1;
+    DEBUGF(INDI::Logger::DBG_SESSION,"%s is offline.", getDeviceName());
+    DEBUGF(INDI::Logger::DBG_SESSION, "Value of F2 PortFD = %d", PortFD);
     return true;
+}
+
+/************************************************************************************
+ *
+* ***********************************************************************************/
+bool FocusLynxF2::RemoteDisconnect()
+{
+  if (isConnected())
+  {
+    setConnected(false, IPS_IDLE);
+    updateProperties();
+  }
+
+  // When called by F1, the PortFD should be -1; For debbug purpose
+  PortFD = lynxDriveF1->getPortFD();
+  DEBUGF(INDI::Logger::DBG_SESSION,"Remote disconnection: %s is offline.", getDeviceName());
+  DEBUGF(INDI::Logger::DBG_SESSION, "Value of F2 PortFD = %d", PortFD);
+  return true;
 }
 
 /************************************************************************************
@@ -935,3 +927,19 @@ void FocusLynxF2::ISGetProperties(const char *dev)
 /************************************************************************************
  *
 * ***********************************************************************************/
+void FocusLynxF2::simulationTriggered(bool enable)
+{
+    INDI::Focuser::simulationTriggered(enable);
+    // Set the simultation mode on F1 as selected by the user
+    lynxDriveF1->setSimulation(enable);
+}
+
+/************************************************************************************
+ *
+* ***********************************************************************************/
+void FocusLynxF2::debugTriggered(bool enable)
+{
+    INDI::Focuser::debugTriggered(enable);
+    // Set the Debug mode on F1 as selected by the user
+    lynxDriveF1->setDebug(enable);
+}

--- a/libindi/drivers/focuser/focuslynx.h
+++ b/libindi/drivers/focuser/focuslynx.h
@@ -36,7 +36,7 @@ class FocusLynxF1 : public FocusLynxBase
     virtual bool Disconnect() override;
     virtual bool updateProperties() override;
     virtual bool initProperties() override;
-    virtual void ISGetProperties(const char *dev) override;
+//    virtual void ISGetProperties(const char *dev) override;
     int getPortFD();
 
     virtual void setSimulation(bool enable);
@@ -68,9 +68,8 @@ class FocusLynxF2 : public FocusLynxBase
     virtual bool Connect() override;
     virtual bool Disconnect() override;
     virtual bool RemoteDisconnect();
-    virtual bool initProperties();
-    virtual void ISGetProperties(const char *dev);
-    virtual void simulationTriggered(bool enable);
-    virtual void debugTriggered(bool enable);
+    virtual bool initProperties() override;
+    virtual void simulationTriggered(bool enable) override;
+    virtual void debugTriggered(bool enable) override;
 };
 

--- a/libindi/drivers/focuser/focuslynx.h
+++ b/libindi/drivers/focuser/focuslynx.h
@@ -22,6 +22,8 @@
 #include "focuslynxbase.h"
 
 #define POLLMS 1000
+#define FOCUSNAMEF1 "FocusLynx F1"
+#define FOCUSNAMEF2 "FocusLynx F2"
 
 class FocusLynxF1 : public FocusLynxBase
 {
@@ -35,9 +37,10 @@ class FocusLynxF1 : public FocusLynxBase
     virtual bool updateProperties() override;
     virtual bool initProperties() override;
     virtual void ISGetProperties(const char *dev) override;
-    virtual int getVersion(int *major, int *minor, int *sub) override;
     int getPortFD();
 
+    virtual void setSimulation(bool enable);
+    virtual void setDebug(bool enable);
   private:
     // Get functions
     bool getHubConfig();
@@ -53,9 +56,6 @@ class FocusLynxF1 : public FocusLynxBase
     //Network WIFI Info
     IText WifiT[9];
     ITextVectorProperty WifiTP;
-
-    // Store version of the firmawre form the HUB
-    char version[16];
 };
 
 class FocusLynxF2 : public FocusLynxBase
@@ -67,5 +67,10 @@ class FocusLynxF2 : public FocusLynxBase
     const char *getDefaultName() override;
     virtual bool Connect() override;
     virtual bool Disconnect() override;
-    virtual void ISGetProperties(const char *dev) override;
+    virtual bool RemoteDisconnect();
+    virtual bool initProperties();
+    virtual void ISGetProperties(const char *dev);
+    virtual void simulationTriggered(bool enable);
+    virtual void debugTriggered(bool enable);
 };
+

--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -666,7 +666,7 @@ bool FocusLynxBase::ack()
     {
         const char *focusName = IUFindOnSwitch(&ModelSP)->label;
         strncpy(response, focusName, 32);
-        response[32] = '\0';
+        response[31] = '\0';
         nbytes_read = strlen(response) + 1;
     }
     else
@@ -790,12 +790,12 @@ bool FocusLynxBase::getFocusConfig()
     // Get Max Position
     if (isSimulation())
     {
-    if (isAbsolute == false)
-        // Value with high limit to give freedom to user of emulation range
-        snprintf(response, 32, "Max Pos = %06d\n", 100000);
-    else
-        // Value from the TCF-S absolute focuser
-        snprintf(response, 32, "Max Pos = %06d\n", 7000);
+        if (isAbsolute == false)
+            // Value with high limit to give freedom to user of emulation range
+            snprintf(response, 32, "Max Pos = %06d\n", 100000);
+        else
+            // Value from the TCF-S absolute focuser
+            snprintf(response, 32, "Max Pos = %06d\n", 7000);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)

--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -19,15 +19,6 @@
 
 #include "focuslynxbase.h"
 
-#include "indicom.h"
-#include "connectionplugins/connectionserial.h"
-
-#include <cmath>
-#include <memory>
-#include <cstring>
-#include <termios.h>
-#include <unistd.h>
-
 #define LYNXFOCUS_MAX_RETRIES        1
 #define LYNXFOCUS_TIMEOUT            2
 #define LYNXFOCUS_MAXBUF             16
@@ -52,6 +43,7 @@ FocusLynxBase::FocusLynxBase(const char *target)
 * ***********************************************************************************/
 FocusLynxBase::FocusLynxBase()
 {
+    setVersion(VERSION, SUBVERSION);
 
     lynxModels["Optec TCF-Lynx 2"] = "OA";
     lynxModels["Optec TCF-Lynx 3"] = "OB";
@@ -93,8 +85,6 @@ FocusLynxBase::FocusLynxBase()
     simStatus[STATUS_REMOTEIO] = ISS_ON;
     simStatus[STATUS_HNDCTRL]  = ISS_ON;
     simStatus[STATUS_REVERSE]  = ISS_OFF;
-
-    isFromRemote = false;
 }
 
 /************************************************************************************
@@ -112,7 +102,6 @@ bool FocusLynxBase::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser temperature
-
     IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
     IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
@@ -158,7 +147,7 @@ bool FocusLynxBase::initProperties()
     IUFillNumberVector(&BacklashNP, BacklashN, 1, getDeviceName(), "Backlash", "", FOCUS_SETTINGS_TAB, IP_RW, 0,
                        IPS_IDLE);
 
-    // Max Travel
+    // Max Travel relative focusers
     IUFillNumber(&MaxTravelN[0], "Ticks", "", "%.f", 0, 100000, 0., 0.);
     IUFillNumberVector(&MaxTravelNP, MaxTravelN, 1, getDeviceName(), "Max Travel", "", FOCUS_SETTINGS_TAB, IP_RW, 0,
                        IPS_IDLE);
@@ -184,11 +173,13 @@ bool FocusLynxBase::initProperties()
     std::map<std::string, std::string>::iterator iter;
     int nModels = 1;
     ModelS      = (ISwitch *)malloc(sizeof(ISwitch));
-    IUFillSwitch(ModelS, "ZZ", "--", ISS_ON);
+    // Need to be able to select no focuser to avoid troubles with Ekos
+    IUFillSwitch(ModelS, "ZZ", "No Focuser", ISS_ON);
     for (iter = lynxModels.begin(); iter != lynxModels.end(); ++iter)
     {
         ModelS = (ISwitch *)realloc(ModelS, (nModels + 1) * sizeof(ISwitch));
         IUFillSwitch(ModelS + nModels, (iter->second).c_str(), (iter->first).c_str(), ISS_OFF);
+
         nModels++;
     }
     IUFillSwitchVector(&ModelSP, ModelS, nModels, getDeviceName(), "Model", "", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
@@ -217,8 +208,8 @@ bool FocusLynxBase::initProperties()
     // Led intensity value
     IUFillNumber(&LedN[0], "Intensity", "", "%.f", 0, 100, 5., 0.);
     IUFillNumberVector(&LedNP, LedN, 1, getDeviceName(), "Led", "", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
-
     //simPosition = FocusAbsPosN[0].value;
+
     addAuxControls();
 
     return true;
@@ -261,18 +252,20 @@ bool FocusLynxBase::updateProperties()
         defineSwitch(&BacklashCompensationSP);
         defineNumber(&BacklashNP);
 
+        // For absolute focusers the vector is set to RO, as we get value from the HUB
         if (isAbsolute == false)
-            defineNumber(&MaxTravelNP);
+            MaxTravelNP.p = IP_RW;
+        else
+            MaxTravelNP.p = IP_RO;
+        defineNumber(&MaxTravelNP);
 
         defineSwitch(&ResetSP);
 
         // If focuser is relative, we only exposure "Center" command as it cannot home
         if (isAbsolute == false)
             GotoSP.nsp = 1;
-
-        // If Focuser one, add Led property on the main tab
-        if (!strcmp(getFocusTarget(), "F1"))
-            defineNumber(&LedNP);
+        else
+            GotoSP.nsp = 2;
 
         defineSwitch(&GotoSP);
         defineSwitch(&ReverseSP);
@@ -301,8 +294,7 @@ bool FocusLynxBase::updateProperties()
         deleteProperty(BacklashCompensationSP.name);
         deleteProperty(BacklashNP.name);
 
-        if (isAbsolute == false)
-            deleteProperty(MaxTravelNP.name);
+        deleteProperty(MaxTravelNP.name);
 
         deleteProperty(ResetSP.name);
         deleteProperty(GotoSP.name);
@@ -310,9 +302,6 @@ bool FocusLynxBase::updateProperties()
 
         deleteProperty(StatusLP.name);
         deleteProperty(HFocusNameTP.name);
-        // If Focuser one, have to remove Led property
-        if (!strcmp(getFocusTarget(), "F1"))
-            deleteProperty(LedNP.name);
     }
 
     return true;
@@ -335,87 +324,6 @@ bool FocusLynxBase::Handshake()
     DEBUG(INDI::Logger::DBG_SESSION, "Error retreiving data from FocusLynx, please ensure FocusLynxBase controller is "
                                      "powered and the port is correct.");
     return false;
-}
-
-/************************************************************************************
- *
-* ***********************************************************************************/
-bool FocusLynxBase::Connect()
-{
-    DEBUG(INDI::Logger::DBG_DEBUG, "ConnectBase is called");
-
-    int connectrc = 0;
-    char errorMsg[MAXRBUF];
-
-    configurationComplete = false;
-
-    int modelIndex = IUFindOnSwitchIndex(&ModelSP);
-    if (modelIndex == 0)
-    {
-        DEBUG(INDI::Logger::DBG_ERROR, "You must select a model before establishing connection");
-        return false;
-    }
-
-    if (!isSimulation() && (connectrc = tty_connect(serialConnection->port(), 115200, 8, 0, 1, &PortFD)) != TTY_OK)
-    {
-        tty_error_msg(connectrc, errorMsg, MAXRBUF);
-
-        DEBUGF(INDI::Logger::DBG_SESSION, "Failed to connect to port %s. Error: %s", serialConnection->port(),
-               errorMsg);
-
-        return false;
-    }
-
-    return Handshake();
-}
-
-/************************************************************************************
- *
-* ***********************************************************************************/
-bool FocusLynxBase::RemoteConnect()
-/* Function used to give to give remote connect
- *  from F2 to F1 and F2 to F1
- */
-
-{
-    if (!isConnected())
-    {
-        isFromRemote = true;
-        if (Connect())
-        {
-            setConnected(true, IPS_OK);
-            updateProperties();
-        }
-    }
-    return true;
-}
-
-/************************************************************************************
- *
-* ***********************************************************************************/
-bool FocusLynxBase::Disconnect()
-{
-    if (!strcmp(getFocusTarget(), "F1"))
-    {
-        if (!isSimulation())
-            tty_disconnect(PortFD);
-        PortFD = 0;
-    }
-    DEBUG(INDI::Logger::DBG_SESSION, "FocusLynx is offline.");
-    return true;
-}
-
-/************************************************************************************
- *
-* ***********************************************************************************/
-bool FocusLynxBase::RemoteDisconnect()
-{
-    if (isConnected())
-    {
-        setConnected(false, IPS_IDLE);
-        updateProperties();
-    }
-    return true;
 }
 
 /************************************************************************************
@@ -678,6 +586,9 @@ bool FocusLynxBase::ISNewNumber(const char *dev, const char *name, double values
             return true;
         }
 
+        // Max Travel if relative focusers
+        if (!strcmp(MaxTravelNP.name, name))
+
         // Max Travel
         if (strcmp(MaxTravelNP.name, name) == 0)
         {
@@ -742,7 +653,7 @@ bool FocusLynxBase::ack()
     char cmd[32];
     int errcode = 0;
     char errmsg[MAXRBUF];
-    char response[16];
+    char response[32];
     int nbytes_read    = 0;
     int nbytes_written = 0;
 
@@ -753,7 +664,9 @@ bool FocusLynxBase::ack()
 
     if (isSimulation())
     {
-        strncpy(response, "Optec 2\" TCF-S", 16);
+        const char *focusName = IUFindOnSwitch(&ModelSP)->label;
+        strncpy(response, focusName, 32);
+        response[32] = '\0';
         nbytes_read = strlen(response) + 1;
     }
     else
@@ -877,7 +790,12 @@ bool FocusLynxBase::getFocusConfig()
     // Get Max Position
     if (isSimulation())
     {
+    if (isAbsolute == false)
+        // Value with high limit to give freedom to user of emulation range
         snprintf(response, 32, "Max Pos = %06d\n", 100000);
+    else
+        // Value from the TCF-S absolute focuser
+        snprintf(response, 32, "Max Pos = %06d\n", 7000);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -906,6 +824,13 @@ bool FocusLynxBase::getFocusConfig()
         IUUpdateMinMax(&SyncNP);
 
         maxControllerTicks = maxPos;
+
+        // if it is relative focuser and the backup have a value, MaxTravNP[0].value
+        // will be overide by the backup restore call
+        MaxTravelNP.s = IPS_OK;
+        MaxTravelN[0].value = maxPos;
+        IDSetNumber(&MaxTravelNP, NULL);
+
     }
     else
         return false;
@@ -1221,7 +1146,6 @@ bool FocusLynxBase::getFocusConfig()
     TemperatureCompensateOnStartSP.s   = IPS_OK;
     IDSetSwitch(&TemperatureCompensateOnStartSP, nullptr);
 
-    // Added By Philippe Besson the 28th of June for 'END' evalution
     // END is reached
     memset(response, 0, sizeof(response));
     if (isSimulation())
@@ -1246,7 +1170,6 @@ bool FocusLynxBase::getFocusConfig()
         if (strcmp(response, "END"))
             return false;
     }
-    // End of added code by Philippe Besson
 
     tcflush(PortFD, TCIFLUSH);
 
@@ -1601,7 +1524,6 @@ bool FocusLynxBase::getFocusStatus()
         StatusLP.s = IPS_OK;
         IDSetLight(&StatusLP, nullptr);
 
-        // Added By Philippe Besson the 28th of June for 'END' evalution
         // END is reached
         memset(response, 0, sizeof(response));
         if (isSimulation())
@@ -1626,7 +1548,6 @@ bool FocusLynxBase::getFocusStatus()
             if (strcmp(response, "END"))
                 return false;
         }
-        // End of added code by Philippe Besson
 
         tcflush(PortFD, TCIFLUSH);
 
@@ -1700,7 +1621,7 @@ bool FocusLynxBase::setDeviceType(int index)
  *
 * ***********************************************************************************/
 bool FocusLynxBase::setLedLevel(int level)
-// Write via the serial port to the HUB the selected LED intensity level
+// Write via the connected port to the HUB the selected LED intensity level
 
 {
     char cmd[16];
@@ -1762,7 +1683,7 @@ bool FocusLynxBase::setLedLevel(int level)
  *
 * ***********************************************************************************/
 bool FocusLynxBase::setDeviceNickname(const char *nickname)
-// Write via the serial port to the HUB the choiced nikname of he focuser
+// Write via the connected port to the HUB the choiced nikname of he focuser
 {
     char cmd[32];
     int errcode = 0;
@@ -1839,8 +1760,13 @@ bool FocusLynxBase::home()
     {
         strncpy(response, "H", 16);
         nbytes_read              = strlen(response) + 1;
-        simStatus[STATUS_HOMING] = ISS_ON;
         targetPosition           = 0;
+        FocusAbsPosN[0].value = MaxTravelN[0].value;
+        FocusAbsPosNP.s = IPS_OK;
+        IDSetNumber(&FocusAbsPosNP, NULL);
+        simStatus[STATUS_HOMING] = ISS_ON;
+        simStatus[STATUS_HOMED] = ISS_OFF;
+        simPosition = FocusAbsPosN[0].value;
     }
     else
     {
@@ -2730,9 +2656,14 @@ void FocusLynxBase::TimerHit()
                 if (simStatus[STATUS_HOMING] == ISS_ON)
                 {
                     StatusL[STATUS_HOMED].s = IPS_OK;
+                    StatusL[STATUS_HOMING].s = IPS_IDLE;
                     simStatus[STATUS_HOMING] = ISS_OFF;
+                    simStatus[STATUS_HOMED] = ISS_ON;
                 }
             }
+            else
+                StatusL[STATUS_MOVING].s = IPS_BUSY;
+            IDSetLight(&StatusLP, NULL);
         }
 
         if (isHoming && StatusL[STATUS_HOMED].s == IPS_OK)
@@ -2745,6 +2676,8 @@ void FocusLynxBase::TimerHit()
             FocusAbsPosNP.s = IPS_OK;
             IDSetNumber(&FocusRelPosNP, nullptr);
             DEBUG(INDI::Logger::DBG_SESSION, "Focuser reached home position.");
+            if (isSimulation())
+                center();
         }
         else if (StatusL[STATUS_MOVING].s == IPS_IDLE)
         {
@@ -2919,17 +2852,24 @@ const char *FocusLynxBase::getFocusTarget()
 /************************************************************************************
  *
 * ***********************************************************************************/
-
 int FocusLynxBase::getVersion(int *major, int *minor, int *sub)
 {
     INDI_UNUSED(major);
     INDI_UNUSED(minor);
     INDI_UNUSED(sub);
-    // This methode have to be overided by child object
     /* For future use of implementation of new firmware 2.0.0
      * and give ability to keep compatible to actual 1.0.9
-     * WIll be to avoid calling to new functions
+     * Will be to avoid calling to new functions
      * Not yet implemented in this version of the driver
      */
-    return 0;
+    char sMajor[8], sMinor[8], sSub[8];
+    int  rc = sscanf(version, "%[^.].%[^.].%s",sMajor, sMinor, sSub);
+
+    DEBUGF(INDI::Logger::DBG_DEBUG, "Version major: %s, minor: %s, subversion: %s", sMajor, sMinor, sSub);
+    *major = atoi(sMajor);
+    *minor = atoi(sMinor);
+    *sub = atoi(sSub);
+    if (rc == 3)
+        return *major;
+    return 0;  // 0 Means error in this case
 }

--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -226,7 +226,7 @@ void FocusLynxBase::ISGetProperties(const char *dev)
     INDI::Focuser::ISGetProperties(dev);
 
     defineSwitch(&ModelSP);
-    loadConfig(true, "Models");
+    loadConfig(true, "Model");
 }
 
 /************************************************************************************
@@ -1683,7 +1683,7 @@ bool FocusLynxBase::setLedLevel(int level)
  *
 * ***********************************************************************************/
 bool FocusLynxBase::setDeviceNickname(const char *nickname)
-// Write via the connected port to the HUB the choiced nikname of he focuser
+// Write via the connected port to the HUB the choiced nikname of the focuser
 {
     char cmd[32];
     int errcode = 0;


### PR DESCRIPTION
Remove unnecessary procedure as Ekos is able to start correctly both interfaces from the driver.
Improve simulation as absolute focuser (Wasn't correct sequence of events before)
Set options as Simulation and debug in only one driver (F2) to avoid confusion.
Change setting depend if focuser is an absolute or a relative one to reflect correct options (Max travel ticks R or RW)
Allow selection of "no focuser", "ZZ" value, to allow Ekos to start all drivers. FocusBoss manage this case too, without error if commands are sent to the focuser.
Activate network/serial connection !! Hub firmware >= 2.0.4 to works correctly !!