### PR TITLE
Update to USBFocusV3 driver

### DIFF
--- a/libindi/drivers/focuser/usbfocusv3.cpp
+++ b/libindi/drivers/focuser/usbfocusv3.cpp
@@ -1,6 +1,7 @@
 /*
     USB Focus V3
     Copyright (C) 2016 G. Schmidt
+    Copyright (C) 2018 Jarno Paananen
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -29,9 +30,7 @@
 #include <termios.h>
 #include <unistd.h>
 
-#define USBFOCUSV3_TIMEOUT 3
-
-#define SRTUS 25000
+#define USBFOCUSV3_TIMEOUT 5
 
 /***************************** Class USBFocusV3 *******************************/
 
@@ -101,19 +100,19 @@ bool USBFocusV3::initProperties()
     FocusSpeedN[0].max   = 3;
     FocusSpeedN[0].value = 2;
 
-    /* Step Mode */
-    IUFillSwitch(&StepModeS[0], "Half Step", "", ISS_ON);
-    IUFillSwitch(&StepModeS[1], "Full Step", "", ISS_OFF);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 2, getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
-                       IPS_IDLE);
+    // Step Mode
+    IUFillSwitch(&StepModeS[UFOPHSTEPS], "HALF", "Half Step", ISS_ON);
+    IUFillSwitch(&StepModeS[UFOPFSTEPS], "FULL", "Full Step", ISS_OFF);
+    IUFillSwitchVector(&StepModeSP, StepModeS, 2, getDeviceName(), "STEP_MODE", "Step Mode", OPTIONS_TAB, IP_RW,
+                       ISR_1OFMANY, 0, IPS_IDLE);
 
-    /* Direction */
-    IUFillSwitch(&RotDirS[0], "Standard rotation", "", ISS_ON);
-    IUFillSwitch(&RotDirS[1], "Reverse rotation", "", ISS_OFF);
-    IUFillSwitchVector(&RotDirSP, RotDirS, 2, getDeviceName(), "Rotation Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
-                       IPS_IDLE);
+    // Direction
+    IUFillSwitch(&RotDirS[UFOPSDIR], "STANDARD", "Standard rotation", ISS_ON);
+    IUFillSwitch(&RotDirS[UFOPRDIR], "REVERSE", "Reverse rotation", ISS_OFF);
+    IUFillSwitchVector(&RotDirSP, RotDirS, 2, getDeviceName(), "ROTATION_MODE", "Rotation Mode", OPTIONS_TAB, IP_RW,
+                       ISR_1OFMANY, 0, IPS_IDLE);
 
-    /* Focuser temperature */
+    // Focuser temperature
     IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
     IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
@@ -124,26 +123,37 @@ bool USBFocusV3::initProperties()
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Temperature Settings
-    IUFillNumber(&TemperatureSettingN[0], "Coefficient", "", "%3.0f", 0., 999., 1., 15.);
-    IUFillNumber(&TemperatureSettingN[1], "Threshold", "", "%3.0f", 0., 999., 1., 10.);
-    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 2, getDeviceName(), "Temp. Settings", "",
-                       OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
+    IUFillNumber(&TemperatureSettingN[0], "COEFFICIENT", "Coefficient", "%3.0f", 0., 999., 1., 15.);
+    IUFillNumber(&TemperatureSettingN[1], "THRESHOLD", "Threshold", "%3.0f", 0., 999., 1., 10.);
+    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 2, getDeviceName(), "TEMPERATURE_SETTINGS",
+                       "Temp. Settings", OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
-    /* Temperature Compensation Sign */
-    IUFillSwitch(&TempCompSignS[0], "negative", "", ISS_OFF);
-    IUFillSwitch(&TempCompSignS[1], "positive", "", ISS_ON);
-    IUFillSwitchVector(&TempCompSignSP, TempCompSignS, 2, getDeviceName(), "TComp. Sign", "", OPTIONS_TAB, IP_RW,
-                       ISR_1OFMANY, 0, IPS_IDLE);
+    // Temperature Compensation Sign
+    IUFillSwitch(&TempCompSignS[UFOPNSIGN], "NEGATIVE", "Negative", ISS_OFF);
+    IUFillSwitch(&TempCompSignS[UFOPPSIGN], "POSITIVE", "Positive", ISS_ON);
+    IUFillSwitchVector(&TempCompSignSP, TempCompSignS, 2, getDeviceName(), "TCOMP_SIGN", "TComp. Sign", OPTIONS_TAB,
+                       IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureCompensateS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "Temp. Comp.", "",
-                       MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    IUFillSwitch(&TemperatureCompensateS[0], "ENABLE", "Enable", ISS_OFF);
+    IUFillSwitch(&TemperatureCompensateS[1], "DISABLE", "Disable", ISS_ON);
+    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "TEMP_COMPENSATION",
+                       "Temp. Comp.", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+
+    // Compensate for temperature
+    IUFillSwitch(&BacklashDirectionS[BACKLASH_IN], "IN", "In", ISS_OFF);
+    IUFillSwitch(&BacklashDirectionS[BACKLASH_OUT], "OUT", "Out", ISS_ON);
+    IUFillSwitchVector(&BacklashDirectionSP, BacklashDirectionS, 2, getDeviceName(), "BACKLASH_DIRECTION",
+                       "Backlash direction", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+
+    // Backlash compensation steps
+    IUFillNumber(&BacklashSettingN[0], "STEPS", "Steps", "%5.0f", 0., 65535., 1., 0.);
+    IUFillNumberVector(&BacklashSettingNP, BacklashSettingN, 1, getDeviceName(), "BACKLASH_STEPS", "Backlash steps",
+                       OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Reset
-    IUFillSwitch(&ResetS[0], "Reset", "", ISS_OFF);
-    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "Reset", "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
+    IUFillSwitch(&ResetS[0], "RESET", "Reset", ISS_OFF);
+    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "RESET", "Reset", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Firmware version
@@ -183,6 +193,8 @@ bool USBFocusV3::updateProperties()
         defineNumber(&TemperatureSettingNP);
         defineSwitch(&TempCompSignSP);
         defineSwitch(&TemperatureCompensateSP);
+        defineSwitch(&BacklashDirectionSP);
+        defineNumber(&BacklashSettingNP);
         defineSwitch(&ResetSP);
         defineNumber(&FWversionNP);
 
@@ -190,7 +202,8 @@ bool USBFocusV3::updateProperties()
 
         loadConfig(true);
 
-        LOG_INFO("USB Focus V3 paramaters updated, focuser ready for use.");
+        LOG_INFO("USBFocusV3 paramaters updated, focuser ready for use.");
+        SetTimer(POLLMS);
     }
     else
     {
@@ -201,6 +214,8 @@ bool USBFocusV3::updateProperties()
         deleteProperty(TemperatureSettingNP.name);
         deleteProperty(TempCompSignSP.name);
         deleteProperty(TemperatureCompensateSP.name);
+        deleteProperty(BacklashDirectionSP.name);
+        deleteProperty(BacklashSettingNP.name);
         deleteProperty(ResetSP.name);
         deleteProperty(FWversionNP.name);
     }
@@ -210,14 +225,20 @@ bool USBFocusV3::updateProperties()
 
 bool USBFocusV3::Handshake()
 {
-    if (Ack())
-    {
-        LOG_INFO("USB Focus V3 is online. Getting focus parameters...");
-        return true;
-    }
+    int tries = 2;
 
-    LOG_INFO("Error retreiving data from USB Focus V3, please ensure USB Focus V3 controller "
-                                     "is powered and the port is correct.");
+    do
+    {
+        if (Ack())
+        {
+            LOG_INFO("USBFocusV3 is online. Getting focus parameters...");
+            return true;
+        }
+        LOG_INFO("Error retreiving data from USBFocusV3, trying resync...");
+    } while (--tries > 0 && Resync());
+
+    LOG_INFO("Error retreiving data from USBFocusV3, please ensure controller "
+             "is powered and the port is correct.");
     return false;
 }
 
@@ -226,92 +247,138 @@ const char *USBFocusV3::getDefaultName()
     return "USBFocusV3";
 }
 
-bool USBFocusV3::Ack()
+bool USBFocusV3::Resync()
 {
-    char cmd[] = UFOCDEVID;
-
+    char cmd[]         = " "; // Illegal command to trigger error response
     int nbytes_written = 0, nbytes_read = 0, rc = -1;
     char errstr[MAXRBUF];
-    char resp[UFORIDLEN + 1];
+    char resp[UFORESLEN] = {};
 
-    do
+    // Send up to 5 space characters and wait for error
+    // response ("ER=1") after which the communication
+    // is back in sync
+    tcflush(PortFD, TCIOFLUSH);
+
+    for (int resync = 0; resync < UFOCMDLEN; resync++)
     {
-        tcflush(PortFD, TCIOFLUSH);
+        LOGF_INFO("Retry %d...", resync + 1);
 
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
+        if ((rc = tty_write(PortFD, cmd, 1, &nbytes_written)) != TTY_OK)
         {
             tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("Error requesting focuser ID: %s.", errstr);
+            LOGF_ERROR("Error writing resync: %s.", errstr);
             return false;
         }
 
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORIDLEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
+        rc = tty_nread_section(PortFD, resp, UFORESLEN, '\r', 3, &nbytes_read);
+        if (rc == TTY_OK && nbytes_read > 0)
         {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("Error reading focuser ID: %s.", errstr);
-            return false;
+            // We got a response
+            return true;
         }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORIDLEN] = '\0';
-
-    } while (oneMoreRead(resp, UFORIDLEN));
-
-    if (strncmp(resp, UFOID, UFORIDLEN) == 0)
-    {
-        return true;
+        // We didn't get response yet, retry
     }
-    else
+    LOG_ERROR("No valid resync response.");
+    return false;
+}
+
+bool USBFocusV3::sendCommand(const char *cmd, char *resp)
+{
+    int nbytes_written = 0, nbytes_read = 0, rc = -1;
+    char errstr[MAXRBUF];
+    LOGF_DEBUG("CMD: %s.", cmd);
+
+    tcflush(PortFD, TCIOFLUSH);
+    if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
     {
-        LOGF_ERROR("USB Focus V3 not properly identified! Answer was: %s.", resp);
+        tty_error_msg(rc, errstr, MAXRBUF);
+        LOGF_ERROR("Error writing command %s: %s.", cmd, errstr);
         return false;
     }
+
+    if (resp)
+    {
+        if ((rc = tty_nread_section(PortFD, resp, UFORESLEN, '\r', USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
+        {
+            tty_error_msg(rc, errstr, MAXRBUF);
+            LOGF_ERROR("Error reading response for command %s: %s.", cmd, errstr);
+            return false;
+        }
+
+        // If we are moving, check for ACK * response first
+        if (moving && nbytes_read > 0 && resp[0] == UFORSACK)
+        {
+            moving = false;
+            if (nbytes_read > 1)
+            {
+                // Move rest of the response down one byte
+                nbytes_read--;
+                memmove(&resp[0], &resp[1], nbytes_read);
+            }
+        }
+
+        if (nbytes_read < 2)
+        {
+            LOGF_ERROR("Invalid response for command %s: %s.", cmd, resp);
+            return false;
+        }
+        resp[nbytes_read - 2] = '\0'; // Strip \n\r
+        LOGF_DEBUG("RES: %s.", resp);
+    }
+    return true;
+}
+
+// Special version to work around command FTAXXA, which replies without \n\r
+bool USBFocusV3::sendCommandSpecial(const char *cmd, char *resp)
+{
+    int nbytes_written = 0, nbytes_read = 0, rc = -1;
+    char errstr[MAXRBUF];
+    LOGF_DEBUG("CMD: %s.", cmd);
+
+    tcflush(PortFD, TCIOFLUSH);
+    if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        LOGF_ERROR("Error writing command %s: %s.", cmd, errstr);
+        return false;
+    }
+
+    if (resp)
+    {
+        // We assume answer A=x where x is 0 or 1
+        if ((rc = tty_read(PortFD, resp, 3, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
+        {
+            tty_error_msg(rc, errstr, MAXRBUF);
+            LOGF_ERROR("Error reading response for command %s: %s.", cmd, errstr);
+            return false;
+        }
+        resp[nbytes_read] = '\0';
+        LOGF_DEBUG("RES: %s.", resp);
+    }
+    return true;
+}
+
+bool USBFocusV3::Ack()
+{
+    char resp[UFORESLEN] = {};
+    tcflush(PortFD, TCIOFLUSH);
+
+    if (!sendCommand(UFOCDEVID, resp))
+        return false;
+
+    if (strncmp(resp, UFOID, UFORESLEN) != 0)
+    {
+        LOGF_ERROR("USBFocusV3 not properly identified! Answer was: %s.", resp);
+        return false;
+    }
+    return true;
 }
 
 bool USBFocusV3::getControllerStatus()
 {
-    char cmd[] = UFOCREADPARAM;
-
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char resp[UFORSTLEN + 1];
-
-    do
-    {
-        tcflush(PortFD, TCIOFLUSH);
-
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("getControllerStatus error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORSTLEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("getControllerStatus error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORSTLEN] = '\0';
-
-    } while (oneMoreRead(resp, UFORSTLEN));
+    char resp[UFORESLEN] = {};
+    if (!sendCommand(UFOCREADPARAM, resp))
+        return false;
 
     sscanf(resp, "C=%u-%u-%u-%u-%u-%u-%u", &direction, &stepmode, &speed, &stepsdeg, &tcomp_thr, &firmware, &maxpos);
     return true;
@@ -321,10 +388,10 @@ bool USBFocusV3::updateStepMode()
 {
     IUResetSwitch(&StepModeSP);
 
-    if (stepmode == 1)
-        StepModeS[0].s = ISS_ON;
-    else if (stepmode == 0)
-        StepModeS[1].s = ISS_ON;
+    if (stepmode == UFOPHSTEPS)
+        StepModeS[UFOPHSTEPS].s = ISS_ON;
+    else if (stepmode == UFOPFSTEPS)
+        StepModeS[UFOPFSTEPS].s = ISS_ON;
     else
     {
         LOGF_ERROR("Unknown error: focuser step value (%d)", stepmode);
@@ -338,10 +405,10 @@ bool USBFocusV3::updateRotDir()
 {
     IUResetSwitch(&RotDirSP);
 
-    if (direction == 0)
-        RotDirS[0].s = ISS_ON;
-    else if (direction == 1)
-        RotDirS[1].s = ISS_ON;
+    if (direction == UFOPSDIR)
+        RotDirS[UFOPSDIR].s = ISS_ON;
+    else if (direction == UFOPRDIR)
+        RotDirS[UFOPRDIR].s = ISS_ON;
     else
     {
         LOGF_ERROR("Unknown error: rotation direction  (%d)", direction);
@@ -353,44 +420,12 @@ bool USBFocusV3::updateRotDir()
 
 bool USBFocusV3::updateTemperature()
 {
-    char cmd[] = UFOCREADTEMP;
+    char resp[UFORESLEN] = {};
+    if (!sendCommand(UFOCREADTEMP, resp))
+        return false;
 
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char resp[UFORTEMPLEN + 1];
     float temp;
-
-    do
-    {
-        tcflush(PortFD, TCIOFLUSH);
-
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("updateTemperature error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORTEMPLEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("updateTemperature error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORTEMPLEN] = '\0';
-
-    } while (oneMoreRead(resp, UFORTEMPLEN));
-
-    rc = sscanf(resp, "T=%f", &temp);
+    int rc = sscanf(resp, "T=%f", &temp);
 
     if (rc > 0)
     {
@@ -413,44 +448,12 @@ bool USBFocusV3::updateFWversion()
 
 bool USBFocusV3::updatePosition()
 {
-    char cmd[] = UFOCREADPOS;
+    char resp[UFORESLEN] = {};
+    if (!sendCommand(UFOCREADPOS, resp))
+        return false;
 
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char resp[UFORPOSLEN + 1];
     int pos = -1;
-
-    do
-    {
-        tcflush(PortFD, TCIOFLUSH);
-
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("updatePostion error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORPOSLEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("updatePostion error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORPOSLEN] = '\0';
-
-    } while (oneMoreRead(resp, UFORPOSLEN));
-
-    rc = sscanf(resp, "P=%u", &pos);
+    int rc  = sscanf(resp, "P=%u", &pos);
 
     if (rc > 0)
     {
@@ -481,53 +484,24 @@ bool USBFocusV3::updateTempCompSettings()
 
 bool USBFocusV3::updateTempCompSign()
 {
-    char cmd[] = UFOCGETSIGN;
+    char resp[UFORESLEN] = {};
+    // This command seems to have a bug in firmware 1505 that it
+    // doesn't send \n\r in reply like all others except movement
+    // commands so use a special version for it
+    if (!sendCommandSpecial(UFOCGETSIGN, resp))
+        return false;
 
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char resp[UFORSIGNLEN + 1];
     unsigned int sign;
-
-    do
-    {
-        tcflush(PortFD, TCIOFLUSH);
-
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("updateTempCompSign error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORSIGNLEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("updateTempCompSign error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORSIGNLEN] = '\0';
-
-    } while (oneMoreRead(resp, UFORSIGNLEN));
-
-    rc = sscanf(resp, "A=%u", &sign);
+    int rc = sscanf(resp, "A=%u", &sign);
 
     if (rc > 0)
     {
         IUResetSwitch(&TempCompSignSP);
 
-        if (sign == 1)
-            TempCompSignS[0].s = ISS_ON;
-        else if (sign == 0)
-            TempCompSignS[1].s = ISS_ON;
+        if (sign == UFOPNSIGN)
+            TempCompSignS[UFOPNSIGN].s = ISS_ON;
+        else if (sign == UFOPPSIGN)
+            TempCompSignS[UFOPPSIGN].s = ISS_ON;
         else
         {
             LOGF_ERROR("Unknown error: temp. comp. sign  (%d)", sign);
@@ -579,110 +553,49 @@ bool USBFocusV3::updateSpeed()
 
 bool USBFocusV3::setAutoTempCompThreshold(unsigned int thr)
 {
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCTLEN + 1];
-    char resp[UFORDONELEN + 1];
+    char cmd[UFOCMDLEN + 1];
+    snprintf(cmd, UFOCMDLEN + 1, UFOCSETTCTHR, thr);
 
-    snprintf(cmd, UFOCTLEN + 1, "%s%03u", UFOCSETTCTHR, thr);
+    char resp[UFORESLEN] = {};
+    if (!sendCommand(cmd, resp))
+        return false;
 
-    do
+    if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
     {
-        tcflush(PortFD, TCIOFLUSH);
+        tcomp_thr = thr;
+        return true;
+    }
 
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, UFOCTLEN, &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setAutoTempCompThreshold error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORDONELEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setAutoTempCompThreshold error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORDONELEN] = '\0';
-
-        if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
-        {
-            tcomp_thr = thr;
-            return true;
-        }
-
-    } while (oneMoreRead(resp, UFORDONELEN));
-
-    sprintf(errstr, "did not receive DONE.");
-    LOGF_ERROR("setAutoTempCompThreshold error: %s.", errstr);
+    LOG_ERROR("setAutoTempCompThreshold error: did not receive DONE.");
 
     return false;
 }
 
 bool USBFocusV3::setTemperatureCoefficient(unsigned int coefficient)
 {
-    int nbytes_written = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCTLEN + 1];
-    char resp[UFORDONELEN + 1];
+    char cmd[UFOCMDLEN + 1];
+    snprintf(cmd, UFOCMDLEN + 1, UFOCSETSTDEG, coefficient);
 
-    snprintf(cmd, UFOCTLEN + 1, "%s%03u", UFOCSETSTDEG, coefficient);
+    char resp[UFORESLEN] = {};
+    if (!sendCommand(cmd, resp))
+        return false;
 
-    do
+    if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
     {
-        tcflush(PortFD, TCIOFLUSH);
+        stepsdeg = coefficient;
+        return true;
+    }
 
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, UFOCTLEN, &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setTemperatureCoefficient error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        resp[UFORDONELEN] = '\0';
-
-        if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
-        {
-            stepsdeg = coefficient;
-            return true;
-        }
-
-    } while (oneMoreRead(resp, UFORDONELEN));
-
-    sprintf(errstr, "did not receive DONE.");
-    LOGF_ERROR("setTemperatureCoefficient error: %s.", errstr);
+    LOG_ERROR("setTemperatureCoefficient error: did not receive DONE.");
 
     return false;
 }
 
 bool USBFocusV3::reset()
 {
-    char cmd[] = UFOCRESET;
-
-    int nbytes_written = 0, rc = -1;
-    char errstr[MAXRBUF];
-
-    LOGF_DEBUG("CMD: %s.", cmd);
-
-    if ((rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
-    {
-        tty_error_msg(rc, errstr, MAXRBUF);
-        LOGF_ERROR("reset error: %s.", errstr);
+    char resp[UFORESLEN] = {};
+    if (!sendCommand(UFOCRESET, resp))
         return false;
-    }
 
     GetFocusParams();
 
@@ -691,23 +604,19 @@ bool USBFocusV3::reset()
 
 bool USBFocusV3::MoveFocuserUF(FocusDirection dir, unsigned int rticks)
 {
-    int nbytes_written = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCMLEN + 1];
+    char cmd[UFOCMDLEN + 1];
 
     unsigned int ticks;
 
     if ((dir == FOCUS_INWARD) && (rticks > FocusAbsPosN[0].value))
     {
         ticks = FocusAbsPosN[0].value;
-        LOGF_WARN("Requested %u ticks but inward movement has been limited to %u ticks", rticks,
-               ticks);
+        LOGF_WARN("Requested %u ticks but inward movement has been limited to %u ticks", rticks, ticks);
     }
     else if ((dir == FOCUS_OUTWARD) && ((FocusAbsPosN[0].value + rticks) > MaxPositionN[0].value))
     {
         ticks = MaxPositionN[0].value - FocusAbsPosN[0].value;
-        LOGF_WARN("Requested %u ticks but outward movement has been limited to %u ticks",
-               rticks, ticks);
+        LOGF_WARN("Requested %u ticks but outward movement has been limited to %u ticks", rticks, ticks);
     }
     else
     {
@@ -715,88 +624,71 @@ bool USBFocusV3::MoveFocuserUF(FocusDirection dir, unsigned int rticks)
     }
 
     if (dir == FOCUS_INWARD)
-        snprintf(cmd, UFOCMLEN + 1, "%s%05u", UFOCMOVEIN, ticks);
-    else
-        snprintf(cmd, UFOCMLEN + 1, "%s%05u", UFOCMOVEOUT, ticks);
-
-    LOGF_DEBUG("CMD: %s.", cmd);
-
-    if ((rc = tty_write(PortFD, cmd, UFOCMLEN, &nbytes_written)) != TTY_OK)
     {
-        tty_error_msg(rc, errstr, MAXRBUF);
-        LOGF_ERROR("MoveFocuserUF error: %s.", errstr);
-        return false;
+        if (backlashMove == false && backlashIn == true && backlashSteps != 0)
+        {
+            ticks += backlashSteps;
+            backlashTargetPos = targetPos - backlashSteps;
+            backlashMove      = true;
+        }
+        snprintf(cmd, UFOCMDLEN + 1, UFOCMOVEIN, ticks);
     }
-
-    return true;
+    else
+    {
+        if (backlashMove == false && backlashIn == false && backlashSteps != 0)
+        {
+            ticks += backlashSteps;
+            backlashTargetPos = targetPos + backlashSteps;
+            backlashMove      = true;
+        }
+        snprintf(cmd, UFOCMDLEN + 1, UFOCMOVEOUT, ticks);
+    }
+    moving = true;
+    return sendCommand(cmd, nullptr);
 }
 
 bool USBFocusV3::setStepMode(FocusStepMode mode)
 {
-    int nbytes_written = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCSMLEN + 1];
+    char resp[UFORESLEN] = {};
+    char cmd[UFOCMDLEN + 1];
 
     if (mode == FOCUS_HALF_STEP)
-        snprintf(cmd, UFOCSMLEN + 1, "%s", UFOCSETHSTEPS);
+        snprintf(cmd, UFOCMDLEN + 1, "%s", UFOCSETHSTEPS);
     else
-        snprintf(cmd, UFOCSMLEN + 1, "%s", UFOCSETFSTEPS);
+        snprintf(cmd, UFOCMDLEN + 1, "%s", UFOCSETFSTEPS);
 
-    LOGF_DEBUG("CMD: %s.", cmd);
-
-    if ((rc = tty_write(PortFD, cmd, UFOCSMLEN, &nbytes_written)) != TTY_OK)
-    {
-        tty_error_msg(rc, errstr, MAXRBUF);
-        LOGF_ERROR("setStepMode error: %s.", errstr);
+    if (!sendCommand(cmd, resp))
         return false;
-    }
-    else
-    {
-        stepmode = mode;
-    }
 
+    stepmode = mode;
     return true;
 }
 
 bool USBFocusV3::setRotDir(unsigned int dir)
 {
-    int nbytes_written = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCDLEN + 1];
+    char resp[UFORESLEN] = {};
+    char cmd[UFOCMDLEN + 1];
 
     if (dir == UFOPSDIR)
-        snprintf(cmd, UFOCDLEN + 1, "%s", UFOCSETSDIR);
+        snprintf(cmd, UFOCMDLEN + 1, "%s", UFOCSETSDIR);
     else
-        snprintf(cmd, UFOCDLEN + 1, "%s", UFOCSETRDIR);
+        snprintf(cmd, UFOCMDLEN + 1, "%s", UFOCSETRDIR);
 
-    tcflush(PortFD, TCIOFLUSH);
-
-    LOGF_DEBUG("CMD: %s.", cmd);
-
-    if ((rc = tty_write(PortFD, cmd, UFOCDLEN, &nbytes_written)) != TTY_OK)
-    {
-        tty_error_msg(rc, errstr, MAXRBUF);
-        LOGF_ERROR("setRotDir error: %s.", errstr);
+    if (!sendCommand(cmd, resp))
         return false;
-    }
-    else
-    {
-        direction = dir;
-    }
 
+    direction = dir;
     return true;
 }
 
 bool USBFocusV3::setMaxPos(unsigned int maxp)
 {
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCMMLEN + 1];
-    char resp[UFORDONELEN + 1];
+    char cmd[UFOCMDLEN + 1];
+    char resp[UFORESLEN] = {};
 
     if (maxp >= 1 && maxp <= 65535)
     {
-        snprintf(cmd, UFOCMMLEN + 1, "%s%05u", UFOCSETMAX, maxp);
+        snprintf(cmd, UFOCMDLEN + 1, UFOCSETMAX, maxp);
     }
     else
     {
@@ -804,55 +696,25 @@ bool USBFocusV3::setMaxPos(unsigned int maxp)
         return false;
     }
 
-    do
+    if (!sendCommand(cmd, resp))
+        return false;
+
+    if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
     {
-        tcflush(PortFD, TCIOFLUSH);
+        maxpos              = maxp;
+        FocusAbsPosN[0].max = maxpos;
+        return true;
+    }
 
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, UFOCMMLEN, &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setMaxPos error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORDONELEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setMaxPos error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORDONELEN] = '\0';
-
-        if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
-        {
-            maxpos              = maxp;
-            FocusAbsPosN[0].max = maxpos;
-            return true;
-        }
-
-    } while (oneMoreRead(resp, UFORDONELEN));
-
-    sprintf(errstr, "did not receive DONE.");
-    LOGF_ERROR("setMaxPos error: %s.", errstr);
+    LOG_ERROR("setMaxPos error: did not receive DONE.");
 
     return false;
 }
 
 bool USBFocusV3::setSpeed(unsigned short drvspeed)
 {
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCSLEN + 1];
-    char resp[UFORDONELEN + 1];
+    char cmd[UFOCMDLEN + 1];
+    char resp[UFORESLEN] = {};
 
     unsigned int spd;
 
@@ -874,7 +736,7 @@ bool USBFocusV3::setSpeed(unsigned short drvspeed)
 
     if (spd != UFOPSPDERR)
     {
-        snprintf(cmd, UFOCSLEN + 1, "%s%03u", UFOCSETSPEED, spd);
+        snprintf(cmd, UFOCMDLEN + 1, UFOCSETSPEED, spd);
     }
     else
     {
@@ -882,117 +744,52 @@ bool USBFocusV3::setSpeed(unsigned short drvspeed)
         return false;
     }
 
-    do
+    if (!sendCommand(cmd, resp))
+        return false;
+
+    if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
     {
-        tcflush(PortFD, TCIOFLUSH);
+        speed = spd;
+        return true;
+    }
 
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, UFOCSLEN, &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setSpeed error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORDONELEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setSpeed error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORDONELEN] = '\0';
-
-        if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
-        {
-            speed = spd;
-            return true;
-        }
-
-    } while (oneMoreRead(resp, UFORDONELEN));
-
-    sprintf(errstr, "did not receive DONE.");
-    LOGF_ERROR("setSpeed error: %s.", errstr);
+    LOG_ERROR("setSpeed error: did not receive DONE.");
 
     return false;
 }
 
 bool USBFocusV3::setTemperatureCompensation(bool enable)
 {
-    int nbytes_written = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCTCLEN + 1];
+    char cmd[UFOCMDLEN + 1];
+    char resp[UFORESLEN] = {};
 
     if (enable)
-        snprintf(cmd, UFOCTCLEN + 1, "%s", UFOCSETAUTO);
+        snprintf(cmd, UFOCMDLEN + 1, "%s", UFOCSETAUTO);
     else
-        snprintf(cmd, UFOCTCLEN + 1, "%s", UFOCSETMANU);
+        snprintf(cmd, UFOCMDLEN + 1, "%s", UFOCSETMANU);
 
-    LOGF_DEBUG("CMD: %s.", cmd);
-
-    if ((rc = tty_write(PortFD, cmd, UFOCTCLEN, &nbytes_written)) != TTY_OK)
-    {
-        tty_error_msg(rc, errstr, MAXRBUF);
-        LOGF_ERROR("setTemperatureCompensation error: %s.", errstr);
+    if (!sendCommand(cmd, resp))
         return false;
-    }
 
     return true;
 }
 
 bool USBFocusV3::setTempCompSign(unsigned int sign)
 {
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-    char errstr[MAXRBUF];
-    char cmd[UFOCTLEN + 1];
-    char resp[UFORDONELEN + 1];
+    char cmd[UFOCMDLEN + 1];
+    char resp[UFORESLEN] = {};
 
-    snprintf(cmd, UFOCDLEN + 1, "%s%1u", UFOCSETSIGN, sign);
+    snprintf(cmd, UFOCMDLEN + 1, UFOCSETSIGN, sign);
 
-    do
+    if (!sendCommand(cmd, resp))
+        return false;
+
+    if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
     {
-        tcflush(PortFD, TCIOFLUSH);
+        return true;
+    }
 
-        LOGF_DEBUG("CMD: %s.", cmd);
-
-        if ((rc = tty_write(PortFD, cmd, UFOCDLEN, &nbytes_written)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setTempCompSign error: %s.", errstr);
-            return false;
-        }
-
-        usleep(SRTUS);
-
-        if ((rc = tty_read(PortFD, resp, UFORDONELEN, USBFOCUSV3_TIMEOUT, &nbytes_read)) != TTY_OK)
-        {
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("setTempCompSign error: %s.", errstr);
-            return false;
-        }
-
-        LOGF_DEBUG("RES: %s.", resp);
-
-        usleep(SRTUS);
-
-        resp[UFORDONELEN] = '\0';
-
-        if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
-        {
-            return true;
-        }
-
-    } while (oneMoreRead(resp, UFORDONELEN));
-
-    sprintf(errstr, "did not receive DONE.");
-    LOGF_ERROR("setTempCompSign error: %s.", errstr);
+    LOG_ERROR("setTempCompSign error: did not receive DONE.");
 
     return false;
 }
@@ -1011,9 +808,10 @@ bool USBFocusV3::ISNewSwitch(const char *dev, const char *name, ISState *states,
             {
                 StepModeSP.s = IPS_OK;
                 IDSetSwitch(&StepModeSP, nullptr);
+                return true;
             }
 
-            if (target_mode == 0)
+            if (target_mode == UFOPHSTEPS)
                 rc = setStepMode(FOCUS_HALF_STEP);
             else
                 rc = setStepMode(FOCUS_FULL_STEP);
@@ -1042,13 +840,10 @@ bool USBFocusV3::ISNewSwitch(const char *dev, const char *name, ISState *states,
             {
                 RotDirSP.s = IPS_OK;
                 IDSetSwitch(&RotDirSP, nullptr);
+                return true;
             }
 
-            if (target_mode == 0)
-                rc = setRotDir(UFOPSDIR);
-            else
-                rc = setRotDir(UFOPRDIR);
-
+            rc = setRotDir(target_mode);
             if (!rc)
             {
                 IUResetSwitch(&RotDirSP);
@@ -1094,13 +889,10 @@ bool USBFocusV3::ISNewSwitch(const char *dev, const char *name, ISState *states,
             {
                 TempCompSignSP.s = IPS_OK;
                 IDSetSwitch(&TempCompSignSP, nullptr);
+                return true;
             }
 
-            if (target_mode == 0)
-                rc = setTempCompSign(UFOPNSIGN);
-            else
-                rc = setTempCompSign(UFOPPSIGN);
-
+            rc = setTempCompSign(target_mode);
             if (!rc)
             {
                 IUResetSwitch(&TempCompSignSP);
@@ -1112,6 +904,16 @@ bool USBFocusV3::ISNewSwitch(const char *dev, const char *name, ISState *states,
 
             TempCompSignSP.s = IPS_OK;
             IDSetSwitch(&TempCompSignSP, nullptr);
+            return true;
+        }
+
+        if (strcmp(BacklashDirectionSP.name, name) == 0)
+        {
+            IUUpdateSwitch(&BacklashDirectionSP, states, names, n);
+            int target_direction  = IUFindOnSwitchIndex(&BacklashDirectionSP);
+            backlashIn            = (target_direction == BACKLASH_IN);
+            BacklashDirectionSP.s = IPS_OK;
+            IDSetSwitch(&BacklashDirectionSP, nullptr);
             return true;
         }
 
@@ -1154,7 +956,7 @@ bool USBFocusV3::ISNewNumber(const char *dev, const char *name, double values[],
         {
             IUUpdateNumber(&TemperatureSettingNP, values, names, n);
             if (!setAutoTempCompThreshold(TemperatureSettingN[1].value) ||
-                !setTemperatureCoefficient(TemperatureSettingN[0].value))
+                !setTemperatureCoefficient(TemperatureSettingN[UFOPNSIGN].value))
             {
                 TemperatureSettingNP.s = IPS_ALERT;
                 IDSetNumber(&TemperatureSettingNP, nullptr);
@@ -1163,6 +965,15 @@ bool USBFocusV3::ISNewNumber(const char *dev, const char *name, double values[],
 
             TemperatureSettingNP.s = IPS_OK;
             IDSetNumber(&TemperatureSettingNP, nullptr);
+            return true;
+        }
+
+        if (strcmp(name, BacklashSettingNP.name) == 0)
+        {
+            IUUpdateNumber(&BacklashSettingNP, values, names, n);
+            backlashSteps       = std::round(BacklashSettingN[0].value);
+            BacklashSettingNP.s = IPS_OK;
+            IDSetNumber(&BacklashSettingNP, nullptr);
             return true;
         }
 
@@ -1176,41 +987,6 @@ bool USBFocusV3::ISNewNumber(const char *dev, const char *name, double values[],
     }
 
     return INDI::Focuser::ISNewNumber(dev, name, values, names, n);
-}
-
-bool USBFocusV3::oneMoreRead(char *response, unsigned int maxlen)
-{
-    if (strncmp(response, UFORSACK, std::min((unsigned int)strlen(UFORSACK), maxlen)) == 0)
-    {
-        return true;
-    }
-
-    if (strncmp(response, UFORSEQU, std::min((unsigned int)strlen(UFORSEQU), maxlen)) == 0)
-    {
-        return true;
-    }
-
-    if (strncmp(response, UFORSAUTO, std::min((unsigned int)strlen(UFORSAUTO), maxlen)) == 0)
-    {
-        return true;
-    }
-
-    if (strncmp(response, UFORSERR, std::min((unsigned int)strlen(UFORSERR), maxlen)) == 0)
-    {
-        return true;
-    }
-
-    if (strncmp(response, UFORSDONE, std::min((unsigned int)strlen(UFORSDONE), maxlen)) == 0)
-    {
-        return true;
-    }
-
-    if (strncmp(response, UFORSRESET, std::min((unsigned int)strlen(UFORSRESET), maxlen)) == 0)
-    {
-        return true;
-    }
-
-    return false;
 }
 
 void USBFocusV3::GetFocusParams()
@@ -1276,9 +1052,9 @@ IPState USBFocusV3::MoveAbsFocuser(uint32_t targetTicks)
     bool rc = false;
 
     if (ticks < 0)
-        rc = MoveFocuserUF(FOCUS_INWARD, (unsigned int)labs(ticks));
+        rc = MoveFocuserUF(FOCUS_INWARD, -ticks);
     else if (ticks > 0)
-        rc = MoveFocuserUF(FOCUS_OUTWARD, (unsigned int)labs(ticks));
+        rc = MoveFocuserUF(FOCUS_OUTWARD, ticks);
 
     if (!rc)
         return IPS_ALERT;
@@ -1323,7 +1099,6 @@ void USBFocusV3::TimerHit()
 {
     if (!isConnected())
     {
-        SetTimer(POLLMS);
         return;
     }
 
@@ -1367,14 +1142,23 @@ void USBFocusV3::TimerHit()
 
     if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
     {
-        if (fabs(targetPos - FocusAbsPosN[0].value) < 1)
+        if (backlashMove && (fabs(backlashTargetPos - FocusAbsPosN[0].value) < 1))
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
-            LOG_INFO("Focuser reached requested position.");
+            // Backlash target reached, now go to real target
+            MoveAbsFocuser(targetPos);
+            backlashMove = false;
+        }
+        else
+        {
+            if (fabs(targetPos - FocusAbsPosN[0].value) < 1)
+            {
+                FocusAbsPosNP.s = IPS_OK;
+                FocusRelPosNP.s = IPS_OK;
+                IDSetNumber(&FocusAbsPosNP, nullptr);
+                IDSetNumber(&FocusRelPosNP, nullptr);
+                lastPos = FocusAbsPosN[0].value;
+                LOG_INFO("Focuser reached requested position.");
+            }
         }
     }
 
@@ -1383,28 +1167,27 @@ void USBFocusV3::TimerHit()
 
 bool USBFocusV3::AbortFocuser()
 {
-    char cmd[] = UFOCABORT;
-    int nbytes_written;
-
-    LOGF_DEBUG("CMD: %s.", cmd);
-
-    if (tty_write(PortFD, cmd, strlen(cmd), &nbytes_written) == TTY_OK)
-    {
-        FocusAbsPosNP.s = IPS_IDLE;
-        FocusRelPosNP.s = IPS_IDLE;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
-        IDSetNumber(&FocusRelPosNP, nullptr);
-        return true;
-    }
-    else
+    char resp[UFORESLEN] = {};
+    if (!sendCommand(UFOCABORT, resp))
         return false;
+
+    FocusAbsPosNP.s = IPS_IDLE;
+    FocusRelPosNP.s = IPS_IDLE;
+    IDSetNumber(&FocusAbsPosNP, nullptr);
+    IDSetNumber(&FocusRelPosNP, nullptr);
+    backlashMove = false;
+    moving       = false;
+    return true;
 }
 
 float USBFocusV3::CalcTimeLeft(timeval start, float req)
 {
     double timesince;
     double timeleft;
-    struct timeval now { 0, 0 };
+    struct timeval now
+    {
+        0, 0
+    };
     gettimeofday(&now, nullptr);
 
     timesince =
@@ -1412,4 +1195,13 @@ float USBFocusV3::CalcTimeLeft(timeval start, float req)
     timesince = timesince / 1000;
     timeleft  = req - timesince;
     return timeleft;
+}
+
+bool USBFocusV3::saveConfigItems(FILE *fp)
+{
+    INDI::Focuser::saveConfigItems(fp);
+
+    IUSaveConfigNumber(fp, &BacklashSettingNP);
+    IUSaveConfigSwitch(fp, &BacklashDirectionSP);
+    return true;
 }

--- a/libindi/drivers/focuser/usbfocusv3.h
+++ b/libindi/drivers/focuser/usbfocusv3.h
@@ -1,6 +1,7 @@
 /*
     USB Focus V3
     Copyright (C) 2016 G. Schmidt
+    Copyright (C) 2018 Jarno Paananen
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -25,63 +26,50 @@
 /***************************** USB Focus V3 Commands **************************/
 
 #define UFOCREADPARAM "SGETAL"
-#define UFOCDEVID     "SWHOIS"
-#define UFOCREADPOS   "FPOSRO"
-#define UFOCREADTEMP  "FTMPRO"
-#define UFOCMOVEOUT   "O"
-#define UFOCMOVEIN    "I"
-#define UFOCABORT     "FQUITx"
-#define UFOCSETMAX    "M"
-#define UFOCSETSPEED  "SMO"
-#define UFOCSETTCTHR  "SMA"
-#define UFOCSETSDIR   "SMROTH"
-#define UFOCSETRDIR   "SMROTT"
+#define UFOCDEVID "SWHOIS"
+#define UFOCREADPOS "FPOSRO"
+#define UFOCREADTEMP "FTMPRO"
+#define UFOCMOVEOUT "O%05u"
+#define UFOCMOVEIN "I%05u"
+#define UFOCABORT "FQUITx"
+#define UFOCSETMAX "M%05u"
+#define UFOCSETSPEED "SMO%03u"
+#define UFOCSETTCTHR "SMA%03u"
+#define UFOCSETSDIR "SMROTH"
+#define UFOCSETRDIR "SMROTT"
 #define UFOCSETFSTEPS "SMSTPF"
 #define UFOCSETHSTEPS "SMSTPD"
-#define UFOCSETSTDEG  "FLA"
-#define UFOCGETSIGN   "FTAXXA"
-#define UFOCSETSIGN   "FZAXX"
-#define UFOCSETAUTO   "FAMODE"
-#define UFOCSETMANU   "FMMODE"
-#define UFOCRESET     "SEERAZ"
+#define UFOCSETSTDEG "FLA%03u"
+#define UFOCGETSIGN "FTAXXA"
+#define UFOCSETSIGN "FZAXX%1u"
+#define UFOCSETAUTO "FAMODE"
+#define UFOCSETMANU "FMMODE"
+#define UFOCRESET "SEERAZ"
 
 /**************************** USB Focus V3 Constants **************************/
 
 #define UFOID "UFO"
 
-#define UFORSACK   "*"
-#define UFORSEQU   "="
-#define UFORSAUTO  "AP"
-#define UFORSDONE  "DONE"
-#define UFORSERR   "ER="
+#define UFORSACK '*'
+#define UFORSAUTO "AP"
+#define UFORSDONE "DONE"
+#define UFORSERR "ER=1"
 #define UFORSRESET "EEPROM RESET"
 
-#define UFOPSDIR   0 // standard direction
-#define UFOPRDIR   1 // reverse direction
+#define UFOPSDIR 0   // standard direction
+#define UFOPRDIR 1   // reverse direction
 #define UFOPFSTEPS 0 // full steps
 #define UFOPHSTEPS 1 // half steps
-#define UFOPPSIGN  0 // positive temp. comp. sign
-#define UFOPNSIGN  1 // negative temp. comp. sign
+#define UFOPPSIGN 0  // positive temp. comp. sign
+#define UFOPNSIGN 1  // negative temp. comp. sign
 
 #define UFOPSPDERR 0 // invalid speed
-#define UFOPSPDAV  2 // average speed
-#define UFOPSPDSL  3 // slow speed
-#define UFOPSPDUS  4 // ultra slow speed
+#define UFOPSPDAV 2  // average speed
+#define UFOPSPDSL 3  // slow speed
+#define UFOPSPDUS 4  // ultra slow speed
 
-#define UFORTEMPLEN 8  // maximum length of returned temperature string
-#define UFORSIGNLEN 3  // maximum length of temp. comp. sign string
-#define UFORPOSLEN  7  // maximum length of returned position string
-#define UFORSTLEN   26 // maximum length of returned status string
-#define UFORIDLEN   3  // maximum length of returned temperature string
-#define UFORDONELEN 4  // length of done response
-
-#define UFOCTLEN  6 // length of temp parameter setting commands
-#define UFOCMLEN  6 // length of move commands
-#define UFOCMMLEN 6 // length of max. move commands
-#define UFOCSLEN  6 // length of speed commands
-#define UFOCDLEN  6 // length of direction commands
-#define UFOCSMLEN 6 // length of step mode commands
-#define UFOCTCLEN 6 // length of temp compensation commands
+#define UFORESLEN 32 // maximum length of returned response with some margin (28 characters is actual maximum)
+#define UFOCMDLEN 6  // length of all commands
 
 /******************************************************************************/
 
@@ -91,7 +79,11 @@ class USBFocusV3 : public INDI::Focuser
     USBFocusV3();
     virtual ~USBFocusV3() = default;
 
-    typedef enum { FOCUS_HALF_STEP, FOCUS_FULL_STEP } FocusStepMode;
+    typedef enum
+    {
+        FOCUS_HALF_STEP,
+        FOCUS_FULL_STEP
+    } FocusStepMode;
 
     virtual bool Handshake() override;
     bool getControllerStatus();
@@ -105,9 +97,11 @@ class USBFocusV3 : public INDI::Focuser
     virtual bool SetFocuserSpeed(int speed) override;
     virtual bool AbortFocuser() override;
     virtual void TimerHit() override;
+    virtual bool saveConfigItems(FILE *fp) override;
 
   private:
-    bool oneMoreRead(char *response, unsigned int maxlen);
+    bool sendCommand(const char *cmd, char *response);
+    bool sendCommandSpecial(const char *cmd, char *response);
 
     void GetFocusParams();
     bool reset();
@@ -121,8 +115,8 @@ class USBFocusV3 : public INDI::Focuser
     bool updateSpeed();
     bool updateFWversion();
 
-    bool isMoving();
     bool Ack();
+    bool Resync();
 
     bool MoveFocuserUF(FocusDirection dir, unsigned int rticks);
     bool setStepMode(FocusStepMode mode);
@@ -135,21 +129,30 @@ class USBFocusV3 : public INDI::Focuser
     bool setTemperatureCompensation(bool enable);
     float CalcTimeLeft(timeval, float);
 
-    unsigned int direction { 0 }; // 0 standard, 1 reverse
-    unsigned int stepmode { 0 };  // 0 full steps, 1 half steps
-    unsigned int speed { 0 };     // 2 average, 3 slow, 4 ultra slow
-    unsigned int stepsdeg { 0 };  // steps per degree for temperature compensation
-    unsigned int tcomp_thr { 0 }; // temperature compensation threshold
-    unsigned int firmware { 0 };  // firmware version
-    unsigned int maxpos { 0 };    // maximum step position (0..65535)
+    unsigned int direction{ 0 }; // 0 standard, 1 reverse
+    unsigned int stepmode{ 0 };  // 0 full steps, 1 half steps
+    unsigned int speed{ 0 };     // 2 average, 3 slow, 4 ultra slow
+    unsigned int stepsdeg{ 0 };  // steps per degree for temperature compensation
+    unsigned int tcomp_thr{ 0 }; // temperature compensation threshold
+    unsigned int firmware{ 0 };  // firmware version
+    unsigned int maxpos{ 0 };    // maximum step position (0..65535)
 
-    double targetPos { 0 };
-    double lastPos { 0 };
-    double lastTemperature { 0 };
-    unsigned int currentSpeed { 0 };
+    double targetPos{ 0 };
+    double backlashTargetPos{ 0 };
+    double lastPos{ 0 };
+    int backlashSteps{ 0 };
+    bool backlashIn{ false };
+    bool backlashMove{ false };
+    bool moving{ false };
 
-    struct timeval focusMoveStart { 0, 0 };
-    float focusMoveRequest { 0 };
+    double lastTemperature{ 0 };
+    unsigned int currentSpeed{ 0 };
+
+    struct timeval focusMoveStart
+    {
+        0, 0
+    };
+    float focusMoveRequest{ 0 };
 
     INumber TemperatureN[1];
     INumberVectorProperty TemperatureNP;
@@ -171,6 +174,18 @@ class USBFocusV3 : public INDI::Focuser
 
     ISwitch TemperatureCompensateS[2];
     ISwitchVectorProperty TemperatureCompensateSP;
+
+    INumber BacklashSettingN[1];
+    INumberVectorProperty BacklashSettingNP;
+
+    typedef enum
+    {
+        BACKLASH_IN  = 0,
+        BACKLASH_OUT = 1
+    } BacklashDirection;
+
+    ISwitch BacklashDirectionS[2];
+    ISwitchVectorProperty BacklashDirectionSP;
 
     ISwitch ResetS[1];
     ISwitchVectorProperty ResetSP;


### PR DESCRIPTION
This PR does a quite big overhaul of the USBFocusV3 driver:
- Serial communication changed to deal with lines instead of fixed
lengths. This fixes issues with reading temperature for example as the
response length varies. Old code didn't work correctly when
temperature was between +/- 0-9.99 degrees as the response was shorter
than expected.
- Also removed ad-hoc usleeps that weren't really necessary at all and
centralized serial access to a couple of functions instead of each
command separately.
- Added code to try to restore command sync in case something else
like ModemManager has written something to the serial port before. The
protocol doesn't have any sync mechanism and assumes all commands are
six characters long. This doesn't work quite as well as I hoped, but is
better than nothing.
- Fixed property names to better conform to style in other drivers and
use label texts correctly.
- Added support for backlash compensation. If focuser is moved in the
direction of backlash, it's moved a configurable number of steps extra
and then brought back to the correct place. Setting the value to zero
(default) disables this feature.

Probably forgot something as this has been in the making for almost a
year now :) Also ran the source through clang-format so there is some
noise from that as well.