### PR TITLE
Prevents indi_fli_wheel crash for FLI-CFW-1-8 model.

### DIFF
--- a/3rdparty/libfli/unix/libusb/libfli-usb-sys.c
+++ b/3rdparty/libfli/unix/libusb/libfli-usb-sys.c
@@ -572,14 +572,16 @@ long libusb_list(char *pattern, flidomain_t domain, char ***names)
 
     if (FLIOpen(&dev, fli_device_name, domain) == 0) /* Opened and should have model */
     {
-      strncpy(fli_model_name, DEVICE->devinfo.model, sizeof(fli_model_name) - 1);
+		if(DEVICE->devinfo.model == NULL)
+			DEVICE->devinfo.model = strdup("DEVICE->devinfo.model is NULL");
+	  strncpy(fli_model_name, DEVICE->devinfo.model, sizeof(fli_model_name) - 1);
       FLIClose(dev);
     }
     else
     {
       libusb_device_handle *usb_han;
 
-      if(libusb_open(usb_dev, &usb_han) == 0)
+      if( (libusb_open(usb_dev, &usb_han) == 0) && (usb_desc.iProduct > 0) )
       {
         libusb_get_string_descriptor_ascii(usb_han, usb_desc.iProduct,
           (unsigned char *) fli_model_name, sizeof(fli_model_name) - 1);


### PR DESCRIPTION
Present INDI driver does not use FLI kernel module. So I was not able to connect my FLI Filter Wheel CFW-1-8 via usb port.
I supposed the problem was inability to detect DEVICE→devinfo.model.
I modified this file /indi/3rdparty/libfli/unix/libusb/libfli-usb-sys.c to verify the content of devinfo.model. If this descriptor is empty, I provide for completing it. This solution prevents FLI driver crash and reactivates the functions of my CFW. 
[log_17-51-42.txt](https://github.com/indilib/indi/files/3438343/log_17-51-42.txt)
