### PR TITLE
Added fix for QHY5-M- CancelQHYCCDExposing* crash

### DIFF
--- a/3rdparty/indi-qhy/qhy_ccd.cpp
+++ b/3rdparty/indi-qhy/qhy_ccd.cpp
@@ -929,17 +929,26 @@ bool QHYCCD::AbortExposure()
     }
     pthread_mutex_unlock(&condMutex);
 
-    int rc = CancelQHYCCDExposingAndReadout(camhandle);
-    if (rc == QHYCCD_SUCCESS)
+    if (std::string(camid) != "QHY5-M-")
+    {
+        int rc = CancelQHYCCDExposingAndReadout(camhandle);
+        if (rc == QHYCCD_SUCCESS)
+        {
+            InExposure = false;
+            LOG_INFO("Exposure aborted.");
+            return true;
+        }
+        else
+            LOGF_ERROR("Abort exposure failed (%d)", rc);
+
+        return false;
+    }
+    else
     {
         InExposure = false;
         LOG_INFO("Exposure aborted.");
         return true;
     }
-    else
-        LOGF_ERROR("Abort exposure failed (%d)", rc);
-
-    return false;
 }
 
 bool QHYCCD::UpdateCCDFrame(int x, int y, int w, int h)


### PR DESCRIPTION
Tried both CancelQHYCCDExposingAndReadout and CancelQHYCCDExposing from the SDK with the QHY5-M- (SSAG). In either case, this results in a crash of the indi driver. Added a condition to bypass this call for the QHY5-M-. The device now works using Ekos as a guide camera.