### PR TITLE
Implement CW/CCW motion controls in ScopeDome driver

### DIFF
--- a/libindi/drivers.xml
+++ b/libindi/drivers.xml
@@ -423,7 +423,7 @@
 <devGroup group="Domes">
         <device label="ScopeDome Dome">
                 <driver name="ScopeDome Dome">indi_scopedome_dome</driver>
-                <version>1.0</version>
+                <version>1.1</version>
         </device>
         <device label="Baader Dome">
                 <driver name="Baader Dome">indi_baader_dome</driver>

--- a/libindi/drivers/dome/scopedome_dome.cpp
+++ b/libindi/drivers/dome/scopedome_dome.cpp
@@ -714,7 +714,16 @@ IPState ScopeDome::MoveAbs(double az)
 
     LOGF_DEBUG("azDiff rel = %f", azDiff);
 
-    int rc = 0;
+    return MoveRel(azDiff);
+}
+
+/************************************************************************************
+ *
+* ***********************************************************************************/
+IPState ScopeDome::MoveRel(double azDiff)
+{
+    int rc;
+    
     if (azDiff < 0)
     {
         uint16_t steps = (uint16_t)(-azDiff * stepsPerTurn / 360.0);
@@ -740,22 +749,6 @@ IPState ScopeDome::MoveAbs(double az)
         LOGF_ERROR("Error moving dome: %d", rc);
     }
     return IPS_BUSY;
-}
-
-/************************************************************************************
- *
-* ***********************************************************************************/
-IPState ScopeDome::MoveRel(double azDiff)
-{
-    targetAz = DomeAbsPosN[0].value + azDiff;
-
-    if (targetAz < DomeAbsPosN[0].min)
-        targetAz += DomeAbsPosN[0].max;
-    if (targetAz > DomeAbsPosN[0].max)
-        targetAz -= DomeAbsPosN[0].max;
-
-    // It will take a few cycles to reach final position
-    return MoveAbs(targetAz);
 }
 
 /************************************************************************************

--- a/libindi/drivers/dome/scopedome_dome.cpp
+++ b/libindi/drivers/dome/scopedome_dome.cpp
@@ -770,6 +770,7 @@ IPState ScopeDome::Move(DomeDirection dir, DomeMotionCommand operation)
     // Map to button outputs
     if (operation == MOTION_START)
     {
+        refineMove = false;
         if (dir == DOME_CW)
         {
             setOutputState(OUT_CW, ISS_ON);

--- a/libindi/drivers/dome/scopedome_dome.cpp
+++ b/libindi/drivers/dome/scopedome_dome.cpp
@@ -647,10 +647,11 @@ void ScopeDome::TimerHit()
             {
                 azDiff += 360;
             }
-            if (fabs(azDiff) <= DomeParamN[0].value)
+            if (refineMove == false || fabs(azDiff) <= DomeParamN[0].value)
             {
-                DomeAbsPosN[0].value = targetAz;
-                DomeAbsPosNP.s       = IPS_OK;
+                if (refineMove)
+                    DomeAbsPosN[0].value = targetAz;
+                DomeAbsPosNP.s = IPS_OK;
                 LOG_INFO("Dome reached requested azimuth angle.");
 
                 if (getDomeState() == DOME_PARKING)
@@ -714,6 +715,7 @@ IPState ScopeDome::MoveAbs(double az)
 
     LOGF_DEBUG("azDiff rel = %f", azDiff);
 
+    refineMove = true;
     return MoveRel(azDiff);
 }
 
@@ -721,6 +723,15 @@ IPState ScopeDome::MoveAbs(double az)
  *
 * ***********************************************************************************/
 IPState ScopeDome::MoveRel(double azDiff)
+{
+    refineMove = false;
+    return sendMove(azDiff);
+}
+
+/************************************************************************************
+ *
+* ***********************************************************************************/
+IPState ScopeDome::sendMove(double azDiff)
 {
     int rc;
 

--- a/libindi/drivers/dome/scopedome_dome.cpp
+++ b/libindi/drivers/dome/scopedome_dome.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
  ScopeDome Dome INDI Driver
 
- Copyright(c) 2017-2018 Jarno Paananen. All rights reserved.
+ Copyright(c) 2017-2019 Jarno Paananen. All rights reserved.
 
  based on:
 
@@ -87,7 +87,7 @@ void ISSnoopDevice(XMLEle *root)
 
 ScopeDome::ScopeDome()
 {
-    setVersion(1, 0);
+    setVersion(1, 1);
     targetAz         = 0;
     shutterState     = SHUTTER_UNKNOWN;
     simShutterStatus = SHUTTER_CLOSED;
@@ -756,6 +756,31 @@ IPState ScopeDome::MoveRel(double azDiff)
 
     // It will take a few cycles to reach final position
     return MoveAbs(targetAz);
+}
+
+/************************************************************************************
+ *
+* ***********************************************************************************/
+IPState ScopeDome::Move(DomeDirection dir, DomeMotionCommand operation)
+{
+    // Map to button outputs
+    if(operation == MOTION_START)
+    {
+        if (dir == DOME_CW)
+        {
+            setOutputState(OUT_CW, ISS_ON);
+            setOutputState(OUT_CCW, ISS_OFF);
+        }
+        else
+        {
+            setOutputState(OUT_CW, ISS_OFF);
+            setOutputState(OUT_CCW, ISS_ON);
+        }
+        return IPS_BUSY;
+    }
+    setOutputState(OUT_CW, ISS_OFF);
+    setOutputState(OUT_CCW, ISS_OFF);
+    return IPS_OK;
 }
 
 /************************************************************************************

--- a/libindi/drivers/dome/scopedome_dome.cpp
+++ b/libindi/drivers/dome/scopedome_dome.cpp
@@ -723,7 +723,7 @@ IPState ScopeDome::MoveAbs(double az)
 IPState ScopeDome::MoveRel(double azDiff)
 {
     int rc;
-    
+
     if (azDiff < 0)
     {
         uint16_t steps = (uint16_t)(-azDiff * stepsPerTurn / 360.0);
@@ -757,7 +757,7 @@ IPState ScopeDome::MoveRel(double azDiff)
 IPState ScopeDome::Move(DomeDirection dir, DomeMotionCommand operation)
 {
     // Map to button outputs
-    if(operation == MOTION_START)
+    if (operation == MOTION_START)
     {
         if (dir == DOME_CW)
         {

--- a/libindi/drivers/dome/scopedome_dome.h
+++ b/libindi/drivers/dome/scopedome_dome.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
  ScopeDome Dome INDI Driver
 
- Copyright(c) 2017 Jarno Paananen. All rights reserved.
+ Copyright(c) 2017-2019 Jarno Paananen. All rights reserved.
 
  based on:
 
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#include "indibase/indidome.h"
+#include "indidome.h"
 #include <memory>
 
 /**
@@ -411,6 +411,7 @@ class ScopeDome : public INDI::Dome
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
 
+    virtual IPState Move(DomeDirection dir, DomeMotionCommand operation) override;
     virtual IPState MoveRel(double azDiff) override;
     virtual IPState MoveAbs(double az) override;
     virtual IPState ControlShutter(ShutterOperation operation) override;

--- a/libindi/drivers/dome/scopedome_dome.h
+++ b/libindi/drivers/dome/scopedome_dome.h
@@ -436,6 +436,7 @@ class ScopeDome : public INDI::Dome
 
     DomeStatus status{ DOME_UNKNOWN };
     double targetAz{ 0 };
+    bool refineMove{ false };
     ShutterOperation targetShutter{ SHUTTER_OPEN };
     bool sim{ false };
     double simShutterTimer{ 0 };
@@ -485,6 +486,8 @@ class ScopeDome : public INDI::Dome
     std::unique_ptr<ScopeDomeCard> interface;
 
     void reconnect();
+
+    IPState sendMove(double azDiff);
 
     // I/O helper functions
     bool readFloat(ScopeDomeCommand cmd, float &dst);


### PR DESCRIPTION
In current version pressing CW or CCW motion buttons crashes due to unimplemented Move method in the driver class when dome base class tries to call it causing it to call itself instead ending up in infinite recursion.