### PR TITLE
Added support for multiple read modes in QHY sCMOS cameras

### DIFF
--- a/3rdparty/indi-qhy/qhy_ccd.h
+++ b/3rdparty/indi-qhy/qhy_ccd.h
@@ -24,7 +24,6 @@
 #include <qhyccd.h>
 #include <indiccd.h>
 #include <indifilterinterface.h>
-
 #include <unistd.h>
 #include <functional>
 #include <pthread.h>
@@ -98,6 +97,9 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
 
         INumber SpeedN[1];
         INumberVectorProperty SpeedNP;
+        
+        INumber ReadModeN[1];
+        INumberVectorProperty ReadModeNP;
 
         INumber USBTrafficN[1];
         INumberVectorProperty USBTrafficNP;
@@ -161,6 +163,7 @@ class QHYCCD : public INDI::CCD, public INDI::FilterInterface
         bool HasTransferBit { false };
         bool HasCoolerAutoMode { false };
         bool HasCoolerManualMode { false };
+        bool HasReadMode { false };
 
         qhyccd_handle *m_CameraHandle {nullptr};
         INDI::CCDChip::CCD_FRAME m_ImageFrameType;

--- a/3rdparty/indi-qhy/qhy_ccd_test.cpp
+++ b/3rdparty/indi-qhy/qhy_ccd_test.cpp
@@ -32,7 +32,7 @@ int main(int , char **)
     int USB_TRAFFIC = 10;
     int CHIP_GAIN = 10;
     int CHIP_OFFSET = 140;
-    int EXPOSURE_TIME = 20000;
+    int EXPOSURE_TIME = 1;
     int camBinX = 1;
     int camBinY = 1;
     
@@ -227,6 +227,48 @@ int main(int , char **)
             return 1;
         }
     }
+    
+    // check read mode in QHY42
+    uint32_t currentReadMode = 0;
+    char *modeName=(char *)malloc((200)*sizeof(char));;
+    retVal = GetQHYCCDReadMode(pCamHandle, &currentReadMode);
+    if (QHYCCD_SUCCESS == retVal) {
+        printf("Default read mode: %d \n", currentReadMode);
+        retVal = GetQHYCCDReadModeName(pCamHandle , currentReadMode, modeName);
+        if (QHYCCD_SUCCESS == retVal) {
+            printf("Default read mode name %s \n", modeName);
+        } else {
+            printf("Error reading mode name \n");
+            getchar();
+            return 1;
+        }
+        
+        // Set read modes and read resolution for each one
+        uint32_t readModes = 0;
+        uint32_t imageRMw, imageRMh;
+        uint32_t i=0;
+        retVal = GetQHYCCDNumberOfReadModes(pCamHandle, &readModes);
+        for(i=0;i<readModes;i++)
+        {
+            // Set read mode and get resolution
+            retVal = SetQHYCCDReadMode(pCamHandle,i);
+            if (QHYCCD_SUCCESS == retVal) {
+                // Get resolution
+                retVal = GetQHYCCDReadModeName(pCamHandle , i, modeName);
+                    if (QHYCCD_SUCCESS == retVal) {
+                        printf("Read mode name %s \n", modeName);
+                    } else {
+                        printf("Error reading mode name \n");
+                        getchar();
+                        return 1;
+                    }
+                    retVal = GetQHYCCDReadModeResolution(pCamHandle, i, &imageRMw, &imageRMh);
+                printf("GetQHYCCDChipInfo in this ReadMode: imageW: %d imageH: %d \n", imageRMw, imageRMh);
+            }
+        }
+        
+    }
+    
 
     // set exposure time
     retVal = SetQHYCCDParam(pCamHandle, CONTROL_EXPOSURE, EXPOSURE_TIME);


### PR DESCRIPTION
Added support for multiple read modes in QHY sCMOS cameras, code has been tested in one QHY42Pro, that allows two read modes:

* HDR: output is a single 4096*2048 resolution image, it contains two images. Left is low gain channel image and right side is high gain channel image.
* STD: output is a single 2048*2048 resolution image. 

Implementation uses INumber types, as future improvement I plan to use ISwitch that will provide a more user friendly implementation, showing read modes names instead its index number.