### PR TITLE
Corected wrong "Sync" setting position.

### DIFF
--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -2332,7 +2332,7 @@ bool FocusLynxBase::sync(uint32_t position)
 
     memset(response, 0, sizeof(response));
 
-    snprintf(cmd, 32, "<%sSCCP%06d>", getFocusTarget(), int(MaxTravelN[0].value - position));
+    snprintf(cmd, 32, "<%sSCCP%06d>", getFocusTarget(), position);
     LOGF_DEBUG("CMD (%s)", cmd);
 
     if (isSimulation())


### PR DESCRIPTION
Was due to test and validation with focuser configured in "Reverse" mode.