### PR TITLE
Typo in source package name?

### DIFF
--- a/debian/libatik/control
+++ b/debian/libatik/control
@@ -1,4 +1,4 @@
-Source: libsatik
+Source: libatik
 Section: libs
 Priority: extra
 Maintainer: Jasem Mutlaq <mutlaqja@ikarustech.com>


### PR DESCRIPTION
There seems to be some confusion in PPA that causes new indi-atik builds to fail as libatik hasn't been updated. Wondering if this might have something to do with it.