### PR TITLE
Fix setting and saving GPS snoop device in weather base class

### DIFF
--- a/libindi/libs/indibase/indiweather.cpp
+++ b/libindi/libs/indibase/indiweather.cpp
@@ -252,6 +252,26 @@ bool INDI::Weather::ISNewNumber(const char *dev, const char *name, double values
     return DefaultDevice::ISNewNumber(dev, name, values, names, n);
 }
 
+
+bool INDI::Weather::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
+{
+    //  first check if it's for our device
+    if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
+    {
+        if (!strcmp(name, ActiveDeviceTP.name))
+        {
+            ActiveDeviceTP.s = IPS_OK;
+            IUUpdateText(&ActiveDeviceTP, texts, names, n);
+            //  Update client display
+            IDSetText(&ActiveDeviceTP, nullptr);
+
+            IDSnoopDevice(ActiveDeviceT[0].text, "GEOGRAPHIC_COORD");
+            return true;
+        }
+    }
+    return DefaultDevice::ISNewText(dev, name, texts, names, n);
+}
+
 bool INDI::Weather::ISSnoopDevice(XMLEle *root)
 {
     XMLEle *ep           = nullptr;
@@ -506,6 +526,7 @@ bool INDI::Weather::saveConfigItems(FILE *fp)
 {
     INDI::DefaultDevice::saveConfigItems(fp);
 
+    IUSaveConfigText(fp, &ActiveDeviceTP);
     IUSaveConfigNumber(fp, &LocationNP);
     IUSaveConfigNumber(fp, &UpdatePeriodNP);
 

--- a/libindi/libs/indibase/indiweather.h
+++ b/libindi/libs/indibase/indiweather.h
@@ -89,6 +89,7 @@ class INDI::Weather : public INDI::DefaultDevice
     virtual bool updateProperties();
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
+    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n);
 
     virtual bool ISSnoopDevice(XMLEle *root);
 


### PR DESCRIPTION
Noticed I couldn't set GPSD as snoop device for Wunderground driver and discovered that the snoop device field didn't actually do anything so added the necessary code to update and save the device name.