### PR TITLE
Add NIR preflash for Moravian CCD if hardware supports it

### DIFF
--- a/3rdparty/indi-mi/mi_ccd.cpp
+++ b/3rdparty/indi-mi/mi_ccd.cpp
@@ -214,6 +214,8 @@ MICCD::MICCD(int camId, bool eth) : FilterInterface(this)
     hasGain    = false;
     useShutter = true;
 
+    canDoPreflash = false;
+
     setDeviceName(name);
     setVersion(INDI_MI_VERSION_MAJOR, INDI_MI_VERSION_MINOR);
 }
@@ -266,6 +268,12 @@ bool MICCD::initProperties()
     IUFillSwitchVector(&ReadModeSP, ReadModeS, numReadModes, getDeviceName(), "CCD_READ_MODE", "Read Mode",
                        MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
+    // NIR Preflash
+    IUFillNumber(&PreflashN[0], "NIR_EXPOSURE_TIME", "Preflash duration (s)", "%4.2f", 0, 30, 0.01, 0);
+    IUFillNumber(&PreflashN[1], "NIR_CLEAR_NUM", "Num. clear", "%2.0f", 1, 10, 1, 3);
+    IUFillNumberVector(&PreflashNP, PreflashN, 2, getDeviceName(), "NIR_PRE_FLASH", "NIR Preflash",
+                       MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
     addAuxControls();
 
     setDriverInterface(getDriverInterface() | FILTER_INTERFACE);
@@ -295,6 +303,9 @@ void MICCD::ISGetProperties(const char *dev)
 
         if (hasGain)
             defineNumber(&GainNP);
+
+        if (canDoPreflash)
+            defineNumber(&PreflashNP);
 
         if (numFilters > 0)
         {
@@ -327,6 +338,9 @@ bool MICCD::updateProperties()
         if (hasGain)
             defineNumber(&GainNP);
 
+        if (canDoPreflash)
+            defineNumber(&PreflashNP);
+
         if (numFilters > 0)
         {
             INDI::FilterInterface::updateProperties();
@@ -356,6 +370,9 @@ bool MICCD::updateProperties()
 
         if (hasGain)
             deleteProperty(GainNP.name);
+
+        if (canDoPreflash)
+            deleteProperty(PreflashNP.name);
 
         if (numFilters > 0)
         {
@@ -419,7 +436,10 @@ bool MICCD::Connect()
 
     gxccd_get_boolean_parameter(cameraHandle, GBP_GAIN, &hasGain);
 
+    gxccd_get_boolean_parameter(cameraHandle, GBP_PREFLASH, &canDoPreflash);
+
     SetCCDCapability(cap);
+
     return true;
 }
 
@@ -482,6 +502,17 @@ bool MICCD::setupParams()
         }
     }
 
+    if (!sim && canDoPreflash)
+    {
+        if (gxccd_set_preflash(cameraHandle, PreflashN[0].value, PreflashN[1].value) < 0)
+        {
+            char errorStr[MAX_ERROR_LEN];
+            gxccd_get_last_error(cameraHandle, errorStr, sizeof(errorStr));
+            LOGF_ERROR("Setting default NIR preflash value failed: %s.", errorStr);
+            PreflashNP.s = IPS_ALERT;
+        }
+    }
+
     return true;
 }
 
@@ -519,6 +550,7 @@ bool MICCD::StartExposure(float duration)
         else
             mode = prm - IUFindOnSwitchIndex(&ReadModeSP);
         gxccd_set_read_mode(cameraHandle, mode);
+
         // send binned coords
         int x = PrimaryCCD.getSubX() / PrimaryCCD.getBinX();
         int y = PrimaryCCD.getSubY() / PrimaryCCD.getBinY();
@@ -883,6 +915,31 @@ bool MICCD::ISNewNumber(const char *dev, const char *name, double values[], char
             }
 
             IDSetNumber(&TemperatureRampNP, NULL);
+            return true;
+        }
+
+        if (!strcmp(name, PreflashNP.name))
+        {
+            IUUpdateNumber(&PreflashNP, values, names, n);
+
+            // set NIR pre-flash if available.
+            if (canDoPreflash)
+            {
+                if (!isSimulation() && gxccd_set_preflash(cameraHandle, PreflashN[0].value, PreflashN[1].value) < 0)
+                {
+                    char errorStr[MAX_ERROR_LEN];
+                    gxccd_get_last_error(cameraHandle, errorStr, sizeof(errorStr));
+                    LOGF_ERROR("Setting NIR preflash failed: %s.", errorStr);
+                    PreflashNP.s = IPS_ALERT;
+                }
+                else
+                {
+                    PreflashNP.s = IPS_OK;
+                }
+            }
+
+            IDSetNumber(&PreflashNP, NULL);
+
             return true;
         }
     }

--- a/3rdparty/indi-mi/mi_ccd.h
+++ b/3rdparty/indi-mi/mi_ccd.h
@@ -85,6 +85,9 @@ class MICCD : public INDI::CCD, public INDI::FilterInterface
     ISwitch ReadModeS[3];
     ISwitchVectorProperty ReadModeSP;
 
+    INumber PreflashN[2];
+    INumberVectorProperty PreflashNP;
+
   private:
     char name[MAXINDIDEVICE];
 
@@ -107,6 +110,8 @@ class MICCD : public INDI::CCD, public INDI::FilterInterface
     int timerID;
 
     bool downloading;
+
+    bool canDoPreflash;
 
     INDI::CCDChip::CCD_FRAME imageFrameType;
 


### PR DESCRIPTION
The latest version of Moravian CCD supports Near-IR Preflash to deal with the RBI effect. See here for further information: [What is Residual Bulk Image and how to deal with it](http://gxccd.com/art?id=418&lang=409)

Current INDI driver seems not have NIR preflash settings. I added related settings in driver Main Control page.

The setting contains to options:

1. Preflash duration in seconds. Value ranges from 0s to 30s with minimum step 0.01 s. For 0s duration it just disable preflash.

2. Number of clears. Value ranges from 1 to 10.

I have tested the code with my G2-3200. The CCD works OK with some delay before normal exposure (depends on both duration and number of clears settings).