### PR TITLE
Lx200ap fix detect time format

### DIFF
--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -509,6 +509,33 @@ bool LX200AstroPhysics::ReadScopeStatus()
     return true;
 }
 
+// Called by updateProperties - pulled from lx200ap_10micron
+void LX200AstroPhysics::getBasicData()
+{
+    DEBUGFDEVICE(getDefaultName(), DBG_SCOPE, "<%s>", __FUNCTION__);
+
+    // cannot call LX200Generic::getBasicData(); as getTimeFormat :Gc# and getSiteName :GM# are not implemented on AP
+    // TODO delete SiteNameT SiteNameTP
+    if (!isSimulation())
+    {
+        checkLX200Format(PortFD);
+        timeFormat = LX200_24;
+
+        if (genericCapability & LX200_HAS_TRACKING_FREQ)
+        {
+            if (getTrackFreq(PortFD, &TrackFreqN[0].value) < 0)
+                DEBUG(INDI::Logger::DBG_ERROR, "Failed to get tracking frequency from device.");
+            else
+                IDSetNumber(&TrackingFreqNP, nullptr);
+        }
+    }
+
+    sendScopeLocation();
+    sendScopeTime();
+}
+
+
+
 bool LX200AstroPhysics::setBasicDataPart0()
 {
     int err;

--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -521,13 +521,9 @@ void LX200AstroPhysics::getBasicData()
         checkLX200Format(PortFD);
         timeFormat = LX200_24;
 
-        if (genericCapability & LX200_HAS_TRACKING_FREQ)
-        {
-            if (getTrackFreq(PortFD, &TrackFreqN[0].value) < 0)
-                DEBUG(INDI::Logger::DBG_ERROR, "Failed to get tracking frequency from device.");
-            else
-                IDSetNumber(&TrackingFreqNP, nullptr);
-        }
+        // not used by lx200ap
+        IDSetText(&SiteNameTP, nullptr);
+        IDSetNumber(&TrackingFreqNP, nullptr);
     }
 
     sendScopeLocation();

--- a/libindi/drivers/telescope/lx200ap.h
+++ b/libindi/drivers/telescope/lx200ap.h
@@ -64,6 +64,7 @@ class LX200AstroPhysics : public LX200Generic
     virtual bool Goto(double, double) override;
     virtual bool updateTime(ln_date *utc, double utc_offset) override;
     virtual bool updateLocation(double latitude, double longitude, double elevation) override;
+    virtual void getBasicData();
     virtual bool SetSlewRate(int index) override;
 
     virtual int  SendPulseCmd(int direction, int duration_msec) override;


### PR DESCRIPTION
The default time format (12/24 hr) check in LX200Generic does not work on AP mounts.  Following the 10Micron driver we replace getBasicData() with one custom to lx200ap.