### PR TITLE
Avalon Stargo 1.4 - Reversed mode for focuser

### DIFF
--- a/3rdparty/indi-avalon/CMakeLists.txt
+++ b/3rdparty/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 3)
+set(AVALON_VERSION_MINOR 4)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/3rdparty/indi-avalon/ChangeLog
+++ b/3rdparty/indi-avalon/ChangeLog
@@ -1,3 +1,8 @@
+Version 1.4 - 2019-04-14
+	+ control for reversing focuser direction added
+	+ storing focuser parameters into the config file added
+	+ connection handling of focuser follows the base device
+
 Version 1.3 - 2019-02-08 (bug fix release)
         + control added to activate/deactivate focuser on AUX1
 	  focuser status read only if focuser is activated

--- a/3rdparty/indi-avalon/lx200stargo.cpp
+++ b/3rdparty/indi-avalon/lx200stargo.cpp
@@ -263,10 +263,18 @@ bool LX200StarGo::ISNewSwitch(const char *dev, const char *name, ISState *states
             if (IUUpdateSwitch(&Aux1FocuserSP, states, names, n) < 0)
                 return false;
             bool enabled = (IUFindOnSwitchIndex(&Aux1FocuserSP) == 0);
-            focuserAux1->activate(enabled);
-            Aux1FocuserSP.s = enabled ? IPS_OK : IPS_IDLE;
-            IDSetSwitch(&Aux1FocuserSP, nullptr);
-            return true;
+            if (focuserAux1->activate(enabled))
+            {
+                Aux1FocuserSP.s = enabled ? IPS_OK : IPS_IDLE;
+                IDSetSwitch(&Aux1FocuserSP, nullptr);
+                return true;
+            }
+            else
+            {
+                Aux1FocuserSP.s = IPS_ALERT;
+                IDSetSwitch(&Aux1FocuserSP, nullptr);
+                return false;
+            }
         }
     }
 
@@ -384,6 +392,24 @@ bool LX200StarGo::updateProperties()
     }
 
     return true;
+}
+
+/**************************************************************************************
+**
+***************************************************************************************/
+bool LX200StarGo::Connect()
+{
+    if (! DefaultDevice::Connect())
+        return false;
+
+    // activate focuser AUX1 if the switch is set to "activated"
+    return focuserAux1->activate((IUFindOnSwitchIndex(&Aux1FocuserSP) == 0));
+}
+
+bool LX200StarGo::Disconnect()
+{
+    focuserAux1->activate(false);
+    return DefaultDevice::Disconnect();
 }
 
 /**************************************************************************************

--- a/3rdparty/indi-avalon/lx200stargo.cpp
+++ b/3rdparty/indi-avalon/lx200stargo.cpp
@@ -936,12 +936,14 @@ bool LX200StarGo::getLST_String(char* input)
 bool LX200StarGo::saveConfigItems(FILE *fp)
 {
     LOG_DEBUG(__FUNCTION__);
-    LX200Telescope::saveConfigItems(fp);
-
     IUSaveConfigText(fp, &SiteNameTP);
+    IUSaveConfigSwitch(fp, &Aux1FocuserSP);
 
-    return true;
+    focuserAux1->saveConfigItems(fp);
+
+    return LX200Telescope::saveConfigItems(fp);
 }
+
 
 /*********************************************************************************
  * Queries

--- a/3rdparty/indi-avalon/lx200stargo.h
+++ b/3rdparty/indi-avalon/lx200stargo.h
@@ -150,6 +150,8 @@ protected:
     virtual bool UnPark() override;
     virtual bool saveConfigItems(FILE *fp) override;
     virtual bool Goto(double ra, double dec) override;
+    virtual bool Connect();
+    virtual bool Disconnect();
 
     // StarGo stuff
     virtual bool syncHomePosition();

--- a/3rdparty/indi-avalon/lx200stargofocuser.cpp
+++ b/3rdparty/indi-avalon/lx200stargofocuser.cpp
@@ -67,6 +67,10 @@ void LX200StarGoFocuser::initProperties(const char *groupName)
     IUFillNumber(&FocusSyncPosN[0], "FOCUS_SYNC_POSITION_VALUE", "Ticks", "%4.0f", 0.0, 100000.0, 1000.0, 0);
     IUFillNumberVector(&FocusSyncPosNP, FocusSyncPosN, 1, getDeviceName(), "FOCUS_SYNC_POSITION", "Sync", deviceName, IP_WO, 0, IPS_OK);
 
+    IUFillSwitch(&FocusReverseS[0], "FOCUS_REVERSE_NO", "Normal", ISS_ON);
+    IUFillSwitch(&FocusReverseS[1], "FOCUS_REVERSE_YES", "Reversed", ISS_OFF);
+    IUFillSwitchVector(&FocusReverseSP, FocusReverseS, 2, getDeviceName(), "FOCUS_REVERSE", "Direction", deviceName, IP_RW, ISR_1OFMANY, 60, IPS_OK);
+
 }
 
 /**
@@ -88,6 +92,7 @@ bool LX200StarGoFocuser::updateProperties()
             baseDevice->defineNumber(&FocusRelPosNP);
             baseDevice->defineSwitch(&FocusAbortSP);
             baseDevice->defineNumber(&FocusSyncPosNP);
+            baseDevice->defineSwitch(&FocusReverseSP);
         }
         else {
             baseDevice->deleteProperty(FocusSpeedNP.name);
@@ -97,6 +102,7 @@ bool LX200StarGoFocuser::updateProperties()
             baseDevice->deleteProperty(FocusRelPosNP.name);
             baseDevice->deleteProperty(FocusAbortSP.name);
             baseDevice->deleteProperty(FocusSyncPosNP.name);
+            baseDevice->deleteProperty(FocusReverseSP.name);
         }
         return true;
 
@@ -121,9 +127,14 @@ bool LX200StarGoFocuser::ISNewSwitch(const char *dev, const char *name, ISState 
         if (!strcmp(name, FocusMotionSP.name))
         {
             return changeFocusMotion(states, names, n);
-        } else if (!strcmp(name, FocusAbortSP.name))
+        }
+        else if (!strcmp(name, FocusAbortSP.name))
         {
             return changeFocusAbort(states, names, n);
+        }
+        else if (!strcmp(name, FocusReverseSP.name))
+        {
+            return setFocuserDirection(states, names, n);
         }
     }
 
@@ -220,6 +231,19 @@ bool LX200StarGoFocuser::changeFocusSpeed(double values[], char* names[], int n)
     return true;
 }
 
+bool LX200StarGoFocuser::setFocuserDirection(ISState* states, char* names[], int n) {
+
+    if (IUUpdateSwitch(&FocusReverseSP, states, names, n) < 0)
+        return false;
+
+    focuserReversed = (IUFindOnSwitchIndex(&FocusReverseSP) > 0 ? REVERSED_ENABLED : REVERSED_DISABLED);
+
+    FocusReverseSP.s = IPS_OK;
+    IDSetSwitch(&FocusReverseSP, nullptr);
+
+    return true;
+}
+
 
 bool LX200StarGoFocuser::changeFocusAbort(ISState* states, char* names[], int n) {
     INDI_UNUSED(states);
@@ -313,7 +337,7 @@ bool LX200StarGoFocuser::ReadFocuserStatus() {
 
     int absolutePosition = 0;
     if (sendQueryFocuserPosition(&absolutePosition)) {
-        FocusAbsPosN[0].value = absolutePosition;
+        FocusAbsPosN[0].value = (focuserReversed == REVERSED_DISABLED) ? absolutePosition : -absolutePosition;
         IDSetNumber(&FocusAbsPosNP, nullptr);
     }
     else
@@ -481,7 +505,7 @@ bool LX200StarGoFocuser::sendQueryFocuserPosition(int* position) {
 bool LX200StarGoFocuser::sendMoveFocuserToPosition(int position) {
     // Command  - :X16pppppp#
     // Response - Nothing
-    targetFocuserPosition = position;
+    targetFocuserPosition = (focuserReversed == REVERSED_DISABLED) ? position : -position;
     char command[AVALON_COMMAND_BUFFER_LENGTH] = {0};
     sprintf(command, ":X16%06d#", AVALON_FOCUSER_POSITION_OFFSET + targetFocuserPosition);
     if (!baseDevice->transmit(command)) {
@@ -511,7 +535,7 @@ bool LX200StarGoFocuser::isFocuserMoving() {
 }
 
 bool LX200StarGoFocuser::atFocuserTargetPosition() {
-    return FocusAbsPosN[0].value == targetFocuserPosition;
+    return FocusAbsPosN[0].value == (focuserReversed == REVERSED_DISABLED) ? targetFocuserPosition : -targetFocuserPosition;
 }
 
 

--- a/3rdparty/indi-avalon/lx200stargofocuser.cpp
+++ b/3rdparty/indi-avalon/lx200stargofocuser.cpp
@@ -413,7 +413,7 @@ IPState LX200StarGoFocuser::syncFocuser(int absolutePosition) {
 
 bool LX200StarGoFocuser::isConnected() {
     if (baseDevice == nullptr) return false;
-    return (focuserActivated && baseDevice->isConnected());
+    return focuserActivated;
 }
 
 const char *LX200StarGoFocuser::getDeviceName() {
@@ -426,13 +426,10 @@ const char *LX200StarGoFocuser::getDefaultName()
     return deviceName;
 }
 
-void LX200StarGoFocuser::activate(bool enabled)
+bool LX200StarGoFocuser::activate(bool enabled)
 {
-    if (focuserActivated != enabled)
-    {
-        focuserActivated = enabled;
-        updateProperties();
-    }
+    focuserActivated = enabled;
+    return updateProperties();
 }
 
 bool LX200StarGoFocuser::saveConfigItems(FILE *fp)

--- a/3rdparty/indi-avalon/lx200stargofocuser.cpp
+++ b/3rdparty/indi-avalon/lx200stargofocuser.cpp
@@ -435,6 +435,14 @@ void LX200StarGoFocuser::activate(bool enabled)
     }
 }
 
+bool LX200StarGoFocuser::saveConfigItems(FILE *fp)
+{
+    IUSaveConfigSwitch(fp, &FocusReverseSP);
+
+    return true;
+}
+
+
 /***************************************************************************
  * LX200 queries, sent to baseDevice
  ***************************************************************************/

--- a/3rdparty/indi-avalon/lx200stargofocuser.cpp
+++ b/3rdparty/indi-avalon/lx200stargofocuser.cpp
@@ -478,7 +478,7 @@ bool LX200StarGoFocuser::sendSyncFocuserToPosition(int position) {
     // Command  - :X0Cpppppp#
     // Response - Nothing
     char command[AVALON_COMMAND_BUFFER_LENGTH] = {0};
-    sprintf(command, ":X0C%06d#", AVALON_FOCUSER_POSITION_OFFSET + position);
+    sprintf(command, ":X0C%06d#", AVALON_FOCUSER_POSITION_OFFSET + ((focuserReversed == REVERSED_DISABLED) ? position : -position));
     if (!baseDevice->transmit(command)) {
         DEBUGF(INDI::Logger::DBG_ERROR, "%s: Failed to send AUX1 sync command.", getDeviceName());
         return false;

--- a/3rdparty/indi-avalon/lx200stargofocuser.h
+++ b/3rdparty/indi-avalon/lx200stargofocuser.h
@@ -46,7 +46,7 @@ public:
 
     bool isConnected();
 
-    void activate(bool enabled);
+    bool activate(bool enabled);
 
     bool saveConfigItems(FILE *fp);
 

--- a/3rdparty/indi-avalon/lx200stargofocuser.h
+++ b/3rdparty/indi-avalon/lx200stargofocuser.h
@@ -58,6 +58,7 @@ protected:
     bool changeFocusRelPos(double values[], char* names[], int n);
     bool changeFocusAbort(ISState* states, char* names[], int n);
     bool changeFocusSyncPos(double values[], char* names[], int n);
+    bool setFocuserDirection(ISState *states, char *names[], int n);
 
     bool SetFocuserSpeed(int speed) override;
     IPState MoveFocuser(FocusDirection dir, int speed, uint16_t duration) override;
@@ -77,6 +78,7 @@ protected:
     bool startMovingFocuserOutward;
     uint32_t moveFocuserDurationRemaining;
     bool focuserActivated;
+    int focuserReversed = REVERSED_DISABLED;
 
 
     // LX200 commands

--- a/3rdparty/indi-avalon/lx200stargofocuser.h
+++ b/3rdparty/indi-avalon/lx200stargofocuser.h
@@ -48,6 +48,8 @@ public:
 
     void activate(bool enabled);
 
+    bool saveConfigItems(FILE *fp);
+
 protected:
 
     // Avalon specifics

--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,11 @@
+indi-avalon (1.4) stretch; urgency=medium
+
+  * Control to reverse focuser direction added
+  * Saving focuser configuration settings added
+  * Connection handling of focuser follows the base device
+
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Sun, 14 Apr 2019 19:32:34 +0200
+
 indi-avalon (1.3) stretch; urgency=medium
 
   * Enabling/disabling focuser.


### PR DESCRIPTION
**New features**
- control for reversing focuser direction added
- storing focuser parameters into the config file added

**Bug fixes**
- connection handling of focuser follows the base device