### PR TITLE
Support for driving output ports of Onstep controller

### DIFF
--- a/libindi/drivers/telescope/lx200_OnStep.cpp
+++ b/libindi/drivers/telescope/lx200_OnStep.cpp
@@ -22,6 +22,8 @@
 
 */
 
+#define ONSTEP_NOTDONE
+
 #include "lx200_OnStep.h"
 
 #define LIBRARY_TAB  "Library"
@@ -242,6 +244,12 @@ bool LX200_OnStep::initProperties()
     IUFillSwitch(&OSOutput2S[0], "0", "OFF", ISS_ON);
     IUFillSwitch(&OSOutput2S[1], "1", "ON", ISS_OFF);
     IUFillSwitchVector(&OSOutput2SP, OSOutput2S, 2, getDeviceName(), "Output 2", "Output 2", OUTPUT_TAB, IP_RW, ISR_ATMOST1, 60, IPS_ALERT);
+
+    IUFillNumber(&OutputPWM[0], "PWM_OUTPUT_1", "Output 1", "%g", 0, 255, 1, 0);
+    IUFillNumber(&OutputPWM[1], "PWM_OUTPUT_2", "Output 2", "%g", 0, 255, 1, 0);
+
+    IUFillNumberVector(&OutputPWM_NP, OutputPWM, 2, getDeviceName(), "PWM_Outputs", "PWM Outputs",  OUTPUT_TAB, IP_WO, 60, IPS_OK);
+
 #endif
     
     // ============== STATUS_TAB
@@ -336,6 +344,8 @@ bool LX200_OnStep::updateProperties()
         //Outputs
         defineSwitch(&OSOutput1SP);
         defineSwitch(&OSOutput2SP);
+
+        defineNumber(&OutputPWM_NP);
     #endif
         // OnStep Status
         defineText(&OnstepStatTP);
@@ -419,6 +429,9 @@ bool LX200_OnStep::updateProperties()
         //Outputs
         deleteProperty(OSOutput1SP.name);
         deleteProperty(OSOutput2SP.name);
+
+        deleteProperty(OutputPWM_NP.name);
+
     #endif
 
         // OnStep Status

--- a/libindi/drivers/telescope/lx200_OnStep.h
+++ b/libindi/drivers/telescope/lx200_OnStep.h
@@ -256,6 +256,11 @@ class LX200_OnStep : public LX200Generic, public INDI::FocuserInterface
     ISwitchVectorProperty OSOutput2SP;
     ISwitch OSOutput2S[2];
     
+
+    INumber OutputPWM[2];
+    INumberVectorProperty OutputPWM_NP;
+
+
     char OSStat[RB_MAX_LEN];
     char OldOSStat[RB_MAX_LEN];
 

--- a/libindi/drivers/telescope/lx200_OnStep.h
+++ b/libindi/drivers/telescope/lx200_OnStep.h
@@ -80,6 +80,11 @@
 #define OnStep
 #define RB_MAX_LEN 64
 
+#define PORTS_COUNT 10
+#define STARTING_PORT 0
+
+
+
 enum Errors {ERR_NONE, ERR_MOTOR_FAULT, ERR_ALT, ERR_LIMIT_SENSE, ERR_DEC, ERR_AZM, ERR_UNDER_POLE, ERR_MERIDIAN, ERR_SYNC, ERR_PARK, ERR_GOTO_SYNC};
 
 class LX200_OnStep : public LX200Generic, public INDI::FocuserInterface
@@ -257,8 +262,8 @@ class LX200_OnStep : public LX200Generic, public INDI::FocuserInterface
     ISwitch OSOutput2S[2];
     
 
-    INumber OutputPWM[2];
-    INumberVectorProperty OutputPWM_NP;
+    INumber OutputPorts[PORTS_COUNT];
+    INumberVectorProperty OutputPorts_NP;
 
 
     char OSStat[RB_MAX_LEN];


### PR DESCRIPTION
This pull request adds support for driving output ports of Onstep controller.
It adds a new tab "Outputs" which allows entering values for 10 outputs. 
Both binary and analog values can be passed to Onstep controller.
Onstep will interpret the values accordingly: 
* if output is binary, then any value above 0 will toggle the output to high
* if output is analogy, the analog output will be set per the input value
With my RAMPS based Onstep I can toggle output 6 as binary and set values between 0 and 255 on port 7.
This code intentionally does not impose any validations on values, passed to Onstep in order to support future enhancements in Onstep. 