### PR TITLE
Added one missing command of the HUB focuser

### DIFF
--- a/libindi/drivers/focuser/focuslynx.cpp
+++ b/libindi/drivers/focuser/focuslynx.cpp
@@ -49,7 +49,7 @@ void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names
 
 void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
 {
-    // Only call the corrected Focuser to execute evaluate the newText
+    // Only call the corrected Focuser to execute evaluate the new Text
     if (!strcmp(dev, lynxDriveF1->getDeviceName()))
         lynxDriveF1->ISNewText(dev, name, texts, names, n);
     else if (!strcmp(dev, lynxDriveF2->getDeviceName()))
@@ -142,7 +142,7 @@ bool FocusLynxF1::initProperties()
     IUFillText(&WifiT[0], "Installed", "", "");
     IUFillText(&WifiT[1], "Connected", "", "");
     IUFillText(&WifiT[2], "Firmware", "", "");
-    IUFillText(&WifiT[3], "FV OK", "", "");
+    IUFillText(&WifiT[3], "Firm. Version OK", "", "");
     IUFillText(&WifiT[4], "SSID", "", "");
     IUFillText(&WifiT[5], "Ip address", "", "");
     IUFillText(&WifiT[6], "Security mode", "", "");

--- a/libindi/drivers/focuser/focuslynxbase.h
+++ b/libindi/drivers/focuser/focuslynxbase.h
@@ -45,7 +45,7 @@
 #define HUB_SETTINGS_TAB "Device"
 
 #define VERSION                 1
-#define SUBVERSION              41
+#define SUBVERSION              42
 
 class FocusLynxBase : public INDI::Focuser
 {
@@ -156,6 +156,7 @@ class FocusLynxBase : public INDI::Focuser
     bool setTemperatureCompensation(bool enable);
     bool setTemperatureCompensationMode(char mode);
     bool setTemperatureCompensationCoeff(char mode, int16_t coeff);
+    bool setTemperatureInceptions(char mode, int32_t inter);
     bool setTemperatureCompensationOnStart(bool enable);
 
     // Backlash
@@ -195,13 +196,13 @@ class FocusLynxBase : public INDI::Focuser
     ISwitch TemperatureCompensateOnStartS[2];
     ISwitchVectorProperty TemperatureCompensateOnStartSP;
 
-    // Temperature Coefficient
-    INumber TemperatureCoeffN[5];
-    INumberVectorProperty TemperatureCoeffNP;
-
     // Temperature Coefficient Mode
     ISwitch TemperatureCompensateModeS[5];
     ISwitchVectorProperty TemperatureCompensateModeSP;
+
+    // Temperature coefficient and Intercept for selected mode
+    INumber TemperatureParamN[2];
+    INumberVectorProperty TemperatureParamNP;
 
     // Enable/Disable backlash
     ISwitch BacklashCompensationS[2];


### PR DESCRIPTION
Change the setting tab to avoid overload of it. Noe the Temp Coefficient and the new Temp Intercept value are only visible/writable for the selected mode (A, B, C, D or E).
Modify cast action with using of the C++ semantic static_cast<...>