### PR TITLE
Override JPEG as V4L2 compressed format systematically.

### DIFF
--- a/libindi/libs/webcam/v4l2_base.cpp
+++ b/libindi/libs/webcam/v4l2_base.cpp
@@ -202,6 +202,7 @@ bool V4L2_Base::is_compressed() const
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 17, 0))
     switch (fmt.fmt.pix.pixelformat)
     {
+        case V4L2_PIX_FMT_JPEG:
         case V4L2_PIX_FMT_MJPEG:
             DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG, "%s: format %c%c%c%c patched to be considered compressed",
                          __FUNCTION__, fmt.fmt.pix.pixelformat, fmt.fmt.pix.pixelformat >> 8,


### PR DESCRIPTION
Apparently Raspberry Pi Camera v2 is managed by a kernel driver which
marks JPEG frames as uncompressed. This is weird.
Pull this change if required, this is probably innocuous as JPEG frame should always be considered compressed.