### PR TITLE
Fixed typos in conf files

### DIFF
--- a/3rdparty/indi-talon6/CMakeLists.txt
+++ b/3rdparty/indi-talon6/CMakeLists.txt
@@ -20,7 +20,7 @@ include_directories( ${INDI_INCLUDE_DIR})
 
 include(CMakeCommon)
 
-########### MaxDome II ###########
+########### Talon6  ###########
 set(indi_talon6_SRCS
    ${CMAKE_CURRENT_SOURCE_DIR}/talon6.cpp
    )

--- a/3rdparty/indi-talon6/indi_talon6.xml.cmake
+++ b/3rdparty/indi-talon6/indi_talon6.xml.cmake
@@ -1,4 +1,4 @@
-<?xml version="0.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <driversList>
 <devGroup group="Domes">
 	<device label="Talon6">


### PR DESCRIPTION
This driver is not included in the stable / nightly releases. There are no compile errors, I think it is the installation that is failing. 
Found a minor typo in xml.cmake that can cause this issue.
I will check in the next nightly