### PR TITLE
Add Slew Accuracy to Sky Sensor 2000 PC

### DIFF
--- a/libindi/drivers/telescope/lx200ss2000pc.h
+++ b/libindi/drivers/telescope/lx200ss2000pc.h
@@ -46,7 +46,6 @@ class LX200SS2000PC : public LX200Generic
     INumber SlewAccuracyN[2];
     INumberVectorProperty SlewAccuracyNP;
 
-    double Elevation, Latitud, Longitude;
     static const int ShortTimeOut;
     static const int LongTimeOut;
 };

--- a/libindi/drivers/telescope/lx200ss2000pc.h
+++ b/libindi/drivers/telescope/lx200ss2000pc.h
@@ -25,20 +25,29 @@
 class LX200SS2000PC : public LX200Generic
 {
   public:
-    LX200SS2000PC();
+    LX200SS2000PC(void);
 
-    virtual const char *getDefaultName();
+    virtual const char *getDefaultName(void);
     virtual bool updateTime(ln_date *utc, double utc_offset);
+    virtual bool initProperties();
+    virtual bool updateProperties();
+    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
 
   protected:
-    virtual void getBasicData();
-    virtual bool isSlewComplete();
+    virtual void getBasicData(void);
+    virtual bool isSlewComplete(void);
+    virtual bool saveConfigItems(FILE *fp);
 
   private:
     bool getCalendarDate(int &year, int &month, int &day);
     bool setCalenderDate(int year, int month, int day);
     bool setUTCOffset(const int offset_in_hours);
 
+    INumber SlewAccuracyN[2];
+    INumberVectorProperty SlewAccuracyNP;
+
+    double Elevation, Latitud, Longitude;
     static const int ShortTimeOut;
     static const int LongTimeOut;
 };
+


### PR DESCRIPTION
This change adds a configurable slew accuracy parameter to the SkySensor 2000 PC hand controller. 

The previous default difference between current and target RA/DEC was 0.01, and that caused slews to not end. Work around was to Abort the slew manually. 

Now there is no need for this workaround. One can set the slew accuracy to a different value than the default 3 arc minutes. On my Vixen GPDX with the Sky Sensor 2000 PC ROM version 2.05, a value of 4 arc minutes seems to work well indoors.