### PR TITLE
Initialize ConnectionModeSP to avoid uninitialized access

### DIFF
--- a/libindi/libs/indibase/defaultdevice.h
+++ b/libindi/libs/indibase/defaultdevice.h
@@ -476,7 +476,7 @@ class INDI::DefaultDevice : public INDI::BaseDevice
 
     // Connection modes
     ISwitch *ConnectionModeS = nullptr;
-    ISwitchVectorProperty ConnectionModeSP;
+    ISwitchVectorProperty ConnectionModeSP {};
 
     std::vector<Connection::Interface *> connections;
     Connection::Interface *activeConnection = nullptr;


### PR DESCRIPTION
Forgot this from previous patch, its name is compared against in DefaultDevice::ISNewSwitch() before being actually initialized in DefaultDevice::ISGetProperties(). Probably harmless, but gave a Valgrind warning anyway.