### PR TITLE
Libdspau: Point CMAKE_MODULE_PATH to directory under main INDI repository for FindFFTW3.cmake

### DIFF
--- a/3rdparty/libdspau/CMakeLists.txt
+++ b/3rdparty/libdspau/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(libdspau C)
 cmake_minimum_required(VERSION 2.4.7)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../cmake_modules/")
 include(GNUInstallDirs)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error -std=c99")


### PR DESCRIPTION
Currently the CMake module path points to non-existent directory and finding FFTW3 fails even though installed, at least under Ubuntu 18.04.