### PR TITLE
Version 1.3 of the Sestosenso Focusser. Hack to make it work

### DIFF
--- a/libindi/drivers.xml
+++ b/libindi/drivers.xml
@@ -289,7 +289,7 @@
         </device>
         <device label="Sesto Senso">
                 <driver name="Sesto Senso">indi_sestosenso_focus</driver>
-                <version>1.2</version>
+                <version>1.3</version>
         </device>
         <device label="Lakeside">
                 <driver name="Lakeside">indi_lakeside_focus</driver>

--- a/libindi/drivers/focuser/sestosenso.cpp
+++ b/libindi/drivers/focuser/sestosenso.cpp
@@ -71,9 +71,9 @@ void ISSnoopDevice(XMLEle *root)
 
 SestoSenso::SestoSenso()
 {
-    setVersion(1, 2);
+    setVersion(1, 3);
     // Can move in Absolute & Relative motions, can AbortFocuser motion.
-    FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_CAN_ABORT | FOCUSER_CAN_SYNC | FOCUSER_CAN_REVERSE);
+    FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_CAN_ABORT);
 }
 
 bool SestoSenso::initProperties()
@@ -351,6 +351,8 @@ bool SestoSenso::SetFocuserMaxPosition(uint32_t ticks)
 
 bool SestoSenso::setMaxLimit(uint32_t limit)
 {
+    return true;
+
     char cmd[SESTO_LEN] = {0}, res[SESTO_LEN] = {0};
     snprintf(cmd, SESTO_LEN, "#SM;%07d!", limit);
 
@@ -372,6 +374,8 @@ bool SestoSenso::setMaxLimit(uint32_t limit)
 
 bool SestoSenso::setMinLimit(uint32_t limit)
 {
+    return true;
+
     char cmd[SESTO_LEN] = {0}, res[SESTO_LEN] = {0};
     snprintf(cmd, SESTO_LEN, "#Sm;%07d!", limit);
 


### PR DESCRIPTION
Quick fix to stop the focuser direction reversal after a SM;xxxxx! command. This hack simply means that these command will no longer be sent. This is intended to allow people to use the focuser until the proper solution is completed. A more complete version will be released at a later date.