### PR TITLE
Fix possible resource leak found by static checker

### DIFF
--- a/libindi/indidriver.c
+++ b/libindi/indidriver.c
@@ -1310,10 +1310,9 @@ void IUSaveDefaultConfig(const char *source_config, const char *dest_config, con
                 int ch = 0;
                 while ((ch = getc(fpin)) != EOF)
                     putc(ch, fpout);
-
-                fclose(fpin);
+		fclose(fpout);
             }
-            fclose(fpout);
+	    fclose(fpin);
         }
     }
 }


### PR DESCRIPTION
The original code snippet is:

        FILE *fpin = fopen(configFileName, "r");
        if (fpin != NULL)
        {
            FILE *fpout = fopen(configDefaultFileName, "w");
            if (fpout != NULL)
            {
                int ch = 0;
                while ((ch = getc(fpin)) != EOF)
                    putc(ch, fpout);

                fclose(fpin);
            }
            fclose(fpout);
        }
	...
However, fclose(fpin) must be exchanged with fclose(fpout), that is:

        FILE *fpin = fopen(configFileName, "r");
        if (fpin != NULL)
        {
            FILE *fpout = fopen(configDefaultFileName, "w");
            if (fpout != NULL)
            {
                int ch = 0;
                while ((ch = getc(fpin)) != EOF)
                    putc(ch, fpout);
                fclose(fpout);
            }
            fclose(fpin);
        }
	...