### PR TITLE
limit the QHY devicecount to prevent writing to random memory

### DIFF
--- a/3rdparty/indi-qhy/qhy_ccd.cpp
+++ b/3rdparty/indi-qhy/qhy_ccd.cpp
@@ -74,6 +74,13 @@ std::vector<std::string> GetDevicesIDs()
     deviceCount = ScanQHYCCD();
 #endif
 
+    if (deviceCount > MAX_DEVICES)
+    {
+        deviceCount = MAX_DEVICES;
+        IDLog("Devicescan found %d devices. The driver is compiled to support only up to %d devices.",
+               deviceCount, MAX_DEVICES);
+    }
+
     for (int i = 0; i < deviceCount; i++)
     {
         memset(camid, '\0', MAXINDIDEVICE);


### PR DESCRIPTION
Hi,

I noticed in http://indilib.org/forum/ekos/2219-items-from-last-night-s-indi-ekos-kstars-session.html?start=48#20094 with up to 7 QHY cameras and the loops in the driver ignore the array end that holds the cameras.

Karsten