### PR TITLE
Add shorter logging macros to indilogger.h

### DIFF
--- a/3rdparty/indi-maxdomeii/maxdomeii.cpp
+++ b/3rdparty/indi-maxdomeii/maxdomeii.cpp
@@ -19,29 +19,16 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "maxdomeii.h"
-
 #include "config.h"
+#include "maxdomeii.h"
 #include "maxdomeiidriver.h"  // MaxDome II Command Set
 
 #include <connectionplugins/connectionserial.h>
 
 #include <memory>
-
 #include <math.h>
 #include <string.h>
 #include <unistd.h>
-
-// logging macros
-#define LOG_DEBUG(txt)  DEBUG(INDI::Logger::DBG_DEBUG, (txt))
-#define LOG_INFO(txt)   DEBUG(INDI::Logger::DBG_SESSION, (txt))
-#define LOG_WARN(txt)   DEBUG(INDI::Logger::DBG_WARNING, (txt))
-#define LOG_ERROR(txt)  DEBUG(INDI::Logger::DBG_ERROR, (txt))
-
-#define LOGF_DEBUG(...) DEBUGF(INDI::Logger::DBG_DEBUG, __VA_ARGS__)
-#define LOGF_INFO(...)  DEBUGF(INDI::Logger::DBG_SESSION, __VA_ARGS__)
-#define LOGF_WARN(...)  DEBUGF(INDI::Logger::DBG_WARNING, __VA_ARGS__)
-#define LOGF_ERROR(...) DEBUGF(INDI::Logger::DBG_ERROR, __VA_ARGS__)
 
 
 // We declare an auto pointer to dome.

--- a/3rdparty/indi-maxdomeii/maxdomeiidriver.cpp
+++ b/3rdparty/indi-maxdomeii/maxdomeiidriver.cpp
@@ -54,19 +54,6 @@
 #define EXIT_SHUTTER            0x04 // Command send to shutter on program exit
 #define ABORT_SHUTTER           0x07
 
-// logging macros
-#define LOG_DEBUG(txt)  DEBUGDEVICE(device_str, INDI::Logger::DBG_DEBUG, (txt))
-#define LOG_INFO(txt)   DEBUGDEVICE(device_str, INDI::Logger::DBG_SESSION, (txt))
-#define LOG_WARN(txt)   DEBUGDEVICE(device_str, INDI::Logger::DBG_WARNING, (txt))
-#define LOG_ERROR(txt)  DEBUGDEVICE(device_str, INDI::Logger::DBG_ERROR, (txt))
-#define LOG_EXTRA(...)  DEBUGDEVICE(device_str, INDI::Logger::DBG_EXTRA_1, (txt))
-
-#define LOGF_DEBUG(...) DEBUGFDEVICE(device_str, INDI::Logger::DBG_DEBUG, __VA_ARGS__)
-#define LOGF_INFO(...)  DEBUGFDEVICE(device_str, INDI::Logger::DBG_SESSION, __VA_ARGS__)
-#define LOGF_WARN(...)  DEBUGFDEVICE(device_str, INDI::Logger::DBG_WARNING, __VA_ARGS__)
-#define LOGF_ERROR(...) DEBUGFDEVICE(device_str, INDI::Logger::DBG_ERROR, __VA_ARGS__)
-#define LOGF_EXTRA(...) DEBUGFDEVICE(device_str, INDI::Logger::DBG_EXTRA_1, __VA_ARGS__)
-
 
 // Error messages
 const char *ErrorMessages[] = {
@@ -83,7 +70,7 @@ const char *ErrorMessages[] = {
 char device_str[MAXINDIDEVICE] = "MaxDome II";
 
 
-void hex_dump(char *buf, const char *data, int size)
+void hexDump(char *buf, const char *data, int size)
 {
     for (int i = 0; i < size; i++)
         sprintf(buf + 3 * i, "%02X ", (unsigned char)data[i]);
@@ -95,6 +82,12 @@ void hex_dump(char *buf, const char *data, int size)
 void MaxDomeIIDriver::SetPortFD(int port_fd)
 {
     fd = port_fd;
+}
+
+// This method is required by the logging macros
+const char *MaxDomeIIDriver::getDeviceName()
+{
+    return device_str;
 }
 
 void MaxDomeIIDriver::SetDevice(const char *name)
@@ -232,7 +225,7 @@ int MaxDomeIIDriver::SendCommand(char cmdId, const char *payload, int payloadLen
 
     memcpy(cmd + 3, payload, payloadLen);
 
-    //hex_dump(hexbuf, cmd, 4 + payloadLen);
+    //hexDump(hexbuf, cmd, 4 + payloadLen);
     //LOGF_DEBUG("CMD (%s)", hexbuf);
 
     tcflush(fd, TCIOFLUSH);
@@ -253,7 +246,7 @@ int MaxDomeIIDriver::SendCommand(char cmdId, const char *payload, int payloadLen
         return -6;
     }
 
-    //hex_dump(hexbuf, buffer, nbytes);
+    //hexDump(hexbuf, buffer, nbytes);
     //LOGF_DEBUG("RES (%s)", hexbuf);
 
     return 0;

--- a/3rdparty/indi-maxdomeii/maxdomeiidriver.h
+++ b/3rdparty/indi-maxdomeii/maxdomeiidriver.h
@@ -48,7 +48,7 @@ enum ShStatus
 
 extern const char *ErrorMessages[];
 
-void hex_dump(char *buf, const char *data, int size);
+void hexDump(char *buf, const char *data, int size);
 
 
 class MaxDomeIIDriver
@@ -56,6 +56,7 @@ class MaxDomeIIDriver
     public:
         MaxDomeIIDriver() { fd = 0; }
 
+        const char *getDeviceName();
         void SetPortFD(int port_fd);
         void SetDevice(const char *name);
 

--- a/3rdparty/indi-maxdomeii/test_maxdomeii.cpp
+++ b/3rdparty/indi-maxdomeii/test_maxdomeii.cpp
@@ -2,12 +2,12 @@
 #include "maxdomeiidriver.h"
 
 
-TEST(MaxDomeIIDriver, hex_dump)
+TEST(MaxDomeIIDriver, hexDump)
 {
     char data[] = "abcd";
     char out[(sizeof(data) - 1)*3];
 
-    hex_dump(out, data, sizeof(data) - 1);
+    hexDump(out, data, sizeof(data) - 1);
     ASSERT_STREQ(out, "61 62 63 64");
 }
 

--- a/3rdparty/indi-qhy/qhy_ccd.cpp
+++ b/3rdparty/indi-qhy/qhy_ccd.cpp
@@ -25,6 +25,12 @@
 #include "config.h"
 #include <stream/streammanager.h>
 
+// Avoid duplicated definitions (macros previously defined in indibase)
+#undef LOG_DEBUG
+#undef LOG_INFO
+#undef LOG_WARN
+#undef LOG_ERROR
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <log4z.h>

--- a/libindi/drivers/telescope/celestrondriver.cpp
+++ b/libindi/drivers/telescope/celestrondriver.cpp
@@ -37,24 +37,10 @@
 
 #define CELESTRON_TIMEOUT 5 /* FD timeout in seconds */
 
-// logging macros
-#define LOG_DEBUG(txt)  DEBUGDEVICE(device_str, INDI::Logger::DBG_DEBUG, (txt))
-#define LOG_INFO(txt)   DEBUGDEVICE(device_str, INDI::Logger::DBG_SESSION, (txt))
-#define LOG_WARN(txt)   DEBUGDEVICE(device_str, INDI::Logger::DBG_WARNING, (txt))
-#define LOG_ERROR(txt)  DEBUGDEVICE(device_str, INDI::Logger::DBG_ERROR, (txt))
-#define LOG_EXTRA(...)  DEBUGDEVICE(device_str, INDI::Logger::DBG_EXTRA_1, (txt))
-
-#define LOGF_DEBUG(...) DEBUGFDEVICE(device_str, INDI::Logger::DBG_DEBUG, __VA_ARGS__)
-#define LOGF_INFO(...)  DEBUGFDEVICE(device_str, INDI::Logger::DBG_SESSION, __VA_ARGS__)
-#define LOGF_WARN(...)  DEBUGFDEVICE(device_str, INDI::Logger::DBG_WARNING, __VA_ARGS__)
-#define LOGF_ERROR(...) DEBUGFDEVICE(device_str, INDI::Logger::DBG_ERROR, __VA_ARGS__)
-#define LOGF_EXTRA(...) DEBUGFDEVICE(device_str, INDI::Logger::DBG_EXTRA_1, __VA_ARGS__)
-
-
 using namespace Celestron;
 
-
 char device_str[MAXINDIDEVICE] = "Celestron GPS";
+
 
 // Account for the quadrant in declination
 double Celestron::trimDecAngle(double angle)
@@ -112,6 +98,11 @@ void hex_dump(char *buf, const char *data, int size)
         buf[3 * size - 1] = '\0';
 }
 
+// This method is required by the logging macros
+const char *CelestronDriver::getDeviceName()
+{
+    return device_str;
+}
 
 void CelestronDriver::set_device(const char *name)
 {
@@ -556,7 +547,7 @@ bool CelestronDriver::get_radec(double *ra, double *dec, bool precise)
     fs_sexa(RAStr, *ra, 2, 3600);
     fs_sexa(DecStr, *dec, 2, 3600);
 
-    LOGF_EXTRA("RA-DEC (%s,%s)", RAStr, DecStr);
+    LOGF_EXTRA1("RA-DEC (%s,%s)", RAStr, DecStr);
     return true;
 }
 
@@ -582,7 +573,7 @@ bool CelestronDriver::get_azalt(double *az, double *alt, bool precise)
     char AzStr[16], AltStr[16];
     fs_sexa(AzStr, *az, 3, 3600);
     fs_sexa(AltStr, *alt, 2, 3600);
-    LOGF_EXTRA("RES <%s> ==> AZM-ALT (%s,%s)", response, AzStr, AltStr);
+    LOGF_EXTRA1("RES <%s> ==> AZM-ALT (%s,%s)", response, AzStr, AltStr);
     return true;
 }
 

--- a/libindi/drivers/telescope/celestrondriver.h
+++ b/libindi/drivers/telescope/celestrondriver.h
@@ -89,6 +89,7 @@ class CelestronDriver
         CelestronDriver() {}
 
         // Misc.
+        const char *getDeviceName();
         void set_port_fd(int port_fd) { fd = port_fd; }
         void set_simulation(bool enable) { simulation = enable; }
         void set_device(const char *name);

--- a/libindi/drivers/telescope/celestrongps.cpp
+++ b/libindi/drivers/telescope/celestrongps.cpp
@@ -35,17 +35,6 @@ Version with experimental pulse guide support. GC 04.12.2015
 #include <cstring>
 #include <unistd.h>
 
-// logging macros
-#define LOG_DEBUG(txt)  DEBUG(INDI::Logger::DBG_DEBUG, (txt))
-#define LOG_INFO(txt)   DEBUG(INDI::Logger::DBG_SESSION, (txt))
-#define LOG_WARN(txt)   DEBUG(INDI::Logger::DBG_WARNING, (txt))
-#define LOG_ERROR(txt)   DEBUG(INDI::Logger::DBG_ERROR, (txt))
-
-#define LOGF_DEBUG(...) DEBUGF(INDI::Logger::DBG_DEBUG, __VA_ARGS__)
-#define LOGF_INFO(...)  DEBUGF(INDI::Logger::DBG_SESSION, __VA_ARGS__)
-#define LOGF_WARN(...)  DEBUGF(INDI::Logger::DBG_WARNING, __VA_ARGS__)
-#define LOGF_ERROR(...)  DEBUGF(INDI::Logger::DBG_ERROR, __VA_ARGS__)
-
 // Simulation Parameters
 #define GOTO_RATE       5        // slew rate, degrees/s
 #define SLEW_RATE       0.5      // slew rate, degrees/s

--- a/libindi/libs/indibase/indilogger.h
+++ b/libindi/libs/indibase/indilogger.h
@@ -77,13 +77,13 @@
 #define LOG_EXTRA2(txt)  DEBUG(INDI::Logger::DBG_EXTRA_2, (txt))
 #define LOG_EXTRA3(txt)  DEBUG(INDI::Logger::DBG_EXTRA_3, (txt))
 
-#define LOGF_ERROR(...) DEBUGF(INDI::Logger::DBG_ERROR, __VA_ARGS__)
-#define LOGF_WARN(...)  DEBUGF(INDI::Logger::DBG_WARNING, __VA_ARGS__)
-#define LOGF_INFO(...)  DEBUGF(INDI::Logger::DBG_SESSION, __VA_ARGS__)
-#define LOGF_DEBUG(...) DEBUGF(INDI::Logger::DBG_DEBUG, __VA_ARGS__)
-#define LOGF_EXTRA1(...) DEBUGF(INDI::Logger::DBG_EXTRA_1, __VA_ARGS__)
-#define LOGF_EXTRA2(...) DEBUGF(INDI::Logger::DBG_EXTRA_2, __VA_ARGS__)
-#define LOGF_EXTRA3(...) DEBUGF(INDI::Logger::DBG_EXTRA_3, __VA_ARGS__)
+#define LOGF_ERROR(fmt, ...) DEBUGF(INDI::Logger::DBG_ERROR, (fmt), __VA_ARGS__)
+#define LOGF_WARN(fmt, ...)  DEBUGF(INDI::Logger::DBG_WARNING, (fmt), __VA_ARGS__)
+#define LOGF_INFO(fmt, ...)  DEBUGF(INDI::Logger::DBG_SESSION, (fmt), __VA_ARGS__)
+#define LOGF_DEBUG(fmt, ...) DEBUGF(INDI::Logger::DBG_DEBUG, (fmt), __VA_ARGS__)
+#define LOGF_EXTRA1(fmt, ...) DEBUGF(INDI::Logger::DBG_EXTRA_1, (fmt), __VA_ARGS__)
+#define LOGF_EXTRA2(fmt, ...) DEBUGF(INDI::Logger::DBG_EXTRA_2, (fmt), __VA_ARGS__)
+#define LOGF_EXTRA3(fmt, ...) DEBUGF(INDI::Logger::DBG_EXTRA_3, (fmt), __VA_ARGS__)
 
 
 namespace INDI

--- a/libindi/libs/indibase/indilogger.h
+++ b/libindi/libs/indibase/indilogger.h
@@ -56,9 +56,35 @@
 #define DEBUG(priority, msg) INDI::Logger::getInstance().print(getDeviceName(), priority, __FILE__, __LINE__, msg)
 #define DEBUGF(priority, msg, ...) \
     INDI::Logger::getInstance().print(getDeviceName(), priority, __FILE__, __LINE__, msg, __VA_ARGS__)
+
 #define DEBUGDEVICE(device, priority, msg) INDI::Logger::getInstance().print(device, priority, __FILE__, __LINE__, msg)
 #define DEBUGFDEVICE(device, priority, msg, ...) \
     INDI::Logger::getInstance().print(device, priority, __FILE__, __LINE__, msg, __VA_ARGS__)
+
+/**
+ * @brief Shorter logging macros. In order to use these macros, the function
+ * (or method) "getDeviceName()" must be defined in the calling scope.
+ *
+ * Usage examples:
+ *	    LOG_DEBUG("hello " << "world");
+ *	    LOGF_WARN("hello %s", "world");
+ */
+#define LOG_ERROR(txt)  DEBUG(INDI::Logger::DBG_ERROR, (txt))
+#define LOG_WARN(txt)   DEBUG(INDI::Logger::DBG_WARNING, (txt))
+#define LOG_INFO(txt)   DEBUG(INDI::Logger::DBG_SESSION, (txt))
+#define LOG_DEBUG(txt)  DEBUG(INDI::Logger::DBG_DEBUG, (txt))
+#define LOG_EXTRA1(txt)  DEBUG(INDI::Logger::DBG_EXTRA_1, (txt))
+#define LOG_EXTRA2(txt)  DEBUG(INDI::Logger::DBG_EXTRA_2, (txt))
+#define LOG_EXTRA3(txt)  DEBUG(INDI::Logger::DBG_EXTRA_3, (txt))
+
+#define LOGF_ERROR(...) DEBUGF(INDI::Logger::DBG_ERROR, __VA_ARGS__)
+#define LOGF_WARN(...)  DEBUGF(INDI::Logger::DBG_WARNING, __VA_ARGS__)
+#define LOGF_INFO(...)  DEBUGF(INDI::Logger::DBG_SESSION, __VA_ARGS__)
+#define LOGF_DEBUG(...) DEBUGF(INDI::Logger::DBG_DEBUG, __VA_ARGS__)
+#define LOGF_EXTRA1(...) DEBUGF(INDI::Logger::DBG_EXTRA_1, __VA_ARGS__)
+#define LOGF_EXTRA2(...) DEBUGF(INDI::Logger::DBG_EXTRA_2, __VA_ARGS__)
+#define LOGF_EXTRA3(...) DEBUGF(INDI::Logger::DBG_EXTRA_3, __VA_ARGS__)
+
 
 namespace INDI
 {


### PR DESCRIPTION
Currently, only celestrongps and maxdome_ii drivers are using these macros.