### PR TITLE
Initializing parking mode correctly for rolloff roofs

### DIFF
--- a/libindi/libs/indibase/indidome.cpp
+++ b/libindi/libs/indibase/indidome.cpp
@@ -1412,10 +1412,10 @@ bool Dome::InitPark()
         return false;
     }
 
+    SyncParkStatus(isParked());
+
     if (parkDataType != PARK_NONE)
     {
-        SyncParkStatus(isParked());
-
         LOGF_DEBUG("InitPark Axis1 %.2f", Axis1ParkPosition);
         ParkPositionN[AXIS_AZ].value = Axis1ParkPosition;
         IDSetNumber(&ParkPositionNP, nullptr);


### PR DESCRIPTION
For rolloff roofs, the parking state is not initialized. As a result, the INDI client shows neither parked nor unparked as selected. This creates subsequent problems when a user wants to park the roof and gets the result that it is already closed.