### PR TITLE
Fix more unitialized variables in eqmod driver

### DIFF
--- a/3rdparty/indi-eqmod/align/triangulate.h
+++ b/3rdparty/indi-eqmod/align/triangulate.h
@@ -48,5 +48,5 @@ class Triangulate
     std::map<HtmID, PointSet::Point> *pmap;
     std::vector<HtmID> vvertices;
     std::vector<Face *> vfaces;
-    bool isvalid;
+    bool isvalid {false};
 };

--- a/3rdparty/indi-eqmod/eqmod.cpp
+++ b/3rdparty/indi-eqmod/eqmod.cpp
@@ -494,6 +494,8 @@ bool EQMod::loadProperties()
 bool EQMod::updateProperties()
 {
     INumber *latitude;
+    INumber *longitude;
+    INumber *elevation;
 
     INDI::Telescope::updateProperties();
 
@@ -626,6 +628,13 @@ bool EQMod::updateProperties()
             parkDEEncoder = GetAxis2Park();
 
             latitude = IUFindNumber(&LocationNP, "LAT");
+            longitude = IUFindNumber(&LocationNP, "LONG");
+            elevation = IUFindNumber(&LocationNP, "ELEV");
+            if (latitude && longitude && elevation)
+                updateLocation(latitude->value, longitude->value, elevation->value);
+            else
+                updateLocation(0.0, 0.0, 0.0);
+
             if ((latitude) && (latitude->value < 0.0))
                 SetSouthernHemisphere(true);
             else

--- a/3rdparty/indi-eqmod/skywatcher.h
+++ b/3rdparty/indi-eqmod/skywatcher.h
@@ -298,8 +298,8 @@ class Skywatcher
     uint32_t DEStepInit; // Initial DE position in step
     uint32_t RAStepHome; // Home RA position in step
     uint32_t DEStepHome; // Home DE position in step
-    uint32_t RAPeriod;   // Current RA worm period
-    uint32_t DEPeriod;   // Current DE worm period
+    uint32_t RAPeriod {256};   // Current RA worm period
+    uint32_t DEPeriod {256};   // Current DE worm period
 
     uint32_t lastRAStep {0xFFFFFFFF};
     uint32_t lastDEStep {0xFFFFFFFF};


### PR DESCRIPTION
Testing with valgrind shows that these values were used from EQMod::ReadScopeStatus before initialization.

BTW, the location is saved to config file immediately after each change but it is not auto-loaded on startup. Is this correct behavior?