### PR TITLE
Switch align action buttons back to off to allow pressing same button multiple times

### DIFF
--- a/3rdparty/indi-eqmod/align/align.cpp
+++ b/3rdparty/indi-eqmod/align/align.cpp
@@ -681,9 +681,8 @@ bool Align::ISNewSwitch(const char *dev, const char *name, ISState *states, char
                 IUFindNumber(AlignCountNP, "ALIGNCOUNT_TRIANGLES")->value = pointset->getNbTriangles();
                 IDSetNumber(AlignCountNP, nullptr);
             }
-
+            sw->s          = ISS_OFF; // Reset back to off to allow pressing same button multiple times
             AlignListSP->s = IPS_OK;
-            IUUpdateSwitch(AlignListSP, states, names, n);
             IDSetSwitch(AlignListSP, nullptr);
             return true;
         }


### PR DESCRIPTION
Noticed I couldn't write align data out after adding couple of new sync points, but pressing the button didn't do anything as it was already "on" after I had saved the data just a bit earlier. So reset the buttons back to off state so they can be pressed multiple times without changing to another button in between and they are all "action" type switches anyway.

Also noticed there was an extra IUUpdateSwitch() call as the same call had been done before checking which button was turned on.