### PR TITLE
Hitecastro DC Focuser 2 - Change command to move focuser

### DIFF
--- a/libindi/drivers/focuser/hitecastrodcfocuser.cpp
+++ b/libindi/drivers/focuser/hitecastrodcfocuser.cpp
@@ -305,7 +305,7 @@ IPState HitecAstroDCFocuser::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     command[0] = dir == FOCUS_INWARD ? 0x50 : 0x52;
     command[1] = (unsigned char)((ticks >> 8) & 0xFF);
     command[2] = (unsigned char)(ticks & 0xFF);
-    command[3] = 0x05;
+    command[3] = 0x03;
     command[4] = (unsigned char)(speed & 0xFF);
     command[5] = 0;
     command[6] = 0;
@@ -369,7 +369,7 @@ IPState HitecAstroDCFocuser::MoveFocuser(FocusDirection dir, int speed, uint16_t
     command[0] = dir == FOCUS_INWARD ? 0x54 : 0x56;
     command[1] = (unsigned char)((speed >> 8) & 0xFF);
     command[2] = (unsigned char)(speed & 0xFF);
-    command[3] = 0x05;
+    command[3] = 0x03;
     command[4] = 0;
     command[5] = 0;
     command[6] = 0;


### PR DESCRIPTION
https://github.com/indilib/indi/issues/495

Managed to get the Hitecastro DC Focus controller 2 driver working. The patch is:
danniesim@20a11ef

I am not sure if this breaks the "non 2" version of the controller - the Hitecastro DC Focus controller ( note there is no "2") as I don't have that hardware. One idea is to have a configuration option so that the user can select between the versions.

