### PR TITLE
Initialize backlash on eqmod connect

### DIFF
--- a/3rdparty/indi-eqmod/eqmod.cpp
+++ b/3rdparty/indi-eqmod/eqmod.cpp
@@ -607,6 +607,12 @@ bool EQMod::updateProperties()
                 }
             }
 
+            LOG_DEBUG("Init backlash.");
+            mount->SetBacklashUseRA((IUFindSwitch(UseBacklashSP, "USEBACKLASHRA")->s == ISS_ON ? true : false));
+            mount->SetBacklashUseDE((IUFindSwitch(UseBacklashSP, "USEBACKLASHDE")->s == ISS_ON ? true : false));
+            mount->SetBacklashRA((uint32_t)(IUFindNumber(BacklashNP, "BACKLASHRA")->value));
+            mount->SetBacklashDE((uint32_t)(IUFindNumber(BacklashNP, "BACKLASHDE")->value));
+
             mount->Init();
 
             zeroRAEncoder  = mount->GetRAEncoderZero();


### PR DESCRIPTION
When the values are loaded from skel, the backlash setting was not sent to mount, so the mount values were uninitialized.

This fixes https://github.com/indilib/indi/issues/457