### PR TITLE
Decode ATIK firmware version correctly in pProp->Protocol

### DIFF
--- a/3rdparty/indi-atik/atik_ccd.cpp
+++ b/3rdparty/indi-atik/atik_ccd.cpp
@@ -357,8 +357,10 @@ bool ATIKCCD::setupParams()
     PrimaryCCD.setMinMaxStep("CCD_BINNING", "HOR_BIN", 1, binX, 1, false);
     PrimaryCCD.setMinMaxStep("CCD_BINNING", "VER_BIN", 1, binY, 1, false);
 
-    IUSaveText(&VersionInfoS[VERSION_FIRMWARE], std::to_string(pProp.Protocol).c_str());
-    LOGF_INFO("Detected camera %s %s with firmware %s", pProp.Manufacturer, pProp.Description, std::to_string(pProp.Protocol).c_str());
+    char firmware[8] = {0};
+    snprintf(firmware, sizeof(firmware), "%d.%d", prop.Protocol >> 8, prop.Protocol & 0xff);
+    IUSaveText(&VersionInfoS[VERSION_FIRMWARE], firmware);
+    LOGF_INFO("Detected camera %s %s with firmware %s", pProp.Manufacturer, pProp.Description, firmware);
 
     uint32_t cap = 0;
 


### PR DESCRIPTION
ATIK library call: ArtemisProperties(...) returns by reference call
struct ARTEMISPROPERTIES *pProp, where pProp->Protocol contains
the firmware version of the camera. The firmware is however
decoded as major.minor, where major = prop.Protocol >> 8
and minor = prop.Protocol & 0xff. This patch was tested with
camera ATIK 414EX where used firmware is: 3.44 and pProp->Protocol = 812.