### PR TITLE
Correct setting of latitude and longitude on Sky Sensor 2000 PC

### DIFF
--- a/libindi/drivers/telescope/lx200ss2000pc.h
+++ b/libindi/drivers/telescope/lx200ss2000pc.h
@@ -43,6 +43,11 @@ class LX200SS2000PC : public LX200Generic
     bool setCalenderDate(int year, int month, int day);
     bool setUTCOffset(const int offset_in_hours);
 
+    bool updateLocation(double latitude, double longitude, double elevation);
+    int setLongitude(double Long);
+    int setLatitude(double Long);
+    int sendCommand(int fd, const char *data);
+
     INumber SlewAccuracyN[2];
     INumberVectorProperty SlewAccuracyNP;
 


### PR DESCRIPTION
The setting of latitude and longitude on Sky Sensor 2000 PC is different from the generic LX200. First, a space is required between the Sg and St command and its arguments. Also, seconds can be used unlike the generic LX200.