### PR TITLE
Fix pulse guide support for AP mounts.  

### DIFF
--- a/libindi/drivers/telescope/lx200ap_experimental.h
+++ b/libindi/drivers/telescope/lx200ap_experimental.h
@@ -41,6 +41,8 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual void ISGetProperties(const char *dev) override;
 
+    void guideTimeout();
+
   protected:
 
     virtual const char *getDefaultName() override;
@@ -63,7 +65,16 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     virtual bool updateLocation(double latitude, double longitude, double elevation) override;
     virtual bool SetSlewRate(int index) override;
 
+    // Guide Commands
+    virtual IPState GuideNorth(float ms) override;
+    virtual IPState GuideSouth(float ms) override;
+    virtual IPState GuideEast(float ms) override;
+    virtual IPState GuideWest(float ms) override;
     virtual int  SendPulseCmd(int direction, int duration_msec) override;
+    virtual bool GuideNS(INDI_DIR_NS dir, TelescopeMotionCommand command);
+    virtual bool GuideWE(INDI_DIR_WE dir, TelescopeMotionCommand command);
+
+    static void guideTimeoutHelper(void *p);
 
     virtual bool getUTFOffset(double *offset) override;
 
@@ -132,6 +143,9 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     double currentAlt=0, currentAz=0;
     double lastRA=0, lastDE=0;
     double lastAZ=0, lastAL=0;
+
+    int GuideNSTID;
+    int GuideWETID;
 
     bool motionCommanded=false;
     bool mountInitialized=false;

--- a/libindi/drivers/telescope/lx200apdriver.cpp
+++ b/libindi/drivers/telescope/lx200apdriver.cpp
@@ -747,19 +747,27 @@ int APSendPulseCmd(int fd, int direction, int duration_msec)
     DEBUGFDEVICE(lx200ap_name, AP_DBG_SCOPE, "<%s>", __FUNCTION__);
     int nbytes_write = 0;
     char cmd[20];
+
+    // GTOCP3 supports 3 digits for msec duration
+    if (duration_msec > 999)
+    {
+        DEBUGFDEVICE(lx200ap_name, INDI::Logger::DBG_DEBUG, "APSendPulseCmd requested %d msec limited to 999 msec!", duration_msec);
+        duration_msec = 999;
+    }
+
     switch (direction)
     {
         case LX200_NORTH:
-            sprintf(cmd, ":Mn%04d#", duration_msec);
+            sprintf(cmd, ":Mn%03d#", duration_msec);
             break;
         case LX200_SOUTH:
-            sprintf(cmd, ":Ms%04d#", duration_msec);
+            sprintf(cmd, ":Ms%03d#", duration_msec);
         break;
         case LX200_EAST:
-            sprintf(cmd, ":Me%04d#", duration_msec);
+            sprintf(cmd, ":Me%03d#", duration_msec);
         break;
         case LX200_WEST:
-            sprintf(cmd, ":Mw%04d#", duration_msec);
+            sprintf(cmd, ":Mw%03d#", duration_msec);
         break;
         default:
             return 1;

--- a/libindi/drivers/telescope/lx200telescope.h
+++ b/libindi/drivers/telescope/lx200telescope.h
@@ -149,7 +149,7 @@ public:
     int timeFormat=-1;
     int currentSiteNum;
     int trackingMode;
-    long guide_direction;
+    long guide_direction=-1;
     bool sendTimeOnStartup=true, sendLocationOnStartup=true;
 
     unsigned int DBG_SCOPE;


### PR DESCRIPTION
CP3 documentation states duration can go up to 999msec so for longer requests we manually time the pulse in the driver.

Also the AP driver was using the LX200Telescope implementation of GuideNorth/South/East/West which was trying to set the slew speed of the mount to the guide speed.  On AP mounts we must use a different command to do this.  I implemented these functions in the experimental driver.