### PR TITLE
ISO date setLocalDate, override

### DIFF
--- a/libindi/drivers/telescope/lx200_10micron.cpp
+++ b/libindi/drivers/telescope/lx200_10micron.cpp
@@ -451,6 +451,7 @@ int LX200_10MICRON::setStandardProcedureAndExpect(int fd, const char *data, cons
 
     return 0;
 }
+
 int LX200_10MICRON::setStandardProcedureAndReturnResponse(int fd, const char *data, char *response, int max_response_length)
 {
     int error_type;
@@ -502,6 +503,14 @@ bool LX200_10MICRON::SyncConfigBehaviour(bool cmcfg)
         return false;
     }
     return true;
+}
+
+bool LX200_10MICRON::setLocalDate(uint8_t days, uint8_t months, uint16_t years)
+{
+    DEBUGFDEVICE(getDefaultName(), DBG_SCOPE, "<%s>", __FUNCTION__);
+    char data[64];
+    snprintf(data, sizeof(data), ":SC%04d-%02d-%02d#", years, months, days);
+    return 0 == setStandardProcedureAndExpect(fd, data, "1");
 }
 
 int LX200_10MICRON::SetRefractionModelTemperature(double temperature)

--- a/libindi/drivers/telescope/lx200_10micron.h
+++ b/libindi/drivers/telescope/lx200_10micron.h
@@ -93,18 +93,19 @@ class LX200_10MICRON : public LX200Generic
     LX200_10MICRON();
     ~LX200_10MICRON() {}
 
-    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+    bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+    bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
 
-    virtual const char *getDefaultName() override;
-    virtual bool Handshake() override;
-    virtual bool initProperties() override;
-    virtual bool updateProperties() override;
-    virtual bool ReadScopeStatus() override;
-    virtual bool Park() override;
-    virtual bool UnPark() override;
-    virtual bool SyncConfigBehaviour(bool cmcfg);
+    const char *getDefaultName() override;
+    bool Handshake() override;
+    bool initProperties() override;
+    bool updateProperties() override;
+    bool ReadScopeStatus() override;
+    bool Park() override;
+    bool UnPark() override;
+    bool SyncConfigBehaviour(bool cmcfg);
+    bool setLocalDate(uint8_t days, uint8_t months, uint16_t years) override;
 
     int AddSyncPoint(double MRa, double MDec, double MSide, double PRa, double PDec, double SidTime);
     int AddSyncPointHere(double PRa, double PDec);
@@ -116,7 +117,7 @@ class LX200_10MICRON : public LX200Generic
     int setStandardProcedureAndReturnResponse(int fd, const char *data, char *response, int max_response_length);
 
   protected:
-    virtual void getBasicData() override;
+    void getBasicData() override;
 
     IText ProductT[4];
     ITextVectorProperty ProductTP;


### PR DESCRIPTION
SCOPE   16.312062 sec   : <setLocalDate>
SCOPE   16.312073 sec   : CMD <:SC2018-01-30#>
SCOPE   16.492003 sec   : CMD <:SC2018-01-30#> successful.
