### PR TITLE
Use free instead of delete as the memory is from malloc and realloc

### DIFF
--- a/libindi/libs/indibase/indilightboxinterface.cpp
+++ b/libindi/libs/indibase/indilightboxinterface.cpp
@@ -82,7 +82,7 @@ bool LightBoxInterface::updateLightBoxProperties()
         {
             device->deleteProperty(FilterIntensityNP.name);
             FilterIntensityNP.nnp = 0;
-            delete (FilterIntensityN);
+            free (FilterIntensityN);
             FilterIntensityN = nullptr;
         }
     }


### PR DESCRIPTION
This is the delete() usage I mentioned earlier.