### PR TITLE
Starbook 0.3

### DIFF
--- a/3rdparty/indi-starbook/CMakeLists.txt
+++ b/3rdparty/indi-starbook/CMakeLists.txt
@@ -27,7 +27,7 @@ include(CMakeCommon)
 ############# STARBOOK ###############
 set(indi_starbook_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/indi_starbook.cpp ${CMAKE_CURRENT_SOURCE_DIR}/starbook_types.cpp)
 
-add_executable(indi_starbook_telescope ${indi_starbook_SRCS})
+add_executable(indi_starbook_telescope ${indi_starbook_SRCS} connectioncurl.cpp connectioncurl.h)
 
 target_link_libraries(indi_starbook_telescope ${INDI_LIBRARIES} ${NOVA_LIBRARIES} ${CURL_LIBRARIES})
 
@@ -47,7 +47,7 @@ if (INDI_BUILD_UNITTESTS)
 
     include_directories(${GTEST_INCLUDE_DIRS})
 
-    add_executable(test_starbook test_starbook.cpp ${indi_starbook_SRCS})
+    add_executable(test_starbook test_starbook.cpp ${indi_starbook_SRCS} connectioncurl.cpp connectioncurl.h)
 
 
     #   test shouldn't be so dependent on external libs, but here we are

--- a/3rdparty/indi-starbook/CMakeLists.txt
+++ b/3rdparty/indi-starbook/CMakeLists.txt
@@ -27,7 +27,7 @@ include(CMakeCommon)
 ############# STARBOOK ###############
 set(indi_starbook_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/indi_starbook.cpp ${CMAKE_CURRENT_SOURCE_DIR}/starbook_types.cpp)
 
-add_executable(indi_starbook_telescope ${indi_starbook_SRCS} connectioncurl.cpp connectioncurl.h)
+add_executable(indi_starbook_telescope ${indi_starbook_SRCS} connectioncurl.cpp connectioncurl.h command_interface.cpp command_interface.h)
 
 target_link_libraries(indi_starbook_telescope ${INDI_LIBRARIES} ${NOVA_LIBRARIES} ${CURL_LIBRARIES})
 
@@ -47,7 +47,7 @@ if (INDI_BUILD_UNITTESTS)
 
     include_directories(${GTEST_INCLUDE_DIRS})
 
-    add_executable(test_starbook test_starbook.cpp ${indi_starbook_SRCS} connectioncurl.cpp connectioncurl.h)
+    add_executable(test_starbook test_starbook.cpp ${indi_starbook_SRCS} connectioncurl.cpp connectioncurl.h command_interface.cpp command_interface.h)
 
 
     #   test shouldn't be so dependent on external libs, but here we are

--- a/3rdparty/indi-starbook/command_interface.cpp
+++ b/3rdparty/indi-starbook/command_interface.cpp
@@ -9,9 +9,7 @@
 
 namespace starbook {
 
-    CommandInterface::CommandInterface(Connection::Curl *new_connection) {
-        connection = new_connection;
-    }
+    CommandInterface::CommandInterface(Connection::Curl *new_connection) : connection(new_connection) {}
 
     static std::string read_buffer;
 
@@ -46,8 +44,8 @@ namespace starbook {
         }
 
         // all responses are hidden in HTML comments ...
-        std::__cxx11::regex response_comment_re("<!--(.*)-->", std::regex_constants::ECMAScript);
-        std::__cxx11::smatch comment_match;
+        std::regex response_comment_re("<!--(.*)-->", std::regex_constants::ECMAScript);
+        std::smatch comment_match;
         if (!regex_search(read_buffer, comment_match, response_comment_re)) {
             return "";
         }

--- a/3rdparty/indi-starbook/command_interface.cpp
+++ b/3rdparty/indi-starbook/command_interface.cpp
@@ -1,0 +1,97 @@
+//
+// Created by not7cd on 05/01/19.
+//
+
+#include <regex>
+#include "indi_starbook.h"
+
+namespace starbook {
+
+    CommandInterface::CommandInterface(Connection::Curl *new_connection) {
+        connection = new_connection;
+    }
+
+    static std::string read_buffer;
+
+    static size_t WriteCallback(void *contents, size_t size, size_t nmemb, void *userp) {
+        INDI_UNUSED(userp);
+        size_t real_size = size * nmemb;
+        read_buffer.append((char *) contents, real_size);
+        return real_size;
+    }
+
+    std::__cxx11::string CommandInterface::SendCommand(std::__cxx11::string cmd) {
+        int rc = 0;
+        CURL *handle = connection->getHandle();
+        std::ostringstream cmd_url;
+
+        cmd_url << "http://" << connection->host() << ":" << connection->port() << "/" << cmd;
+        last_cmd_url = cmd_url.str();
+
+        read_buffer.clear();
+        curl_easy_setopt(handle, CURLOPT_USERAGENT, "curl/7.58.0");
+
+        /* send all data to this function  */
+        curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, WriteCallback);
+        curl_easy_setopt(handle, CURLOPT_WRITEDATA, &read_buffer);
+        curl_easy_setopt(handle, CURLOPT_URL, cmd_url.str().c_str());
+
+        rc = curl_easy_perform(handle);
+
+        if (rc != CURLE_OK) {
+            return "";
+        }
+
+        // all responses are hidden in HTML comments ...
+        std::__cxx11::regex response_comment_re("<!--(.*)-->", std::regex_constants::ECMAScript);
+        std::__cxx11::smatch comment_match;
+        if (!regex_search(read_buffer, comment_match, response_comment_re)) {
+            return "";
+        }
+
+        return comment_match[1].str();
+    }
+
+    ResponseCode CommandInterface::SendOkCommand(const std::__cxx11::string &cmd) {
+        std::__cxx11::string response = CommandInterface::SendCommand(cmd);
+        return ParseCommandResponse(response);
+    }
+
+    ResponseCode CommandInterface::ParseCommandResponse(const std::__cxx11::string &response) {
+        if (response == "OK")
+            return OK;
+        else if (response == "ERROR:FORMAT")
+            return ERROR_FORMAT;
+        else if (response == "ERROR:ILLEGAL STATE")
+            return ERROR_ILLEGAL_STATE;
+        else if (response == "ERROR:BELOW HORIZONE") /* it's not a typo */
+            return ERROR_BELOW_HORIZON;
+
+        return ERROR_UNKNOWN;
+    }
+
+    starbook::StarbookState starbook::CommandInterface::ParseState(const std::__cxx11::string &value) {
+        if (value == "SCOPE")
+            return SCOPE;
+        else if (value == "GUIDE")
+            return GUIDE;
+        else if (value == "USER")
+            return USER;
+        else if (value == "INIT")
+            return INIT;
+
+        return UNKNOWN;
+    }
+
+    ResponseCode CommandInterface::GotoRaDec(double ra, double dec) {
+        std::ostringstream cmd;
+        cmd << "GOTORADEC?" << starbook::Equ{ra, dec};
+        return SendOkCommand(cmd.str());
+    }
+
+    ResponseCode CommandInterface::Align(double ra, double dec) {
+        std::ostringstream cmd;
+        cmd << "ALIGN?" << starbook::Equ{ra, dec};
+        return SendOkCommand(cmd.str());
+    }
+}

--- a/3rdparty/indi-starbook/command_interface.cpp
+++ b/3rdparty/indi-starbook/command_interface.cpp
@@ -3,7 +3,8 @@
 //
 
 #include <regex>
-#include "indi_starbook.h"
+#include <inditelescope.h>
+#include "command_interface.h"
 
 
 namespace starbook {
@@ -156,5 +157,30 @@ namespace starbook {
             return OK;
         }
         return ERROR_UNKNOWN;
+    }
+
+    ResponseCode CommandInterface::SetTime(ln_date &utc) {
+        std::ostringstream cmd;
+        cmd << "SETTIME?TIME=" << static_cast<starbook::UTC &>(utc);
+        return SendOkCommand(cmd.str());
+    }
+
+    ResponseCode CommandInterface::Move(INDI_DIR_NS dir, INDI::Telescope::TelescopeMotionCommand command) {
+        std::ostringstream cmd;
+        cmd << "MOVE?NORTH="
+            << (dir == DIRECTION_NORTH && command == INDI::Telescope::TelescopeMotionCommand::MOTION_START ? 1 : 0)
+            << "&SOUTH="
+            << (dir == DIRECTION_SOUTH && command == INDI::Telescope::TelescopeMotionCommand::MOTION_START ? 1 : 0);
+
+        return SendOkCommand(cmd.str());
+    }
+
+    ResponseCode CommandInterface::Move(INDI_DIR_WE dir, INDI::Telescope::TelescopeMotionCommand command) {
+        std::ostringstream cmd;
+        cmd << "MOVE?WEST="
+            << (dir == DIRECTION_WEST && command == INDI::Telescope::TelescopeMotionCommand::MOTION_START ? 1 : 0)
+            << "&EAST="
+            << (dir == DIRECTION_EAST && command == INDI::Telescope::TelescopeMotionCommand::MOTION_START ? 1 : 0);
+        return SendOkCommand(cmd.str());
     }
 }

--- a/3rdparty/indi-starbook/command_interface.cpp
+++ b/3rdparty/indi-starbook/command_interface.cpp
@@ -22,7 +22,7 @@ namespace starbook {
         return real_size;
     }
 
-    std::__cxx11::string CommandInterface::SendCommand(std::__cxx11::string cmd) {
+    std::string CommandInterface::SendCommand(std::string cmd) {
         int rc = 0;
         CURL *handle = connection->getHandle();
         std::ostringstream cmd_url;
@@ -181,6 +181,15 @@ namespace starbook {
             << (dir == DIRECTION_WEST && command == INDI::Telescope::TelescopeMotionCommand::MOTION_START ? 1 : 0)
             << "&EAST="
             << (dir == DIRECTION_EAST && command == INDI::Telescope::TelescopeMotionCommand::MOTION_START ? 1 : 0);
+        return SendOkCommand(cmd.str());
+    }
+
+    ResponseCode CommandInterface::SetSpeed(int speed) {
+        if (speed < 0 || speed > 7)
+            return ERROR_FORMAT;
+
+        std::ostringstream cmd;
+        cmd << "SETSPEED?speed=" << speed;
         return SendOkCommand(cmd.str());
     }
 }

--- a/3rdparty/indi-starbook/command_interface.h
+++ b/3rdparty/indi-starbook/command_interface.h
@@ -1,0 +1,73 @@
+//
+// Created by not7cd on 05/01/19.
+//
+
+#pragma once
+
+#include <inditelescope.h>
+#include "starbook_types.h"
+#include "connectioncurl.h"
+
+namespace starbook {
+
+    class CommandInterface {
+    public:
+
+        explicit CommandInterface(Connection::Curl *connection);
+
+        std::string last_cmd_url;
+
+        std::string SendCommand(std::string command);
+
+        ResponseCode SendOkCommand(const std::string &cmd);
+
+        ResponseCode ParseCommandResponse(const std::string &response);
+
+        StarbookState ParseState(const std::string &value);
+
+        ResponseCode Start() {
+            return SendOkCommand("START");
+        }
+
+        ResponseCode Reset() {
+            return SendOkCommand("RESET");
+        }
+
+        ResponseCode GotoRaDec(double ra, double dec);
+
+        ResponseCode Align(double ra, double dec);
+
+        ResponseCode Move();
+
+        ResponseCode Home() {
+            return SendOkCommand("HOME");
+        }
+
+        ResponseCode Stop() {
+            return SendOkCommand("STOP");
+        }
+
+        ResponseCode GetStatus();
+
+        ResponseCode GetPlace();
+
+        ResponseCode GetTime();
+
+        ResponseCode GetRound();
+
+        ResponseCode GetXY();
+
+        ResponseCode Version();
+
+        ResponseCode SetSpeed();
+
+        ResponseCode SetPlace();
+
+        ResponseCode SetTime();
+
+    private:
+        Connection::Curl *connection = nullptr;
+
+    };
+
+}

--- a/3rdparty/indi-starbook/command_interface.h
+++ b/3rdparty/indi-starbook/command_interface.h
@@ -11,6 +11,12 @@
 namespace starbook {
 
     typedef struct {
+        ln_equ_posn equ;
+        StarbookState state;
+        bool executing_goto;
+    } StatusResponse;
+
+    typedef struct {
         std::string full_str;
         float major_minor;
     } VersionResponse;
@@ -23,14 +29,6 @@ namespace starbook {
         std::string last_cmd_url;
 
         std::string last_response;
-
-        std::string SendCommand(std::string command);
-
-        ResponseCode SendOkCommand(const std::string &cmd);
-
-        ResponseCode ParseCommandResponse(const std::string &response);
-
-        StarbookState ParseState(const std::string &value);
 
         ResponseCode Start() {
             return SendOkCommand("START");
@@ -54,7 +52,7 @@ namespace starbook {
             return SendOkCommand("STOP");
         }
 
-        ResponseCode GetStatus();
+        ResponseCode GetStatus(StatusResponse &res);
 
         ResponseCode GetPlace();
 
@@ -73,6 +71,15 @@ namespace starbook {
         ResponseCode SetTime();
 
     private:
+
+        std::string SendCommand(std::string command);
+
+        ResponseCode SendOkCommand(const std::string &cmd);
+
+        ResponseCode ParseCommandResponse(const std::string &response);
+
+        StarbookState ParseState(const std::string &value);
+
         Connection::Curl *connection = nullptr;
 
     };

--- a/3rdparty/indi-starbook/command_interface.h
+++ b/3rdparty/indi-starbook/command_interface.h
@@ -42,7 +42,9 @@ namespace starbook {
 
         ResponseCode Align(double ra, double dec);
 
-        ResponseCode Move();
+        ResponseCode Move(INDI_DIR_NS dir, INDI::Telescope::TelescopeMotionCommand command);
+
+        ResponseCode Move(INDI_DIR_WE dir, INDI::Telescope::TelescopeMotionCommand command);
 
         ResponseCode Home() {
             return SendOkCommand("HOME");
@@ -68,7 +70,7 @@ namespace starbook {
 
         ResponseCode SetPlace();
 
-        ResponseCode SetTime();
+        ResponseCode SetTime(ln_date &utc);
 
     private:
 

--- a/3rdparty/indi-starbook/command_interface.h
+++ b/3rdparty/indi-starbook/command_interface.h
@@ -66,7 +66,7 @@ namespace starbook {
 
         ResponseCode Version(VersionResponse &res);
 
-        ResponseCode SetSpeed();
+        ResponseCode SetSpeed(int speed);
 
         ResponseCode SetPlace();
 

--- a/3rdparty/indi-starbook/command_interface.h
+++ b/3rdparty/indi-starbook/command_interface.h
@@ -10,12 +10,19 @@
 
 namespace starbook {
 
+    typedef struct {
+        std::string full_str;
+        float major_minor;
+    } VersionResponse;
+
     class CommandInterface {
     public:
 
         explicit CommandInterface(Connection::Curl *connection);
 
         std::string last_cmd_url;
+
+        std::string last_response;
 
         std::string SendCommand(std::string command);
 
@@ -57,7 +64,7 @@ namespace starbook {
 
         ResponseCode GetXY();
 
-        ResponseCode Version();
+        ResponseCode Version(VersionResponse &res);
 
         ResponseCode SetSpeed();
 

--- a/3rdparty/indi-starbook/command_interface.h
+++ b/3rdparty/indi-starbook/command_interface.h
@@ -72,6 +72,10 @@ namespace starbook {
 
         ResponseCode SetTime(ln_date &utc);
 
+        ResponseCode SaveSetting() {
+            return SendOkCommand("SAVESETTING");
+        }
+
     private:
 
         std::string SendCommand(std::string command);

--- a/3rdparty/indi-starbook/connectioncurl.cpp
+++ b/3rdparty/indi-starbook/connectioncurl.cpp
@@ -1,0 +1,99 @@
+//
+// Created by not7cd on 04/01/19.
+//
+
+#include "connectioncurl.h"
+
+#include <cstring>
+
+namespace Connection {
+    Curl::Curl(INDI::DefaultDevice *dev) : Interface(dev, CONNECTION_CUSTOM) {
+        curl_global_init(CURL_GLOBAL_ALL);
+
+        IUFillText(&AddressT[0], "ADDRESS", "Address", "");
+        IUFillText(&AddressT[1], "PORT", "Port", "");
+        IUFillTextVector(&AddressTP, AddressT, 2, getDeviceName(), "DEVICE_ADDRESS", "Server", CONNECTION_TAB,
+                         IP_RW, 60, IPS_IDLE);
+    }
+
+    Curl::~Curl() {
+        curl_global_cleanup();
+    }
+
+    bool Curl::Connect() {
+        if (AddressT[0].text == nullptr || AddressT[0].text[0] == '\0' || AddressT[1].text == nullptr ||
+            AddressT[1].text[0] == '\0') {
+            LOG_ERROR("Error! Server address is missing or invalid.");
+            return false;
+        }
+
+        const char *hostname = AddressT[0].text;
+        const char *port = AddressT[1].text;
+
+        LOGF_INFO("Creating HTTP handle for %s@%s", hostname, port);
+        if (handle != nullptr) {
+            LOG_WARN("Found old handle, recreating");
+            curl_easy_cleanup(handle);
+        }
+        handle = curl_easy_init();
+        if (handle == nullptr) {
+            LOG_ERROR("Can't create HTTP handle");
+            return false;
+        }
+
+        LOG_DEBUG("Handle creation successful, attempting handshake...");
+        bool rc = Handshake();
+
+        if (rc) {
+            LOGF_INFO("%s is online.", getDeviceName());
+//            m_Device->saveConfig(true, "DEVICE_ADDRESS");
+        } else
+            LOG_DEBUG("Handshake failed.");
+
+        return rc;
+    }
+
+    bool Curl::Disconnect() {
+        curl_easy_cleanup(handle);
+        return true;
+    }
+
+    void Curl::Activated() {
+        m_Device->defineText(&AddressTP);
+//        m_Device->loadConfig(true, "DEVICE_ADDRESS");
+    }
+
+    void Curl::Deactivated() {
+        m_Device->deleteProperty(AddressTP.name);
+    }
+
+    bool Curl::saveConfigItems(FILE *fp) {
+        IUSaveConfigText(fp, &AddressTP);
+        return true;
+    }
+
+    void Curl::setDefaultHost(const char *addressHost) {
+        IUSaveText(&AddressT[0], addressHost);
+    }
+
+    void Curl::setDefaultPort(uint32_t addressPort) {
+        char portStr[8];
+        snprintf(portStr, 8, "%d", addressPort);
+        IUSaveText(&AddressT[1], portStr);
+    }
+
+    bool Curl::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) {
+        if (!strcmp(dev, m_Device->getDeviceName())) {
+            if (!strcmp(name, AddressTP.name)) {
+                IUUpdateText(&AddressTP, texts, names, n);
+                AddressTP.s = IPS_OK;
+                IDSetText(&AddressTP, nullptr);
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+

--- a/3rdparty/indi-starbook/connectioncurl.cpp
+++ b/3rdparty/indi-starbook/connectioncurl.cpp
@@ -41,6 +41,8 @@ namespace Connection {
             return false;
         }
 
+        SetupHandle();
+
         LOG_DEBUG("Handle creation successful, attempting handshake...");
         bool rc = Handshake();
 
@@ -51,6 +53,13 @@ namespace Connection {
             LOG_DEBUG("Handshake failed.");
 
         return rc;
+    }
+
+    void Curl::SetupHandle() const {
+        curl_easy_setopt(handle, CURLOPT_TIMEOUT, HANDLE_TIMEOUT);
+        curl_easy_setopt(handle, CURLOPT_NOPROGRESS, 1L);
+        // if debug
+        curl_easy_setopt(handle, CURLOPT_VERBOSE, 1);
     }
 
     bool Curl::Disconnect() {

--- a/3rdparty/indi-starbook/connectioncurl.h
+++ b/3rdparty/indi-starbook/connectioncurl.h
@@ -48,7 +48,11 @@ namespace Connection {
         ITextVectorProperty AddressTP;
         IText AddressT[2]{};
 
+        const ulong HANDLE_TIMEOUT = 2;
+
         CURL *handle = nullptr;
+
+        void SetupHandle() const;
     };
 
 }

--- a/3rdparty/indi-starbook/connectioncurl.h
+++ b/3rdparty/indi-starbook/connectioncurl.h
@@ -1,0 +1,54 @@
+//
+// Created by not7cd on 04/01/19.
+//
+
+#pragma once
+
+#include <connectionplugins/connectioninterface.h>
+#include <string>
+#include <cstdlib>
+#include <curl/curl.h>
+#include <inditelescope.h>
+
+
+namespace Connection {
+    class Curl : public Interface {
+    public:
+        explicit Curl(INDI::DefaultDevice *dev);
+
+        ~Curl() override;
+
+        bool Connect() override;
+
+        bool Disconnect() override;
+
+        void Activated() override;
+
+        void Deactivated() override;
+
+        std::string name() override { return "CONNECTION_OTHER"; }
+
+        std::string label() override { return "HTTP"; }
+
+        const char *host() const { return AddressT[0].text; }
+
+        uint32_t port() const { return static_cast<uint32_t>(atoi(AddressT[1].text)); }
+
+        bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+
+        bool saveConfigItems(FILE *fp) override;
+
+        void setDefaultHost(const char *addressHost);
+
+        void setDefaultPort(uint32_t addressPort);
+
+        CURL *getHandle() const { return handle; }
+
+    protected:
+        ITextVectorProperty AddressTP;
+        IText AddressT[2]{};
+
+        CURL *handle = nullptr;
+    };
+
+}

--- a/3rdparty/indi-starbook/indi_starbook.cpp
+++ b/3rdparty/indi-starbook/indi_starbook.cpp
@@ -227,7 +227,7 @@ bool Starbook::updateTime(ln_date *utc, double utc_offset) {
 }
 
 bool Starbook::getFirmwareVersion() {
-    starbook::VersionResponse res = {};
+    starbook::VersionResponse res;
     starbook::ResponseCode rc = cmd_interface->Version(res);
 
     if (rc != starbook::OK) {

--- a/3rdparty/indi-starbook/indi_starbook.cpp
+++ b/3rdparty/indi-starbook/indi_starbook.cpp
@@ -161,34 +161,30 @@ bool Starbook::ReadScopeStatus()
 
 bool Starbook::Goto(double ra, double dec)
 {
-    starbook::ResponseCode rc;
     std::ostringstream params;
     ra = ra * 15; // CONVERSION
     params << "?" << starbook::Equ{ ra, dec };
 
 
-    rc = cmd_interface->GotoRaDec(ra, dec);
+    starbook::ResponseCode rc = cmd_interface->GotoRaDec(ra, dec);
     LogResponse("Goto", rc);
     return rc == starbook::OK;
 }
 
 bool Starbook::Sync(double ra, double dec)
 {
-    starbook::ResponseCode rc;
     std::ostringstream params;
     ra = ra * 15; // CONVERSION
     params << "?" << starbook::Equ{ ra, dec };
 
-
-    rc = cmd_interface->Align(ra, dec);
+    starbook::ResponseCode rc = cmd_interface->Align(ra, dec);
     LogResponse("Sync", rc);
     return rc == starbook::OK;
 }
 
 bool Starbook::Abort()
 {
-    starbook::ResponseCode rc;
-    rc = cmd_interface->Stop();
+    starbook::ResponseCode rc = cmd_interface->Stop();
     LogResponse("Abort", rc);
     return rc == starbook::OK;
 }
@@ -197,8 +193,7 @@ bool Starbook::Park()
 {
     // TODO Park
     LOG_WARN("HOME command is unstable");
-    starbook::ResponseCode rc;
-    rc = cmd_interface->Home();
+    starbook::ResponseCode rc = cmd_interface->Home();
     LogResponse("Park", rc);
     return rc == starbook::OK;
 }
@@ -211,41 +206,28 @@ bool Starbook::UnPark()
 }
 
 bool Starbook::MoveNS(INDI_DIR_NS dir, INDI::Telescope::TelescopeMotionCommand command) {
-    std::ostringstream params;
-    params << "?NORTH="
-           << ((dir == DIRECTION_NORTH && command == MOTION_START) ? 1 : 0)
-           << "&SOUTH="
-           << ((dir == DIRECTION_SOUTH && command == MOTION_START) ? 1 : 0);
-
-    LOGF_INFO("Move! %s", params.str().c_str());
-    return cmd_interface->SendOkCommand("MOVE" + params.str());
+    starbook::ResponseCode rc = cmd_interface->Move(dir, command);
+    LogResponse("MoveNS", rc);
+    return rc == starbook::OK;
 }
 
 bool Starbook::MoveWE(INDI_DIR_WE dir, INDI::Telescope::TelescopeMotionCommand command) {
-    std::ostringstream params;
-    params << "?WEST="
-           << ((dir == DIRECTION_WEST && command == MOTION_START) ? 1 : 0)
-           << "&EAST="
-           << ((dir == DIRECTION_EAST && command == MOTION_START) ? 1 : 0);
-
-    LOGF_INFO("Move! %s", params.str().c_str());
-    return cmd_interface->SendOkCommand("MOVE" + params.str());
+    starbook::ResponseCode rc = cmd_interface->Move(dir, command);
+    LogResponse("MoveWE", rc);
+    return rc == starbook::OK;
 }
 
 bool Starbook::updateTime(ln_date *utc, double utc_offset) {
     INDI_UNUSED(utc_offset);
 
-    std::ostringstream params;
-    params << "?TIME=" << *static_cast<starbook::UTC *>(utc);
-
-    LOGF_INFO("Time! %s", params.str().c_str());
-
-    return cmd_interface->SendOkCommand("SETTIME" + params.str());
+    starbook::ResponseCode rc = cmd_interface->SetTime(*utc);
+    LogResponse("updateTime", rc);
+    return rc == starbook::OK;
 
 }
 
 bool Starbook::getFirmwareVersion() {
-    starbook::VersionResponse res;
+    starbook::VersionResponse res = {};
     starbook::ResponseCode rc = cmd_interface->Version(res);
 
     if (rc != starbook::OK) {

--- a/3rdparty/indi-starbook/indi_starbook.h
+++ b/3rdparty/indi-starbook/indi_starbook.h
@@ -24,6 +24,7 @@
 #include <inditelescope.h>
 #include <curl/curl.h>
 #include "starbook_types.h"
+#include "connectioncurl.h"
 
 class Starbook : public INDI::Telescope
 {
@@ -50,7 +51,7 @@ private:
 
     starbook::StarbookState ParseState(const std::string &value);
 
-    CURL *handle;
+    Connection::Curl *curlConnection = nullptr;
 
 protected:
     IText VersionT[1]{};

--- a/3rdparty/indi-starbook/indi_starbook.h
+++ b/3rdparty/indi-starbook/indi_starbook.h
@@ -23,8 +23,10 @@
 
 #include <inditelescope.h>
 #include <curl/curl.h>
+#include <memory>
 #include "starbook_types.h"
 #include "connectioncurl.h"
+#include "command_interface.h"
 
 class Starbook : public INDI::Telescope
 {
@@ -40,18 +42,13 @@ public:
     bool ReadScopeStatus() override;
 
 private:
-
-    std::string SendCommand(std::string command);
-
-    bool SendOkCommand(const std::string &cmd);
-
-    starbook::ResponseCode ParseCommandResponse(const std::string &response);
+    std::unique_ptr<starbook::CommandInterface> cmd_interface;
 
     starbook::StarbookState state;
 
-    starbook::StarbookState ParseState(const std::string &value);
-
     Connection::Curl *curlConnection = nullptr;
+
+    void LogResponse(const std::string &cmd, const starbook::ResponseCode &rc);
 
 protected:
     IText VersionT[1]{};

--- a/3rdparty/indi-starbook/starbook_types.h
+++ b/3rdparty/indi-starbook/starbook_types.h
@@ -67,6 +67,7 @@ namespace starbook {
         UNKNOWN,
     };
 
+    /// @brief possible response codes returned by starbook
     enum ResponseCode {
         OK,
         ERROR_ILLEGAL_STATE, /* Starbook has wrong internal state to accept command */

--- a/3rdparty/indi-starbook/starbook_types.h
+++ b/3rdparty/indi-starbook/starbook_types.h
@@ -63,6 +63,7 @@ namespace starbook {
         INIT, /* Initial state after boot */
         GUIDE, /* ??? */
         SCOPE, /* After START command or user input */
+        USER,
         UNKNOWN,
     };
 


### PR DESCRIPTION
Main change in this patch is custom connection plugin and command interface.
I'm taking away much of unneeded connection handling from logic inside `Starbook` class.
Code is more bloated but hopefully more testable and safe. This is also preparation for more intelligent state handling. With knowledge of current Starbook state, we can prevent some errors and inform user. This should streamline initial connection where any wrong command can put Starbook into a _bad state_.

I need assistance with `Connection::Curl`, I can't get `saveConfig()` and `loadConfig()` working.