### PR TITLE
Fix error deleting property for lx200ap

### DIFF
--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -174,7 +174,7 @@ bool LX200AstroPhysics::updateProperties()
         deleteProperty(APSlewSpeedSP.name);
         deleteProperty(SwapSP.name);
         deleteProperty(SyncCMRSP.name);
-        defineSwitch(&APGuideSpeedSP);
+        deleteProperty(APGuideSpeedSP.name);
         deleteProperty(SlewAccuracyNP.name);
     }
 


### PR DESCRIPTION
This fixes a bug when deleting an lx200ap specific property.