### PR TITLE
Lx200ap experimental 20171230

### DIFF
--- a/libindi/CMakeLists.txt
+++ b/libindi/CMakeLists.txt
@@ -475,6 +475,7 @@ SET(lx200generic_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/telescope/lx200zeq25.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/telescope/lx200gotonova.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/telescope/lx200pulsar2.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/drivers/telescope/lx200ap_experimentaldriver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/telescope/lx200ap_experimental.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/telescope/lx200ap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/drivers/telescope/lx200fs2.cpp

--- a/libindi/drivers/telescope/lx200ap.cpp
+++ b/libindi/drivers/telescope/lx200ap.cpp
@@ -99,15 +99,15 @@ bool LX200AstroPhysics::initProperties()
     IUFillSwitchVector(&SwapSP, SwapS, 2, getDeviceName(), "SWAP", "Swap buttons", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], ":CM#", ":CM#", ISS_ON);
-    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], ":CMR#", ":CMR#", ISS_OFF);
+    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], ":CM#", ":CM#", ISS_OFF);
+    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], ":CMR#", ":CMR#", ISS_ON);
     IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // guide speed
     IUFillSwitch(&APGuideSpeedS[0], "0.25", "0.25x", ISS_OFF);
-    IUFillSwitch(&APGuideSpeedS[1], "0.5", "0.50x", ISS_ON);
-    IUFillSwitch(&APGuideSpeedS[2], "1.0", "1.0x", ISS_OFF);
+    IUFillSwitch(&APGuideSpeedS[1], "0.5", "0.50x", ISS_OFF);
+    IUFillSwitch(&APGuideSpeedS[2], "1.0", "1.0x", ISS_ON);
     IUFillSwitchVector(&APGuideSpeedSP, APGuideSpeedS, 3, getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 

--- a/libindi/drivers/telescope/lx200ap_experimental.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimental.cpp
@@ -730,7 +730,7 @@ bool LX200AstroPhysicsExperimental::IsMountParked(bool *isParked)
         return false;
 
     // if within an arcsec then assume RA is constant
-    if (abs(ra1-ra2) < (1.0/(15.0*3600.0)))
+    if (fabs(ra1-ra2) < (1.0/(15.0*3600.0)))
     {
         *isParked=false;
         return true;
@@ -1169,34 +1169,28 @@ bool LX200AstroPhysicsExperimental::UnPark()
     // The AP :PO# should only be used during initilization and not here as indicated by email from Preston on 2017-12-12
 
     // check the unpark from position and set mount as appropriate
-    ParkPosition unparkPos = (ParkPosition) IUFindOnSwitchIndex(&UnparkFromSP);
+    ParkPosition unparkPos;
+    
+    unparkPos = (ParkPosition) IUFindOnSwitchIndex(&UnparkFromSP);
+
     DEBUGF(INDI::Logger::DBG_DEBUG, "Unpark() -> unpark position = %d", unparkPos);
-
-    bool syncmount;
-    double unparkAlt, unparkAz;
-
-    syncmount = false;
 
     if (unparkPos == PARK_LAST)
     {
         DEBUG(INDI::Logger::DBG_SESSION, "Unparking from last parked position...");
-        syncmount = false;
     }
     else
     {
+        double unparkAlt, unparkAz;
+	
         if (!calcParkPosition(unparkPos, &unparkAlt, &unparkAz))
         {
             DEBUG(INDI::Logger::DBG_ERROR, "Error calculating unpark position!");
             return false;
         }
 
-        syncmount = true;
-    }
+        DEBUGF(INDI::Logger::DBG_DEBUG, "unparkPos=%d unparkAlt=%f unparkAz=%f", unparkPos, unparkAlt, unparkAz);
 
-    DEBUGF(INDI::Logger::DBG_DEBUG, "unparkPos=%d syncmount=%d unparkAlt=%f unparkAz=%f", unparkPos, syncmount, unparkAlt, unparkAz);
-
-    if (syncmount)
-    {
         if (setAPObjectAZ(PortFD, unparkAz) < 0 || (setAPObjectAlt(PortFD, unparkAlt)) < 0)
         {
             DEBUG(INDI::Logger::DBG_ERROR, "Error setting Az/Alt.");

--- a/libindi/drivers/telescope/lx200ap_experimental.h
+++ b/libindi/drivers/telescope/lx200ap_experimental.h
@@ -30,7 +30,9 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     LX200AstroPhysicsExperimental();
     ~LX200AstroPhysicsExperimental() {}
 
-    typedef enum { MCV_E, MCV_F, MCV_G, MCV_H, MCV_I, MCV_J, MCV_L, MCV_P, MCV_UNKNOWN} ControllerVersion;
+    typedef enum { MCV_E, MCV_F, MCV_G, MCV_H, MCV_I, MCV_J, MCV_K_UNUSED,
+                   MCV_L, MCV_M, MCV_N, MCV_O, MCV_P, MCV_Q, MCV_R, MCV_S,
+                   MCV_T, MCV_U, MCV_V, MCV_UNKNOWN} ControllerVersion;
     typedef enum { GTOCP1=1, GTOCP2, GTOCP3, GTOCP4, GTOCP_UNKNOWN} ServoVersion;
 
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
@@ -103,6 +105,10 @@ class LX200AstroPhysicsExperimental : public LX200Generic
 
     // Side of pier
     void syncSideOfPier();
+    bool IsMountInitialized(bool *initialized);
+    bool IsMountParked(bool *isParked);
+    bool getMountStatus(bool *isParked);
+    bool getFirmwareVersion(void);
 
     bool timeUpdated=false, locationUpdated=false;
     ControllerVersion firmwareVersion = MCV_UNKNOWN;
@@ -114,4 +120,5 @@ class LX200AstroPhysicsExperimental : public LX200Generic
 
     bool motionCommanded=false;
     bool mountInitialized=false;
+    bool mountParked=false;
 };

--- a/libindi/drivers/telescope/lx200ap_experimental.h
+++ b/libindi/drivers/telescope/lx200ap_experimental.h
@@ -35,10 +35,14 @@ class LX200AstroPhysicsExperimental : public LX200Generic
                    MCV_T, MCV_U, MCV_V, MCV_UNKNOWN} ControllerVersion;
     typedef enum { GTOCP1=1, GTOCP2, GTOCP3, GTOCP4, GTOCP_UNKNOWN} ServoVersion;
 
+    typedef enum { PARK_LAST=0, PARK_CUSTOM=0, PARK_PARK1=1, PARK_PARK2=2, PARK_PARK3=3, PARK_PARK4=4} ParkPosition;
+
+    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual void ISGetProperties(const char *dev) override;
 
   protected:
+
     virtual const char *getDefaultName() override;
     virtual bool initProperties() override;
     virtual bool updateProperties() override;    
@@ -97,6 +101,15 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     ISwitch APGuideSpeedS[3];
     ISwitchVectorProperty APGuideSpeedSP;
 
+    ISwitch UnparkFromS[5];
+    ISwitchVectorProperty UnparkFromSP;
+
+    ISwitch ParkToS[5];
+    ISwitchVectorProperty ParkToSP;
+
+    INumberVectorProperty MeridianDelayNP;
+    INumber MeridianDelayN[1];
+
     IText VersionT[1];
     ITextVectorProperty VersionInfo;
 
@@ -109,6 +122,8 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     bool IsMountParked(bool *isParked);
     bool getMountStatus(bool *isParked);
     bool getFirmwareVersion(void);
+    bool calcParkPosition(ParkPosition pos, double *parkAlt, double *parkAz);
+    void disclaimerMessage(void);
 
     bool timeUpdated=false, locationUpdated=false;
     ControllerVersion firmwareVersion = MCV_UNKNOWN;

--- a/libindi/drivers/telescope/lx200ap_experimentaldriver.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimentaldriver.cpp
@@ -1,0 +1,179 @@
+#if 0
+LX200 Astro- Physics Driver
+Copyright (C) 2007 Markus Wildi
+
+This library is free software;
+you can redistribute it and / or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation;
+either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY;
+without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library;
+if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
+
+#endif
+
+
+// This file contains functions which require the 'V' firmware level and will NOT work with previous versions!
+// Used only by the lx200ap_experimental driver in conjuction with the routines in lx200ap_driver.cpp which work
+// with all firmware versions
+
+
+#include <cmath>
+//#include "lx200apdriver.h"
+
+#include "indicom.h"
+#include "indilogger.h"
+#include "lx200ap_experimentaldriver.h"
+
+#include <cstring>
+#include <unistd.h>
+
+#ifndef _WIN32
+#include <termios.h>
+#endif
+
+#define LX200_TIMEOUT 5 /* FD timeout in seconds */
+
+char lx200ap_exp_name[MAXINDIDEVICE];
+unsigned int AP_EXP_DBG_SCOPE;
+
+void set_lx200ap_exp_name(const char *deviceName, unsigned int debug_level)
+{
+    strncpy(lx200ap_exp_name, deviceName, MAXINDIDEVICE);
+    AP_EXP_DBG_SCOPE = debug_level;
+}
+
+
+// experimental functions!!!
+
+int setAPMeridianDelay(int fd, double mdelay)
+{
+    char cmd[32];
+    char hourstr[16];
+    int nbytes_write = 0;
+
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "<%s>", __FUNCTION__);
+
+    if (mdelay < 0)
+    {
+        DEBUGFDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR, "Meridian delay < 0 not supp\
+                     orted! mdelay=%f", mdelay);
+                return -1;
+    }
+
+    // convert from decimal hours to format for command
+    if (fs_sexa(hourstr, mdelay, 2, 3600) < 0)
+    {
+        DEBUGFDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR, "Unable to format meridian d\
+                     elay %f to time format!", mdelay);
+                     return -1;
+    }
+
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "Meridian Delay %f -> %s", mdelay, hourstr)\
+            ;
+
+    sprintf(cmd, ":SM%s#", hourstr);
+
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", cmd);
+
+    tty_write_string(fd, cmd, &nbytes_write);
+
+    tcflush(fd, TCIFLUSH);
+
+    return 0;
+}
+
+int getAPMeridianDelay(int fd, double *mdelay)
+{
+    int error_type;
+    int nbytes_write = 0;
+    int nbytes_read  = 0;
+    char temp_string[16];
+
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "<%s>", __FUNCTION__);
+
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:GM#");
+
+    if ((error_type = tty_write_string(fd, "#:GM#", &nbytes_write)) != TTY_OK)
+        return error_type;
+
+    if ((error_type = tty_read_section(fd, temp_string, '#', LX200_TIMEOUT, &nbytes_read\
+                                       )) != TTY_OK)
+    {
+        DEBUGFDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR, "getAPMeridianDelay: error %\
+                     d, %d", error_type,
+                     nbytes_read);
+        return error_type;
+    }
+
+    tcflush(fd, TCIFLUSH);
+
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "RES <%s>", temp_string);
+
+    if (f_scansexa(temp_string, mdelay))
+    {
+        DEBUGFDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR, "getAPMeridianDelay: unable \
+                     to process %s", temp_string);
+                     return -1;
+    }
+
+    return 0;
+}
+
+
+
+
+int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus)
+{
+    char temp_string[64];
+    int error_type;
+    int nbytes_write = 0;
+    int nbytes_read  = 0;
+
+    DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "EXPERIMENTAL: check status...");
+
+    if (fd <= 0)
+    {
+        DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR,
+                    "check_lx200ap_connection: not a valid file descriptor received");
+
+        return -1;
+    }
+
+    if ((error_type = tty_write_string(fd, "#:GOS#", &nbytes_write)) != TTY_OK)
+    {
+        DEBUGFDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR,
+                     "check_lx200ap_connection: unsuccessful write to telescope, %d", nbytes_write);
+
+        return error_type;
+    }
+    tty_read_section(fd, temp_string, '#', LX200_TIMEOUT, &nbytes_read);
+    tcflush(fd, TCIFLUSH);
+    if (nbytes_read > 1)
+    {
+        temp_string[nbytes_read - 1] = '\0';
+
+        DEBUGFDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "check_lx200ap_status: received bytes %d, [%s]",
+                     nbytes_write, temp_string);
+
+        *parkStatus = temp_string[0];
+        *slewStatus = temp_string[3];
+
+        return 0;
+    }
+
+
+    DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR, "check_lx200ap_status: wrote, but nothing received.");
+
+    return -1;
+}

--- a/libindi/drivers/telescope/lx200ap_experimentaldriver.h
+++ b/libindi/drivers/telescope/lx200ap_experimentaldriver.h
@@ -1,0 +1,34 @@
+/*
+    LX200 AP Driver
+    Copyright (C) 2007 Markus Wildi
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void set_lx200ap_exp_name(const char *deviceName, unsigned int debug_level);
+int setAPMeridianDelay(int fd, double mdelay);
+int getAPMeridianDelay(int fd, double *mdelay);
+int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libindi/drivers/telescope/lx200apdriver.cpp
+++ b/libindi/drivers/telescope/lx200apdriver.cpp
@@ -769,3 +769,49 @@ int APSendPulseCmd(int fd, int direction, int duration_msec)
     tcflush(fd, TCIFLUSH);
     return 0;
 }
+
+// experimental function!!!
+int check_lx200ap_status(int fd, char *parkStatus)
+{
+    int i = 0;
+    char temp_string[64];
+    int error_type;
+    int nbytes_write = 0;
+    int nbytes_read  = 0;
+
+    DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_DEBUG, "EXPERIMENTAL: check status...");
+
+    if (fd <= 0)
+    {
+        DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_ERROR,
+                    "check_lx200ap_connection: not a valid file descriptor received");
+
+        return -1;
+    }
+
+    if ((error_type = tty_write_string(fd, "#:GOS#", &nbytes_write)) != TTY_OK)
+    {
+        DEBUGFDEVICE(lx200ap_name, INDI::Logger::DBG_ERROR,
+                     "check_lx200ap_connection: unsuccessful write to telescope, %d", nbytes_write);
+
+        return error_type;
+    }
+    tty_read_section(fd, temp_string, '#', LX200_TIMEOUT, &nbytes_read);
+    tcflush(fd, TCIFLUSH);
+    if (nbytes_read > 1)
+    {
+        temp_string[nbytes_read - 1] = '\0';
+
+        DEBUGFDEVICE(lx200ap_name, INDI::Logger::DBG_DEBUG, "check_lx200ap_status: received bytes %d, [%s]",
+                     nbytes_write, temp_string);
+
+        *parkStatus = temp_string[0];
+
+        return 0;
+    }
+
+
+    DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_ERROR, "check_lx200ap_status: wrote, but nothing received.");
+
+    return -1;
+}

--- a/libindi/drivers/telescope/lx200apdriver.cpp
+++ b/libindi/drivers/telescope/lx200apdriver.cpp
@@ -770,10 +770,10 @@ int APSendPulseCmd(int fd, int direction, int duration_msec)
     return 0;
 }
 
+#if 0
 // experimental function!!!
-int check_lx200ap_status(int fd, char *parkStatus)
+int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus)
 {
-    int i = 0;
     char temp_string[64];
     int error_type;
     int nbytes_write = 0;
@@ -806,6 +806,7 @@ int check_lx200ap_status(int fd, char *parkStatus)
                      nbytes_write, temp_string);
 
         *parkStatus = temp_string[0];
+        *slewStatus = temp_string[3];
 
         return 0;
     }
@@ -815,3 +816,4 @@ int check_lx200ap_status(int fd, char *parkStatus)
 
     return -1;
 }
+#endif

--- a/libindi/drivers/telescope/lx200apdriver.h
+++ b/libindi/drivers/telescope/lx200apdriver.h
@@ -61,6 +61,7 @@ int setAPSiteLatitude(int fd, double Lat);
 int setAPRATrackRate(int fd, double rate);
 int setAPDETrackRate(int fd, double rate);
 int APSendPulseCmd(int fd, int direction, int duration_msec);
+int check_lx200ap_status(int fd, char *parkStatus);
 
 #ifdef __cplusplus
 }

--- a/libindi/drivers/telescope/lx200apdriver.h
+++ b/libindi/drivers/telescope/lx200apdriver.h
@@ -61,7 +61,7 @@ int setAPSiteLatitude(int fd, double Lat);
 int setAPRATrackRate(int fd, double rate);
 int setAPDETrackRate(int fd, double rate);
 int APSendPulseCmd(int fd, int direction, int duration_msec);
-int check_lx200ap_status(int fd, char *parkStatus);
+//int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This update contains improvements to the lx200ap_experimental telescope driver.  

Changes:

- checks for 'V' level of firmware and will not load if not present
- adds ability to choose from 4 park positions as defined by Astro-Physics
- better mount initialization