### PR TITLE
Prevent Portage errors while installing on Gentoo

### DIFF
--- a/3rdparty/libinovasdk/CMakeLists.txt
+++ b/3rdparty/libinovasdk/CMakeLists.txt
@@ -27,13 +27,10 @@ IF(UNIX AND NOT WIN32 AND NOT APPLE)
  ENDIF (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "armv6l")
 ENDIF(UNIX AND NOT WIN32 AND NOT APPLE)
 
-# Make sure symbolic links are installed
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/make_inovasdk_symlink.cmake "
-exec_program(${CMAKE_COMMAND} ARGS -E create_symlink libinovasdk.so.${INOVASDK_VERSION} ${LIB_INSTALL_DIR}${LIB_POSTFIX}/libinovasdk.so.${INOVASDK_SOVERSION})\n
-exec_program(${CMAKE_COMMAND} ARGS -E create_symlink libinovasdk.so.${INOVASDK_SOVERSION} ${LIB_INSTALL_DIR}${LIB_POSTFIX}/libinovasdk.so)\n
-")
-
 install( FILES ${CMAKE_BINARY_DIR}/libinovasdk.so.${INOVASDK_VERSION} DESTINATION ${LIB_INSTALL_DIR}${LIB_POSTFIX})
 install( FILES inovasdk.h DESTINATION include/inovasdk)
 install( FILES 99-inovaplx.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 install( SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/make_inovasdk_symlink.cmake)
+# Make sure symbolic links are installed
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"libinovasdk.so.${INOVASDK_VERSION}\" \"libinovasdk.so.${INOVASDK_SOVERSION}\" WORKING_DIRECTORY \"\$ENV{DESTDIR}/${BUILD_ROOT}${LIB_INSTALL_DIR}${LIB_POSTFIX}\" )" )
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"libinovasdk.so.${INOVASDK_SOVERSION}\" \"libinovasdk.so\" WORKING_DIRECTORY \"\$ENV{DESTDIR}/${BUILD_ROOT}${LIB_INSTALL_DIR}${LIB_POSTFIX}\" )" )

--- a/3rdparty/libqhy/CMakeLists.txt
+++ b/3rdparty/libqhy/CMakeLists.txt
@@ -44,12 +44,6 @@ ENDIF(UNIX AND NOT WIN32)
 install(FILES 85-qhy.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 install(FILES ${CMAKE_BINARY_DIR}/libqhy.so.${LIBQHY_VERSION} DESTINATION ${LIB_INSTALL_DIR}${LIB_POSTFIX})
 
-# Make sure symbolic links are installed
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/make_libqhy_symlink.cmake "
-exec_program(${CMAKE_COMMAND} ARGS -E create_symlink libqhy.so.${LIBQHY_VERSION} ${LIB_INSTALL_DIR}${LIB_POSTFIX}/libqhy.so.${LIBQHY_SOVERSION})\n
-exec_program(${CMAKE_COMMAND} ARGS -E create_symlink libqhy.so.${LIBQHY_SOVERSION} ${LIB_INSTALL_DIR}${LIB_POSTFIX}/libqhy.so)\n
-")
-
 ENDIF (APPLE)
 
 install(FILES qhyccd.h qhyccdcamdef.h qhyccderr.h qhyccdstruct.h log4z.h qhycam.h DESTINATION include/libqhy)
@@ -60,4 +54,7 @@ install(
    file(GLOB QHY_FIRMWARE ${CMAKE_CURRENT_SOURCE_DIR}/firmware/*) \n
    file(INSTALL DESTINATION ${FIRMWARE_INSTALL_DIR} TYPE FILE FILES \${QHY_FIRMWARE})"
  )
+# Make sure symbolic links are installed
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"libqhy.so.${LIBQHY_VERSION}\" \"libqhy.so.${LIBQHY_SOVERSION}\" WORKING_DIRECTORY \"\$ENV{DESTDIR}/${BUILD_ROOT}${LIB_INSTALL_DIR}${LIB_POSTFIX}\" )" )
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"libqhy.so.${LIBQHY_SOVERSION}\" \"libqhy.so\" WORKING_DIRECTORY \"\$ENV{DESTDIR}/${BUILD_ROOT}${LIB_INSTALL_DIR}${LIB_POSTFIX}\" )" )
 

--- a/3rdparty/libsbig/CMakeLists.txt
+++ b/3rdparty/libsbig/CMakeLists.txt
@@ -27,14 +27,11 @@ IF(UNIX AND NOT WIN32 AND NOT APPLE)
  ENDIF (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "armv6l")
 ENDIF(UNIX AND NOT WIN32 AND NOT APPLE)
 
-# Make sure symbolic links are installed
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/make_sbig_symlink.cmake "
-exec_program(${CMAKE_COMMAND} ARGS -E create_symlink libsbigudrv.so.${SBIG_VERSION} ${LIB_INSTALL_DIR}${LIB_POSTFIX}/libsbigudrv.so.${SBIG_SOVERSION})\n
-exec_program(${CMAKE_COMMAND} ARGS -E create_symlink libsbigudrv.so.${SBIG_SOVERSION} ${LIB_INSTALL_DIR}${LIB_POSTFIX}/libsbigudrv.so)\n
-")
-
 install( FILES ${CMAKE_BINARY_DIR}/libsbigudrv.so.${SBIG_VERSION} DESTINATION ${LIB_INSTALL_DIR}${LIB_POSTFIX})
 install( FILES sbigudrv.h DESTINATION include/libsbig)
 install( FILES sbigucam.hex sbiglcam.hex sbigfcam.hex sbigpcam.hex stfga.bin DESTINATION ${FIRMWARE_INSTALL_DIR})
 install( FILES 51-sbig-debian.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 install( SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/make_sbig_symlink.cmake)
+# Make sure symbolic links are installed
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"libsbigudrv.so.${SBIG_VERSION}\" \"libsbigudrv.so.${SBIG_SOVERSION}\" WORKING_DIRECTORY \"\$ENV{DESTDIR}/${BUILD_ROOT}${LIB_INSTALL_DIR}${LIB_POSTFIX}\" )" )
+install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink \"libsbigudrv.so.${SBIG_SOVERSION}\" \"libsbigudrv.so\" WORKING_DIRECTORY \"\$ENV{DESTDIR}/${BUILD_ROOT}${LIB_INSTALL_DIR}${LIB_POSTFIX}\" )" )


### PR DESCRIPTION
This fixes sandbox ACCESS_VIOLATION errors while installing libqhy, libsbig and libinovasdk on Gentoo. Symlinks to .so are created in working directory instead of live system.