### PR TITLE
fixing a typo I made

### DIFF
--- a/libindi/libs/indibase/alignment/MathPluginManagement.cpp
+++ b/libindi/libs/indibase/alignment/MathPluginManagement.cpp
@@ -361,7 +361,7 @@ void MathPluginManagement::EnumeratePlugins()
     #endif
 
     dp    = opendir(MATH_PLUGINS_DIRECTORY);
-    snprintf(MATH_PLUGINS_DIRECTORY, 2048 - 1, "%s%s", INDI_MATH_PLUGINS_DIRECTORY, "/");
+    snprintf(MATH_PLUGINS_DIRECTORY, 2048 - 1, "%s%s", MATH_PLUGINS_DIRECTORY, "/");
     if (dp)
     {
         while (true)

--- a/libindi/libs/indibase/alignment/MathPluginManagement.cpp
+++ b/libindi/libs/indibase/alignment/MathPluginManagement.cpp
@@ -361,7 +361,7 @@ void MathPluginManagement::EnumeratePlugins()
     #endif
 
     dp    = opendir(MATH_PLUGINS_DIRECTORY);
-    snprintf(MATH_PLUGINS_DIRECTORY, 2048 - 1, "%s%s", MATH_PLUGINS_DIRECTORY, "/");
+    strncat(MATH_PLUGINS_DIRECTORY, "/", 1);
     if (dp)
     {
         while (true)


### PR DESCRIPTION
In my previous commit to this file, I wrote a series of if statements that should make the path to the math plugins correct in various system configurations including embedded within app bundles.  Unfortunately, in the last step, I made a typo that overwrote the result of the if statement with the default value.  This bug didn't show up till now because on Linux, the INDI_MATH_PLUGINS_DIRECTORY is the correct directory.  On OS X, I didn't see any issue either because on my system, the plugins are there. It was only with the new craft recipes that the issue became apparent.