### PR TITLE
Initialize the remaining IText members outside base classes

### DIFF
--- a/3rdparty/indi-apogee/apogee_ccd.h
+++ b/3rdparty/indi-apogee/apogee_ccd.h
@@ -83,10 +83,10 @@ class ApogeeCCD : public INDI::CCD
     ISwitch PortTypeS[2];
     ISwitchVectorProperty PortTypeSP;
 
-    IText NetworkInfoT[2];
+    IText NetworkInfoT[2] {};
     ITextVectorProperty NetworkInfoTP;
 
-    IText CamInfoT[2];
+    IText CamInfoT[2] {};
     ITextVectorProperty CamInfoTP;
 
     ISwitch FanStatusS[4];

--- a/3rdparty/indi-armadillo-platypus/arm_plat_focuser_common.h
+++ b/3rdparty/indi-armadillo-platypus/arm_plat_focuser_common.h
@@ -120,6 +120,6 @@ protected:
 
 
     // Firmware Version
-    IText FirmwareVersionT[1];
+    IText FirmwareVersionT[1] {};
     ITextVectorProperty FirmwareVersionTP;
 };

--- a/3rdparty/indi-fishcamp/indi_fishcamp.h
+++ b/3rdparty/indi-fishcamp/indi_fishcamp.h
@@ -73,7 +73,7 @@ class FishCampCCD : public INDI::CCD
     INumber CoolerN[1];
     INumberVectorProperty CoolerNP;
 
-    IText CamInfoT[6];
+    IText CamInfoT[6] {};
     ITextVectorProperty CamInfoTP;
 
     int cameraNum;

--- a/3rdparty/indi-fli/fli_ccd.h
+++ b/3rdparty/indi-fli/fli_ccd.h
@@ -92,7 +92,7 @@ class FLICCD : public INDI::CCD
     ISwitch PortS[4];
     ISwitchVectorProperty PortSP;
 
-    IText CamInfoT[3];
+    IText CamInfoT[3] {};
     ITextVectorProperty CamInfoTP;
 
     INumber CoolerN[1];

--- a/3rdparty/indi-fli/fli_cfw.h
+++ b/3rdparty/indi-fli/fli_cfw.h
@@ -67,7 +67,7 @@ class FLICFW : public INDI::FilterWheel
     ISwitch PortS[4];
     ISwitchVectorProperty PortSP;
 
-    IText FilterInfoT[3];
+    IText FilterInfoT[3] {};
     ITextVectorProperty FilterInfoTP;
 
     ISwitch FilterS[2];

--- a/3rdparty/indi-fli/fli_pdf.h
+++ b/3rdparty/indi-fli/fli_pdf.h
@@ -70,7 +70,7 @@ class FLIPDF : public INDI::Focuser
     ISwitch HomeS[1];
     ISwitchVectorProperty HomeSP;
 
-    IText FocusInfoT[3];
+    IText FocusInfoT[3] {};
     ITextVectorProperty FocusInfoTP;
 
     int timerID;

--- a/3rdparty/indi-gige/src/indi_gige.h
+++ b/3rdparty/indi-gige/src/indi_gige.h
@@ -70,7 +70,7 @@ class GigECCD : public INDI::CCD
 
     INumber indiprop_gain[1];
     INumberVectorProperty indiprop_gain_prop;
-    IText indiprop_info[3];
+    IText indiprop_info[3] {};
     ITextVectorProperty indiprop_info_prop;
 
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);

--- a/3rdparty/indi-gphoto/gphoto_ccd.h
+++ b/3rdparty/indi-gphoto/gphoto_ccd.h
@@ -144,7 +144,7 @@ class GPhotoCCD : public INDI::CCD, public INDI::FocuserInterface
 
     ISwitch mConnectS[2];
     ISwitchVectorProperty mConnectSP;
-    IText mPortT[1];
+    IText mPortT[1] {};
     ITextVectorProperty PortTP;
 
     INumber mMirrorLockN[1];

--- a/3rdparty/indi-gpsd/gps_driver.h
+++ b/3rdparty/indi-gpsd/gps_driver.h
@@ -35,7 +35,7 @@ class GPSD : public INDI::GPS
     GPSD();
     virtual ~GPSD();
 
-    IText GPSstatusT[1];
+    IText GPSstatusT[1] {};
     ITextVectorProperty GPSstatusTP;
 
     INumber PolarisN[1];

--- a/3rdparty/indi-gpsnmea/gpsnmea_driver.h
+++ b/3rdparty/indi-gpsnmea/gpsnmea_driver.h
@@ -32,7 +32,7 @@ class GPSNMEA : public INDI::GPS
     GPSNMEA();
     virtual ~GPSNMEA() = default;
 
-    IText GPSstatusT[1];
+    IText GPSstatusT[1] {};
     ITextVectorProperty GPSstatusTP;
 
     static void* parseNMEAHelper(void *);

--- a/3rdparty/indi-inovaplx/inovaplx_ccd.h
+++ b/3rdparty/indi-inovaplx/inovaplx_ccd.h
@@ -64,7 +64,7 @@ private:
     float ExposureRequest;      
 
     // We declare the CCD properties
-    IText iNovaInformationT[5];
+    IText iNovaInformationT[5] {};
     ITextVectorProperty iNovaInformationTP;
 
     INumber CameraPropertiesN[2];

--- a/3rdparty/indi-nexdome/nex_dome.h
+++ b/3rdparty/indi-nexdome/nex_dome.h
@@ -52,7 +52,7 @@ protected:
 	INumber HomePositionN[1];
 	INumber BatteryLevelN[2];
 	INumberVectorProperty BatteryLevelNP;
-	IText FirmwareVersionT[1];
+	IText FirmwareVersionT[1] {};
         ITextVectorProperty FirmwareVersionTP;
 	ISwitch ReversedS[2];
 	ISwitchVectorProperty ReversedSP;

--- a/3rdparty/indi-sbig/sbig_ccd.h
+++ b/3rdparty/indi-sbig/sbig_ccd.h
@@ -180,7 +180,7 @@ class SBIGCCD : public INDI::CCD, public INDI::FilterInterface
     DEVICE device;
     char name[MAXINDINAME];
 
-    IText ProductInfoT[2];
+    IText ProductInfoT[2] {};
     ITextVectorProperty ProductInfoTP;
 
     ISwitch PortS[8];
@@ -202,7 +202,7 @@ class SBIGCCD : public INDI::CCD, public INDI::FilterInterface
     INumberVectorProperty CoolerNP;
 
     // CFW GROUP:
-    IText FilterProdcutT[2];
+    IText FilterProdcutT[2] {};
     ITextVectorProperty FilterProdcutTP;
 
     ISwitch FilterTypeS[MAX_CFW_TYPES];

--- a/3rdparty/indi-shelyak/indi_shelyakeshel_spectrograph.h
+++ b/3rdparty/indi-shelyak/indi_shelyakeshel_spectrograph.h
@@ -41,7 +41,7 @@ class ShelyakEshel : public INDI::DefaultDevice
 
     // Options
     ITextVectorProperty PortTP;
-    IText PortT[1];
+    IText PortT[1] {};
 
     // Spectrograph Settings
     INumberVectorProperty SettingsNP;

--- a/3rdparty/indi-sx/sxao.h
+++ b/3rdparty/indi-sx/sxao.h
@@ -73,7 +73,7 @@ private:
   ISwitch Center[2];
   ISwitchVectorProperty CenterP;
 
-  IText FWT[1];
+  IText FWT[1] {};
   ITextVectorProperty FWTP;
 
   ILight AtLimitL[4];

--- a/libindi/drivers/auxiliary/astrometrydriver.h
+++ b/libindi/drivers/auxiliary/astrometrydriver.h
@@ -97,7 +97,7 @@ class AstrometryDriver : public INDI::DefaultDevice
     ISwitchVectorProperty SolverSP;
 
     // Solver Settings
-    IText SolverSettingsT[2];
+    IText SolverSettingsT[2] {};
     ITextVectorProperty SolverSettingsTP;
 
     // Solver Results
@@ -105,7 +105,7 @@ class AstrometryDriver : public INDI::DefaultDevice
     INumberVectorProperty SolverResultNP;
 
     ITextVectorProperty ActiveDeviceTP;
-    IText ActiveDeviceT[1];
+    IText ActiveDeviceT[1] {};
 
     IBLOBVectorProperty SolverDataBP;
     IBLOB SolverDataB[1];

--- a/libindi/drivers/auxiliary/flip_flat.h
+++ b/libindi/drivers/auxiliary/flip_flat.h
@@ -75,11 +75,11 @@ class FlipFlat : public INDI::DefaultDevice, public INDI::LightBoxInterface, pub
 
     // Status
     ITextVectorProperty StatusTP;
-    IText StatusT[3];
+    IText StatusT[3] {};
 
     // Firmware version
     ITextVectorProperty FirmwareTP;
-    IText FirmwareT[1];
+    IText FirmwareT[1] {};
 
     int PortFD { -1 };
     int productID { 0 };

--- a/libindi/drivers/auxiliary/skysafari.h
+++ b/libindi/drivers/auxiliary/skysafari.h
@@ -73,7 +73,7 @@ class SkySafari : public INDI::DefaultDevice
 
     // Settings
     ITextVectorProperty SettingsTP;
-    IText SettingsT[3];
+    IText SettingsT[3] {};
     enum
     {
         INDISERVER_HOST,
@@ -83,7 +83,7 @@ class SkySafari : public INDI::DefaultDevice
 
     // Active Devices
     ITextVectorProperty ActiveDeviceTP;
-    IText ActiveDeviceT[1];
+    IText ActiveDeviceT[1] {};
     enum
     {
         ACTIVE_TELESCOPE

--- a/libindi/drivers/auxiliary/snapcap.h
+++ b/libindi/drivers/auxiliary/snapcap.h
@@ -81,11 +81,11 @@ class SnapCap : public INDI::DefaultDevice, public INDI::LightBoxInterface, publ
 
     // Status
     ITextVectorProperty StatusTP;
-    IText StatusT[3];
+    IText StatusT[3] {};
 
     // Firmware version
     ITextVectorProperty FirmwareTP;
-    IText FirmwareT[1];
+    IText FirmwareT[1] {};
 
     // Abort
     ISwitch AbortS[1];

--- a/libindi/drivers/auxiliary/watchdog.h
+++ b/libindi/drivers/auxiliary/watchdog.h
@@ -75,13 +75,13 @@ class WatchDog : public INDI::DefaultDevice
     INumber HeartBeatN[1];
 
     ITextVectorProperty SettingsTP;
-    IText SettingsT[3];
+    IText SettingsT[3] {};
 
     ISwitchVectorProperty ShutdownProcedureSP;
     ISwitch ShutdownProcedureS[3];
 
     ITextVectorProperty ActiveDeviceTP;
-    IText ActiveDeviceT[2];
+    IText ActiveDeviceT[2] {};
     enum { ACTIVE_TELESCOPE, ACTIVE_DOME };
 
     WatchDogClient *watchdogClient;

--- a/libindi/drivers/dome/dome_script.h
+++ b/libindi/drivers/dome/dome_script.h
@@ -50,7 +50,7 @@ class DomeScript : public INDI::Dome
     bool RunScript(int script, ...);
 
     ITextVectorProperty ScriptsTP;
-    IText ScriptsT[15];
+    IText ScriptsT[15] {};
     double TargetAz { 0 };
     int TimeSinceUpdate { 0 };
 };

--- a/libindi/drivers/filter_wheel/ifwoptec.h
+++ b/libindi/drivers/filter_wheel/ifwoptec.h
@@ -105,7 +105,7 @@ class FilterIFW : public INDI::FilterWheel
 
     // Filter Wheel ID
     ITextVectorProperty WheelIDTP;
-    IText WheelIDT[1];
+    IText WheelIDT[1] {};
 
     // Home function
     ISwitchVectorProperty HomeSP;
@@ -121,7 +121,7 @@ class FilterIFW : public INDI::FilterWheel
 
     // Firmware of teh IFW
     ITextVectorProperty FirmwareTP;
-    IText FirmwareT[1];
+    IText FirmwareT[1] {};
 
     //Filter position in simulation mode
     int actualSimFilter { 1 };

--- a/libindi/drivers/focuser/focuslynx.h
+++ b/libindi/drivers/focuser/focuslynx.h
@@ -45,15 +45,15 @@ class FocusLynxF1 : public FocusLynxBase
     bool getHubConfig();
 
     // HUB Main Parameter
-    IText HubT[2];
+    IText HubT[2] {};
     ITextVectorProperty HubTP;
 
     // Network Wired Info
-    IText WiredT[2];
+    IText WiredT[2] {};
     ITextVectorProperty WiredTP;
 
     //Network WIFI Info
-    IText WifiT[9];
+    IText WifiT[9] {};
     ITextVectorProperty WifiTP;
 };
 

--- a/libindi/drivers/focuser/focuslynxbase.h
+++ b/libindi/drivers/focuser/focuslynxbase.h
@@ -232,7 +232,7 @@ class FocusLynxBase : public INDI::Focuser
     INumberVectorProperty MaxTravelNP;
 
     // Focus name configure in the HUB
-    IText HFocusNameT[1];
+    IText HFocusNameT[1] {};
     ITextVectorProperty HFocusNameTP;
 
     bool isAbsolute;

--- a/libindi/drivers/focuser/sestosenso.h
+++ b/libindi/drivers/focuser/sestosenso.h
@@ -61,7 +61,7 @@ protected:
     INumber TemperatureN[1];
     INumberVectorProperty TemperatureNP;
 
-    IText FirmwareT[1];
+    IText FirmwareT[1] {};
     ITextVectorProperty FirmwareTP;
 
     INumber SyncN[1];

--- a/libindi/drivers/focuser/steeldrive.h
+++ b/libindi/drivers/focuser/steeldrive.h
@@ -128,7 +128,7 @@ class SteelDrive : public INDI::Focuser
     INumber SyncN[1];
     INumberVectorProperty SyncNP;
 
-    IText VersionT[2];
+    IText VersionT[2] {};
     ITextVectorProperty VersionTP;
 
     FocusCustomSetting fSettings[5];

--- a/libindi/drivers/rotator/gemini.h
+++ b/libindi/drivers/rotator/gemini.h
@@ -273,7 +273,7 @@ protected:
     ISwitchVectorProperty ResetSP;
 
     // Focus and rotator name configure in the HUB
-    IText HFocusNameT[2];
+    IText HFocusNameT[2] {};
     ITextVectorProperty HFocusNameTP;
 
     // Led Intensity Value

--- a/libindi/drivers/telescope/celestrongps.h
+++ b/libindi/drivers/telescope/celestrongps.h
@@ -94,7 +94,7 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface
         CELESTRON_DIRECTION guide_direction;
 
         /* Firmware */
-        IText FirmwareT[5];
+        IText FirmwareT[5] {};
         ITextVectorProperty FirmwareTP;
 
         //INumberVectorProperty HorizontalCoordsNP;

--- a/libindi/drivers/telescope/ieqpro.h
+++ b/libindi/drivers/telescope/ieqpro.h
@@ -94,7 +94,7 @@ class IEQPro : public INDI::Telescope, public INDI::GuiderInterface
     void getStartupData();
 
     /* Firmware */
-    IText FirmwareT[5];
+    IText FirmwareT[5] {};
     ITextVectorProperty FirmwareTP;
 
     /* Tracking Mode */

--- a/libindi/drivers/telescope/ioptronv3.h
+++ b/libindi/drivers/telescope/ioptronv3.h
@@ -96,7 +96,7 @@ class IOptronV3 : public INDI::Telescope, public INDI::GuiderInterface
     void getStartupData();
 
     /* Firmware */
-    IText FirmwareT[5];
+    IText FirmwareT[5] {};
     ITextVectorProperty FirmwareTP;
 
     /* GPS Status */

--- a/libindi/drivers/telescope/lx200_10micron.h
+++ b/libindi/drivers/telescope/lx200_10micron.h
@@ -119,7 +119,7 @@ class LX200_10MICRON : public LX200Generic
   protected:
     void getBasicData() override;
 
-    IText ProductT[4];
+    IText ProductT[4] {};
     ITextVectorProperty ProductTP;
 
     virtual int SetRefractionModelTemperature(double temperature);
@@ -150,7 +150,7 @@ class LX200_10MICRON : public LX200Generic
     INumber NewAlignmentPointsN[1];
     INumberVectorProperty NewAlignmentPointsNP;
 
-    IText NewModelNameT[1];
+    IText NewModelNameT[1] {};
     ITextVectorProperty NewModelNameTP;
 
   private:

--- a/libindi/drivers/telescope/lx200_OnStep.h
+++ b/libindi/drivers/telescope/lx200_OnStep.h
@@ -77,7 +77,7 @@ class LX200_OnStep : public LX200Generic
     void OSUpdateFocuser();
 
     ITextVectorProperty ObjectInfoTP;
-    IText ObjectInfoT[1];
+    IText ObjectInfoT[1] {};
 
     ISwitchVectorProperty StarCatalogSP;
     ISwitch StarCatalogS[3];
@@ -101,11 +101,11 @@ class LX200_OnStep : public LX200Generic
     INumber ElevationLimitN[2];
 
     ITextVectorProperty VersionTP;
-    IText VersionT[5];
+    IText VersionT[5] {};
 
     // OnStep Status controls
     ITextVectorProperty OnstepStatTP;
-    IText OnstepStat[10];
+    IText OnstepStat[10] {};
 
     // Focuser controls
     // Focuser 1
@@ -144,7 +144,7 @@ class LX200_OnStep : public LX200Generic
     // Align Buttons
     ISwitchVectorProperty OSAlignSP;
     ISwitch OSAlignS[4];
-    IText OSAlignT[1];
+    IText OSAlignT[1] {};
     ITextVectorProperty OSAlignTP;
 
     ISwitchVectorProperty TrackCompSP;

--- a/libindi/drivers/telescope/lx200ap.h
+++ b/libindi/drivers/telescope/lx200ap.h
@@ -101,10 +101,10 @@ class LX200AstroPhysics : public LX200Generic
     ISwitch APGuideSpeedS[3];
     ISwitchVectorProperty APGuideSpeedSP;
 
-    IText VersionT[1];
+    IText VersionT[1] {};
     ITextVectorProperty VersionInfo;
 
-    IText DeclinationAxisT[1];
+    IText DeclinationAxisT[1] {};
     ITextVectorProperty DeclinationAxisTP;
 
     INumber SlewAccuracyN[2];

--- a/libindi/drivers/telescope/lx200ap_experimental.h
+++ b/libindi/drivers/telescope/lx200ap_experimental.h
@@ -110,7 +110,7 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     INumberVectorProperty MeridianDelayNP;
     INumber MeridianDelayN[1];
 
-    IText VersionT[1];
+    IText VersionT[1] {};
     ITextVectorProperty VersionInfo;
 
   private:

--- a/libindi/drivers/telescope/lx200ap_gtocp2.h
+++ b/libindi/drivers/telescope/lx200ap_gtocp2.h
@@ -94,7 +94,7 @@ class LX200AstroPhysicsGTOCP2 : public LX200Generic
     ISwitch APGuideSpeedS[3];
     ISwitchVectorProperty APGuideSpeedSP;
 
-    IText VersionT[1];
+    IText VersionT[1] {};
     ITextVectorProperty VersionInfo;
 
   private:

--- a/libindi/drivers/telescope/lx200autostar.h
+++ b/libindi/drivers/telescope/lx200autostar.h
@@ -39,7 +39,7 @@ class LX200Autostar : public LX200Generic
     virtual bool updateProperties();
 
     ITextVectorProperty VersionTP;
-    IText VersionT[5];
+    IText VersionT[5] {};
 
     INumberVectorProperty FocusSpeedNP;
     INumber FocusSpeedN[1];

--- a/libindi/drivers/telescope/lx200classic.h
+++ b/libindi/drivers/telescope/lx200classic.h
@@ -37,7 +37,7 @@ class LX200Classic : public LX200Generic
 
   protected:
     ITextVectorProperty ObjectInfoTP;
-    IText ObjectInfoT[1];
+    IText ObjectInfoT[1] {};
 
     ISwitchVectorProperty StarCatalogSP;
     ISwitch StarCatalogS[3];

--- a/libindi/drivers/telescope/lx200telescope.h
+++ b/libindi/drivers/telescope/lx200telescope.h
@@ -177,7 +177,7 @@ public:
 
     /* Site Name */
     ITextVectorProperty SiteNameTP;
-    IText SiteNameT[1];
+    IText SiteNameT[1] {};
 
     /* Focus motion */
     ISwitchVectorProperty FocusMotionSP;

--- a/libindi/drivers/telescope/pmc8.h
+++ b/libindi/drivers/telescope/pmc8.h
@@ -107,7 +107,7 @@ class PMC8 : public INDI::Telescope, public INDI::GuiderInterface
     void getStartupData();
 
     /* Firmware */
-    IText FirmwareT[1];
+    IText FirmwareT[1] {};
     ITextVectorProperty FirmwareTP;
 
     /* Tracking Mode */

--- a/libindi/drivers/telescope/skywatcherAPIMount.h
+++ b/libindi/drivers/telescope/skywatcherAPIMount.h
@@ -97,7 +97,7 @@ private:
         MOUNT_NAME,
         IS_DC_MOTOR
     };
-    IText BasicMountInfo[4];
+    IText BasicMountInfo[4] {};
     ITextVectorProperty BasicMountInfoV;
 
     enum

--- a/libindi/drivers/telescope/skywatcherAltAzSimple.h
+++ b/libindi/drivers/telescope/skywatcherAltAzSimple.h
@@ -85,7 +85,7 @@ private:
         MOUNT_NAME,
         IS_DC_MOTOR
     };
-    IText BasicMountInfo[4];
+    IText BasicMountInfo[4] {};
     ITextVectorProperty BasicMountInfoV;
 
     enum

--- a/libindi/drivers/telescope/telescope_script.h
+++ b/libindi/drivers/telescope/telescope_script.h
@@ -51,5 +51,5 @@ class ScopeScript : public INDI::Telescope
     bool RunScript(int script, ...);
 
     ITextVectorProperty ScriptsTP;
-    IText ScriptsT[15];
+    IText ScriptsT[15] {};
 };

--- a/libindi/drivers/video/v4l2driver.h
+++ b/libindi/drivers/video/v4l2driver.h
@@ -116,9 +116,9 @@ class V4L2_Driver : public INDI::CCD
     ISwitch ColorProcessingS[3];
 
     /* Texts */
-    IText PortT[1];
-    IText camNameT[1];
-    IText CaptureColorSpaceT[3];
+    IText PortT[1] {};
+    IText camNameT[1] {};
+    IText CaptureColorSpaceT[3] {};
 
     /* Numbers */
     //INumber *ExposeTimeN;

--- a/libindi/drivers/weather/mbox.h
+++ b/libindi/drivers/weather/mbox.h
@@ -62,7 +62,7 @@ class MBox : public INDI::Weather
     ISwitch ResetS[1];
     ISwitchVectorProperty ResetSP;
 
-    IText FirmwareT[1];
+    IText FirmwareT[1] {};
     ITextVectorProperty FirmwareTP;
 
 

--- a/libindi/drivers/weather/weathermeta.h
+++ b/libindi/drivers/weather/weathermeta.h
@@ -53,7 +53,7 @@ class WeatherMeta : public INDI::DefaultDevice
     void updateUpdatePeriod();
 
     // Active stations
-    IText ActiveDeviceT[4];
+    IText ActiveDeviceT[4] {};
     ITextVectorProperty ActiveDeviceTP;
 
     // Stations status

--- a/libindi/drivers/weather/wunderground.h
+++ b/libindi/drivers/weather/wunderground.h
@@ -48,7 +48,7 @@ class WunderGround : public INDI::Weather
     virtual bool updateLocation(double latitude, double longitude, double elevation);
 
   private:
-    IText wunderAPIKeyT[1];
+    IText wunderAPIKeyT[1] {};
     ITextVectorProperty wunderAPIKeyTP;
 
     double wunderLat, wunderLong;

--- a/libindi/libs/indibase/alignment/MathPluginManagement.cpp
+++ b/libindi/libs/indibase/alignment/MathPluginManagement.cpp
@@ -24,6 +24,7 @@ MathPluginManagement::MathPluginManagement() : CurrentInMemoryDatabase(nullptr),
     pTransformTelescopeToCelestial(&MathPlugin::TransformTelescopeToCelestial),
     pLoadedMathPlugin(&BuiltInPlugin), LoadedMathPluginHandle(nullptr)
 {
+    memset(&AlignmentSubsystemCurrentMathPlugin, 0, sizeof(IText));
 }
 
 void MathPluginManagement::InitProperties(Telescope *ChildTelescope)

--- a/libindi/libs/indibase/alignment/MathPluginManagement.h
+++ b/libindi/libs/indibase/alignment/MathPluginManagement.h
@@ -126,7 +126,7 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
     InMemoryDatabase *CurrentInMemoryDatabase;
 
     // The following property is used for configuration purposes only and is not propagated to the client
-    IText AlignmentSubsystemCurrentMathPlugin {};
+    IText AlignmentSubsystemCurrentMathPlugin;
     ITextVectorProperty AlignmentSubsystemCurrentMathPluginV;
 
     // The following hold links to the current loaded math plugin

--- a/libindi/libs/indibase/alignment/MathPluginManagement.h
+++ b/libindi/libs/indibase/alignment/MathPluginManagement.h
@@ -126,7 +126,7 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
     InMemoryDatabase *CurrentInMemoryDatabase;
 
     // The following property is used for configuration purposes only and is not propagated to the client
-    IText AlignmentSubsystemCurrentMathPlugin;
+    IText AlignmentSubsystemCurrentMathPlugin {};
     ITextVectorProperty AlignmentSubsystemCurrentMathPluginV;
 
     // The following hold links to the current loaded math plugin


### PR DESCRIPTION
This patch adds initializers for the remaining IText members in similar way that was done in base classes earlier.