### PR TITLE
Avalon StarGO: focuser bugfix

### DIFF
--- a/3rdparty/indi-avalon/CMakeLists.txt
+++ b/3rdparty/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 0)
+set(AVALON_VERSION_MINOR 1)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/3rdparty/indi-avalon/lx200stargo.cpp
+++ b/3rdparty/indi-avalon/lx200stargo.cpp
@@ -456,7 +456,16 @@ bool LX200StarGo::ReadScopeStatus()
     TrackState = newTrackState;
     NewRaDec(currentRA, currentDEC);
 
-    return syncSideOfPier();
+    if (! syncSideOfPier())
+    {
+       LOG_ERROR("Cannot determine scope status, failed to determine pier side.");
+       return false;
+    }
+
+    if (focuser.get() != nullptr)
+        return focuser.get()->ReadFocuserStatus();
+    else
+        return true;
 }
 
 /**************************************************************************************

--- a/3rdparty/indi-avalon/lx200stargo.cpp
+++ b/3rdparty/indi-avalon/lx200stargo.cpp
@@ -462,7 +462,7 @@ bool LX200StarGo::ReadScopeStatus()
        return false;
     }
 
-    if (focuser.get() != nullptr)
+    if (focuser.get() != nullptr && TrackState != SCOPE_SLEWING)
         return focuser.get()->ReadFocuserStatus();
     else
         return true;

--- a/3rdparty/indi-avalon/lx200stargofocuser.cpp
+++ b/3rdparty/indi-avalon/lx200stargofocuser.cpp
@@ -305,12 +305,14 @@ int LX200StarGoFocuser::getAbsoluteFocuserPositionFromRelative(int relativePosit
 }
 
 
-void LX200StarGoFocuser::ReadFocuserStatus() {
+bool LX200StarGoFocuser::ReadFocuserStatus() {
     int absolutePosition = 0;
     if (sendQueryFocuserPosition(&absolutePosition)) {
         FocusAbsPosN[0].value = absolutePosition;
         IDSetNumber(&FocusAbsPosNP, nullptr);
     }
+    else
+        return false;
 
     if (isFocuserMoving() && atFocuserTargetPosition()) {
         FocusAbsPosNP.s = IPS_OK;
@@ -318,6 +320,8 @@ void LX200StarGoFocuser::ReadFocuserStatus() {
         FocusRelPosNP.s = IPS_OK;
         IDSetNumber(&FocusRelPosNP, nullptr);
     }
+
+    return true;
 }
 
 bool LX200StarGoFocuser::SetFocuserSpeed(int speed) {

--- a/3rdparty/indi-avalon/lx200stargofocuser.cpp
+++ b/3rdparty/indi-avalon/lx200stargofocuser.cpp
@@ -305,7 +305,7 @@ int LX200StarGoFocuser::getAbsoluteFocuserPositionFromRelative(int relativePosit
 }
 
 
-void LX200StarGoFocuser::focuserStatus() {
+void LX200StarGoFocuser::ReadFocuserStatus() {
     int absolutePosition = 0;
     if (sendQueryFocuserPosition(&absolutePosition)) {
         FocusAbsPosN[0].value = absolutePosition;

--- a/3rdparty/indi-avalon/lx200stargofocuser.h
+++ b/3rdparty/indi-avalon/lx200stargofocuser.h
@@ -36,6 +36,7 @@ public:
 
     void initProperties(const char *groupName);
     bool updateProperties();
+    bool ReadFocuserStatus();
 
     bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
     bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
@@ -48,7 +49,6 @@ public:
 protected:
 
     // Avalon specifics
-    void ReadFocuserStatus();
     bool changeFocusSpeed(double values[], char* names[], int n);
     bool changeFocusMotion(ISState* states, char* names[], int n);
     bool changeFocusTimer(double values[], char* names[], int n);

--- a/3rdparty/indi-avalon/lx200stargofocuser.h
+++ b/3rdparty/indi-avalon/lx200stargofocuser.h
@@ -48,7 +48,7 @@ public:
 protected:
 
     // Avalon specifics
-    void focuserStatus();
+    void ReadFocuserStatus();
     bool changeFocusSpeed(double values[], char* names[], int n);
     bool changeFocusMotion(ISState* states, char* names[], int n);
     bool changeFocusTimer(double values[], char* names[], int n);


### PR DESCRIPTION
Focuser status is updated regularly with the scope status. This fixes the problem that the focuser position was not shown after a move, preventing all relative focuser moves.

Now both absolute and relative focuser movement is working.