### PR TITLE
Various FocusLynx fixes / enhancements

### DIFF
--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -1536,7 +1536,15 @@ bool FocusLynxBase::getFocusTemp()
         char compensateMode;
         rc = sscanf(response, "%16[^=]= %c", key, &compensateMode);
         if (rc != 2)
-            return false;
+        {
+            if (rc == 1 && key[0] == 'T'){
+                //If the controller does not support this it could be null. Assume A mode in this case.
+                compensateMode = 'A';
+            }
+            else{
+                return false;
+            }
+        }
 
         IUResetSwitch(&TemperatureCompensateModeSP);
         int index = compensateMode - 'A';

--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -43,6 +43,7 @@ FocusLynxBase::FocusLynxBase()
     //  lynxModels["Optec Gemini (reserved for future use)"] = "OG";
     lynxModels["Optec Leo"] = "OI";
     lynxModels["Optec Leo High-Torque"] = "OJ";
+    lynxModels["Optec Sagitta"] = "OK";
     lynxModels["FocusLynx QuickSync FT Hi-Torque"] = "FA";
     lynxModels["FocusLynx QuickSync FT Hi-Speed"] = "FB";
     //  lynxModels["FocusLynx QuickSync SV (reserved for future use)"] = "FC";

--- a/libindi/drivers/focuser/focuslynxbase.cpp
+++ b/libindi/drivers/focuser/focuslynxbase.cpp
@@ -2996,11 +2996,23 @@ bool FocusLynxBase::isResponseOK()
         response[nbytes_read - 1] = '\0';
         LOGF_DEBUG("RES (%s)", response);
 
-        if (response[0] == '!')
+        if (!strcmp(response, "!"))
             return true;
         else
         {
-            LOGF_ERROR("Controller error: %s", response);
+            memset(response, 0, sizeof(response));
+            while (strstr(response, "END") == nullptr)
+            {
+                if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
+                {
+                    tty_error_msg(errcode, errmsg, MAXRBUF);
+                    LOGF_ERROR("TTY error: %s", errmsg);
+                    return false;
+                }
+                response[nbytes_read - 1] = '\0';
+                LOGF_ERROR("Controller error: %s", response);
+            }
+
             return false;
         }
     }

--- a/libindi/drivers/focuser/focuslynxbase.h
+++ b/libindi/drivers/focuser/focuslynxbase.h
@@ -35,7 +35,7 @@
 #include <cstring>
 
 #define LYNXFOCUS_MAX_RETRIES          1
-#define LYNXFOCUS_TIMEOUT              2
+#define LYNXFOCUS_TIMEOUT              3
 #define LYNXFOCUS_MAXBUF               16
 #define LYNXFOCUS_TEMPERATURE_FREQ     20      /* Update every 20 POLLMS cycles. For POLLMS 500ms = 10 seconds freq */
 #define LYNXFOCUS_POSITION_THRESHOLD    5      /* Only send position updates to client if the diff exceeds 5 steps */
@@ -45,7 +45,7 @@
 #define HUB_SETTINGS_TAB "Device"
 
 #define VERSION                 1
-#define SUBVERSION              42
+#define SUBVERSION              43
 
 class FocusLynxBase : public INDI::Focuser
 {


### PR DESCRIPTION
This fixes an issue with the new Optec ThirdLynx FocusLynx controller (which allows a value in a response to be null be default). It also changes the isResponseOK() to match the behavior of the Optec Gemini (by reading to the END for commands) and adds the new Optec Sagitta focuser device type.