### PR TITLE
Incompatible frame sizes are reduced internally to ensure compatibility

### DIFF
--- a/3rdparty/indi-asi/asi_ccd.cpp
+++ b/3rdparty/indi-asi/asi_ccd.cpp
@@ -44,6 +44,9 @@ static int iAvailableCamerasCount;
 static ASI_CAMERA_INFO *pASICameraInfo;
 static ASICCD *cameras[MAX_DEVICES];
 
+static bool warn_roi_height = true;
+static bool warn_roi_width = true;
+
 //pthread_cond_t cv         = PTHREAD_COND_INITIALIZER;
 //pthread_mutex_t condMutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -1079,10 +1082,16 @@ bool ASICCD::UpdateCCDFrame(int x, int y, int w, int h)
     // ZWO rules are this: width%8 = 0, height%2 = 0
     // if this condition is not met, we set it internally to slightly smaller values
 
-    if (subW % 8 > 0)
-        LOGF_WARN ("Frame width of %d at binning %d is not allowed. Reducing by %dpx.", subW, binX, subW % 8);
-    if (subH % 2 > 0)
-        LOGF_WARN ("Frame height of %d at binning %d is not allowed. Reducing by %dpx.", subH, binY, subH % 2);
+    if (warn_roi_width && subW % 8 > 0)
+    {
+        LOGF_INFO ("Incompatible frame width %dpx. Reducing by %dpx.", subW, subW % 8);
+        warn_roi_width = false;
+    }
+    if (warn_roi_height && subH % 2 > 0)
+    {
+        LOGF_INFO ("Incompatible frame height %dpx. Reducing by %dpx.", subH, subH % 2);
+        warn_roi_height = false;
+    }
 
     subW -= subW % 8;
     subH -= subH % 2;

--- a/3rdparty/indi-asi/asi_ccd.cpp
+++ b/3rdparty/indi-asi/asi_ccd.cpp
@@ -1071,9 +1071,19 @@ bool ASICCD::UpdateCCDFrame(int x, int y, int w, int h)
         return false;
     }
 
-    // ZWO rules are this
-    // width%8 = 0
-    // height%2 = 0
+    m_SubX = subX;
+    m_SubY = subY;
+    m_SubW = subW;
+    m_SubH = subH;
+
+    // ZWO rules are this: width%8 = 0, height%2 = 0
+    // if this condition is not met, we set it internally to slightly smaller values
+
+    if (subW % 8 > 0)
+        LOGF_WARN ("Frame width of %d at binning %d is not allowed. Reducing by %dpx.", subW, binX, subW % 8);
+    if (subH % 2 > 0)
+        LOGF_WARN ("Frame height of %d at binning %d is not allowed. Reducing by %dpx.", subH, binY, subH % 2);
+
     subW -= subW % 8;
     subH -= subH % 2;
 
@@ -1103,11 +1113,6 @@ bool ASICCD::UpdateCCDFrame(int x, int y, int w, int h)
 
     LOGF_DEBUG("Setting frame buffer size to %d bytes.", nbuf);
     PrimaryCCD.setFrameBufferSize(nbuf);
-
-    m_SubX = subX;
-    m_SubY = subY;
-    m_SubW = subW;
-    m_SubH = subH;
 
     // Always set BINNED size
     Streamer->setSize(subW, subH);


### PR DESCRIPTION
ASI requires, that a ROI has a width mod 8 = 0 and height mod 2 = 0. To ensure this, the driver reduces the frame size internally by the respective mod values, if necessary. That means there might be a difference between the set frame size and the size of the captured image.

This is done intentionally to avoid very technical error message that might annoy users. For details about this decision see the discussion here: https://indilib.org/forum/ccds-dslrs/4956-indi-asi-driver-bug-causes-false-binned-images.html