### PR TITLE
Extended telescope joystick motion control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ libindi/make_tcfs_symlink.cmake
 *.cbp
 install_manifest.txt
 .idea
+*.kdev4
 libindi/examples/tutorial_eight/tutorial_eight
 libindi/examples/tutorial_five/tutorial_dome
 libindi/examples/tutorial_five/tutorial_rain

--- a/libindi/libs/indibase/indicontroller.cpp
+++ b/libindi/libs/indibase/indicontroller.cpp
@@ -208,7 +208,7 @@ bool Controller::ISSnoopDevice(XMLEle *root)
             const char *elemName = findXMLAttValu(ep, "name");
             const char *setting  = getControllerSetting(elemName);
             if (setting == nullptr)
-                return false;
+                continue;
 
             mag = atof(pcdataXMLEle(ep));
 

--- a/libindi/libs/indibase/indicontroller.cpp
+++ b/libindi/libs/indibase/indicontroller.cpp
@@ -201,7 +201,7 @@ bool Controller::ISSnoopDevice(XMLEle *root)
     const char *propName = findXMLAttValu(root, "name");
 
     // Check axis
-    if (!strcmp("JOYSTICK_AXIS", propName))
+    if (!strcmp("JOYSTICK_AXES", propName))
     {
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
         {
@@ -270,7 +270,7 @@ void Controller::enableJoystick()
             IDSnoopDevice("Joystick", JoystickSettingTP.tp[i].text);
     }
 
-    IDSnoopDevice("Joystick", "JOYSTICK_AXIS");
+    IDSnoopDevice("Joystick", "JOYSTICK_AXES");
     IDSnoopDevice("Joystick", "JOYSTICK_BUTTONS");
 }
 

--- a/libindi/libs/indibase/inditelescope.cpp
+++ b/libindi/libs/indibase/inditelescope.cpp
@@ -2373,16 +2373,30 @@ void Telescope::processNSWE(double mag, double angle)
                 angle = 270;
         }
 
+        // Snap angle to x or y direction if close to corresponding axis (i.e. deviation < 15°)
+        if (angle > 75 && angle < 105)
+        {
+            angle = 90;
+        }
+        if (angle > 165 && angle < 195)
+        {
+            angle = 180;
+        }
+        if (angle > 255 && angle < 285)
+        {
+            angle = 270;
+        }
+        if (angle > 345 || angle < 15)
+        {
+            angle = 0;
+        }
+
         // North
         if (angle > 0 && angle < 180)
         {
             // Don't try to move if you're busy and moving in the same direction
             if (MovementNSSP.s != IPS_BUSY || MovementNSS[0].s != ISS_ON)
                 MoveNS(DIRECTION_NORTH, MOTION_START);
-
-            // If angle is close to 90, make it exactly 90 to reduce noise that could trigger east/west motion as well
-            if (angle > 80 && angle < 110)
-                angle = 90;
 
             MovementNSSP.s                     = IPS_BUSY;
             MovementNSSP.sp[DIRECTION_NORTH].s = ISS_ON;
@@ -2395,10 +2409,6 @@ void Telescope::processNSWE(double mag, double angle)
             // Don't try to move if you're busy and moving in the same direction
             if (MovementNSSP.s != IPS_BUSY || MovementNSS[1].s != ISS_ON)
                 MoveNS(DIRECTION_SOUTH, MOTION_START);
-
-            // If angle is close to 270, make it exactly 270 to reduce noise that could trigger east/west motion as well
-            if (angle > 260 && angle < 280)
-                angle = 270;
 
             MovementNSSP.s                     = IPS_BUSY;
             MovementNSSP.sp[DIRECTION_NORTH].s = ISS_OFF;

--- a/libindi/libs/indibase/inditelescope.cpp
+++ b/libindi/libs/indibase/inditelescope.cpp
@@ -52,6 +52,7 @@ Telescope::Telescope()
 
     controller = new Controller(this);
     controller->setJoystickCallback(joystickHelper);
+    controller->setAxisCallback(axisHelper);
     controller->setButtonCallback(buttonHelper);
 
     currentPierSide = PIER_EAST;
@@ -59,6 +60,9 @@ Telescope::Telescope()
 
     currentPECState = PEC_OFF;
     lastPECState    = PEC_UNKNOWN;
+
+    motionDirWEValue = 0;
+    motionDirNSValue = 0;
 }
 
 Telescope::~Telescope()
@@ -208,13 +212,19 @@ bool Telescope::initProperties()
     IUFillSwitchVector(&ScopeConfigsSP, ScopeConfigs, 6, getDeviceName(), "APPLY_SCOPE_CONFIG", "Scope Configs",
                        OPTIONS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_OK);
 
+    controller->initProperties();
+
+    // Joystick motion control
+    IUFillSwitch(&MotionControlModeT[0], "MOTION_CONTROL_MODE_JOYSTICK", "4-Way Joystick", ISS_ON);
+    IUFillSwitch(&MotionControlModeT[1], "MOTION_CONTROL_MODE_AXES", "Two Separate Axes", ISS_OFF);
+    IUFillSwitchVector(&MotionControlModeTP, MotionControlModeT, 2, getDeviceName(), "MOTION_CONTROL_MODE", "Motion Control",
+                       "Joystick", IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+
     // Lock Axis
     IUFillSwitch(&LockAxisS[0], "LOCK_AXIS_1", "West/East", ISS_OFF);
     IUFillSwitch(&LockAxisS[1], "LOCK_AXIS_2", "North/South", ISS_OFF);
     IUFillSwitchVector(&LockAxisSP, LockAxisS, 2, getDeviceName(), "JOYSTICK_LOCK_AXIS", "Lock Axis", "Joystick", IP_RW,
                        ISR_ATMOST1, 60, IPS_IDLE);
-
-    controller->initProperties();
 
     TrackState = SCOPE_IDLE;
 
@@ -342,6 +352,9 @@ bool Telescope::updateProperties()
     if (isConnected())
     {
         controller->mapController("MOTIONDIR", "N/S/W/E Control", Controller::CONTROLLER_JOYSTICK, "JOYSTICK_1");
+        controller->mapController("MOTIONDIRNS", "N/S Control", Controller::CONTROLLER_AXIS, "AXIS_8");
+        controller->mapController("MOTIONDIRWE", "W/E Control", Controller::CONTROLLER_AXIS, "AXIS_7");
+
         if (nSlewRate >= 4)
         {
             controller->mapController("SLEWPRESET", "Slew Rate", Controller::CONTROLLER_JOYSTICK, "JOYSTICK_2");
@@ -455,6 +468,7 @@ bool Telescope::updateProperties()
     if (CanGOTO())
     {
         controller->updateProperties();
+
         ISwitchVectorProperty *useJoystick = getSwitch("USEJOYSTICK");
         if (useJoystick)
         {
@@ -462,14 +476,22 @@ bool Telescope::updateProperties()
             {
                 if (useJoystick->sp[0].s == ISS_ON)
                 {
+                    defineSwitch(&MotionControlModeTP);
+                    loadConfig(true, "MOTION_CONTROL_MODE");
                     defineSwitch(&LockAxisSP);
                     loadConfig(true, "LOCK_AXIS");
                 }
                 else
+                {
+                    deleteProperty(MotionControlModeTP.name);
                     deleteProperty(LockAxisSP.name);
+                }
             }
             else
+            {
+                deleteProperty(MotionControlModeTP.name);
                 deleteProperty(LockAxisSP.name);
+            }
         }
     }
 
@@ -613,7 +635,7 @@ bool Telescope::saveConfigItems(FILE *fp)
         IUSaveConfigNumber(fp, &TrackRateNP);
 
     controller->saveConfigItems(fp);
-
+    IUSaveConfigSwitch(fp, &MotionControlModeTP);
     IUSaveConfigSwitch(fp, &LockAxisSP);
 
     return true;
@@ -1416,6 +1438,23 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         }
 
         ///////////////////////////////////
+        // Joystick Motion Control Mode
+        ///////////////////////////////////
+        if (!strcmp(name, MotionControlModeTP.name))
+        {
+            IUUpdateSwitch(&MotionControlModeTP, states, names, n);
+            MotionControlModeTP.s = IPS_OK;
+            IDSetSwitch(&MotionControlModeTP, nullptr);
+            if (MotionControlModeT[MOTION_CONTROL_JOYSTICK].s == ISS_ON)
+                DEBUG(Logger::DBG_SESSION, "Motion control is set to 4-way joystick.");
+            else if (MotionControlModeT[MOTION_CONTROL_AXES].s == ISS_ON)
+                DEBUG(Logger::DBG_SESSION, "Motion control is set to 2 separate axes.");
+            else
+                DEBUGF(Logger::DBG_WARNING, "Motion control is set to unknown value %d!", n);
+            return true;
+        }
+
+        ///////////////////////////////////
         // Joystick Lock Axis
         ///////////////////////////////////
         if (!strcmp(name, LockAxisSP.name))
@@ -1450,9 +1489,16 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
     {
         ISwitchVectorProperty *useJoystick = getSwitch("USEJOYSTICK");
         if (useJoystick && useJoystick->sp[0].s == ISS_ON)
+        {
+            defineSwitch(&MotionControlModeTP);
             defineSwitch(&LockAxisSP);
+        }
         else
+        {
+            deleteProperty(MotionControlModeTP.name);
             deleteProperty(LockAxisSP.name);
+        }
+
     }
 
     //  Nobody has claimed this, so, ignore it
@@ -2198,7 +2244,7 @@ void Telescope::processButton(const char *button_n, ISState state)
 
 void Telescope::processJoystick(const char *joystick_n, double mag, double angle)
 {
-    if (!strcmp(joystick_n, "MOTIONDIR"))
+    if (MotionControlModeTP.sp[MOTION_CONTROL_JOYSTICK].s == ISS_ON && !strcmp(joystick_n, "MOTIONDIR"))
     {
         if ((TrackState == SCOPE_PARKING) || (TrackState == SCOPE_PARKED))
         {
@@ -2210,6 +2256,63 @@ void Telescope::processJoystick(const char *joystick_n, double mag, double angle
     }
     else if (!strcmp(joystick_n, "SLEWPRESET"))
         processSlewPresets(mag, angle);
+}
+
+void Telescope::processAxis(const char *axis_n, double value)
+{
+    if (MotionControlModeTP.sp[MOTION_CONTROL_AXES].s == ISS_ON) {
+        if (!strcmp(axis_n, "MOTIONDIRNS") || !strcmp(axis_n, "MOTIONDIRWE"))
+        {
+            if ((TrackState == SCOPE_PARKING) || (TrackState == SCOPE_PARKED))
+            {
+                DEBUG(Logger::DBG_WARNING, "Cannot slew while mount is parking/parked.");
+                return;
+            }
+
+            if (!strcmp(axis_n, "MOTIONDIRNS"))
+            {
+                // South
+                if (value > 0) {
+                    motionDirNSValue = -1;
+                }
+                // North
+                else if (value < 0) {
+                    motionDirNSValue = 1;
+                }
+                else {
+                    motionDirNSValue = 0;
+                }
+            }
+            else if (!strcmp(axis_n, "MOTIONDIRWE"))
+            {
+                // East
+                if (value > 0) {
+                    motionDirWEValue = 1;
+                }
+                // West
+                else if (value < 0)
+                {
+                    motionDirWEValue = -1;
+                }
+                else {
+                    motionDirWEValue = 0;
+                }
+            }
+
+            float x = motionDirWEValue * sqrt(1 - pow(motionDirNSValue, 2) / 2.0f);
+            float y = motionDirNSValue * sqrt(1 - pow(motionDirWEValue, 2) / 2.0f);
+            float angle = atan2(y, x) * (180.0 / 3.141592653589);
+            float mag = sqrt(pow(y, 2) + pow(x, 2));
+            while (angle < 0) {
+                angle += 360;
+            }
+            if (mag == 0) {
+                angle = 0;
+            }
+
+            processNSWE(mag, angle);
+        }
+    }
 }
 
 void Telescope::processNSWE(double mag, double angle)
@@ -2365,6 +2468,11 @@ void Telescope::processSlewPresets(double mag, double angle)
 void Telescope::joystickHelper(const char *joystick_n, double mag, double angle, void *context)
 {
     static_cast<Telescope *>(context)->processJoystick(joystick_n, mag, angle);
+}
+
+void Telescope::axisHelper(const char *axis_n, double value, void *context)
+{
+    static_cast<Telescope *>(context)->processAxis(axis_n, value);
 }
 
 void Telescope::buttonHelper(const char *button_n, ISState state, void *context)

--- a/libindi/libs/indibase/inditelescope.h
+++ b/libindi/libs/indibase/inditelescope.h
@@ -342,6 +342,7 @@ class Telescope : public DefaultDevice
 
     // Joystick helpers
     static void joystickHelper(const char *joystick_n, double mag, double angle, void *context);
+    static void axisHelper(const char *axis_n, double value, void *context);
     static void buttonHelper(const char *button_n, ISState state, void *context);
 
     /**
@@ -551,6 +552,7 @@ class Telescope : public DefaultDevice
     // Joystick
     void processNSWE(double mag, double angle);
     void processJoystick(const char *joystick_n, double mag, double angle);
+    void processAxis(const char *axis_n, double value);
     void processSlewPresets(double mag, double angle);
     void processButton(const char *button_n, ISState state);
 
@@ -673,6 +675,14 @@ class Telescope : public DefaultDevice
     ISwitchVectorProperty DomeClosedLockTP;
     ISwitch DomeClosedLockT[4];
 
+    // Switch for choosing between motion control by 4-way joystick or two seperate axes
+    ISwitchVectorProperty MotionControlModeTP;
+    ISwitch MotionControlModeT[2];
+    enum {
+        MOTION_CONTROL_JOYSTICK,
+        MOTION_CONTROL_AXES
+    };
+
     // Lock Joystick Axis to one direciton only
     ISwitch LockAxisS[2];
     ISwitchVectorProperty LockAxisSP;
@@ -780,7 +790,10 @@ private:
     IPState lastEqState;
 
     uint8_t telescopeConnection = CONNECTION_SERIAL | CONNECTION_TCP;
+
     Controller *controller;
+    float motionDirNSValue;
+    float motionDirWEValue;
 };
 
 }


### PR DESCRIPTION
Dear maintainers,

when I tried to use an XBox 360 wireless controller for slew control, I realized that

- the only joystick which got mapped correctly (as JOYSTICK_1) was the left analog joystick;
- the other joysticks (JOYSTICK_2 and JOYSTICK_3) where partly mapped to the right analog joystick's axes, partly to the two triggers;
- the directional pad wasn't mapped to any JOYSTICK_* at all.

To this end, I implemented a mechanism which allows for explicitly defining which joystick axes are to be used for controlling N/S and W/E motion, respectively.

During the course of this work, I also fixed two general bugs regarding joystick axis handling.

Finally, I modified the code responsible for snapping a joystick's angle to x/y direction. I have the impression that this greatly facilitates controlling the RA and DEC axes separately.

Hope you like the changes I made... 

Cheers --
    Torsten
