### PR TITLE
Fix qhy compile errors

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -99,9 +99,10 @@ ENDIF ()
 IF ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     SET(WITH_DSI Off)
 ENDIF ()
-# Disable apogee with gcc 4.8 and earlier versions
+# Disable apogee and qhy with gcc 4.8 and earlier versions
 IF (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.0)
     SET(WITH_APOGEE Off)
+    SET(WITH_QHY Off)
 ENDIF ()
 
 ## EQMod

--- a/3rdparty/libqhy/qhyccd.h
+++ b/3rdparty/libqhy/qhyccd.h
@@ -62,12 +62,12 @@ EXPORTC void STDCALL msSleep(uint32_t ms);
 EXPORTC uint32_t qhyccd_handle2index(qhyccd_handle *pHandle);
 
 #ifdef LINUX
-static uint32_t DeviceIsQHYCCD(uint32_t index, libusb_device *pDevice);
+uint32_t DeviceIsQHYCCD(uint32_t index, libusb_device *pDevice);
 #else
-static uint32_t DeviceIsQHYCCD(uint32_t index, uint32_t vid, uint32_t pid);
+uint32_t DeviceIsQHYCCD(uint32_t index, uint32_t vid, uint32_t pid);
 #endif
-static uint32_t QHYCCDSeriesMatch(uint32_t index, qhyccd_handle *pHandle);
-static uint32_t GetIdFromCam(qhyccd_handle *pHandle, char *id);
+uint32_t QHYCCDSeriesMatch(uint32_t index, qhyccd_handle *pHandle);
+uint32_t GetIdFromCam(qhyccd_handle *pHandle, char *id);
 uint32_t qhyccd_handle2index(qhyccd_handle *pHandle);
 uint32_t InitQHYCCDClass(uint32_t camtype, uint32_t index);
 

--- a/docker/opensuse/Dockerfile
+++ b/docker/opensuse/Dockerfile
@@ -4,7 +4,7 @@ RUN zypper refresh && zypper  --non-interactive update
 
 RUN zypper --non-interactive install lsb-release \
         cmake curl dcraw wget git openssh gcc gcc-c++ clang swig \
-        libcurl-devel boost-devel cfitsio-devel \
+        libcurl-devel boost-devel libboost_regex1_65_1-devel cfitsio-devel \
         libftdi1-devel libgphoto2-devel gsl-devel libjpeg-devel \
         libnova-devel openal-soft-devel libraw-devel libusb-devel \
         fftw-devel zlib-devel libconfuse-devel python3-devel doxygen \


### PR DESCRIPTION
- External functions cannot be static
- current libqhy does not support gcc < 4.9