### PR TITLE
Correct order of Bayer pattern in DSLR RAW

### DIFF
--- a/3rdparty/indi-gphoto/gphoto_readimage.cpp
+++ b/3rdparty/indi-gphoto/gphoto_readimage.cpp
@@ -344,10 +344,10 @@ int read_libraw(const char *filename, uint8_t **memptr, size_t *memsize, int *n_
     *h            = RawProcessor.imgdata.rawdata.sizes.height;
     *bitsperpixel = 16;
     // cdesc contains counter-clock wise e.g. RGBG CFA pattern while we want it sequential as RGGB
-    bayer_pattern[0] = RawProcessor.imgdata.idata.cdesc[0];
-    bayer_pattern[1] = RawProcessor.imgdata.idata.cdesc[1];
-    bayer_pattern[2] = RawProcessor.imgdata.idata.cdesc[3];
-    bayer_pattern[3] = RawProcessor.imgdata.idata.cdesc[2];
+    bayer_pattern[0] = RawProcessor.imgdata.idata.cdesc[RawProcessor.COLOR(0, 0)];
+    bayer_pattern[1] = RawProcessor.imgdata.idata.cdesc[RawProcessor.COLOR(0, 1)];
+    bayer_pattern[2] = RawProcessor.imgdata.idata.cdesc[RawProcessor.COLOR(1, 0)];
+    bayer_pattern[3] = RawProcessor.imgdata.idata.cdesc[RawProcessor.COLOR(1, 1)];
     bayer_pattern[4] = '\0';
 
     int first_visible_pixel = RawProcessor.imgdata.rawdata.sizes.raw_width * RawProcessor.imgdata.sizes.top_margin +


### PR DESCRIPTION
See LibRAW API: https://www.libraw.org/docs/API-CXX.html#COLOR

For testing I used my (old) Nikon D50 which has bayer pattern:
>dcraw -i -v IMG_0001.NEF

Timestamp: Tue Jan  1 23:02:51 2019
Camera: Nikon D50
ISO speed: 400
Shutter: 1/60.0 sec
Aperture: f/4.5
Focal length: 31.0 mm
Embedded ICC profile: no
Number of raw images: 1
Thumb size:  3008 x 2000
Full size:   3040 x 2014
Image size:  3039 x 2014
Output size: 3039 x 2014
Raw colors: 3
Filter pattern: BG/GR
Daylight multipliers: 2.458272 0.928173 1.258317
Camera multipliers: 570.000000 256.000000 389.000000 256.000000

Taking an image with INDI gphoto driver (incorrect order) resulted in:
...
FRAME   = 'Light   '           / Frame Type
XBAYROFF=                    0 / X offset of Bayer array
YBAYROFF=                    0 / Y offset of Bayer array
BAYERPAT= 'RGGB    '           / Bayer color pattern
SCALE   =        -1.609140E+03 / arcsecs per pixel
DATE-OBS= '2019-01-04T22:02:34.207' / UTC start date of observation
COMMENT Generated by INDI
...

The correct order according to LibRaw resulted in:
...
FRAME   = 'Light   '           / Frame Type
XBAYROFF=                    0 / X offset of Bayer array
YBAYROFF=                    0 / Y offset of Bayer array
BAYERPAT= 'BGGR    '           / Bayer color pattern
SCALE   =        -1.609140E+03 / arcsecs per pixel
DATE-OBS= '2019-01-04T23:07:46.947' / UTC start date of observation
COMMENT Generated by INDI
...

This can also be verified with e.g. PixInsight.