### PR TITLE
Fix crash with eqmod simulator due to uninitialized variables

### DIFF
--- a/3rdparty/indi-eqmod/skywatcher.cpp
+++ b/3rdparty/indi-eqmod/skywatcher.cpp
@@ -78,7 +78,6 @@ bool Skywatcher::Handshake()
     if (isSimulation())
     {
         telescope->simulator->Connect();
-        return true;
     }
 
     unsigned long tmpMCVersion = 0;


### PR DESCRIPTION
As I have a HEQ5 mount I was interested in seeing how the alignment changes looked like and first tried with simulator only to see it crash due to buffer overflow in line 430 of skywatcher.cpp:     sprintf(boardinfo[1], "%04lx", (MCVersion >> 8));

In gdb I noticed the MCVersion variable wasn't set and contained some garbage which sprintf then happily tried to print to too small buffer. Removing this one return statement makes the driver initialize the simulated MountCode and MCVersion variables correctly and things work again.