### PR TITLE
Need to advertise GUIDER_INTERFACE so PHD2 will accept mount

### DIFF
--- a/libindi/drivers/telescope/pmc8.cpp
+++ b/libindi/drivers/telescope/pmc8.cpp
@@ -115,7 +115,6 @@ bool PMC8::initProperties()
     IUFillSwitchVector(&MountTypeSP, MountTypeS, 3, getDeviceName(), "MOUNT_TYPE", "Mount Type", CONNECTION_TAB,
 		 IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-
     /* Tracking Mode */
     AddTrackMode("TRACK_SIDEREAL", "Sidereal", true);
     AddTrackMode("TRACK_SOLAR", "Solar");
@@ -151,6 +150,9 @@ bool PMC8::initProperties()
 
     IUFillText(&FirmwareT[0], "Version", "Version", "");
     IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "Firmware", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+
+    // needed so PHD2 will recognize mount
+    setDriverInterface(getDriverInterface() | GUIDER_INTERFACE);
 
     return true;
 }


### PR DESCRIPTION
Recent versions of PHD2 was not allowing the user of the PMC8 driver.  This was because the PMC8 driver did not advertise it had a GUIDER_INTERFACE.  This patch corrects the problem.  I have verified the latest PHD2 (built from their git repository) will properly recognize the PMC8 now with this fix.