### PR TITLE
Added bounds check to antiblooming switch index

### DIFF
--- a/3rdparty/indi-qsi/qsi_ccd.cpp
+++ b/3rdparty/indi-qsi/qsi_ccd.cpp
@@ -395,9 +395,15 @@ bool QSICCD::setupParams()
 
     if (canSetAB)
     {
-        IUResetSwitch(&ABSP);
-        ABS[cAB].s = ISS_ON;
-        defineSwitch(&ABSP);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "Antiblooming setting is. %d.", cAB);
+
+        // cAB returns 3 on some a sample QSI 660 WSG
+        if(cAB == 0 || cAB == 1 )
+        {
+            IUResetSwitch(&ABSP);
+            ABS[cAB].s = ISS_ON;
+            defineSwitch(&ABSP);
+        }
     }
 
     QSICamera::FanMode fMode = QSICamera::fanOff;


### PR DESCRIPTION
On my QSI 660 WSG the call to QSICam.get_AntiBlooming(&cAB); sets the value of 3 in cAB.  Since it is only a 2 element vector this causes an indi driver crash.  Added a bounds check to fix the crash while I look to see if the QSI api itself has been updated with additional enum values for anti-blooming.