### PR TITLE
Min/max/sync handling

### DIFF
--- a/libindi/drivers/focuser/nfocus.cpp
+++ b/libindi/drivers/focuser/nfocus.cpp
@@ -751,7 +751,7 @@ bool NFocus::ISNewNumber(const char *dev, const char *name, double values[], cha
                 if (mmpp == &MinMaxPositionN[0])
                 {
                     new_min = (values[i]);
-                    nset += static_cast<int>(new_min >= 1 && new_min <= 65000);
+                    nset += static_cast<int>(new_min >= 0 && new_min <= 65000);
                 }
                 else if (mmpp == &MinMaxPositionN[1])
                 {

--- a/libindi/drivers/focuser/nfocus.cpp
+++ b/libindi/drivers/focuser/nfocus.cpp
@@ -852,8 +852,11 @@ bool NFocus::ISNewNumber(const char *dev, const char *name, double values[], cha
             }
 
             LOGF_DEBUG("Focuser sycned to %g ticks", new_apos);
-            SyncN[0].value = new_apos;
-            SyncNP.s       = IPS_OK;
+            SyncN[0].value        = new_apos;
+            FocusAbsPosN[0].value = new_apos;
+            currentPosition       = new_apos;
+
+            SyncNP.s        = IPS_OK;
             IDSetNumber(&SyncNP, nullptr);
             IDSetNumber(&FocusAbsPosNP, nullptr);
             return true;


### PR DESCRIPTION
The current nFocus implementation has some problems:
1. The "minimum tick" value does not allow 0, it must be positive.
2. Synching does neither change the absolute position nor does it internally change the current
 position.

Both should be fixed now.