### PR TITLE
20180410 lx200ap unparkfix

### DIFF
--- a/libindi/drivers/telescope/lx200ap_experimental.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimental.cpp
@@ -148,12 +148,15 @@ void LX200AstroPhysicsExperimental::ISGetProperties(const char *dev)
 
     defineSwitch(&UnparkFromSP);
 
+    // MSF 2018/04/10 - disable this behavior for now - we want to have
+    //                  UnparkFromSP to always start out as "Last Parked" for safety
+    
     // load config to get unpark from position user wants BEFORE we connect to mount
-    if (!isConnected())
-    {
-        LOG_DEBUG("Loading unpark from location from config file");
-        loadConfig(true, UnparkFromSP.name);
-    }
+    //    if (!isConnected())
+    //    {
+    //        LOG_DEBUG("Loading unpark from location from config file");
+    //        loadConfig(true, UnparkFromSP.name);
+    //    }
 
     if (isConnected())
     {

--- a/libindi/drivers/telescope/lx200ap_experimental.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimental.cpp
@@ -1309,7 +1309,6 @@ bool LX200AstroPhysicsExperimental::saveConfigItems(FILE *fp)
     IUSaveConfigSwitch(fp, &SyncCMRSP);
     IUSaveConfigSwitch(fp, &APSlewSpeedSP);
     IUSaveConfigSwitch(fp, &APGuideSpeedSP);
-    IUSaveConfigSwitch(fp, &UnparkFromSP);
     IUSaveConfigSwitch(fp, &ParkToSP);
 
     return true;


### PR DESCRIPTION
Currently the UnparkFrom position is saved with other config options.  It is better to have it always default to "Last Parked" which is the safest option.  If someone needs to override it for a one time situation then at least it will go back to the safe option when they reconnect to the mount the next time.

Also disabled code to try to read in the UnParkFromSP property in case someone ran the original driver and the value is saved in their config.