### PR TITLE
EQMod pulse limits and deferring status update during pulses

### DIFF
--- a/3rdparty/indi-eqmod/eqmod.h
+++ b/3rdparty/indi-eqmod/eqmod.h
@@ -134,6 +134,10 @@ class EQMod : public INDI::Telescope, public INDI::GuiderInterface
     ISwitchVectorProperty *RAPPECSP         = NULL;
     ISwitchVectorProperty *DEPPECSP         = NULL;
 
+    INumber *MinPulseN                   = NULL;
+    INumber *MinPulseTimerN              = NULL;
+    INumberVectorProperty *PulseLimitsNP = NULL;
+
     enum Hemisphere
     {
         NORTH = 0,
@@ -201,6 +205,9 @@ class EQMod : public INDI::Telescope, public INDI::GuiderInterface
     // save PPEC status when guiding
     bool restartguideRAPPEC;
     bool restartguideDEPPEC;
+
+    // One bit for each axis
+    uint8_t pulseInProgress;
 
   public:
     EQMod();

--- a/3rdparty/indi-eqmod/indi_eqmod_sk.xml
+++ b/3rdparty/indi-eqmod/indi_eqmod_sk.xml
@@ -15,6 +15,14 @@
 0.5
 </defNumber>
 </defNumberVector>
+<defNumberVector device="EQMod Mount" name="PULSE_LIMITS" label="Pulse Limits" group="Motion Control" state="Idle" perm="rw">
+<defNumber name="MIN_PULSE" label="Minimum pulse (ms)" format="%3.0f" min="0.0" max="100.0" step="10">
+10
+</defNumber>
+<defNumber name="MIN_PULSE_TIMER" label="Minimum pulse timer (ms)" format="%3.0f" min="0.0" max="500" step="50">
+100
+</defNumber>
+</defNumberVector>
 <defTextVector device="EQMod Mount" name="MOUNTINFORMATION" label="Mount Information" group="Firmware" state="Idle" perm="ro" message="Mount Info message">
 <defText name="MOUNT_TYPE" label="Mount Type"></defText> 
 <defText name="MOTOR_CONTROLLER" label="Firmware Version"></defText> 


### PR DESCRIPTION
This change adds support for setting minimum pulse length and running short pulses synchronously without timer in EQMod.

As communication delay is quite big especially with Bluetooth serial connection, it's better to ignore very short pulses altogether rather than overcorrect with too long pulses. This delay seems to be around 50ms for Bluetooth connection and supposedly around 16ms for EQDIR cables and 32ms via handset in PC Direct mode (I have only tested BT version, other info from http://eq-mod.sourceforge.net/prerequisites.html)

Also added support for doing short pulses without timer by sleeping the remaining time after communication delay from starting the pulse. Timer is also now started before starting the pulse to remove that excess time from the delay. 

Last change is skipping reading scope status during a pulse as that causes major delay and shouldn't be that urgent. Ideally the status would be deferred until pulses are complete, but this simple version just skips it as it is retried after a second anyway.

The default values are on the conservative side (minimum pulse 10ms, minimum pulse timer 100ms) but previous behavior (except skipping status read) can be restored by setting both values to zero. I've personally run tests with values 50 and 150ms, but those are probably not suitable values for wired connections.

![image](https://user-images.githubusercontent.com/19999913/40318783-7496f00c-5d2e-11e8-857f-5beafddb357a.png)
