### PR TITLE
udev rule for /dev/integra_focusing_rotator0 and set the mandatory ba…

### DIFF
--- a/libindi/drivers/focuser/99-focusers.rules
+++ b/libindi/drivers/focuser/99-focusers.rules
@@ -5,4 +5,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", MODE="0666"
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="134a", MODE="0666"
 
 # Gemini Telescope Design Integra85 Focusing Rotator
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0043", MODE="0666", SYMLINK+="integra_focusing_rotator%n", ENV{ID_MM_DEVICE_IGNORE}="1"
+# Uncomment the SUBSYSTEMS line below if you have no other Arduino devices and want to use a
+# more logical name than ttyACM0 and activate with: udevadm control --reload-rules
+#SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0043", MODE="0666", SYMLINK+="integra_focusing_rotator%n", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/libindi/drivers/focuser/99-focusers.rules
+++ b/libindi/drivers/focuser/99-focusers.rules
@@ -3,3 +3,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="04d8", MODE="0666"
 
 # Focus Master
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="134a", MODE="0666"
+
+# Gemini Telescope Design Integra85 Focusing Rotator
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2a03", ATTRS{idProduct}=="0043", MODE="0666", SYMLINK+="integra_focusing_rotator%n", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/libindi/drivers/rotator/integra.cpp
+++ b/libindi/drivers/rotator/integra.cpp
@@ -166,9 +166,10 @@ bool Integra::initProperties()
 
     addDebugControl();
 
-    // 2018-03-08 JM: Disable custom port and baud rates. User should select those
-    //serialConnection->setDefaultPort("/dev/integra_focusing_rotator1");
-    //serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
+    // udev creates /dev/integra_focusing_rotator0 for the first focusing_rotator, 1 for the second and so on
+    serialConnection->setDefaultPort("/dev/integra_focusing_rotator0");
+    // mandatory baud speed. The device does not work with anything else
+    serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
 
     return true;
 }

--- a/libindi/drivers/rotator/integra.cpp
+++ b/libindi/drivers/rotator/integra.cpp
@@ -166,9 +166,10 @@ bool Integra::initProperties()
 
     addDebugControl();
 
-    // udev creates /dev/integra_focusing_rotator0 for the first focusing_rotator, 1 for the second and so on
-    serialConnection->setDefaultPort("/dev/integra_focusing_rotator0");
-    // mandatory baud speed. The device does not work with anything else
+    // The device uses an Arduino which shows up as /dev/ttyACM0 on Linux
+    // An udev rule example is provided that can create a more logical name like /dev/integra_focusing_rotator0
+    serialConnection->setDefaultPort("/dev/ttyACM0");
+    // Set mandatory baud speed. The device does not work with anything else.
     serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
 
     return true;


### PR DESCRIPTION
…udspeed. Also prevent the modem manager to probe the device as it breaks it.