### PR TITLE
Path updates and OS X Changes

### DIFF
--- a/3rdparty/indi-apogee/apogee_ccd.cpp
+++ b/3rdparty/indi-apogee/apogee_ccd.cpp
@@ -40,12 +40,21 @@
 
 #include <memory>
 
+#ifdef OSX_EMBEDED_MODE
+ #include "Alta.h"
+ #include "AltaF.h"
+ #include "Ascent.h"
+ #include "Aspen.h"
+ #include "Quad.h"
+ #include "ApgLogger.h"
+#else
 #include <libapogee/Alta.h>
 #include <libapogee/AltaF.h>
 #include <libapogee/Ascent.h>
 #include <libapogee/Aspen.h>
 #include <libapogee/Quad.h>
 #include <libapogee/ApgLogger.h>
+#endif
 
 #include <fitsio.h>
 

--- a/3rdparty/indi-apogee/apogee_ccd.h
+++ b/3rdparty/indi-apogee/apogee_ccd.h
@@ -26,9 +26,9 @@
 #include <indiguiderinterface.h>
 #include <iostream>
 
-#include <ApogeeCam.h>
-#include <FindDeviceEthernet.h>
-#include <FindDeviceUsb.h>
+#include "ApogeeCam.h"
+#include "FindDeviceEthernet.h"
+#include "FindDeviceUsb.h"
 
 class ApogeeCCD : public INDI::CCD
 {

--- a/3rdparty/indi-dsi/CMakeLists.txt
+++ b/3rdparty/indi-dsi/CMakeLists.txt
@@ -6,7 +6,7 @@ LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake_modules/"
 include(GNUInstallDirs)
 
 IF(APPLE)
-set(FIRMWARE_INSTALL_DIR "/usr/local/lib/firmware")
+set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/dsi")
 ELSE(APPLE)
 set(RULES_INSTALL_DIR "/etc/udev/rules.d")
 set(FIRMWARE_INSTALL_DIR "/lib/firmware")

--- a/3rdparty/indi-dsi/DsiDevice.cpp
+++ b/3rdparty/indi-dsi/DsiDevice.cpp
@@ -205,12 +205,15 @@ void DSI::Device::initImager(const char *devname)
                 {
                     libusb_kernel_driver_active(handle, 0);
                     libusb_claim_interface(handle, 0);
-                    char hexpath[MAXRBUF] = "/usr/local/lib/firmware/meade-deepskyimager.hex";
-                    // Override in case an environment variable is defined.
-                    if (getenv("DSI_FIRMWARE_DIR") != NULL)
-                        snprintf(hexpath, MAXRBUF, "%s/meade-deepskyimager.hex", getenv("DSI_FIRMWARE_DIR"));
+                    char driverSupportPath[MAXRBUF];
+                    //On OS X, Prefer embedded App location if it exists
+                    if (getenv("INDIPREFIX") != NULL)
+                    	snprintf(driverSupportPath, MAXRBUF, "%s/Contents/Resources", getenv("INDIPREFIX"));
+                    else
+                    	strncpy(driverSupportPath, "/usr/local/lib/indi", MAXRBUF);
+                    strncat(driverSupportPath, "/DriverSupport/dsi/meade-deepskyimager.hex", MAXRBUF);
                     char errmsg[MAXRBUF];
-                    if (fx2_ram_download(handle, hexpath, 1, errmsg))
+                    if (fx2_ram_download(handle, driverSupportPath, 1, errmsg))
                         throw dsi_exception(std::string("failed to upload firmware: ") + errmsg);
                     libusb_close(handle);
                 }

--- a/3rdparty/indi-qhy/qhy_ccd.cpp
+++ b/3rdparty/indi-qhy/qhy_ccd.cpp
@@ -121,15 +121,15 @@ void ISInit()
     }
 #endif
 
-#if defined(OSX_EMBEDED_MODE)
-    char firmwarePath[128];
-    sprintf(firmwarePath, "%s/Contents/Resources", getenv("INDIPREFIX"));
-    OSXInitQHYCCDFirmware(firmwarePath);
-#elif defined(__APPLE__)
-    char firmwarePath[128] = "/usr/local/lib/qhy";
-    if (getenv("QHY_FIRMWARE_DIR") != NULL)
-        strncpy(firmwarePath, getenv("QHY_FIRMWARE_DIR"), 128);
-    OSXInitQHYCCDFirmware(firmwarePath);
+//On OS X, Prefer embedded App location if it exists
+#if defined(__APPLE__)
+	char driverSupportPath[128];
+	if (getenv("INDIPREFIX") != NULL)
+		sprintf(driverSupportPath, "%s/Contents/Resources", getenv("INDIPREFIX"));
+	else
+		strncpy(driverSupportPath, "/usr/local/lib/indi", 128);
+	strncat(driverSupportPath, "/DriverSupport/qhy", 128);
+	OSXInitQHYCCDFirmware(driverSupportPath);
 #endif
 
     std::vector<std::string> devices = GetDevicesIDs();

--- a/3rdparty/libapogee/CMakeLists.txt
+++ b/3rdparty/libapogee/CMakeLists.txt
@@ -9,7 +9,7 @@ include(GNUInstallDirs)
 
 IF(APPLE)
 set(APOGEE_VERSION "3.0.3.2.3.4")
-set(CONF_DIR "/usr/local/etc" CACHE STRING "Base configuration directory")
+set(CONF_DIR "/usr/local/lib/indi/DriverSupport/" CACHE STRING "Base configuration directory")
 ELSE(APPLE)
 set(APOGEE_VERSION "3.0.3234")
 set(CONF_DIR "/etc" CACHE STRING "Base configuration directory")
@@ -67,4 +67,3 @@ install(
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 install(FILES 99-apogee.rules DESTINATION ${UDEVRULES_INSTALL_DIR})
 ENDIF()
-

--- a/3rdparty/libapogee/apgHelper.cpp
+++ b/3rdparty/libapogee/apgHelper.cpp
@@ -394,12 +394,18 @@ std::string apgHelper::GetCfgDir()
 {
     std::string path;
 
-    // N.B. Prefer environment variable over compiled value if it exists
-    if (getenv("APOGEE_ETC_DIR") != NULL)
-        path = help::FixPath( getenv("APOGEE_ETC_DIR"));
-    else
-        path = help::FixPath( sysconfdir );
-    path.append( "Apogee/");
+    //On OS X, Prefer embedded App location if it exists
+#if defined(__APPLE__)
+	std::string driverSupportPath;
+	if (getenv("INDIPREFIX") != NULL)
+		driverSupportPath = std::string(getenv("INDIPREFIX")).append("/Contents/Resources");
+	else
+		driverSupportPath = "/usr/local/lib/indi";
+	path = help::FixPath( driverSupportPath );
+#else
+	path = help::FixPath( sysconfdir );
+#endif
+    path.append( "Apogee/" );
     return path;
 }
 

--- a/3rdparty/libapogee/linux/GenOneLinuxUSB.h
+++ b/3rdparty/libapogee/linux/GenOneLinuxUSB.h
@@ -15,7 +15,12 @@
 
 #include <string>
 #include <vector>
-#include <libusb-1.0/libusb.h>
+
+#ifdef OSX_EMBEDED_MODE
+	#include <libusb.h>
+#else
+	#include <libusb-1.0/libusb.h>
+#endif
 
 #include "../IUsb.h"
 

--- a/3rdparty/libqhy/CMakeLists.txt
+++ b/3rdparty/libqhy/CMakeLists.txt
@@ -14,7 +14,7 @@ set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
 IF (APPLE)
 
-set(FIRMWARE_INSTALL_DIR "/usr/local/lib/qhy/firmware" CACHE STRING "QHY firmware installation directory")
+set(FIRMWARE_INSTALL_DIR "/usr/local/lib/indi/DriverSupport/qhy" CACHE STRING "QHY firmware installation directory")
 exec_program(cp ARGS ${CMAKE_CURRENT_SOURCE_DIR}/libqhy.dylib ${CMAKE_BINARY_DIR}/libqhy.${LIBQHY_VERSION}.dylib)
 install(FILES ${CMAKE_BINARY_DIR}/libqhy.${LIBQHY_VERSION}.dylib DESTINATION ${LIB_INSTALL_DIR})
 

--- a/macosx/INDI Server/CMAppDelegate.m
+++ b/macosx/INDI Server/CMAppDelegate.m
@@ -331,7 +331,9 @@
     sleep(1);
     log = fopen([logname cStringUsingEncoding:NSASCIIStringEncoding], "r");
   }
-  _statusImage.image = [NSImage imageNamed:@"NSStatusAvailable"];
+  dispatch_async(dispatch_get_main_queue(), ^{
+     _statusImage.image = [NSImage imageNamed:@"NSStatusAvailable"];
+   });
   service = [[NSNetService alloc] initWithDomain:@"" type:@"_indi._tcp" name:@"" port:7624];
   if(service) {
     [service setDelegate:self];
@@ -340,7 +342,9 @@
   else {
     NSLog(@"An error occurred initializing the NSNetService object.");
   }
-  _statusLabel.stringValue = @"Server is running (idle)";
+  dispatch_async(dispatch_get_main_queue(), ^{
+     _statusLabel.stringValue = @"Server is running (idle)";
+  });
   while (true) {
     pos = ftell(log);
     while (!fgets(buffer, 1024, log)) {
@@ -357,17 +361,19 @@
       NSLog(@"Failed %s", driver);
       [self setStatus:FAILED to:[NSString stringWithCString:driver encoding:NSASCIIStringEncoding]];
     } else if (sscanf(buffer, "CLIENTS %d", &count) == 1) {
-      switch (count) {
-        case 0:
-          _statusLabel.stringValue = @"Server is running (idle)";
-          break;
-        case 1:
-          _statusLabel.stringValue = @"Server is running (1 client)";
-          break;
-        default:
-          _statusLabel.stringValue = [NSString stringWithFormat:@"Server is running (%d clients)", count];
-          break;
-      }
+      dispatch_async(dispatch_get_main_queue(), ^{
+         switch (count) {
+           case 0:
+             _statusLabel.stringValue = @"Server is running (idle)";
+             break;
+           case 1:
+             _statusLabel.stringValue = @"Server is running (1 client)";
+             break;
+           default:
+             _statusLabel.stringValue = [NSString stringWithFormat:@"Server is running (%d clients)", count];
+             break;
+         }
+      });
     }
   }
 }

--- a/macosx/INDI Server/INDI Server-Info.plist
+++ b/macosx/INDI Server/INDI Server-Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.4.2</string>
+	<string>2.6.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.4.2</string>
+	<string>1.6.0</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.education</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
This pull request will apply the OS X installation path changes for KStars, INDI Server, and home-brew INDI as was discussed by Peter and myself.  In a home-brew install, the firmware and other camera support files will install to subfolders in /usr/local/lib/indi/DriverSupport.  Currently in a home-brew install, these subfolders will be for DSI, Apogee, and QHY files.  For KStars and INDIServer, these files will be placed in a similar manner into the app bundle in /Contents/Resources/DriverSupport. Thus at runtime, if the INDIPrefix Environment variable exists on OS X such as in KStars and INDI Server, the drivers will look for their files in this folder in the app bundle.  But if it doesn't exist, such as in a home-brew install, then it will look in the default folder listed above.  This will eliminate separate firmware location environment variables for each driver and just use the one.  It will also ensure that each driver gets its own unique folder for its files (helpful for the embedded versions), and that they are all collected in one place (helpful for the home-brew version).  I also attempted to integrate some of the other OS X driver updates that Peter had integrated in his pull request, but others seemed to already have been done.  One item I did not include in this pull request that Peter had done that will still need to be updated is the Xcode project file since there were so many updates in it. 

I am attaching a screenshot to show how this folder is organized.  Note that it is in the KStars app bundle so it includes gphoto as well, but this is not a part of this pull request, it is a separate part of the KStars app bundle build.  But this screenshot should show the general layout of the folder.

<img width="248" alt="screen shot 2018-01-22 at 11 08 58 pm" src="https://user-images.githubusercontent.com/19987848/35257770-4a7bac94-ffc9-11e7-8551-c64afd73e988.png">
