### PR TITLE
Correct SetMotionMode Comments in skywatcherAPI Driver

### DIFF
--- a/libindi/drivers/telescope/skywatcherAPI.cpp
+++ b/libindi/drivers/telescope/skywatcherAPI.cpp
@@ -526,9 +526,9 @@ bool SkywatcherAPI::SetGotoTargetOffset(AXISID Axis, long OffsetInMicrosteps)
     return TalkWithAxis(Axis, 'H', Parameters, Response);
 }
 
-/// Func - 0 Low speed slew to mode (goto)
+/// Func - 0 High speed slew to mode (goto)
 /// Func - 1 Low speed slew mode
-/// Func - 2 High speed slew to mode (goto)
+/// Func - 2 Low speed slew to mode (goto)
 /// Func - 3 High speed slew mode
 bool SkywatcherAPI::SetMotionMode(AXISID Axis, char Func, char Direction)
 {

--- a/libindi/drivers/telescope/skywatcherAPI.h
+++ b/libindi/drivers/telescope/skywatcherAPI.h
@@ -187,9 +187,9 @@ class SkywatcherAPI
     /// \brief Set the motion mode per the specified axis
     /// \param[in] Axis - The axis to use.
     /// \param[in] Func - the slewing mode
-    /// - 0 = Low speed SlewTo mode
+    /// - 0 = High speed SlewTo mode
     /// - 1 = Low speed Slew mode
-    /// - 2 = High speed SlewTo mode
+    /// - 2 = Low speed SlewTo mode
     /// - 3 = High Speed Slew mode
     /// \param[in] Direction - the direction to slew in
     /// - 0 = Forward


### PR DESCRIPTION
The comments describing the "SetMotionMode" function "Func" parameter
were incorrectly labelled.

The changes in this commit have no affect on the code itself which was handling the parameters correctly. However it makes sense to correct the commenting as it only serves to add confusion otherwise.