### PR TITLE
Little changes to improve behaviour

### DIFF
--- a/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.cpp
+++ b/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.cpp
@@ -166,13 +166,15 @@ bool ShelyakAlpy::Connect()
     return false;
   }
   DEBUGF(INDI::Logger::DBG_SESSION, "%s is online.", getDeviceName());
+  
+  //DEBUGF(INDI::Logger::DBG_SESSION, "%s is online.", getDeviceName());
+  
   return true;
 }
 
 bool ShelyakAlpy::Disconnect()
 { 
-  //TODO : set defalt state.
-  //set off lamps  
+  //set default state at disconnection: set off lamps  
   int rc, nbytes_written;
   char reset[3] = {'0','0',0x0a};
   //clean alpy configuration. Reset all.
@@ -243,20 +245,22 @@ bool ShelyakAlpy::ISNewText (const char *dev, const char *name, char *texts[], c
 bool ShelyakAlpy::calibrationUnitCommand(char command, char parameter)
 {
 int rc, nbytes_written;
-
-char reset[3] = {'0','0',0x0a};
-//clean alpy configuration. Reset all.
-if ((rc = tty_write(PortFD, reset, 3, &nbytes_written)) != TTY_OK)
-
-  {
-    char errmsg[MAXRBUF];
-    tty_error_msg(rc, errmsg, MAXRBUF);
-    DEBUGF(INDI::Logger::DBG_ERROR, "error: %s.", errmsg);
-    return false;
-  } else {
-      DEBUGF(INDI::Logger::DBG_SESSION, "sent on serial: %s.", reset);
-
-  }
+//DEBUGF(INDI::Logger::DBG_SESSION, "commande: %s.", command);
+//DEBUGF(INDI::Logger::DBG_SESSION, "parameter: %s.", parameter);
+// char reset[3] = {'0','0',0x0a};
+// //clean alpy configuration. Reset all.
+// if ((rc = tty_write(PortFD, reset, 3, &nbytes_written)) != TTY_OK)
+// 
+// 
+//   {
+//     char errmsg[MAXRBUF];
+//     tty_error_msg(rc, errmsg, MAXRBUF);
+//     DEBUGF(INDI::Logger::DBG_ERROR, "error: %s.", errmsg);
+//     return false;
+//   } else {
+//       DEBUGF(INDI::Logger::DBG_SESSION, "sent on serial: %s.", reset);
+// 
+//   }
   sleep(1); // wait for the calibration unit to actually flip the switch
 
 
@@ -279,7 +283,21 @@ if (parameter==0x33){ //special for dark : have to put both lamps on
       sleep(1); // wait for the calibration unit to actually flip the switch
       return true;
     } else {
-        return true;
+        
+        char reset[3] = {'0','0',0x0a};
+        if ((rc = tty_write(PortFD, reset, 3, &nbytes_written)) != TTY_OK)
+
+        {
+        char errmsg[MAXRBUF];
+        tty_error_msg(rc, errmsg, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "error: %s.", errmsg);
+        return false;
+        } else {
+          DEBUGF(INDI::Logger::DBG_SESSION, "sent on serial: %s.", reset);
+
+        } 
+      sleep(1); // wait for the calibration unit to actually flip the switch
+      return true;
     }
 
 
@@ -300,9 +318,6 @@ if (parameter==0x33){ //special for dark : have to put both lamps on
       sleep(1); // wait for the calibration unit to actually flip the switch
       return true;
 }
-
-  
-
 
 
 }

--- a/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.cpp
+++ b/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.cpp
@@ -110,6 +110,7 @@ bool ShelyakAlpy::initProperties()
   IUFillSwitch(&LampS[1], "ARNE", "ArNe", ISS_OFF);
   IUFillSwitch(&LampS[2], "TUNGSTEN", "Tungsten", ISS_OFF);
   IUFillSwitchVector(&LampSP, LampS, 3, getDeviceName(), "CALIB_LAMPS", "Calibration lamps", CALIBRATION_UNIT_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+   
 
   //--------------------------------------------------------------------------------
   // Options
@@ -169,7 +170,25 @@ bool ShelyakAlpy::Connect()
 }
 
 bool ShelyakAlpy::Disconnect()
-{
+{ 
+  //TODO : set defalt state.
+  //set off lamps  
+  int rc, nbytes_written;
+  char reset[3] = {'0','0',0x0a};
+  //clean alpy configuration. Reset all.
+  if ((rc = tty_write(PortFD, reset, 3, &nbytes_written)) != TTY_OK)
+
+  {
+    char errmsg[MAXRBUF];
+    tty_error_msg(rc, errmsg, MAXRBUF);
+    DEBUGF(INDI::Logger::DBG_ERROR, "error: %s.", errmsg);
+    return false;
+  } else {
+      DEBUGF(INDI::Logger::DBG_SESSION, "sent on serial: %s.", reset);
+
+  }
+  sleep(1); // wait for the calibration unit to actually flip the switch  
+    
   tty_disconnect(PortFD);
   DEBUGF(INDI::Logger::DBG_SESSION, "%s is offline.", getDeviceName());
   return true;

--- a/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.cpp
+++ b/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.cpp
@@ -268,6 +268,22 @@ int rc, nbytes_written;
 if (parameter==0x33){ //special for dark : have to put both lamps on
     char cmd[6] = {0x31,0x31,0x0a,0x32,0x31,0x0a};//"11\n21\n" 
     if(command==0x31){
+    //remise à zéro des lampes
+    char c[3] = {parameter,command,0x0a};
+
+    if ((rc = tty_write(PortFD, c, 3, &nbytes_written)) != TTY_OK)
+
+      {
+        char errmsg[MAXRBUF];
+        tty_error_msg(rc, errmsg, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "error: %s.", errmsg);
+        return false;
+      } else {
+          DEBUGF(INDI::Logger::DBG_SESSION, "sent on serial: %s.", c);
+
+      }
+      sleep(2); // wait for the calibration unit to actually flip the switch
+      
 
     if ((rc = tty_write(PortFD, cmd, 6, &nbytes_written)) != TTY_OK)
 

--- a/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.h
+++ b/3rdparty/indi-shelyak/indi_shelyakalpy_spectrograph.h
@@ -26,7 +26,7 @@
 //On serial connection
 //11\n : calib lamp on
 //21\n : flat lamp on
-//if 11 ans 21 : dark on
+//if 11 and 21 : dark on
 //(and the opposite, 10, 20)
 //00\n : shut off all
 
@@ -76,8 +76,10 @@ private:
   INumberVectorProperty SettingsNP;
   INumber SettingsN[2];
 
+  std::string lastLampOn;
+  
   bool calibrationUnitCommand(char command, char parameter);
-
+  bool resetLamps();
 };
 
 #endif // SHELYAKALPY_SPECTROGRAPH_H


### PR DESCRIPTION
When Flat or calib lamp is on and user clicked directly on Dark, there was a little bug : 
dark goes on, then there was a switch emitted, that lights off lamp that was on before. So the dark goes off. (dark is when signal for flat And signal for calib lamps are on).

Code needs a little refactoring to manage this.