### PR TITLE
Avalon Stargo 1.4.1 - Bugfix for compile problems

### DIFF
--- a/3rdparty/indi-avalon/CMakeLists.txt
+++ b/3rdparty/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 4.1)
+set(AVALON_VERSION_MINOR 4)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/3rdparty/indi-avalon/CMakeLists.txt
+++ b/3rdparty/indi-avalon/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${NOVA_INCLUDE_DIR})
 include(CMakeCommon)
 
 set(AVALON_VERSION_MAJOR 1)
-set(AVALON_VERSION_MINOR 4)
+set(AVALON_VERSION_MINOR 4.1)
 
 set(INDI_DATA_DIR "${CMAKE_INSTALL_PREFIX}/share/indi")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config.h )

--- a/3rdparty/indi-avalon/ChangeLog
+++ b/3rdparty/indi-avalon/ChangeLog
@@ -1,3 +1,6 @@
+Version 1.4.1 - 2019-04-14
+	+ bugfix declaring Connect and Disconnect as override
+
 Version 1.4 - 2019-04-14
 	+ control for reversing focuser direction added
 	+ storing focuser parameters into the config file added

--- a/3rdparty/indi-avalon/lx200stargo.h
+++ b/3rdparty/indi-avalon/lx200stargo.h
@@ -150,8 +150,8 @@ protected:
     virtual bool UnPark() override;
     virtual bool saveConfigItems(FILE *fp) override;
     virtual bool Goto(double ra, double dec) override;
-    virtual bool Connect();
-    virtual bool Disconnect();
+    virtual bool Connect() override;
+    virtual bool Disconnect() override;
 
     // StarGo stuff
     virtual bool syncHomePosition();

--- a/debian/indi-avalon/changelog
+++ b/debian/indi-avalon/changelog
@@ -1,3 +1,9 @@
+indi-avalon (1.4.1) stretch; urgency=medium
+
+  * bugfix declaring Connect and Disconnect as override
+
+ -- Wolfgang Reissenberger <sterne-jaeger@t-online.de>  Sun, 14 Apr 2019 23:20:40 +0200
+
 indi-avalon (1.4) stretch; urgency=medium
 
   * Control to reverse focuser direction added


### PR DESCRIPTION
Bugfix declaring Connect() and Disconnect() as override fixing travis-ci errors.