### PR TITLE
Advertise client that the driver implement the FocuserInterface

### DIFF
--- a/libindi/drivers/telescope/lx200_OnStep.cpp
+++ b/libindi/drivers/telescope/lx200_OnStep.cpp
@@ -274,6 +274,8 @@ bool LX200_OnStep::initProperties()
     IUFillText(&OnstepStat[7], "Error", "", "");
     IUFillTextVector(&OnstepStatTP, OnstepStat, 8, getDeviceName(), "OnStep Status", "", STATUS_TAB, IP_RO, 0, IPS_OK);
 
+    setDriverInterface(getDriverInterface() | FOCUSER_INTERFACE);
+
     return true;
 }
 


### PR DESCRIPTION
The driver LX200_OnStep now implement the FocuserInterface. 
FOCUSER_INTERFACE must be added to DRIVER_INTERFACE so the client know it can use this driver as a focuser.

See:
https://www.ap-i.net/mantis/view.php?id=2051
