### PR TITLE
Updates to pyxis rotator to support 3 inch and 2 inch rotators

### DIFF
--- a/libindi/drivers/rotator/pyxis.h
+++ b/libindi/drivers/rotator/pyxis.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "indirotator.h"
+#include "string.h"
 
 class Pyxis : public INDI::Rotator
 {
@@ -56,6 +57,7 @@ class Pyxis : public INDI::Rotator
     bool setRotationRate(uint8_t rate);
     bool sleepController();
     bool wakeupController();
+    std::string getVersion() ;
 
     void queryParams();
 
@@ -73,5 +75,14 @@ class Pyxis : public INDI::Rotator
     ISwitchVectorProperty PowerSP;
     enum { POWER_SLEEP, POWER_WAKEUP};
 
+    // Firmware version; tells us if 2 inch or 3 inch device
+    IText FirmwareT[1] {};
+    ITextVectorProperty FirmwareTP;
+    IText ModelT[1] {};
+    ITextVectorProperty ModelTP;
+
     uint16_t targetPA = {0};
+
+    // Direction of rotation; 1->angle increasing; -1->angle decreasing
+    int direction = 1 ;
 };


### PR DESCRIPTION
Jasem, my changes.
- Added firmware and model parameters to an info tab
- Use the CVxxxx command to return the firmware version of the rotator and set
    - Firmware parameter
    - Model parameter (3 inch or 2 inch)
    - Correct default rotator rate (delay) of 6ms or 8ms (2 inch)
- Changed isMotionComplete to loop and consume all microsteps and update the PA parameter.
- Sized read in isMotionComplete to be approximately 1 degree so GUI update occurs each degree. Number of steps in 1 degree dependent on rotator model.
- Fixed setRotationRate to read response which was not being done and made setting the rate non-reliable.

I'm new to the indi driver parameter/property api so please take a good look at my changes. Also is my approach, the while loop calling isMotionComplete in TimeHit, ok?   Waiting for the POLLMS interval caused GUI to lag motion.
Best,
David
 