### PR TITLE
Fixes for issues found with Valgrind

### DIFF
--- a/libindi/libs/indibase/indidome.cpp
+++ b/libindi/libs/indibase/indidome.cpp
@@ -61,10 +61,17 @@ Dome::Dome()
 
     parkDataType = PARK_NONE;
     Parkdatafile = "~/.indi/ParkData.xml";
+    ParkdataXmlRoot = nullptr;
 }
 
 Dome::~Dome()
 {
+    if (ParkdataXmlRoot)
+        delXMLEle(ParkdataXmlRoot);
+
+    delete controller;
+    delete serialConnection;
+    delete tcpConnection;
 }
 
 bool Dome::initProperties()

--- a/libindi/libs/indicom.c
+++ b/libindi/libs/indicom.c
@@ -890,6 +890,13 @@ int tty_connect(const char *device, int bit_rate, int word_size, int parity, int
         return TTY_PORT_FAILURE;
     }
 
+    // Get the current options and save them so we can restore the default settings later.
+    if (tcgetattr(t_fd, &tty_setting) == -1)
+    {
+        perror("tty_connect: failed getting tty attributes.");
+        return TTY_PORT_FAILURE;
+    }
+
     /* Control Modes
     Set bps rate */
     switch (bit_rate)


### PR DESCRIPTION
This separate patch fixes a couple of uninitialized variable uses that were found when running under Valgrind:
-  ParkdataXmlRoot was checked against null and potentially tried to be freed
- variables allocated with new() weren't deleted
- tcsetattr() was called with partially uninitialized termios struct. OSX version of tty_connect() already uses tcgetattr() to get current attributes for modification and that's a good practice anyway.