### PR TITLE
Labels renamed to be consistent with the Android App.

### DIFF
--- a/libindi/drivers/telescope/lx200_OnStep.cpp
+++ b/libindi/drivers/telescope/lx200_OnStep.cpp
@@ -682,14 +682,14 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
             {
                 if(!sendOnStepCommandBlind(":hC#"))
                     return false;
-                IDSetSwitch(&SetHomeSP, "Cold Start");
+                IDSetSwitch(&SetHomeSP, "Return Home");
                 SetHomeS[0].s = ISS_OFF;
             }
             else
             {
                 if(!sendOnStepCommandBlind(":hF#"))
                     return false;
-                IDSetSwitch(&SetHomeSP, "Home Init");
+                IDSetSwitch(&SetHomeSP, "At Home (Reset)");
                 SetHomeS[1].s = ISS_OFF;
             }
             IUResetSwitch(&ReticSP);


### PR DESCRIPTION
This change is to make the user interface terminology within INDI, the same as what is on the Android App for OnStep.