### PR TITLE
Fix incorrect usage of sizeof

### DIFF
--- a/libindi/indiserver.c
+++ b/libindi/indiserver.c
@@ -948,11 +948,11 @@ static void newFIFO(void)
         char cmd[MAXSBUF], arg[4][1], var[4][MAXSBUF], tDriver[MAXSBUF], tName[MAXSBUF], envConfig[MAXSBUF],
             envSkel[MAXSBUF], envPrefix[MAXSBUF];
 
-        memset(&tDriver[0], 0, sizeof(MAXSBUF));
-        memset(&tName[0], 0, sizeof(MAXSBUF));
-        memset(&envConfig[0], 0, sizeof(MAXSBUF));
-        memset(&envSkel[0], 0, sizeof(MAXSBUF));
-        memset(&envPrefix[0], 0, sizeof(MAXSBUF));
+        memset(&tDriver[0], 0, sizeof(char) * MAXSBUF);
+        memset(&tName[0], 0, sizeof(char) * MAXSBUF);
+        memset(&envConfig[0], 0, sizeof(char) * MAXSBUF);
+        memset(&envSkel[0], 0, sizeof(char) * MAXSBUF);
+        memset(&envPrefix[0], 0, sizeof(char) * MAXSBUF);
 
         int n = 0;
 


### PR DESCRIPTION
Statement sizeof(MAXSBUF) results in 4, however
we want to zero out char[MAXSBUF], thus
sizeof(char) * MAXSBUF.