### PR TITLE
Fix problems with Pyxis Reverse functionality

### DIFF
--- a/libindi/libs/indibase/indirotatorinterface.cpp
+++ b/libindi/libs/indibase/indirotatorinterface.cpp
@@ -150,7 +150,7 @@ bool RotatorInterface::processSwitch(const char *dev, const char *name, ISState 
         else if (strcmp(name, ReverseRotatorSP.name) == 0)
         {
             bool rc = false;
-            bool enabled = (!strcmp(IUFindOnSwitchName(states, names, n), "REVERSE_ENABLED"));
+            bool enabled = (!strcmp(IUFindOnSwitchName(states, names, n), "ENABLED"));
             rc = ReverseRotator(enabled);
 
             if (rc)

--- a/libindi/libs/indibase/indirotatorinterface.cpp
+++ b/libindi/libs/indibase/indirotatorinterface.cpp
@@ -150,7 +150,7 @@ bool RotatorInterface::processSwitch(const char *dev, const char *name, ISState 
         else if (strcmp(name, ReverseRotatorSP.name) == 0)
         {
             bool rc = false;
-            bool enabled = (!strcmp(IUFindOnSwitchName(states, names, n), "ENABLED"));
+            bool enabled = (!strcmp(IUFindOnSwitchName(states, names, n), "REVERSE_ENABLED"));
             rc = ReverseRotator(enabled);
 
             if (rc)


### PR DESCRIPTION
Jasem, my changes.
- Added firmware and model parameters to an info tab
- Use the CVxxxx command to return the firmware version of the rotator and set
    - Firmware parameter
    - Model parameter (3 inch or 2 inch)
    - Correct default rotator rate (delay) of 6ms or 8ms (2 inch)
    - Changed isMotionComplete to loop and consume all microsteps and update the PA parameter.
    - Sized read buffer in isMotionComplete to be approximately 1 degree so GUI update occurs each degree.  Number of steps in 1 degree dependent on rotator model.
     - Fixed setRotationRate to consume terminator which was not being done and made setting the rate non-reliable.

I'm new to the indi driver parameter/property api so please take a good look at my changes. Also is my approach, the while loop in isMotionComplete, ok?   Waiting for the POLLMS interval caused GUI to lag motion.
Best,
David
 