### PR TITLE
Check focuser limits and implement calibration

### DIFF
--- a/libindi/drivers/focuser/celestron.h
+++ b/libindi/drivers/focuser/celestron.h
@@ -36,6 +36,7 @@ class CelestronSCT : public INDI::Focuser
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
         virtual bool ISNewNumber(const char * dev, const char * name, double values[], char * names[], int n) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
     protected:
         /**
@@ -108,6 +109,15 @@ class CelestronSCT : public INDI::Focuser
 
         bool backlashMove;      // set if a final move is needed
         uint32_t finalPosition;
+
+        ISwitch CalibrateS[2];
+        ISwitchVectorProperty CalibrateSP;
+
+        IText CalibrateStateT[1];
+        ITextVectorProperty CalibrateStateTP;
+
+        bool calibrateInProgress;
+        int calibrateState;
 
         /////////////////////////////////////////////////////////////////////////////
         /// Static Helper Values

--- a/libindi/drivers/focuser/celestronauxpacket.cpp
+++ b/libindi/drivers/focuser/celestronauxpacket.cpp
@@ -28,7 +28,7 @@
 #include <termios.h>
 #include <stdio.h>
 
-#define SHORT_TIMEOUT 1
+#define SHORT_TIMEOUT 2
 
 namespace Aux
 {
@@ -144,7 +144,6 @@ bool Communicator::sendPacket(int portFD, Target dest, Command cmd, buffer data)
 
     buffer txbuff;
     pkt.FillBuffer(txbuff);
-    //Focuser.LogMessage("SendPacket", "txbuff: {0}", BufStr(txbuff));
     int ns;
 
     int ttyrc = 0;
@@ -170,7 +169,8 @@ bool Communicator::readPacket(int portFD, Packet &reply)
         {
             char errmsg[MAXRBUF];
             tty_error_msg(ttyrc, errmsg, MAXRBUF);
-            DEBUGFDEVICE(Communicator::Device.c_str(), INDI::Logger::DBG_ERROR, "readPacket fail read hdr tty %i %s, nr %i", ttyrc, errmsg, nr);
+            DEBUGFDEVICE(Communicator::Device.c_str(), INDI::Logger::DBG_ERROR,
+                         "readPacket fail read hdr tty %i %s, nr %i", ttyrc, errmsg, nr);
             return false;		// read failure is instantly fatal
         }
     }


### PR DESCRIPTION
Check the limits returned from the focuser and only use them if they are sensible.
Implement focuser calibration.