### PR TITLE
Clean up V4L pixel size detection

### DIFF
--- a/libindi/drivers/video/v4l2driver.cpp
+++ b/libindi/drivers/video/v4l2driver.cpp
@@ -28,6 +28,21 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 #include "indistandardproperty.h"
 #include "lx/Lx.h"
 
+// Pixel size info for different cameras
+typedef struct
+{
+    const char *deviceName; // device name reported by V4L
+    const char *commonName; // if null, use device name
+    float pixelSizeX;
+    float pixelSizeY; // if negative, use pixelSizeX also for Y
+} PixelSizeInfo;
+
+static const PixelSizeInfo pixelSizeInfo[] = {
+    { "NexImage 5", nullptr, 2.2f, -1 },
+    { "UVC Camera (046d:0809)", "Logitech Webcam Pro 9000", 3.3f, -1 },
+    { nullptr, nullptr, 5.6f, -1 } // sentinel and default pixel size, needs to be last
+};
+
 V4L2_Driver::V4L2_Driver()
 {
     //sigevent sevp;
@@ -236,17 +251,38 @@ bool V4L2_Driver::updateProperties()
         defineText(&CaptureColorSpaceTP);
 #endif
 
-	if (!strcmp(v4l_base->getDeviceName(), "NexImage 5")) {
-		SetCCDParams(V4LFrame->width, V4LFrame->height, V4LFrame->bpp, 2.2, 2.2);
-		LOG_INFO("Setting pixel size correctly for NexImage 5");
-	} else if (!strcmp(v4l_base->getDeviceName(), "UVC Camera (046d:0809)")) {
-		SetCCDParams(V4LFrame->width, V4LFrame->height, V4LFrame->bpp, 3.3, 3.3);
-		LOG_INFO("Setting pixel size correctly for Logitech Webcam Pro 9000"); 
-	} else {
-		SetCCDParams(V4LFrame->width, V4LFrame->height, V4LFrame->bpp, 5.6, 5.6);
-		LOG_INFO("Setting pixel size to default of 5.6");
-		LOGF_INFO("For future autodetection of pixel size, please report the following: Reported Name: '%s', Common Name (Eg: NexImage 10), Pixel Size to the following thread: https://www.indilib.org/forum/ccds-dslrs/4392-indi-pixel-size-detection.html#33485 ", v4l_base->getDeviceName());
-	}
+        // Check if we have pixel size info
+        const PixelSizeInfo *info = pixelSizeInfo;
+        while (info->deviceName)
+        {
+            if (!strcmp(v4l_base->getDeviceName(), info->deviceName))
+                break;
+            ++info;
+        }
+
+        const char *commonName = info->commonName;
+        float pixX             = info->pixelSizeX;
+        float pixY             = info->pixelSizeY;
+
+        if (!commonName)
+            commonName = info->deviceName;
+        if (pixY < 0)
+            pixY = pixX;
+
+        if (info->deviceName)
+        {
+            LOGF_INFO("Setting pixel size correctly for %s", commonName);
+        }
+        else
+        {
+            LOGF_INFO("Setting pixel size to default of %5.2f", pixX);
+            LOGF_INFO("For future autodetection of pixel size, please report the following: Reported Name: '%s', "
+                      "Common Name (Eg: NexImage 10), Pixel Size to the following thread: "
+                      "https://www.indilib.org/forum/ccds-dslrs/4392-indi-pixel-size-detection.html#33485 ",
+                      v4l_base->getDeviceName());
+        }
+        SetCCDParams(V4LFrame->width, V4LFrame->height, V4LFrame->bpp, pixX, pixY);
+
         PrimaryCCD.setImageExtension("fits");
 
         //v4l_base->setRecorder(Streamer->getRecorder());


### PR DESCRIPTION
This changes the pixel size detection to use a data table instead of nested ifs so it's a bit easier and less error prone to add new entries.