### PR TITLE
[Avalon StarGO] Enabling/disabling focuser

### DIFF
--- a/3rdparty/indi-avalon/CMakeLists.txt
+++ b/3rdparty/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 2)
+set(AVALON_VERSION_MINOR 3)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/3rdparty/indi-avalon/ChangeLog
+++ b/3rdparty/indi-avalon/ChangeLog
@@ -1,4 +1,3 @@
-
 Version 1.3 - 2019-02-08 (bug fix release)
         + control added to activate/deactivate focuser on AUX1
 	  focuser status read only if focuser is activated
@@ -6,32 +5,32 @@ Version 1.3 - 2019-02-08 (bug fix release)
 
 Version 1.2 - 2019-02-08 (bug fix release)
         + pier side display corrected
-	
+
 Version 1.1 - 2019-01-13 (bug fix release)
         + focus status tracking added
-	
+
 Version 1.0 - 2019-01-01 (first official version)
         + first focuser implementation added
 	+ start / stop tracking added
 	+ enabling/disabling meridian flip added
 	+ forcing meridian flip added
 	+ setting guiding speed added
-	
+
 Version 0.5 - 2018-05-19
 	+ forcing meridian flip added
         + enabling/disbling ST4 added
 	+ setting guiding speed added
-	
+
 Version 0.4 - 2018-04-14
 	+ display of parking status
 	+ send LST before unpark
 	+ pier side display corrected
 	+ merged with INDI v 1.7.1
-	
+
 Version 0.3 - 2018-04-12
 	+ showing pier side implemented
 	+ merged with INDI v 1.7.0
-	
+
 Version 0.2 - 2018-03-30
 	+ Moved to 3rdparty
 	+ introduction of LX200Telescope as base class separated
@@ -43,4 +42,3 @@ Version 0.2 - 2018-03-30
 
 Version 0.1 - 2018-03-20
 	+ Initial version, based on LX200Generic
-	

--- a/3rdparty/indi-avalon/ChangeLog
+++ b/3rdparty/indi-avalon/ChangeLog
@@ -1,15 +1,37 @@
+
+Version 1.3 - 2019-02-08 (bug fix release)
+        + control added to activate/deactivate focuser on AUX1
+	  focuser status read only if focuser is activated
+	+ Doubled parking status light removed
+
+Version 1.2 - 2019-02-08 (bug fix release)
+        + pier side display corrected
+	
+Version 1.1 - 2019-01-13 (bug fix release)
+        + focus status tracking added
+	
+Version 1.0 - 2019-01-01 (first official version)
+        + first focuser implementation added
+	+ start / stop tracking added
+	+ enabling/disabling meridian flip added
+	+ forcing meridian flip added
+	+ setting guiding speed added
+	
 Version 0.5 - 2018-05-19
 	+ forcing meridian flip added
         + enabling/disbling ST4 added
 	+ setting guiding speed added
+	
 Version 0.4 - 2018-04-14
 	+ display of parking status
 	+ send LST before unpark
 	+ pier side display corrected
 	+ merged with INDI v 1.7.1
+	
 Version 0.3 - 2018-04-12
 	+ showing pier side implemented
 	+ merged with INDI v 1.7.0
+	
 Version 0.2 - 2018-03-30
 	+ Moved to 3rdparty
 	+ introduction of LX200Telescope as base class separated

--- a/3rdparty/indi-avalon/lx200stargo.cpp
+++ b/3rdparty/indi-avalon/lx200stargo.cpp
@@ -308,10 +308,6 @@ bool LX200StarGo::initProperties()
     IUFillSwitch(&MountGotoHomeS[0], "MOUNT_GOTO_HOME_VALUE", "Goto Home", ISS_OFF);
     IUFillSwitchVector(&MountGotoHomeSP, MountGotoHomeS, 1, getDeviceName(), "MOUNT_GOTO_HOME", "Goto Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_OK);
 
-    IUFillLight(&MountParkingStatusL[0], "MOUNT_IS_PARKED_VALUE", "Parked", IPS_IDLE);
-    IUFillLight(&MountParkingStatusL[1], "MOUNT_IS_UNPARKED_VALUE", "Unparked", IPS_IDLE);
-    IUFillLightVector(&MountParkingStatusLP, MountParkingStatusL, 2, getDeviceName(), "PARKING_STATUS", "Parking Status", MAIN_CONTROL_TAB, IPS_IDLE);
-
     IUFillSwitch(&MountSetParkS[0], "MOUNT_SET_PARK_VALUE", "Set Park", ISS_OFF);
     IUFillSwitchVector(&MountSetParkSP, MountSetParkS, 1, getDeviceName(), "MOUNT_SET_PARK", "Set Park", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_OK);
 
@@ -352,7 +348,6 @@ bool LX200StarGo::updateProperties()
     if (! LX200Telescope::updateProperties()) return false;
     if (isConnected())
     {
-        defineLight(&MountParkingStatusLP);
         defineSwitch(&SyncHomeSP);
         defineSwitch(&MountGotoHomeSP);
         defineSwitch(&MountSetParkSP);
@@ -363,7 +358,6 @@ bool LX200StarGo::updateProperties()
     }
     else
     {
-        deleteProperty(MountParkingStatusLP.name);
         deleteProperty(SyncHomeSP.name);
         deleteProperty(MountGotoHomeSP.name);
         deleteProperty(MountSetParkSP.name);
@@ -856,9 +850,6 @@ void LX200StarGo::SetParked(bool isparked)
 {
     LOGF_DEBUG("%s %s", __FUNCTION__, isparked?"PARKED":"UNPARKED");
     INDI::Telescope::SetParked(isparked);
-    MountParkingStatusL[0].s = isparked ? IPS_OK : IPS_IDLE;
-    MountParkingStatusL[1].s = isparked ? IPS_IDLE : IPS_OK;
-    IDSetLight(&MountParkingStatusLP, nullptr);
 }
 
 bool LX200StarGo::UnPark()
@@ -887,12 +878,6 @@ bool LX200StarGo::UnPark()
     if (sendQuery(":X370#", response) && strcmp(response, "p0") == 0)
     {
         LOG_INFO("Unparking mount...");
-/*        TrackState = SCOPE_TRACKING;
-        SetParked(false);
-        MountParkingStatusL[1].s = IPS_OK;
-        MountParkingStatusL[0].s = IPS_IDLE;
-        IDSetLight(&MountParkingStatusLP, nullptr);
-*/
         return true;
     }
     else

--- a/3rdparty/indi-avalon/lx200stargo.h
+++ b/3rdparty/indi-avalon/lx200stargo.h
@@ -119,8 +119,6 @@ protected:
     // parking position
     ISwitchVectorProperty MountSetParkSP;
     ISwitch MountSetParkS[1];
-    ILightVectorProperty MountParkingStatusLP;
-    ILight MountParkingStatusL[2];
 
     // guiding
     INumberVectorProperty GuidingSpeedNP;

--- a/3rdparty/indi-avalon/lx200stargo.h
+++ b/3rdparty/indi-avalon/lx200stargo.h
@@ -112,6 +112,10 @@ protected:
     ITextVectorProperty MountFirmwareInfoTP;
     IText MountFirmwareInfoT[1] = {};
 
+    // AUX focusers control
+    ISwitchVectorProperty Aux1FocuserSP;
+    ISwitch Aux1FocuserS[2];
+
     // goto home
     ISwitchVectorProperty MountGotoHomeSP;
     ISwitch MountGotoHomeS[1];

--- a/3rdparty/indi-avalon/lx200stargofocuser.cpp
+++ b/3rdparty/indi-avalon/lx200stargofocuser.cpp
@@ -34,6 +34,7 @@ LX200StarGoFocuser::LX200StarGoFocuser(LX200StarGo* defaultDevice, const char *n
 {
     baseDevice = defaultDevice;
     deviceName = name;
+    focuserActivated = false;
 }
 
 /**
@@ -306,6 +307,10 @@ int LX200StarGoFocuser::getAbsoluteFocuserPositionFromRelative(int relativePosit
 
 
 bool LX200StarGoFocuser::ReadFocuserStatus() {
+    // do nothing if not active
+    if (!isConnected())
+        return true;
+
     int absolutePosition = 0;
     if (sendQueryFocuserPosition(&absolutePosition)) {
         FocusAbsPosN[0].value = absolutePosition;
@@ -384,7 +389,7 @@ IPState LX200StarGoFocuser::syncFocuser(int absolutePosition) {
 
 bool LX200StarGoFocuser::isConnected() {
     if (baseDevice == nullptr) return false;
-    return baseDevice->isConnected();
+    return (focuserActivated && baseDevice->isConnected());
 }
 
 const char *LX200StarGoFocuser::getDeviceName() {
@@ -395,6 +400,15 @@ const char *LX200StarGoFocuser::getDeviceName() {
 const char *LX200StarGoFocuser::getDefaultName()
 {
     return deviceName;
+}
+
+void LX200StarGoFocuser::activate(bool enabled)
+{
+    if (focuserActivated != enabled)
+    {
+        focuserActivated = enabled;
+        updateProperties();
+    }
 }
 
 /***************************************************************************

--- a/3rdparty/indi-avalon/lx200stargofocuser.h
+++ b/3rdparty/indi-avalon/lx200stargofocuser.h
@@ -46,6 +46,8 @@ public:
 
     bool isConnected();
 
+    void activate(bool enabled);
+
 protected:
 
     // Avalon specifics
@@ -74,6 +76,7 @@ protected:
     bool startMovingFocuserInward;
     bool startMovingFocuserOutward;
     uint32_t moveFocuserDurationRemaining;
+    bool focuserActivated;
 
 
     // LX200 commands

--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,46 +1,11 @@
-indi-avalon (1.3) bionic; urgency=medium
+indi-avalon (1.3) stretch; urgency=medium
 
-Version 1.3 - 2019-02-08 (bug fix release)
-        + control added to activate/deactivate focuser on AUX1
-	  focuser status read only if focuser is activated
-	+ Doubled parking status light removed
+  * Enabling/disabling focuser.
 
-Version 1.2 - 2019-02-08 (bug fix release)
-        + pier side display corrected
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Mon, 11 Feb 2019 07:28:10 +0100
 
-Version 1.1 - 2019-01-13 (bug fix release)
-        + focus status tracking added
+indi-avalon (1.0) bionic; urgency=medium
 
-Version 1.0 - 2019-01-01 (first official version)
-        + first focuser implementation added
-	+ start / stop tracking added
-	+ enabling/disabling meridian flip added
-	+ forcing meridian flip added
-	+ setting guiding speed added
+  * Initial release.
 
-Version 0.5 - 2018-05-19
-	+ forcing meridian flip added
-        + enabling/disbling ST4 added
-	+ setting guiding speed added
-
-Version 0.4 - 2018-04-14
-	+ display of parking status
-	+ send LST before unpark
-	+ pier side display corrected
-	+ merged with INDI v 1.7.1
-
-Version 0.3 - 2018-04-12
-	+ showing pier side implemented
-	+ merged with INDI v 1.7.0
-
-Version 0.2 - 2018-03-30
-	+ Moved to 3rdparty
-	+ introduction of LX200Telescope as base class separated
-	+ Focuser handling transferred from CanisUrsa's implementation
-	  to LX200StarGoFocuser
-	+ parking, unparking and setting parking position added
-	+ slew home added
-	+ status handling improved
-
-Version 0.1 - 2018-03-20
-	+ Initial version, based on LX200Generic
+ -- Jasem Mutlaq <mutlaqja@ikarustech.com>  Wed, 2 Jan 2019 20:00:00 +0300

--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,5 +1,46 @@
-indi-avalon (1.0) bionic; urgency=medium
+indi-avalon (1.3) bionic; urgency=medium
 
-  * Initial release.
+Version 1.3 - 2019-02-08 (bug fix release)
+        + control added to activate/deactivate focuser on AUX1
+	  focuser status read only if focuser is activated
+	+ Doubled parking status light removed
 
- -- Jasem Mutlaq <mutlaqja@ikarustech.com>  Wed, 2 Jan 2019 20:00:00 +0300
+Version 1.2 - 2019-02-08 (bug fix release)
+        + pier side display corrected
+
+Version 1.1 - 2019-01-13 (bug fix release)
+        + focus status tracking added
+
+Version 1.0 - 2019-01-01 (first official version)
+        + first focuser implementation added
+	+ start / stop tracking added
+	+ enabling/disabling meridian flip added
+	+ forcing meridian flip added
+	+ setting guiding speed added
+
+Version 0.5 - 2018-05-19
+	+ forcing meridian flip added
+        + enabling/disbling ST4 added
+	+ setting guiding speed added
+
+Version 0.4 - 2018-04-14
+	+ display of parking status
+	+ send LST before unpark
+	+ pier side display corrected
+	+ merged with INDI v 1.7.1
+
+Version 0.3 - 2018-04-12
+	+ showing pier side implemented
+	+ merged with INDI v 1.7.0
+
+Version 0.2 - 2018-03-30
+	+ Moved to 3rdparty
+	+ introduction of LX200Telescope as base class separated
+	+ Focuser handling transferred from CanisUrsa's implementation
+	  to LX200StarGoFocuser
+	+ parking, unparking and setting parking position added
+	+ slew home added
+	+ status handling improved
+
+Version 0.1 - 2018-03-20
+	+ Initial version, based on LX200Generic


### PR DESCRIPTION
Querying the focuser status without a focuser connected leads to problems with StarGO when running several hours. It might lead that the StarGO device no longer responds and requires a reset.

With this version, the focuser can be activated and deactivated avoiding unnecessary (and potentially troublesome) querying to the AUX device.