### PR TITLE
Small fixes to SnapCap driver

### DIFF
--- a/libindi/drivers/auxiliary/snapcap.cpp
+++ b/libindi/drivers/auxiliary/snapcap.cpp
@@ -177,7 +177,7 @@ bool SnapCap::updateProperties()
 
 const char *SnapCap::getDefaultName()
 {
-    return (const char *)"SnapScap";
+    return (const char *)"SnapCap";
 }
 
 bool SnapCap::Handshake()
@@ -281,7 +281,12 @@ bool SnapCap::saveConfigItems(FILE *fp)
 
 bool SnapCap::ping()
 {
-    return getFirmwareVersion();
+    bool found = getFirmwareVersion();
+    // Sometimes the controller does a corrupt reply at first connect
+    // so retry once just in case
+    if (!found)
+        found = getFirmwareVersion();
+    return found;
 }
 
 bool SnapCap::getStartupData()


### PR DESCRIPTION
I had made rather embarrassing typo in the name the driver returns and also noticed the controller sometimes gives a corrupt reply to first request which required connecting twice, which isn't good for my remote setup so I added code to retry handshake once which fixes this.