### PR TITLE
Switch Travis linux distro to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
 
 language: cpp
 sudo: required
-dist: trusty
+dist: xenial
 osx_image: xcode8.3
 
 matrix:


### PR DESCRIPTION
The indilib/indi travis ci is currently failing when compiling code with std::regex. The cause appears to be the gcc version on trusty.  It uses 4.8.4 - std::regex isn't properly supported in gcc until 4.9.   There are discussions in a few places.  i.e.,  

https://stackoverflow.com/questions/8561850/compile-stdregex-iterator-with-gcc
https://github.com/RobotLocomotion/drake/issues/1649

I'm proposing switching the ubuntu distro that Travis uses to Xenial, which uses gcc 4.9+.  i.e.,

$ gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.10) 5.4.0 20160609

Test results from my travis branch:  https://github.com/glowmouse/indi/commits/travis
