### PR TITLE
Eqmod: Fix RA drift with HEQ5 firmware 106

### DIFF
--- a/3rdparty/indi-eqmod/CMakeLists.txt
+++ b/3rdparty/indi-eqmod/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ZLIB REQUIRED)
 find_package(GSL REQUIRED)
 
 set(EQMOD_VERSION_MAJOR 0)
-set(EQMOD_VERSION_MINOR 6)
+set(EQMOD_VERSION_MINOR 7)
 
 if (CYGWIN)
 add_definitions(-U__STRICT_ANSI__)

--- a/3rdparty/indi-eqmod/skywatcher.cpp
+++ b/3rdparty/indi-eqmod/skywatcher.cpp
@@ -560,6 +560,15 @@ void Skywatcher::InquireRAEncoderInfo(INumberVectorProperty *encoderNP)
                0x205318, RAStepsWorm);
         RAStepsWorm = 0x205318; // for 114GT mount
     }
+    // Correct drift of 4.1 arcsec per minute with HEQ5 firmware 106
+    // drift correction = 1.00455,  64935/1.00455 = 64640 = 0xFC80
+    if (MCVersion == 0x10601)
+    {
+        LOGF_WARN("%s: forcing RAStepsWorm for HEQ5 with firmware 106 (%x in place of %x)", __FUNCTION__,
+               0xFC80, RAStepsWorm);
+        RAStepsWorm = 0xFC80;
+    }
+
     steppersvalues[1] = (double)RAStepsWorm;
 
     // Highspeed Ratio
@@ -604,6 +613,14 @@ void Skywatcher::InquireDEEncoderInfo(INumberVectorProperty *encoderNP)
         LOGF_WARN("%s: forcing DEStepsWorm for 114GT Mount (%x in place of %x)", __FUNCTION__,
                0x205318, DEStepsWorm);
         DEStepsWorm = 0x205318; // for 114GT mount
+    }
+    // HEQ5 with firmware 106, use same rate as RA
+    // drift correction = 1.00455,  64935/1.00455 = 64640 = 0xFC80
+    if (MCVersion == 0x10601)
+    {
+        LOGF_WARN("%s: forcing DEStepsWorm for HEQ5 with firmware 106 (%x in place of %x)", __FUNCTION__,
+               0xFC80, DEStepsWorm);
+        DEStepsWorm = 0xFC80;
     }
 
     steppersvalues[1] = (double)DEStepsWorm;

--- a/debian/indi-eqmod/changelog
+++ b/debian/indi-eqmod/changelog
@@ -1,3 +1,9 @@
+indi-eqmod (0.7) bionic; urgency=medium
+
+  * New release
+
+ -- Jasem Mutlaq <mutlaqja@ikarustech.com>  Thu, 16 May 2019 08:43:02 +0200
+
 indi-eqmod (0.5) bionic; urgency=medium
 
   * New release


### PR DESCRIPTION
The HEQ5 with the old motor board with firmware version 106 as a bug that make the RA to drift at a rate about 4 arcsec per minute when driven at sidereal rate. Unfortunately this board cannot be upgraded to a new firmware. This issue was the reason for the "drift compensation" slider in EQASCOM.

The solution is to override the Timer Interrupt Frequency returned by the board when this board version is detected, as this is already done for the 80GT and 114GT.

I find the new frequency after some trial and now my mount as no more drift. 
