### PR TITLE
Start/Stop tracking commands. Init mount state at start time.

### DIFF
--- a/libindi/drivers/telescope/ioptronHC8406.cpp
+++ b/libindi/drivers/telescope/ioptronHC8406.cpp
@@ -94,6 +94,7 @@ ioptronHC8406::ioptronHC8406()
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | 
                       TELESCOPE_CAN_ABORT | TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION | 
                       TELESCOPE_HAS_TRACK_MODE | TELESCOPE_CAN_CONTROL_TRACK);
+
 }
 
 bool ioptronHC8406::initProperties()
@@ -150,6 +151,7 @@ bool ioptronHC8406::updateProperties()
         defineSwitch(&CenterRateSP);
         //defineSwitch(&SlewRateSP); //NOT WORK!!
         defineSwitch(&CursorMoveSpeedSP);
+        ioptronHC8406Init();
     }
     else
     {
@@ -331,10 +333,20 @@ bool ioptronHC8406::isSlewComplete()
 
 void ioptronHC8406::getBasicData()
 {
-    UnPark();
     checkLX200Format(PortFD);
     sendScopeLocation();
     sendScopeTime();
+}
+
+void ioptronHC8406::ioptronHC8406Init()
+{
+    //This mount doesn't report anything so we send some CMD
+    //just to get syncronize with the GUI at start time
+    DEBUG(INDI::Logger::DBG_WARNING, "Sending init CMDs. Unpark, Stop tracking");
+    UnPark();
+    TrackState = SCOPE_IDLE;
+    SetTrackEnabled(false);    
+    setioptronHC8406GuideRate(1);
 }
 
 bool ioptronHC8406::Goto(double r, double d)
@@ -703,7 +715,7 @@ int ioptronHC8406::setioptronHC8406StandardProcedure(int fd, const char *data)
 
     error_type = tty_read(fd, bool_return, 1, 5, &nbytes_read);
 
-    // JM: Hack from Jon in the INDI forums to fix longitude/latitude settings failure on ioptronHC8406
+    // JM: Hack from Jon in the INDI forums to fix longitude/latitude settings failure 
     
     usleep(10000);
     tcflush(fd, TCIFLUSH);

--- a/libindi/drivers/telescope/ioptronHC8406.cpp
+++ b/libindi/drivers/telescope/ioptronHC8406.cpp
@@ -92,7 +92,9 @@ ioptronHC8406::ioptronHC8406()
     setVersion(1, 1);
     //setDeviceName("ioptronHC8406");
     setLX200Capability(LX200_HAS_FOCUS);
-    SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT | TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION | TELESCOPE_HAS_TRACK_MODE);
+    SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | 
+                      TELESCOPE_CAN_ABORT | TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION | 
+                      TELESCOPE_HAS_TRACK_MODE | TELESCOPE_CAN_CONTROL_TRACK);
 }
 
 bool ioptronHC8406::initProperties()
@@ -100,15 +102,15 @@ bool ioptronHC8406::initProperties()
     LX200Generic::initProperties();
 
     // Sync Type
-    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], ":CM#", ":CM#", ISS_ON);
-    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], ":CMR#", ":CMR#", ISS_OFF);
-    IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNCCMR", "Sync", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,IPS_IDLE);
+    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], "USE_REGULAR_SYNC", ":CM#", ISS_ON);
+    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], "USE_CMR_SYNC", ":CMR#", ISS_OFF);
+    IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNC_MODE", "Sync", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,IPS_IDLE);
 
     // Cursor move Guiding/Center
-    IUFillSwitch(&CursorMoveSpeedS[USE_GUIDE_SPEED], "Guide Speed", "", ISS_ON);
-    IUFillSwitch(&CursorMoveSpeedS[USE_CENTERING_SPEED], "Centering Speed", "", ISS_OFF);
+    IUFillSwitch(&CursorMoveSpeedS[USE_GUIDE_SPEED],"USE_GUIDE_SPEED", "Guide Speed", ISS_ON);
+    IUFillSwitch(&CursorMoveSpeedS[USE_CENTERING_SPEED],"USE_CENTERING_SPEED", "Centering Speed", ISS_OFF);
     IUFillSwitchVector(&CursorMoveSpeedSP, CursorMoveSpeedS, 2, getDeviceName(),
-	 "MOVE_SPEED", "Cursor Move Speed", MOTION_TAB, IP_RO, ISR_1OFMANY, 0,IPS_IDLE);
+	 "CURSOR_MOVE_MODE", "Cursor Move Speed", MOTION_TAB, IP_RO, ISR_1OFMANY, 0,IPS_IDLE);
 
     // Guide Rate
     IUFillSwitch(&GuideRateS[0], "0.25x", "", ISS_OFF);
@@ -459,7 +461,7 @@ int ioptronHC8406::ioptronHC8406SyncCMR(char *matchedObject)
     int nbytes_write = 0;
     int nbytes_read  = 0;
 
-    DEBUGF(INDI::Logger::DBG_DEBUG, "CMD <%s>", "#:CMR#");
+    DEBUGF(INDI::Logger::DBG_DEBUG, "CMD <%s>", ":CMR#");
 
     if ((error_type = tty_write_string(PortFD, ":CMR#", &nbytes_write)) != TTY_OK)
         return error_type;
@@ -722,7 +724,7 @@ bool ioptronHC8406::SetTrackEnabled(bool enabled)
 {
     DEBUGF(INDI::Logger::DBG_WARNING, "<SetTrackEnabled> NOT A CMD IN HC8406 command set: %d",enabled);
 
-    return false;
+    return true;
 }
 
 bool ioptronHC8406::SetTrackMode(uint8_t mode)

--- a/libindi/drivers/telescope/ioptronHC8406.cpp
+++ b/libindi/drivers/telescope/ioptronHC8406.cpp
@@ -76,6 +76,11 @@ UPGRADE INFO ON: http://www.ioptron.com/Articles.asp?ID=268
 :Mexxx#
 :Mwxxx#   ->Al this commands are broken. Only RA axes, the equivalent :Ms#,:Mn#... work.
 
+Summarizing:
+
+old firmware v1.10: is not possible to start/stop tracking. Guide/move commands OK
+new firmware v1.12: is possible to start/stop tracking. Guide/move commands NOT OK
+
 */
 
 /* SOCAT sniffer

--- a/libindi/drivers/telescope/ioptronHC8406.cpp
+++ b/libindi/drivers/telescope/ioptronHC8406.cpp
@@ -60,6 +60,22 @@ This speeds only are taken into account for protocol buttons, not for the HC But
 :RC0,1,2 -->preselect guide speed  (HC doesn't shows it)
 :Mn# :Ms# :Me# :Mw#  (move until :Q# at guiding or center speed :RG# (works)or :RC#(not work, use :RC0/1/2 instead))
 :MnXXX# :MsXXX# :MeXXX# :MwXXX#  (move XXX ms at guiding speed no mather what :RCx#,:RGX# or :RSX# was issue)
+
+Firmware update (HC v1.10 -> v1.12, also mainboard firmware)
+------------------------------------------------------------------
+HC8406 CMD hardware TEST
+V1.12 2011-08-12
+UPGRADE INFO ON: http://www.ioptron.com/Articles.asp?ID=268
+
+:RT9#     -> stop tracking
+:RT0#     -> start tracking at sidera speed. Formerly only preselect sideral speed but
+             not start the tracking itself
+
+:Me#
+:Mw#
+:Mexxx#
+:Mwxxx#   ->Al this commands are broken. Only RA axes, the equivalent :Ms#,:Mn#... work.
+
 */
 
 /* SOCAT sniffer

--- a/libindi/drivers/telescope/ioptronHC8406.cpp
+++ b/libindi/drivers/telescope/ioptronHC8406.cpp
@@ -845,7 +845,7 @@ bool ioptronHC8406::ReadScopeStatus()
     }
     else if (TrackState == SCOPE_PARKING)
     {
-        if (isSlewComplete())
+        if (true || isSlewComplete()) // isSlewComplete() not work because is base on actual RA/DEC vs target RA/DEC. DO ALWAYS
         {
             SetParked(true);
 	    TrackState = SCOPE_PARKED;

--- a/libindi/drivers/telescope/ioptronHC8406.h
+++ b/libindi/drivers/telescope/ioptronHC8406.h
@@ -58,8 +58,10 @@ class ioptronHC8406 : public LX200Generic
     void sendScopeTime() ;
   private:
     int setioptronHC8406StandardProcedure(int fd, const char *data);
-    void setGuidingEnabled(bool enable);
     int ioptronHC8406SyncCMR(char *matchedObject);
+
+    // Mount Initialization. 
+    void ioptronHC8406Init();
 
     // Settings
     int setioptronHC8406Latitude(double Lat);
@@ -73,7 +75,6 @@ class ioptronHC8406 : public LX200Generic
 
     // Track Mode
     int setioptronHC8406TrackMode(int mode);
-    int getioptronHC8406TrackMode(int *mode);
 
     //Set move rates
     int setMoveRate(int rate,int move_type);


### PR DESCRIPTION
After the mount  firmware update (v1.1 ->v1.12) it is posible to start/stop tracking (:RT9# stop, :RT2# start) so implement SetTrackEnabled() using this CMDs. 

Other minor changes:
.- More descriptive properties
.- New ioptronHC8406Init() function. This mount doesn't report to much so I initialize the mount in order to get a consistent state between GUI and the mount at start time: Unparked, Guide rate x0.5, tracking stopped

IMPORTANT to note: firmware v1.12 has a awfull bug. Guide commands :Mexxx#/:Mwxxx# stop working.  Also  move commands :Me#/:Mw# are broken. Only RA axes, the equivalent on DEC axes :Msxxx#,.. work perfect. Nothing to do with the driver. I asked ioptron to fix it.