### PR TITLE
Fixed bug for pulse guide > 999ms

### DIFF
--- a/libindi/drivers/telescope/lx200ap_experimental.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimental.cpp
@@ -885,12 +885,16 @@ IPState LX200AstroPhysicsExperimental::GuideNorth(uint32_t ms)
         GuideNSTID = 0;
     }
 
-    if (usePulseCommand && ms < MAX_LX200AP_PULSE_LEN)
+    if (usePulseCommand && ms <= MAX_LX200AP_PULSE_LEN)
     {
+        LOGF_DEBUG("GuideNorth using SendPulseCmd() for duration %d", ms);
         SendPulseCmd(LX200_NORTH, ms);
+        GuideNSTID      = IEAddTimer(static_cast<int>(ms), pulseGuideTimeoutHelperNS, this);
     }
     else
     {
+        LOGF_DEBUG("GuideNorth using simulated pulse for duration %d", ms);
+
         if (rememberSlewRate == -1)
             rememberSlewRate = IUFindOnSwitchIndex(&SlewRateSP);
         updateSlewRate(SLEW_GUIDE);
@@ -901,10 +905,9 @@ IPState LX200AstroPhysicsExperimental::GuideNorth(uint32_t ms)
         ISState states[] = { ISS_ON, ISS_OFF };
         const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
         ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        GuideNSTID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperNS, this);
     }
 
-    guide_direction_ns = LX200_NORTH;
-    GuideNSTID      = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperNS, this);
     return IPS_BUSY;
 }
 
@@ -923,12 +926,15 @@ IPState LX200AstroPhysicsExperimental::GuideSouth(uint32_t ms)
         GuideNSTID = 0;
     }
 
-    if (usePulseCommand && ms < MAX_LX200AP_PULSE_LEN)
+    if (usePulseCommand && ms <= MAX_LX200AP_PULSE_LEN)
     {
         SendPulseCmd(LX200_SOUTH, ms);
+        GuideNSTID      = IEAddTimer(static_cast<int>(ms), pulseGuideTimeoutHelperNS, this);
     }
     else
     {
+        LOGF_DEBUG("GuideSouth using simulated pulse for duration %d", ms);
+
         if (rememberSlewRate == -1)
             rememberSlewRate = IUFindOnSwitchIndex(&SlewRateSP);
 
@@ -940,10 +946,9 @@ IPState LX200AstroPhysicsExperimental::GuideSouth(uint32_t ms)
         ISState states[] = { ISS_OFF, ISS_ON };
         const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
         ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        GuideNSTID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperNS, this);
     }
 
-    guide_direction_ns = LX200_SOUTH;
-    GuideNSTID      = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperNS, this);
     return IPS_BUSY;
 }
 
@@ -962,12 +967,15 @@ IPState LX200AstroPhysicsExperimental::GuideEast(uint32_t ms)
         GuideWETID = 0;
     }
 
-    if (usePulseCommand && ms < MAX_LX200AP_PULSE_LEN)
+    if (usePulseCommand && ms <= MAX_LX200AP_PULSE_LEN)
     {
         SendPulseCmd(LX200_EAST, ms);
+        GuideWETID      = IEAddTimer(static_cast<int>(ms), pulseGuideTimeoutHelperWE, this);
     }
     else
     {
+        LOGF_DEBUG("GuideEast using simulated pulse for duration %d", ms);
+
         if (rememberSlewRate == -1)
             rememberSlewRate = IUFindOnSwitchIndex(&SlewRateSP);
 
@@ -979,10 +987,9 @@ IPState LX200AstroPhysicsExperimental::GuideEast(uint32_t ms)
         ISState states[] = { ISS_OFF, ISS_ON };
         const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
         ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        GuideWETID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperWE, this);
     }
 
-    guide_direction_we = LX200_EAST;
-    GuideWETID      = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperWE, this);
     return IPS_BUSY;
 }
 
@@ -1001,12 +1008,15 @@ IPState LX200AstroPhysicsExperimental::GuideWest(uint32_t ms)
         GuideWETID = 0;
     }
 
-    if (usePulseCommand && ms < MAX_LX200AP_PULSE_LEN)
+    if (usePulseCommand && ms <= MAX_LX200AP_PULSE_LEN)
     {
         SendPulseCmd(LX200_WEST, ms);
+        GuideWETID      = IEAddTimer(static_cast<int>(ms), pulseGuideTimeoutHelperWE, this);
     }
     else
     {
+        LOGF_DEBUG("GuideWest using simulated pulse for duration %d", ms);
+
         if (rememberSlewRate == -1)
             rememberSlewRate = IUFindOnSwitchIndex(&SlewRateSP);
 
@@ -1018,11 +1028,66 @@ IPState LX200AstroPhysicsExperimental::GuideWest(uint32_t ms)
         ISState states[] = { ISS_ON, ISS_OFF };
         const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
         ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        GuideWETID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperWE, this);
     }
 
-    guide_direction_we = LX200_WEST;
-    GuideWETID      = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperWE, this);
     return IPS_BUSY;
+}
+
+void LX200AstroPhysicsExperimental::pulseGuideTimeoutHelperNS(void * p)
+{
+    static_cast<LX200AstroPhysicsExperimental *>(p)->AstroPhysicsGuideTimeoutNS(false);
+}
+
+void LX200AstroPhysicsExperimental::pulseGuideTimeoutHelperWE(void * p)
+{
+    static_cast<LX200AstroPhysicsExperimental *>(p)->AstroPhysicsGuideTimeoutWE(false);
+}
+
+void LX200AstroPhysicsExperimental::simulGuideTimeoutHelperNS(void * p)
+{
+    static_cast<LX200AstroPhysicsExperimental *>(p)->AstroPhysicsGuideTimeoutNS(true);
+}
+
+void LX200AstroPhysicsExperimental::simulGuideTimeoutHelperWE(void * p)
+{
+    static_cast<LX200AstroPhysicsExperimental *>(p)->AstroPhysicsGuideTimeoutWE(true);
+}
+
+void LX200AstroPhysicsExperimental::AstroPhysicsGuideTimeoutWE(bool simul)
+{
+    LOGF_DEBUG("AstroPhysicsGuideTimeoutWE() pulse guide simul = %d", simul);
+
+    if (simul == true)
+    {
+        ISState states[] = { ISS_OFF, ISS_OFF };
+        const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
+        ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+    }
+
+    GuideWENP.np[DIRECTION_WEST].value = 0;
+    GuideWENP.np[DIRECTION_EAST].value = 0;
+    GuideWENP.s           = IPS_IDLE;
+    GuideWETID            = 0;
+    IDSetNumber(&GuideWENP, nullptr);
+}
+
+void LX200AstroPhysicsExperimental::AstroPhysicsGuideTimeoutNS(bool simul)
+{
+    LOGF_DEBUG("AstroPhysicsGuideTimeoutNS() pulse guide simul = %d", simul);
+
+    if (simul == true)
+    {
+        ISState states[] = { ISS_OFF, ISS_OFF };
+        const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
+        ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+    }
+
+    GuideNSNP.np[0].value = 0;
+    GuideNSNP.np[1].value = 0;
+    GuideNSNP.s           = IPS_IDLE;
+    GuideNSTID            = 0;
+    IDSetNumber(&GuideNSNP, nullptr);
 }
 
 int LX200AstroPhysicsExperimental::SendPulseCmd(int8_t direction, uint32_t duration_msec)
@@ -1513,6 +1578,8 @@ bool LX200AstroPhysicsExperimental::SetTrackMode(uint8_t mode)
 {
     int err=0;
 
+    LOGF_DEBUG("LX200AstroPhysicsExperimental::SetTrackMode(%d)", mode);
+
     if (mode == TRACK_CUSTOM)
     {
         if (!isSimulation() && (err = selectAPTrackingMode(PortFD, AP_TRACKING_SIDEREAL)) < 0)
@@ -1535,7 +1602,15 @@ bool LX200AstroPhysicsExperimental::SetTrackMode(uint8_t mode)
 
 bool LX200AstroPhysicsExperimental::SetTrackEnabled(bool enabled)
 {
-   return SetTrackMode(enabled ? IUFindOnSwitchIndex(&TrackModeSP) : AP_TRACKING_OFF);
+   bool rc;
+
+   LOGF_DEBUG("LX200AstroPhysicsExperimental::SetTrackEnabled(%d)", enabled);
+
+   rc = SetTrackMode(enabled ? IUFindOnSwitchIndex(&TrackModeSP) : AP_TRACKING_OFF);
+
+   LOGF_DEBUG("LX200AstroPhysicsExperimental::SetTrackMode() returned %d", rc);
+
+   return rc;
 }
 
 bool LX200AstroPhysicsExperimental::SetTrackRate(double raRate, double deRate)

--- a/libindi/drivers/telescope/lx200ap_experimental.h
+++ b/libindi/drivers/telescope/lx200ap_experimental.h
@@ -72,6 +72,14 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     virtual bool GuideNS(INDI_DIR_NS dir, TelescopeMotionCommand command);
     virtual bool GuideWE(INDI_DIR_WE dir, TelescopeMotionCommand command);
 
+    // Pulse Guide specific to AstroPhysics
+    static void pulseGuideTimeoutHelperWE(void * p);
+    static void pulseGuideTimeoutHelperNS(void * p);
+    static void simulGuideTimeoutHelperWE(void * p);
+    static void simulGuideTimeoutHelperNS(void * p);
+    void AstroPhysicsGuideTimeoutWE(bool simul);
+    void AstroPhysicsGuideTimeoutNS(bool simul);
+
     virtual bool getUTFOffset(double *offset) override;
 
     // Tracking

--- a/libindi/drivers/telescope/lx200apdriver.cpp
+++ b/libindi/drivers/telescope/lx200apdriver.cpp
@@ -38,6 +38,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 
 #define LX200_TIMEOUT 5 /* FD timeout in seconds */
 
+// maximum guide pulse request to send to controller
+#define MAX_LX200AP_PULSE_LEN 999
+
 char lx200ap_name[MAXINDIDEVICE];
 unsigned int AP_DBG_SCOPE;
 
@@ -749,7 +752,7 @@ int APSendPulseCmd(int fd, int direction, int duration_msec)
     char cmd[20];
 
     // GTOCP3 supports 3 digits for msec duration
-    if (duration_msec > 999)
+    if (duration_msec > MAX_LX200AP_PULSE_LEN)
     {
         DEBUGFDEVICE(lx200ap_name, INDI::Logger::DBG_DEBUG, "APSendPulseCmd requested %d msec limited to 999 msec!", duration_msec);
         duration_msec = 999;


### PR DESCRIPTION
The lx200ap_experimental driver had leveraged a guide timer routine in lx200telescope.cpp but I believe that function has been modified in such a way that it broke the simulated pulse guides we must do with the AP driver for durations > 999ms.   For a pulse guide > 998ms this meant the pulse guide event NEVER STOPPED and the mount kept moving forever.

I have moved the timeout routines into the AP driver now and have verified pulse guide requests for <= 999ms are handled by the protocol command to the mount controller and > 999ms are handled by the AP INDI driver by initiating a MOVE at GUIDE speed and then turning off the MOVE after the requested duration using a timer.

This is an important fix since it would have pretty much made pulse guiding unusable for the AP experimental driver.  Many times when calibrating the guide setup longer guide motions are required, also when dithering the guide request can be > 999ms.

