### PR TITLE
Bugfix  slew rate after goto

### DIFF
--- a/libindi/drivers/telescope/eq500x.h
+++ b/libindi/drivers/telescope/eq500x.h
@@ -104,6 +104,7 @@ private:
     // Current adjustment rate
     struct _adjustment const * adjustment {nullptr};
     bool _gotoEngaged {false};
+    enum TelescopeSlewRate savedSlewRateIndex {SLEW_MAX};
 };
 
 #endif // EQ500X_H


### PR DESCRIPTION
When a Go-To is requested to the driver, the final slew rate was always "guide". Because SkySafari is not updated with slew rate changes, there was in general a discrepancy between the mount control on the mount settings.

This PR restores the slew rate after a Go-To request and an Abort request. It also makes sure executing a second Go-To while one is running properly restores the original slew rate.

This PR adds tests reproducing the issue, then code fixing that issue. CircleCI validated all tests in the branch this PR originates from, but this PR does not run any actual tests.
