### PR TITLE
Fix for Rapid Looping feature

### DIFF
--- a/3rdparty/indi-asi/asi_ccd.cpp
+++ b/3rdparty/indi-asi/asi_ccd.cpp
@@ -1862,9 +1862,11 @@ void ASICCD::getExposure()
                 PrimaryCCD.setExposureLeft(0.0);
                 DEBUG(INDI::Logger::DBG_SESSION,
                     "Exposure done, downloading image...");
-                grabImage();
                 pthread_mutex_lock(&condMutex);
                 exposureSetRequest(StateIdle);
+                pthread_mutex_unlock(&condMutex);
+                grabImage();
+                pthread_mutex_lock(&condMutex);
                 break;
             }
             else if (status == ASI_EXP_FAILED)


### PR DESCRIPTION
Fixes the issue where the image thread's request state is reset after the call to
grabImage(), which clears the request state set when Rapid Looping is enabled.