### PR TITLE
Indiserver fixes

### DIFF
--- a/libindi/indiserver.c
+++ b/libindi/indiserver.c
@@ -77,6 +77,7 @@
 #define MAXSBUF       512
 #define MAXRBUF       49152 /* max read buffering here */
 #define MAXWSIZ       49152 /* max bytes/write */
+#define SHORTMSGSIZ   2048  /* buf size for most messages */
 #define DEFMAXQSIZ    128   /* default max q behind, MB */
 #define DEFMAXSSIZ    5     /* default max stream behind, MB */
 #define DEFMAXRESTART 10    /* default max restarts */
@@ -92,7 +93,7 @@ typedef struct
     int count;         /* number of consumers left */
     unsigned long cl;  /* content length */
     char *cp;          /* content: buf or malloced */
-    char buf[MAXWSIZ]; /* local buf for most messages */
+    char buf[SHORTMSGSIZ];    /* local buf for most messages */
 } Msg;
 
 /* device + property name */
@@ -1824,7 +1825,9 @@ static int msgQSize(FQ *q)
     for (i = 0; i < nFQ(q); i++)
     {
         Msg *mp = (Msg *)peekiFQ(q, i);
-        l += mp->cl;
+        l += sizeof(Msg);
+        if (mp->cp != mp->buf)
+            l += mp->cl;
     }
 
     return (l);

--- a/libindi/indiserver.c
+++ b/libindi/indiserver.c
@@ -883,23 +883,26 @@ static void indiRun(void)
     for (i = 0; s > 0 && i < ndvrinfo; i++)
     {
         DvrInfo *dp = &dvrinfo[i];
-        if (dp->pid != REMOTEDVR && FD_ISSET(dp->efd, &rs))
+        if (dp->active)
         {
-            if (stderrFromDriver(dp) < 0)
-                return; /* fds effected */
-            s--;
-        }
-        if (s > 0 && FD_ISSET(dp->rfd, &rs))
-        {
-            if (readFromDriver(dp) < 0)
-                return; /* fds effected */
-            s--;
-        }
-        if (s > 0 && FD_ISSET(dp->wfd, &ws) && nFQ(dp->msgq) > 0)
-        {
-            if (sendDriverMsg(dp) < 0)
-                return; /* fds effected */
-            s--;
+            if (dp->pid != REMOTEDVR && FD_ISSET(dp->efd, &rs))
+            {
+                if (stderrFromDriver(dp) < 0)
+                    return; /* fds effected */
+                s--;
+            }
+            if (s > 0 && FD_ISSET(dp->rfd, &rs))
+            {
+                if (readFromDriver(dp) < 0)
+                    return; /* fds effected */
+                s--;
+            }
+            if (s > 0 && FD_ISSET(dp->wfd, &ws) && nFQ(dp->msgq) > 0)
+            {
+                if (sendDriverMsg(dp) < 0)
+                    return; /* fds effected */
+                s--;
+            }
         }
     }
 }


### PR DESCRIPTION
1. Do not use file descriptors from inactive DvrInfo. It crashes when the same fd is re-used. There already is the same handling for clients.

2. Indiserver allocates 50KB for each message, but for the -m option it considers real message size - typically under 0.5KB. When the queue size reaches the default 128MB limit, it allocates more than 12GB of memory, so it is usually killed by OOM killer much earlier.
The patch reduces the buffer to 2KB per message and changes size calculation to report all the allocated memory.