### PR TITLE
Optec Tcfs focuser

### DIFF
--- a/libindi/drivers/focuser/tcfs.cpp
+++ b/libindi/drivers/focuser/tcfs.cpp
@@ -1002,6 +1002,7 @@ void TCFS::TimerHit()
                 FocusModeSP.s = IPS_OK;
                 LOGF_INFO("Entered Auto Mode %s", mode);
                 currentMode = (FocusModeSP.sp[1].s == ISS_ON)?MODE_A:MODE_B;
+                IDSetSwitch(&FocusModeSP, nullptr);
             }
             SetTimer(POLLMS);
             return;

--- a/libindi/drivers/focuser/tcfs.cpp
+++ b/libindi/drivers/focuser/tcfs.cpp
@@ -833,6 +833,7 @@ IPState TCFS::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
         {
             FocusModeSP.sp[2].s = ISS_ON;
         }
+        FocusModeSP.s = IPS_BUSY;
         IDSetSwitch(&FocusModeSP, nullptr);
     }
 
@@ -974,7 +975,7 @@ void TCFS::TimerHit()
             SetTimer(POLLMS);
             return;
         }
-        LOGF_DEBUG("%s READY", __FUNCTION__ );
+        LOGF_DEBUG("%s READY %s", __FUNCTION__, response );
         if(strcmp(response, "*") == 0)
         {
             FocusAbsPosNP.s = IPS_OK;

--- a/libindi/drivers/focuser/tcfs.h
+++ b/libindi/drivers/focuser/tcfs.h
@@ -44,14 +44,14 @@ class TCFS : public INDI::Focuser
         FTMPRO, // Focuser Temperature Read Out
         FSLEEP, // Focuser Sleep
         FWAKUP, // Focuser Wake Up
-        FHOME,  // Focuser Home Command
-        
+        FHOME,  // Focuser Home Command        
         FRSLOP, // Focuser Read Slope Command
         FLSLOP, // Focuser Load Slope Command
         FQUIET, // Focuser Quiet Command
         FDELAY, // Focuser Load Delay Command
         FRSIGN, // Focuser Read Slope Sign Command
         FLSIGN, // Focuser Load Slope Sign Command
+        FFWVER, // Focuser Firmware Version
     };
 
     enum TCFSMode
@@ -80,6 +80,7 @@ class TCFS : public INDI::Focuser
     virtual bool updateProperties();
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
+    virtual bool saveConfigItems(FILE *fp);
 
   protected:
     virtual IPState MoveAbsFocuser(uint32_t targetTicks);
@@ -92,9 +93,9 @@ class TCFS : public INDI::Focuser
     bool read_tcfs(char *response, bool silent = false);
     bool dispatch_command(TCFSCommand command_type, int val=0, TCFSMode m=MANUAL);
 
-    INumber FocusModeAN[2];
+    INumber FocusModeAN[3];
     INumberVectorProperty FocusModeANP;
-    INumber FocusModeBN[2];
+    INumber FocusModeBN[3];
     INumberVectorProperty FocusModeBNP;
     ISwitch FocusTelemetryS[2];
     ISwitchVectorProperty FocusTelemetrySP;
@@ -106,11 +107,8 @@ class TCFS : public INDI::Focuser
     ISwitchVectorProperty FocusGotoSP;
     INumber FocusTemperatureN[1];
     INumberVectorProperty FocusTemperatureNP;
-
-//    ISwitchVectorProperty *FocusPowerSP { nullptr };
-//    ISwitchVectorProperty *FocusModeSP { nullptr };
-//    ISwitchVectorProperty *FocusGotoSP { nullptr };
-//    INumberVectorProperty *FocusTemperatureNP { nullptr };
+    ISwitch FocusStartModeS[3];
+    ISwitchVectorProperty FocusStartModeSP;
 
     unsigned int simulated_position { 3000 };
     float simulated_temperature { 25.4 };


### PR DESCRIPTION
Two changes bundled together.
The main one allows changes to the focuser position whilst it is in Auto mode. Normally disallowed by TCFS this allows the client scheduler to adjust the offset on filter change without manual intervention. The driver puts the focuser in manual mode to change the offset then returns to auto mode.
The second change implements a feature of TCFS Commander which allows not just a temperature gradient but also a zero degree intercept so that the focuser position can be determined for a given ambient temperature (assuming complete linearity). This allows fully automatic operation which can be enabled/disabled by StartMode switch. Arguably this should be a client feature but should help adoption of INDI by TCFS Commander users.
Would you like me to move the driver to Third Party?