### PR TITLE
Disable Moravian driver on gcc <4.9

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -106,10 +106,11 @@ IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set(WITH_GIGE Off)
     set(WITH_FXLOAD Off)
 ENDIF ()
-# Disable apogee and qhy with gcc 4.8 and earlier versions
+# Disable apogee, qhy and mi with gcc 4.8 and earlier versions
 IF (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
     SET(WITH_APOGEE Off)
     SET(WITH_QHY Off)
+    SET(WITH_MI Off)
 ENDIF ()
 
 ## EQMod


### PR DESCRIPTION
Fixes problem with trusty build