### PR TITLE
Fix formatting problem under OSX in debug logging

### DIFF
--- a/3rdparty/indi-fli/fli_ccd.cpp
+++ b/3rdparty/indi-fli/fli_ccd.cpp
@@ -521,7 +521,7 @@ bool FLICCD::UpdateCCDFrame(int x, int y, int w, int h)
         return false;
     }
 
-    DEBUGF(INDI::Logger::DBG_DEBUG, "Binning (%dx%d). Final FLI image area is (%ld, %ld), (%ld, %ld). Size (%dx%d)", PrimaryCCD.getBinX(), PrimaryCCD.getBinY(),
+    DEBUGF(INDI::Logger::DBG_DEBUG, "Binning (%dx%d). Final FLI image area is (%d, %d), (%ld, %ld). Size (%dx%d)", PrimaryCCD.getBinX(), PrimaryCCD.getBinY(),
            x, y, bin_right, bin_bottom, w / PrimaryCCD.getBinX(), h / PrimaryCCD.getBinY());
 
     if (!sim && (err = FLISetImageArea(fli_dev, x, y, bin_right, bin_bottom)))


### PR DESCRIPTION
Old code resulted in.
[2018-02-17T09:19:04.758 CST DEBG ][           org.kde.kstars.indi] - FLI CCD : "[DEBUG] Binning (1x1). Final FLI image area is (140462610448384, 140462610448384), (4872, 3248). Size (4872x3248) "
