### PR TITLE
Initialize ConnectionModeSP to avoid uninitialized access

### DIFF
--- a/libindi/libs/indibase/defaultdevice.cpp
+++ b/libindi/libs/indibase/defaultdevice.cpp
@@ -64,6 +64,7 @@ DefaultDevice::DefaultDevice()
     majorVersion        = 1;
     minorVersion        = 0;
     interfaceDescriptor = GENERAL_INTERFACE;
+    memset(&ConnectionModeSP, 0, sizeof(ConnectionModeSP));
 }
 
 DefaultDevice::~DefaultDevice()


### PR DESCRIPTION
If DefaultDevice doesn't get any connections registered, it doesn't initialize ConnectionModeSP member, but its name is still compared against when DefaultDevice::ISNewSwitch() is called causing an uninitialized access. This happens with at least GPSD and Wunderground drivers and probably others that don't use the default connection plugins. It's unlikely that the uninitialized name would match anything, but better to fix it anyway.