### PR TITLE
Synscan: invert slew direction for AltAz mounts

### DIFF
--- a/libindi/drivers/telescope/synscandriver.cpp
+++ b/libindi/drivers/telescope/synscandriver.cpp
@@ -1331,7 +1331,10 @@ bool SynscanDriver::slewFixedRate(SynscanDirection direction, uint8_t rate)
     // Axis 17 for DE/AL, 16 for RA/AZ
     cmd[2] = (direction == SYN_N || direction == SYN_S) ? 17 : 16;
     // Command 36 positive direction, 37 negative direction
-    cmd[3] = (direction == SYN_N || direction == SYN_W) ? 36 : 37;
+    if (!m_isAltAz)
+        cmd[3] = (direction == SYN_N || direction == SYN_W) ? 36 : 37;
+    else
+        cmd[3] = (direction == SYN_N || direction == SYN_W) ? 37 : 36;
     // Fixed rate (0 to 9) where 0 is stop
     cmd[4] = rate;
 


### PR DESCRIPTION
Slew directions are inverted on my Synscan GOTO Dobson mount (Orion SkyQuest XT8g) using the new driver (it doesn't happen with the Synscan legacy driver), so that the "up" ("north") button moves the tube downwards and, viceversa, the "down" button moves the tube upwards.
The same happens with the "left" button which moves the tube to the right and viceversa.

So, in my mount (and I think also in other AltAz mounts), the negative direction (37) means "North" for the vertical (altitude) axis and "West" for the horizontal (azimuth) axis.

Anyway, I don't know if this is a general issue for all other AltAz mounts, as I can only test it with my own mount.

So, I think it's worth to better investigate this behaviour in order to understand if it's a general behaviour for all AltAz mounts (I guess it is).