### PR TITLE
Fix LX200AP pulse guide to use proper AP serial commands

### DIFF
--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -626,6 +626,13 @@ bool LX200AstroPhysics::Goto(double r, double d)
     return true;
 }
 
+
+int LX200AstroPhysics::SendPulseCmd(int direction, int duration_msec)
+{
+    return APSendPulseCmd(PortFD, direction, duration_msec);
+}
+
+
 bool LX200AstroPhysics::Handshake()
 {
     if (isSimulation())

--- a/libindi/drivers/telescope/lx200ap.h
+++ b/libindi/drivers/telescope/lx200ap.h
@@ -63,6 +63,8 @@ class LX200AstroPhysics : public LX200Generic
     virtual bool updateLocation(double latitude, double longitude, double elevation) override;
     virtual bool SetSlewRate(int index) override;
 
+    virtual int  SendPulseCmd(int direction, int duration_msec);
+
     // Tracking
     virtual bool SetTrackMode(uint8_t mode) override;
     virtual bool SetTrackEnabled(bool enabled) override;

--- a/libindi/drivers/telescope/lx200apdriver.cpp
+++ b/libindi/drivers/telescope/lx200apdriver.cpp
@@ -694,3 +694,34 @@ int setAPDETrackRate(int fd, double rate)
     DEBUGFDEVICE(lx200ap_name, INDI::Logger::DBG_ERROR, "Only received #%d bytes, expected 1.", nbytes_read);
     return -1;
 }
+
+int APSendPulseCmd(int fd, int direction, int duration_msec)
+{
+    DEBUGFDEVICE(lx200ap_name, AP_DBG_SCOPE, "<%s>", __FUNCTION__);
+    int nbytes_write = 0;
+    char cmd[20];
+    switch (direction)
+    {
+        case LX200_NORTH:
+            sprintf(cmd, ":Mn%04d#", duration_msec);
+            break;
+        case LX200_SOUTH:
+            sprintf(cmd, ":Ms%04d#", duration_msec);
+	    break;
+        case LX200_EAST:
+            sprintf(cmd, ":Me%04d#", duration_msec);
+	    break;
+        case LX200_WEST:
+            sprintf(cmd, ":Mw%04d#", duration_msec);
+	    break;
+        default:
+            return 1;
+    }
+
+    DEBUGFDEVICE(lx200ap_name, AP_DBG_SCOPE, "CMD <%s>", cmd);
+
+    tty_write_string(fd, cmd, &nbytes_write);
+
+    tcflush(fd, TCIFLUSH);
+    return 0;
+}

--- a/libindi/drivers/telescope/lx200apdriver.h
+++ b/libindi/drivers/telescope/lx200apdriver.h
@@ -59,6 +59,7 @@ int setAPSiteLongitude(int fd, double Long);
 int setAPSiteLatitude(int fd, double Lat);
 int setAPRATrackRate(int fd, double rate);
 int setAPDETrackRate(int fd, double rate);
+int APSendPulseCmd(int fd, int direction, int duration_msec);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The Astro-Physics mounts use a slightly different serial command for guide movements than the generic LX200 so this patch creates an overriding method for the lx200ap driver to handle these requests.

I've been using it for several imaging sessions now and the guide results are very good under PHD2.