### PR TITLE
Make sure tracking state is set properly after unparking.

### DIFF
--- a/libindi/drivers/telescope/lx200ap_experimental.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimental.cpp
@@ -1468,10 +1468,11 @@ bool LX200AstroPhysicsExperimental::UnPark()
         }
     }
 
+    SetParked(false);
+
     // Enable tracking
     SetTrackEnabled(true);
-
-    SetParked(false);
+    TrackState = SCOPE_TRACKING;
 
     return true;
 }


### PR DESCRIPTION
When unparking the mount the lx200ap_experimental driver would enable tracking but the internal INDI state was not correctly updated to reflect the mount was tracking.  So the INDI Control Panel UI showed the mount was NOT tracking.

This patch updates the TrackState to fix this behavior.  Also reordered the SetParked() and SetTrackEnabled() calls as the SetParked() call then calls SyncParkStatus() which sets the TrackState to SCOPE_IDLE if the mount is unparked.