### PR TITLE
Add missing includes for strcmp and sin/cos in eqmod

### DIFF
--- a/3rdparty/indi-eqmod/align/align.cpp
+++ b/3rdparty/indi-eqmod/align/align.cpp
@@ -19,6 +19,8 @@
 
 #include "../eqmod.h"
 
+#include <cstring>
+#include <cmath>
 #include <libnova/sidereal_time.h>
 #include <libnova/transform.h>
 


### PR DESCRIPTION
After recent revert of alignment subsystem I reenabled only WITH_ALIGN_GEEHALEL option and WITH_ALIGN disabled and noticed that align.cpp didn't compile anymore like it did when I had both options enabled before the alignment changes. From the errors it was clear it uses strcmp and trigonometric functions without including their headers directly and they happen to get included in usual configuration where both alignment systems are enabled.