### PR TITLE
Set a default baud rate of B_115200 for serial connection

### DIFF
--- a/libindi/drivers/auxiliary/sqm.cpp
+++ b/libindi/drivers/auxiliary/sqm.cpp
@@ -105,6 +105,7 @@ bool SQM::initProperties()
     {
         serialConnection = new Connection::Serial(this);
         serialConnection->registerHandshake([&]() { return getDeviceInfo(); });
+        serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
         registerConnection(serialConnection);
     }
 


### PR DESCRIPTION
I found that anything other than 115200 causes the device to crash (has to be unplugged and plugged in again) It also causes the driver to crash and I have to kill the process. It seems to get stuck in the handshake getDeviceInfo() method on the line ` read(PortFD, buffer + received, 39 - received);` 

Setting to 115200 in the driver UI before connecting and it works fine. Thought it might be a good idea to default to this baud rate to prevent any future confusion
