### PR TITLE
Fix port getter for Connection::TCP interface

### DIFF
--- a/libindi/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libindi/libs/indibase/connectionplugins/connectiontcp.h
@@ -59,7 +59,7 @@ class TCP : public Interface
     virtual std::string label() { return "Ethernet"; }
 
     virtual const char *host() const { return AddressT[0].text; }
-    virtual uint32_t port() const { return atoi(AddressT[0].text); }
+    virtual uint32_t port() const { return atoi(AddressT[1].text); }
     ConnectionType connectionType() const { return static_cast<ConnectionType>(IUFindOnSwitchIndex(&TcpUdpSP)); }
 
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n);


### PR DESCRIPTION
TCP instance classes return first section of hostname if hostname is string representing IPv4.
```cpp
tcpConnection->host() // "127.0.0.1"
tcpConnection->port() // 127
```