### PR TITLE
Fix bulb exposures initiated with shutter release cable on Pentax.

### DIFF
--- a/3rdparty/indi-gphoto/gphoto_driver.cpp
+++ b/3rdparty/indi-gphoto/gphoto_driver.cpp
@@ -624,7 +624,7 @@ static void *stop_bulb(void *arg)
                         gphoto_set_widget_num(gphoto, gphoto->bulb_widget, FALSE);
                     }
                 }
-                else
+                if (gphoto->bulb_port[0] && (gphoto->bulb_fd >= 0))
                 {
                     DEBUGDEVICE(device, INDI::Logger::DBG_DEBUG, "Closing remote serial shutter.");
                     ioctl(gphoto->bulb_fd, TIOCMBIC, &RTS_flag);


### PR DESCRIPTION
I had a problem when bulb exposure was started using shutter release cable. It never finished because on bulb stop it assumed using bulb widget and did not close the open fd... This is fixing it.