### PR TITLE
Bugfix  pulse and movement

### DIFF
--- a/libindi/drivers/telescope/eq500x.cpp
+++ b/libindi/drivers/telescope/eq500x.cpp
@@ -674,6 +674,39 @@ void EQ500X::setPierSide(TelescopePierSide side)
     IDSetSwitch(&PierSideSP, "Not supported");
 }
 
+bool EQ500X::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
+{
+    // EQ500X has North/South directions inverted
+    int current_move = (dir == DIRECTION_NORTH) ? LX200_SOUTH : LX200_NORTH;
+
+    switch (command)
+    {
+    case MOTION_START:
+        if (!isSimulation() && MoveTo(PortFD, current_move) < 0)
+        {
+            LOG_ERROR("Error setting N/S motion direction.");
+            return false;
+        }
+        else
+            LOGF_DEBUG("Moving toward %s.",
+                      (current_move == LX200_NORTH) ? "North" : "South");
+        break;
+
+    case MOTION_STOP:
+        if (!isSimulation() && HaltMovement(PortFD, current_move) < 0)
+        {
+            LOG_ERROR("Error stopping N/S motion.");
+            return false;
+        }
+        else
+            LOGF_DEBUG("Movement toward %s halted.",
+                      (current_move == LX200_NORTH) ? "North" : "South");
+        break;
+    }
+
+    return true;
+}
+
 /**************************************************************************************
 **
 ***************************************************************************************/

--- a/libindi/drivers/telescope/eq500x.cpp
+++ b/libindi/drivers/telescope/eq500x.cpp
@@ -933,7 +933,7 @@ char const * EQ500X::MechanicalPoint::toStringRA(char *buf, size_t buf_length) c
 
 bool EQ500X::MechanicalPoint::parseStringRA(char const *buf, size_t buf_length)
 {
-    if (buf_length < sizeof(MechanicalPoint_RA_Format-1))
+    if (buf_length < sizeof(MechanicalPoint_RA_Format)-1)
         return true;
 
     // Mount replies to "#GR:" with "HH:MM:SS".

--- a/libindi/drivers/telescope/eq500x.cpp
+++ b/libindi/drivers/telescope/eq500x.cpp
@@ -98,7 +98,7 @@ const adjustments[] = {
 ***************************************************************************************/
 EQ500X::EQ500X(): LX200Generic()
 {
-    setVersion(1, 0);
+    setVersion(1, 1);
 
     // Sanitize constants: epsilon of a slew rate must be smaller than distance of its smaller sibling
     for (size_t i = 0; i < sizeof(adjustments)/sizeof(adjustments[0])-1; i++)

--- a/libindi/drivers/telescope/eq500x.cpp
+++ b/libindi/drivers/telescope/eq500x.cpp
@@ -108,8 +108,8 @@ EQ500X::EQ500X(): LX200Generic()
     for (size_t i = 0; i < sizeof(adjustments)/sizeof(adjustments[0]); i++)
         assert(adjustments[i].epsilon <= adjustments[i].distance);
 
-    // No pulse guiding (mount doesn't support Mgx commands) nor tracking frequency
-    // setLX200Capability(LX200_HAS_PULSE_GUIDING);
+    // No pulse guiding (mount doesn't support Mgx commands) nor tracking frequency nor nothing generic has actually
+    setLX200Capability(0);
 
     // Sync, goto, abort, location and 4 slew rates, no guiding rates and no park position
     SetTelescopeCapability(TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT | TELESCOPE_HAS_LOCATION | TELESCOPE_HAS_PIER_SIDE, 4);

--- a/libindi/drivers/telescope/eq500x.h
+++ b/libindi/drivers/telescope/eq500x.h
@@ -92,6 +92,7 @@ protected:
     virtual bool Sync(double, double) override;
     virtual bool Abort() override;
     virtual void setPierSide(TelescopePierSide);
+    virtual bool MoveNS(INDI_DIR_NS, TelescopeMotionCommand) override;
 private:
     MechanicalPoint currentMechPosition, targetMechPosition;
     double previousRA = {0}, previousDEC = {0};

--- a/libindi/drivers/telescope/eq500x.md
+++ b/libindi/drivers/telescope/eq500x.md
@@ -1,0 +1,35 @@
+# Omegon EQ500-X Equatorial Mount
+## Installation
+The Omegon EQ500-X Equatorial Mount driver is included with libindi >= 1.7.8. Install with:
+```
+$ sudo add-apt-repository ppa:mutlaqja/ppa
+$ sudo apt-get update
+$ sudo apt-get install libindi1
+```
+## Features
+The Omegon EQ500-X Equatorial Mount driver supports:
+* 4 Slew Rates (max, find, center and guide)
+* Single sidereal tracking rate
+* Goto coordinates (via software adjustment)
+* Sync coordinates
+* Abort movement
+* Location configuration (used for initial sync)
+* Pier side
+* Simulation mode
+* Timed pulse guiding
+## Operation
+* Install the Omegon EQ500-X Equatorial Mount with its pad connected.
+* Orient the right ascension axis towards the pole using either visual alignment or an external alignment tool.
+* Rotate the right ascension axis so that the telescope is on top, and declination axis so that the telescope looks at the pole.
+* Lock axes firmly.
+* Power on the mount using the side button on the pad to select your hemisphere.
+* Plug the USB cable from the pad to the host computer.
+* By default, the pad is recognized as a serial adapter on port /dev/ttyUSB0 (9600 bauds, 8 bits, no parity, 1 stop bit).
+* Execute indiserver with driver `indi_eq500x` using the method of your choice.
+* When you connect the driver after powering up the mount, the initial position is synced to the local sidereal time of the location your client.
+## Issues
+* To improve the precision of the goto feature, the driver provides software adjustment but the performance of the algorithm may suffer from high load on the host.
+* The mount does not offer pulse guiding through LX200 Mg commands, instead a software timed guide pulse is used.
+* Goto movements are expected to always go through the meridian opposite to the pole.
+* However, neither the mount nor the driver will prevent manual movement or tracking through the pole meridian.
+* The driver is unable to read the firmware version for compatibility verification.


### PR DESCRIPTION
Fixes North/South guiding/movement orientation.
Fixes property switch "Use Pulse Cmd" so that it rejects the pulse command feature (only timed moves).
Markdown documentation was missing.