### PR TITLE
Lx200ap setguiderate

### DIFF
--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -1061,6 +1061,7 @@ bool LX200AstroPhysics::saveConfigItems(FILE *fp)
 
     IUSaveConfigSwitch(fp, &SyncCMRSP);
     IUSaveConfigSwitch(fp, &APSlewSpeedSP);
+    IUSaveConfigSwitch(fp, &APGuideSpeedSP);
 
     return true;
 }

--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -99,6 +99,13 @@ bool LX200AstroPhysics::initProperties()
     IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
+    // guide speed
+    IUFillSwitch(&APGuideSpeedS[0], "0.25", "0.25x", ISS_OFF);
+    IUFillSwitch(&APGuideSpeedS[1], "0.5", "0.50x", ISS_ON);
+    IUFillSwitch(&APGuideSpeedS[2], "1.0", "1.0x", ISS_OFF);
+    IUFillSwitchVector(&APGuideSpeedSP, APGuideSpeedS, 3, getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
+                       0, IPS_IDLE);
+
     IUFillText(&VersionT[0], "Number", "", 0);
     IUFillTextVector(&VersionInfo, VersionT, 1, getDeviceName(), "Firmware Info", "", FIRMWARE_TAB, IP_RO, 0, IPS_IDLE);
 
@@ -132,6 +139,7 @@ void LX200AstroPhysics::ISGetProperties(const char *dev)
         defineSwitch(&APSlewSpeedSP);
         defineSwitch(&SwapSP);
         defineSwitch(&SyncCMRSP);
+        defineSwitch(&APGuideSpeedSP);
         defineNumber(&SlewAccuracyNP);
 
         DEBUG(INDI::Logger::DBG_SESSION, "Please initialize the mount before issuing any command.");
@@ -153,6 +161,7 @@ bool LX200AstroPhysics::updateProperties()
         defineSwitch(&APSlewSpeedSP);
         defineSwitch(&SwapSP);
         defineSwitch(&SyncCMRSP);
+        defineSwitch(&APGuideSpeedSP);
         defineNumber(&SlewAccuracyNP);
 
         DEBUG(INDI::Logger::DBG_SESSION, "Please initialize the mount before issuing any command.");
@@ -165,6 +174,7 @@ bool LX200AstroPhysics::updateProperties()
         deleteProperty(APSlewSpeedSP.name);
         deleteProperty(SwapSP.name);
         deleteProperty(SyncCMRSP.name);
+        defineSwitch(&APGuideSpeedSP);
         deleteProperty(SlewAccuracyNP.name);
     }
 
@@ -339,6 +349,25 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
 
         APSlewSpeedSP.s = IPS_OK;
         IDSetSwitch(&APSlewSpeedSP, nullptr);
+        return true;
+    }
+
+    // ===========================================================
+    // Guide Speed.
+    // ===========================================================
+    if (!strcmp(name, APGuideSpeedSP.name))
+    {
+        IUUpdateSwitch(&APGuideSpeedSP, states, names, n);
+        int guideRate = IUFindOnSwitchIndex(&APGuideSpeedSP);
+
+        if (!isSimulation() && (err = selectAPGuideRate(PortFD, guideRate) < 0))
+        {
+            DEBUGF(INDI::Logger::DBG_ERROR, "Error setting guiding to rate (%d).", err);
+            return false;
+        }
+
+        APGuideSpeedSP.s = IPS_OK;
+        IDSetSwitch(&APGuideSpeedSP, nullptr);
         return true;
     }
 

--- a/libindi/drivers/telescope/lx200ap.h
+++ b/libindi/drivers/telescope/lx200ap.h
@@ -98,6 +98,9 @@ class LX200AstroPhysics : public LX200Generic
     ISwitchVectorProperty SyncCMRSP;
     enum { USE_REGULAR_SYNC, USE_CMR_SYNC };
 
+    ISwitch APGuideSpeedS[3];
+    ISwitchVectorProperty APGuideSpeedSP;
+
     IText VersionT[1];
     ITextVectorProperty VersionInfo;
 

--- a/libindi/drivers/telescope/lx200apdriver.cpp
+++ b/libindi/drivers/telescope/lx200apdriver.cpp
@@ -509,6 +509,50 @@ int selectAPTrackingMode(int fd, int trackMode)
     return 0;
 }
 
+int selectAPGuideRate(int fd, int guideRate)
+{
+    int error_type;
+    int nbytes_write = 0;
+    switch (guideRate)
+    {
+    /* 0.25x */
+    case 0:
+
+        DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_DEBUG, "selectAPGuideRate: Setting guide to rate to 0.25x");
+        DEBUGFDEVICE(lx200ap_name, AP_DBG_SCOPE, "CMD <%s>", "#:RG0#");
+
+        if ((error_type = tty_write_string(fd, "#:RG0#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+    /* 0.50x */
+    case 1:
+
+        DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_DEBUG, "selectAPGuideRate: Setting guide to rate to 0.50x");
+        DEBUGFDEVICE(lx200ap_name, AP_DBG_SCOPE, "CMD <%s>", "#:RG1#");
+
+        if ((error_type = tty_write_string(fd, "#:RG1#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+
+    /* 1.00x */
+    case 2:
+
+        DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_DEBUG, "selectAPGuideRate: Setting guide to rate to 1.00x");
+        DEBUGFDEVICE(lx200ap_name, AP_DBG_SCOPE, "CMD <%s>", "#:RG2#");
+
+        if ((error_type = tty_write_string(fd, "#:RG2#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+    default:
+        return -1;
+        break;
+    }
+    return 0;
+}
+
 int swapAPButtons(int fd, int currentSwap)
 {
     int error_type;

--- a/libindi/drivers/telescope/lx200apdriver.h
+++ b/libindi/drivers/telescope/lx200apdriver.h
@@ -51,6 +51,7 @@ int APSyncCMR(int fd, char *matchedObject);
 int selectAPMoveToRate(int fd, int moveToRate);
 int selectAPSlewRate(int fd, int slewRate);
 int selectAPTrackingMode(int fd, int trackMode);
+int selectAPGuideRate(int fd, int guideRate);
 int selectAPPECState(int fd, int pecstate);
 int swapAPButtons(int fd, int currentSwap);
 int setAPObjectRA(int fd, double ra);


### PR DESCRIPTION
This modification allows changing the guide rate used by the lx200ap driver to 0.25x, 0.50x, or 1.0x.  I've tested changing the guide rate and doing a calibration run with PHD2 and the guide rate appears to change as expected.