### PR TITLE
TCFS check for FMMODE response on connect

### DIFF
--- a/libindi/drivers/focuser/tcfs.cpp
+++ b/libindi/drivers/focuser/tcfs.cpp
@@ -178,14 +178,22 @@ bool TCFS::Handshake()
     dispatch_command(FWAKUP);
     read_tcfs(response);
 
-    dispatch_command(FMMODE);
-    read_tcfs(response);
-
+    for(int retry=0; retry<5; retry++)
+    {
+        dispatch_command(FMMODE);
+        read_tcfs(response);
+        if (strcmp(response, "!") == 0)
+        {
+            tcflush(PortFD, TCIOFLUSH);
+            DEBUG(INDI::Logger::DBG_SESSION, "Successfully connected to TCF-S Focuser in Manual Mode.");
+            return true;
+        }
+    }
     tcflush(PortFD, TCIOFLUSH);
 
-    DEBUG(INDI::Logger::DBG_SESSION, "Successfully connected to TCF-S Focuser in Manual Mode.");
+    DEBUG(INDI::Logger::DBG_ERROR, "Failed connection to TCF-S Focuser.");
 
-    return true;
+    return false;
 }
 
 /****************************************************************


### PR DESCRIPTION
When connecting to TCFS focuser, check that a "!" response is received when FMMODE command is issued. This helps confirm that the device is in fact the TCFS focuser and not some other serial device. It is also mandatory for further comms. TCFS manal notes: "A successful return from this command (“!” LF CR) is required before the TCFS/ TCF-S3 will accept any other user commands."
A retry loop is included as the manual also warns that: "Warning: The FMMODE command may need to be executed more than once to successfully exit the serial AUTO loops. The user will see the return character for FMMODE after the serial AUTO loop has been successfully exited. 