### PR TITLE
Changes for new FLI libusb driver under OSX.

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -84,7 +84,6 @@ option(WITH_FXLOAD "Install FX3 compatible fxload tool" Off)
 # Add/remove cases for OSX
 IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(WITH_MI Off)
-    set(WITH_FLI Off)
     set(WITH_SBIG Off)
     set(WITH_INOVAPLX Off)
     set(WITH_DUINO Off)

--- a/3rdparty/indi-fli/fli_ccd.cpp
+++ b/3rdparty/indi-fli/fli_ccd.cpp
@@ -364,7 +364,7 @@ bool FLICCD::setupParams()
         TemperatureN[0].max   = MAX_CCD_TEMP;
         IUUpdateMinMax(&TemperatureNP);
         IDSetNumber(&TemperatureNP, NULL);
-        DEBUGF(INDI::Logger::DBG_SESSION, "FLIGetTemperature() succeed -> %f", FLICam.temperature);
+        DEBUGF(INDI::Logger::DBG_DEBUG, "FLIGetTemperature() succeed -> %f", FLICam.temperature);
     }
 
     SetCCDParams(FLICam.Visible_Area[2] - FLICam.Visible_Area[0], FLICam.Visible_Area[3] - FLICam.Visible_Area[1], 16,

--- a/3rdparty/libfli/CMakeLists.txt
+++ b/3rdparty/libfli/CMakeLists.txt
@@ -31,12 +31,15 @@ set(fli_LIB_SRCS
    unix/libfli-serial.c
    unix/libfli-sys.c
    
-   unix/linux/libfli-parport.c
    #unix/linux/libfli-usb-sys.c
    
    # LIBUSB support
    unix/libusb/libfli-usb-sys.c
 )
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+list(APPEND fli_LIB_SRCS unix/linux/libfli-parport.c)
+endif()
 
 #build a shared library
 ADD_LIBRARY(fli SHARED ${fli_LIB_SRCS})


### PR DESCRIPTION
Three changes.  Disable parallel port driver in libfli for OSX.  Include indi-fli for OSX.  Change method for determining when exposure is complete.  Used method from FLI test program ported to OSX. Test program can be found at http://www.flicamera.com/downloads/sdk/wintakepic.zip  
Not tested under Linux. 