### PR TITLE
Clear allocated IText structs for filter names to avoid crash

### DIFF
--- a/libindi/libs/indibase/indifilterinterface.cpp
+++ b/libindi/libs/indibase/indifilterinterface.cpp
@@ -124,6 +124,7 @@ bool FilterInterface::processText(const char *dev, const char *name, char *texts
                 delete [] FilterNameT;
 
             FilterNameT = new IText[n];
+            memset(FilterNameT, 0, sizeof(IText) * n);
 
             for (int i = 0; i < n; i++)
             {
@@ -189,6 +190,7 @@ void FilterInterface::generateSampleFilters()
         delete [] FilterNameT;
 
     FilterNameT = new IText[MaxFilter];
+    memset(FilterNameT, 0, sizeof(IText) * MaxFilter);
 
     for (int i = 0; i < MaxFilter; i++)
     {


### PR DESCRIPTION
Recompiled INDI today after the memleak fixes and noticed that my SX wheel driver crashed with corrupted free. Noticed that it tried to free "text" member of an IText struct and it was garbage. Back trace showed it had been allocated with new() which doesn't initialize the struct in any way unless it has a constructor. So clear the tables to avoid this. More foolproof way would be to add default initializer to the struct though.