### PR TITLE
Fix handling of negative numbers in JSON

### DIFF
--- a/libindi/drivers/weather/gason.cpp
+++ b/libindi/drivers/weather/gason.cpp
@@ -207,7 +207,7 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
                     *endptr = s;
                     return JSON_BAD_NUMBER;
                 }
-                // Fall through to number handling
+                /* Falls through. */
             case '0':
             case '1':
             case '2':

--- a/libindi/drivers/weather/gason.cpp
+++ b/libindi/drivers/weather/gason.cpp
@@ -207,7 +207,7 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
                     *endptr = s;
                     return JSON_BAD_NUMBER;
                 }
-
+                // Fall through to number handling
             case '0':
             case '1':
             case '2':

--- a/libindi/drivers/weather/gason.cpp
+++ b/libindi/drivers/weather/gason.cpp
@@ -207,7 +207,6 @@ int jsonParse(char *s, char **endptr, JsonValue *value, JsonAllocator &allocator
                     *endptr = s;
                     return JSON_BAD_NUMBER;
                 }
-                break;
 
             case '0':
             case '1':


### PR DESCRIPTION
Now that weather here in Finland has got colder, I noticed that Wunderground weather driver started to give error about unquoted key. I debugged this a bit and noticed that the problem was that negative numbers weren't handled correctly due to an extra break; statement added in commit c6be880a80be51604bc0a068aeb65bf61567307b