### PR TITLE
Fix memory leak in indi_gphoto_ccd

### DIFF
--- a/3rdparty/indi-gphoto/gphoto_driver.cpp
+++ b/3rdparty/indi-gphoto/gphoto_driver.cpp
@@ -793,6 +793,13 @@ static int download_image(gphoto_driver *gphoto, CameraFilePath *fn, int fd)
                 }
                 TIFFClose(tiff);
             }
+            if (fd >= 0)
+            {
+                // The gphoto documentation says I don't need to do this,
+                // but reading the source of gp_file_get_data_and_size says otherwise. :(
+                free((void *)imgData);
+                imgData = nullptr;
+            }
         }
     }
     // For some reason Canon 20D fails when deleting here


### PR DESCRIPTION
The documenation for gp_file_get_data_and_size says the pointer returned is owned by libgphoto2, and will be destroyed when the file is destroyed.  This is only true if you used gp_file_new().  If instead you use gp_file_new_from_fd(), then the pointer returned is entirely owned by the caller, and must be freed. *sigh*
