### PR TITLE
Fix feature stacking streamed frames to simulate absolute exposure

### DIFF
--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -105,7 +105,7 @@ bool V4L2_Driver::initProperties()
     IUFillSwitchVector(&StackModeSP, StackModeS, NARRAY(StackModeS), getDeviceName(), "Stack", "", MAIN_CONTROL_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    stackMode = 0;
+    stackMode = STACK_NONE;
 
     /* Inputs */
     IUFillSwitchVector(&InputsSP, nullptr, 0, getDeviceName(), "V4L2_INPUT", "Inputs", CAPTURE_FORMAT, IP_RW,
@@ -187,9 +187,10 @@ void V4L2_Driver::ISGetProperties(const char *dev)
         else if (FrameRateNP.np != nullptr)
             defineNumber(&FrameRateNP);
 
+        defineSwitch(&StackModeSP);
+
 #ifdef WITH_V4L2_EXPERIMENTS
         defineSwitch(&ImageDepthSP);
-        defineSwitch(&StackModeSP);
         defineSwitch(&ColorProcessingSP);
         defineText(&CaptureColorSpaceTP);
 #endif
@@ -227,9 +228,10 @@ bool V4L2_Driver::updateProperties()
         else if (FrameRateNP.np != nullptr)
             defineNumber(&FrameRateNP);
 
+        defineSwitch(&StackModeSP);
+
 #ifdef WITH_V4L2_EXPERIMENTS
         defineSwitch(&ImageDepthSP);
-        defineSwitch(&StackModeSP);
         defineSwitch(&ColorProcessingSP);
         defineText(&CaptureColorSpaceTP);
 #endif
@@ -273,9 +275,10 @@ bool V4L2_Driver::updateProperties()
         Options    = nullptr;
         v4loptions = 0;
 
+        deleteProperty(StackModeSP.name);
+
 #ifdef WITH_V4L2_EXPERIMENTS
         deleteProperty(ImageDepthSP.name);
-        deleteProperty(StackModeSP.name);
         deleteProperty(ColorProcessingSP.name);
         deleteProperty(CaptureColorSpaceTP.name);
 #endif
@@ -848,11 +851,21 @@ bool V4L2_Driver::setManualExposure(double duration)
 {
     if (nullptr == AbsExposureN)
     {
-        LOGF_ERROR("Failed exposing, the absolute exposure duration control is undefined", "");
-        return false;
+        /* We don't have an absolute exposure control but we can stack gray frames until the exposure elapses */
+        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
+        {
+            LOGF_WARN("Absolute exposure duration control is undefined, stacking up to %.3f seconds using %.16s.",
+                      duration, StackModeS[stackMode].name);
+            return true;
+        }
+        /* We don't have an absolute exposure control and stacking is not configured, bail out */
+        else
+        {
+            LOGF_ERROR("Failed exposing, the absolute exposure duration control is undefined, and stacking is not ready.", "");
+            LOGF_ERROR("Configure grayscale and stacking in order to stack streamed frames up to %.3f seconds.", duration);
+            return false;
+        }
     }
-
-    char errmsg[MAXRBUF];
 
     /* Manual mode should be set before changing Exposure (Auto), if possible.
      * In some cases there might be no control available, so don't fail and try to continue.
@@ -868,6 +881,7 @@ bool V4L2_Driver::setManualExposure(double duration)
             unsigned int const ctrlindex = ManualExposureSP->sp[0].aux ? *(unsigned int *)(ManualExposureSP->sp[0].aux) : 0;
             unsigned int const ctrl_id = (*((unsigned int *)ManualExposureSP->aux));
 
+            char errmsg[MAXRBUF];
             if (v4l_base->setOPTControl(ctrl_id, ctrlindex, errmsg) < 0)
             {
                 ManualExposureSP->sp[0].s = ISS_OFF;
@@ -909,6 +923,7 @@ bool V4L2_Driver::setManualExposure(double duration)
 
         unsigned int const ctrl_id = *((unsigned int *)AbsExposureN->aux0);
 
+        char errmsg[MAXRBUF];
         if (v4l_base->setINTControl(ctrl_id, AbsExposureN->value, errmsg) < 0)
         {
             ImageAdjustNP.s     = IPS_ALERT;
@@ -1103,29 +1118,33 @@ void V4L2_Driver::newFrame(void *p)
     ((V4L2_Driver *)(p))->newFrame();
 }
 
+/** @internal Stack normalized luminance pixels coming from the camera in an accumulator frame.
+ */
 void V4L2_Driver::stackFrame()
 {
+    /* FIXME: use unsigned floats, or double */
+    size_t const size      = v4l_base->getWidth() * v4l_base->getHeight();
+    float const *src       = v4l_base->getLinearY();
+    float const *const end = v4l_base->getLinearY() + size;
+    float *dest            = V4LFrame->stackedFrame;
+
     if (!V4LFrame->stackedFrame)
     {
-        float *src = nullptr, *dest = nullptr;
-
-        V4LFrame->stackedFrame = (float *)malloc(sizeof(float) * v4l_base->getWidth() * v4l_base->getHeight());
-        src                    = v4l_base->getLinearY();
-        dest                   = V4LFrame->stackedFrame;
-        for (int i = 0; i < v4l_base->getWidth() * v4l_base->getHeight(); i++)
-            *dest++ = *src++;
+        /* FIXME: allocate and reset the accumulator frame prior to this function, because memory owner is unclear, and we need more speed while accumulating */
+        V4LFrame->stackedFrame = (float *)malloc(sizeof(float) * size);
+        memcpy(V4LFrame->stackedFrame, src, sizeof(float) * size);
         subframeCount = 1;
     }
     else
     {
-        float *src = nullptr, *dest = nullptr;
-
-        src  = v4l_base->getLinearY();
-        dest = V4LFrame->stackedFrame;
-        for (int i = 0; i < v4l_base->getWidth() * v4l_base->getHeight(); i++)
+        /* Clamp to max float value */
+        float const frameMax = std::numeric_limits<float>::max();
+        while (src < end) if (frameMax - *dest < *src)
         {
-            *dest++ += *src++;
+            *dest++ = frameMax;
+            src++;
         }
+        else *dest++ += *src++;
         subframeCount += 1;
     }
 }
@@ -1249,6 +1268,7 @@ void V4L2_Driver::newFrame()
             {
                 float *src = V4LFrame->stackedFrame;
 
+                /* If we have a dark frame configured, substract it from the stack */
                 if ((stackMode != STACK_TAKE_DARK) && (V4LFrame->darkFrame != nullptr))
                 {
                     float *dark = V4LFrame->darkFrame;
@@ -1264,6 +1284,7 @@ void V4L2_Driver::newFrame()
                     }
                     src = V4LFrame->stackedFrame;
                 }
+
                 //IDLog("Copying stack frame from %p to %p.\n", src, dest);
                 if (stackMode == STACK_MEAN)
                 {
@@ -1273,7 +1294,7 @@ void V4L2_Driver::newFrame()
                         unsigned char *dest = (unsigned char *)PrimaryCCD.getFrameBuffer();
 
                         for (int i = 0; i < v4l_base->getWidth() * v4l_base->getHeight(); i++)
-                            *dest++ = (unsigned char)((*src++ * 255) / subframeCount);
+                            *dest++ = (unsigned char)((*src++ * 255.0f) / subframeCount);
                     }
                     else
                     {
@@ -1281,7 +1302,7 @@ void V4L2_Driver::newFrame()
                         unsigned short *dest = (unsigned short *)PrimaryCCD.getFrameBuffer();
 
                         for (int i = 0; i < v4l_base->getWidth() * v4l_base->getHeight(); i++)
-                            *dest++ = (unsigned short)((*src++ * 65535) / subframeCount);
+                            *dest++ = (unsigned short)((*src++ * 65535.0f) / subframeCount);
                     }
 
                     free(V4LFrame->stackedFrame);
@@ -1289,13 +1310,17 @@ void V4L2_Driver::newFrame()
                 }
                 else if (stackMode == STACK_ADDITIVE)
                 {
+                    /* Clamp additive stacking to frame dynamic range - that is, do not consider normalized source greater than 1.0f */
                     if (ImageDepthS[0].s == ISS_ON)
                     {
                         // depth 8 bits
                         unsigned char *dest = (unsigned char *)PrimaryCCD.getFrameBuffer();
 
                         for (int i = 0; i < v4l_base->getWidth() * v4l_base->getHeight(); i++)
-                            *dest++ = (unsigned char)((*src++ * 255));
+                        {
+                            *dest++ = *src < 1.0f ? (unsigned char)((*src * 255)) : 255;
+                            src++;
+                        }
                     }
                     else
                     {
@@ -1303,7 +1328,10 @@ void V4L2_Driver::newFrame()
                         unsigned short *dest = (unsigned short *)PrimaryCCD.getFrameBuffer();
 
                         for (int i = 0; i < v4l_base->getWidth() * v4l_base->getHeight(); i++)
-                            *dest++ = (unsigned short)((*src++ * 65535));
+                        {
+                            *dest++ = *src < 1.0f ? (unsigned short)((*src * 65535)) : 65535;
+                            src++;
+                        }
                     }
 
                     free(V4LFrame->stackedFrame);


### PR DESCRIPTION
Summary:
This changeset re-enables and fixes the feature stacking streamed frames, in order to simulate absolute exposure on V4L2 cameras not providing any control.
This allows MJPEG-only cameras to stack video frames up to the requested exposure, using either mean or additive consolidation, and darks.
Code is completely unoptimized, and could well hog small-performance systems.
The most suitable stack method for low-light frames is probably the additive algorithm.

Test Plan:
Use a MJPEG camera, preferentially one that rejects absolute exposure because of the lack of V4L2 control.
Try an exposure, see it fail, check the error message displayed in the console.
Switch INDI control to "MEAN" or "ADDITIVE", retry exposure and check the result (in Ekos for instance).
Test stack item "TAKE DARK", the next exposure is kept and substracted from all subsequent exposures.
Test stack item "RESET DARK", this immediately erases the dark frame.

Reviewers: mutlaqja

Differential Revision: https://phabricator.kde.org/D14446