### PR TITLE
Adding support for craft builds for mac to libapogee and libdspau

### DIFF
--- a/3rdparty/libapogee/CMakeLists.txt
+++ b/3rdparty/libapogee/CMakeLists.txt
@@ -29,6 +29,9 @@ include_directories( ${CMAKE_CURRENT_SOURCE_DIR})
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/linux)
 include_directories( ${CURL_INCLUDE_DIR})
 
+# This is for craft builds
+include_directories("${CMAKE_INSTALL_PREFIX}/include")
+
 SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
 

--- a/3rdparty/libdspau/CMakeLists.txt
+++ b/3rdparty/libdspau/CMakeLists.txt
@@ -23,6 +23,9 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/include/libdspau.h.cmake ${CMAKE_CURR
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories( ${CMAKE_CURRENT_BINARY_DIR})
 
+# This is for craft builds
+include_directories("${CMAKE_INSTALL_PREFIX}/include")
+
 set(dspau_lib_srcs
    ${CMAKE_CURRENT_SOURCE_DIR}/src/libdspau-align.c
    ${CMAKE_CURRENT_SOURCE_DIR}/src/libdspau-astro.c


### PR DESCRIPTION
This will resolve build errors in craft because cmake cannot find the header files for the dependencies because they are located in the craft root directory instead of the system root directory.  I already fixed this problem for the main INDI build, but not these libraries.