### PR TITLE
Fix for usbfocusv3 driver

### DIFF
--- a/libindi/drivers/focuser/usbfocusv3.h
+++ b/libindi/drivers/focuser/usbfocusv3.h
@@ -103,6 +103,8 @@ class USBFocusV3 : public INDI::Focuser
     bool sendCommand(const char *cmd, char *response);
     bool sendCommandSpecial(const char *cmd, char *response);
 
+    pthread_mutex_t cmdlock;
+
     void GetFocusParams();
     bool reset();
     bool updateStepMode();


### PR DESCRIPTION
This fix a number of problem with the usbfocusv3 driver: timeout error, truncated data, ... 

One of the problem is because a timer was started part of updateProperties(), this meant that two concurrent timer event where running at the same time.
I also remark the Ascom driver retry the command that return truncated data, maybe to bypass a problem in the firmware.
As I where there I add a mutex for the serial command to avoid other issue of the same kind.

This change include:
- retry failed command as the Ascom driver do.
- lock serial command with a mutex
- ensure we receive the termination string \n\r
- do not run multiple simultaneous timer
- log correctable error as warning.
