### PR TITLE
20190130 fix lx200 ap pulseguide

### DIFF
--- a/libindi/drivers/telescope/lx200ap_experimental.h
+++ b/libindi/drivers/telescope/lx200ap_experimental.h
@@ -33,9 +33,8 @@ class LX200AstroPhysicsExperimental : public LX200Generic
                    MCV_L, MCV_M, MCV_N, MCV_O, MCV_P, MCV_Q, MCV_R, MCV_S,
                    MCV_T, MCV_U, MCV_V, MCV_UNKNOWN} ControllerVersion;
     typedef enum { GTOCP1=1, GTOCP2, GTOCP3, GTOCP4, GTOCP_UNKNOWN} ServoVersion;
-
     typedef enum { PARK_LAST=0, PARK_CUSTOM=0, PARK_PARK1=1, PARK_PARK2=2, PARK_PARK3=3, PARK_PARK4=4} ParkPosition;
-
+    enum APTelescopeSlewRate {AP_SLEW_GUIDE, AP_SLEW_12X, AP_SLEW_64X, AP_SLEW_600X, AP_SLEW_1200X};
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual void ISGetProperties(const char *dev) override;    
@@ -62,6 +61,7 @@ class LX200AstroPhysicsExperimental : public LX200Generic
     virtual bool updateTime(ln_date *utc, double utc_offset) override;
     virtual bool updateLocation(double latitude, double longitude, double elevation) override;
     virtual bool SetSlewRate(int index) override;
+    bool updateAPSlewRate(int index);
 
     // Guide Commands
     virtual IPState GuideNorth(uint32_t ms) override;

--- a/libindi/drivers/telescope/lx200ap_experimentaldriver.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimentaldriver.cpp
@@ -54,6 +54,98 @@ void set_lx200ap_exp_name(const char *deviceName, unsigned int debug_level)
     AP_EXP_DBG_SCOPE = debug_level;
 }
 
+// make this a function with logging instead of a #define like in legacy driver
+int APParkMount(int fd)
+{
+    int error_type;
+    int nbytes_write = 0;
+
+    DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "APParkMount: Sending park command.");
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:KA");
+
+    if ((error_type = tty_write_string(fd, "#:KA", &nbytes_write)) != TTY_OK)
+        return error_type;
+
+    return 0;
+}
+
+// This is a modified version of selectAPMoveRate() from lx200apdriver.cpp
+// This version allows changing the rate to GUIDE as well as 12x/64x/600x/1200x
+// and is required some the experimental AP driver properly handles
+// pulse guide requests over 999ms by simulated it by setting the move rate
+// to GUIDE and then starting and halting a move of the correct duration.
+int selectAPCenterRate(int fd, int centerRate)
+{
+    int error_type;
+    int nbytes_write = 0;
+
+    switch (centerRate)
+    {
+    /* Guide */
+    case 0:
+        DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "selectAPMoveToRate: Setting move to rate to GUIDE");
+        DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:RG#");
+
+        if ((error_type = tty_write_string(fd, "#:RG#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+    /* 12x */
+    case 1:
+        DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "selectAPMoveToRate: Setting move to rate to 12x");
+        DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:RC0#");
+
+        if ((error_type = tty_write_string(fd, "#:RC0#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+    /* 64x */
+    case 2:
+        DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "selectAPMoveToRate: Setting move to rate to 64x");
+        DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:RC1#");
+
+        if ((error_type = tty_write_string(fd, "#:RC1#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+    /* 600x */
+    case 3:
+        DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "selectAPMoveToRate: Setting move to rate to 600x");
+        DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:RC2#");
+        if ((error_type = tty_write_string(fd, "#:RC2#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+    /* 1200x */
+    case 4:
+        DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "selectAPMoveToRate: Setting move to rate to 1200x");
+        DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:RC3#");
+
+        if ((error_type = tty_write_string(fd, "#:RC3#", &nbytes_write)) != TTY_OK)
+            return error_type;
+        break;
+
+    default:
+        return -1;
+        break;
+    }
+    return 0;
+}
+
+// make this a function with logging instead of a #define like in legacy driver
+int APUnParkMount(int fd)
+{
+    int error_type;
+    int nbytes_write = 0;
+
+    DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "APUnParkMount: Sending unpark command.");
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:PO");
+
+    if ((error_type = tty_write_string(fd, "#:PO", &nbytes_write)) != TTY_OK)
+        return error_type;
+
+    return 0;
+}
 
 // experimental functions!!!
 
@@ -131,9 +223,6 @@ int getAPMeridianDelay(int fd, double *mdelay)
     return 0;
 }
 
-
-
-
 int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus)
 {
     char temp_string[64];
@@ -172,7 +261,6 @@ int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus)
 
         return 0;
     }
-
 
     DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_ERROR, "check_lx200ap_status: wrote, but nothing received.");
 

--- a/libindi/drivers/telescope/lx200ap_experimentaldriver.cpp
+++ b/libindi/drivers/telescope/lx200ap_experimentaldriver.cpp
@@ -69,6 +69,21 @@ int APParkMount(int fd)
     return 0;
 }
 
+// make this a function with logging instead of a #define like in legacy driver
+int APUnParkMount(int fd)
+{
+    int error_type;
+    int nbytes_write = 0;
+
+    DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "APUnParkMount: Sending unpark command.");
+    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:PO");
+
+    if ((error_type = tty_write_string(fd, "#:PO", &nbytes_write)) != TTY_OK)
+        return error_type;
+
+    return 0;
+}
+
 // This is a modified version of selectAPMoveRate() from lx200apdriver.cpp
 // This version allows changing the rate to GUIDE as well as 12x/64x/600x/1200x
 // and is required some the experimental AP driver properly handles
@@ -129,21 +144,6 @@ int selectAPCenterRate(int fd, int centerRate)
         return -1;
         break;
     }
-    return 0;
-}
-
-// make this a function with logging instead of a #define like in legacy driver
-int APUnParkMount(int fd)
-{
-    int error_type;
-    int nbytes_write = 0;
-
-    DEBUGDEVICE(lx200ap_exp_name, INDI::Logger::DBG_DEBUG, "APUnParkMount: Sending unpark command.");
-    DEBUGFDEVICE(lx200ap_exp_name, AP_EXP_DBG_SCOPE, "CMD <%s>", "#:PO");
-
-    if ((error_type = tty_write_string(fd, "#:PO", &nbytes_write)) != TTY_OK)
-        return error_type;
-
     return 0;
 }
 

--- a/libindi/drivers/telescope/lx200ap_experimentaldriver.h
+++ b/libindi/drivers/telescope/lx200ap_experimentaldriver.h
@@ -25,9 +25,12 @@ extern "C" {
 #endif
 
 void set_lx200ap_exp_name(const char *deviceName, unsigned int debug_level);
+int selectAPCenterRate(int fd, int centerRate);
 int setAPMeridianDelay(int fd, double mdelay);
 int getAPMeridianDelay(int fd, double *mdelay);
 int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus);
+int APParkMount(int fd);
+int APUnParkMount(int fd);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This patch changes the lx200ap_experiemental driver to not rely on the lx200telescope.cpp routines for setting the 'move' ('centering') rates of the mount.   The AP driver has to simulate a pulse guide for durations > 999ms.  This is done by changing the centering rate to 'GUIDE'.  The other centering rates supported are '12x', '64x', '600x' and '1200x'.  A new routine was created in lx200ap_experimentaldriver.cpp that supports the 'GUIDE' rate.

I have tested this change and it fixes a bug where you could end up having simulated pulse guide events happen at a rate other than GUIDE rate.

Also the macros for park and unpark were replaced by functions for better logging.