### PR TITLE
Celestron Focuser position not update with Evolution mount

### DIFF
--- a/libindi/drivers/telescope/celestrongps.cpp
+++ b/libindi/drivers/telescope/celestrongps.cpp
@@ -778,46 +778,6 @@ bool CelestronGPS::ReadScopeStatus()
     //IDSetNumber(&HorizontalCoordsNP, nullptr);
     NewRaDec(currentRA, currentDEC);
 
-    if (!HasPierSide())
-        return true;
-
-    char sop;
-    INDI::Telescope::TelescopePierSide pierSide = PIER_UNKNOWN;
-    char psc = 'U';
-    if (driver.get_pier_side(&sop))
-    {
-        // manage version and hemisphere nonsense
-        // HC versions less than 5.24 reverse the side of pier if the mount
-        // is in the Southern hemisphere.  StarSense doesn't
-        if (LocationN[LOCATION_LATITUDE].value < 0)
-        {
-            if (fwInfo.controllerVersion <= 5.24 && fwInfo.controllerVariant != ISSTARSENSE)
-            {
-                // swap the char reported
-                if (sop == 'E')
-                    sop = 'W';
-                else if (sop == 'W')
-                    sop = 'E';
-            }
-        }
-        // The Celestron and INDI pointing states are opposite
-        if (sop == 'W')
-        {
-            pierSide = PIER_EAST;
-            psc = 'E';
-        }
-        else if (sop == 'E')
-        {
-            pierSide = PIER_WEST;
-            psc = 'W';
-        }
-    }
-
-    LOGF_DEBUG("latitude %g, sop %c, PierSide %c",
-               LocationN[LOCATION_LATITUDE].value,
-               sop, psc);
-    setPierSide(pierSide);
-
     // focuser
     if (fwInfo.hasFocuser)
     {
@@ -860,6 +820,46 @@ bool CelestronGPS::ReadScopeStatus()
             }
         }
     }
+
+    if (!HasPierSide())
+        return true;
+
+    char sop;
+    INDI::Telescope::TelescopePierSide pierSide = PIER_UNKNOWN;
+    char psc = 'U';
+    if (driver.get_pier_side(&sop))
+    {
+        // manage version and hemisphere nonsense
+        // HC versions less than 5.24 reverse the side of pier if the mount
+        // is in the Southern hemisphere.  StarSense doesn't
+        if (LocationN[LOCATION_LATITUDE].value < 0)
+        {
+            if (fwInfo.controllerVersion <= 5.24 && fwInfo.controllerVariant != ISSTARSENSE)
+            {
+                // swap the char reported
+                if (sop == 'E')
+                    sop = 'W';
+                else if (sop == 'W')
+                    sop = 'E';
+            }
+        }
+        // The Celestron and INDI pointing states are opposite
+        if (sop == 'W')
+        {
+            pierSide = PIER_EAST;
+            psc = 'E';
+        }
+        else if (sop == 'E')
+        {
+            pierSide = PIER_WEST;
+            psc = 'W';
+        }
+    }
+
+    LOGF_DEBUG("latitude %g, sop %c, PierSide %c",
+               LocationN[LOCATION_LATITUDE].value,
+               sop, psc);
+    setPierSide(pierSide);
 
     return true;
 }


### PR DESCRIPTION
Celestron NexStar Evolution mounts do not seem to support retrieval of pier side information. At least with my mount (latest FW), the Celestron GPS driver even warns about that fact upon startup.

The ReadScopeStatus() operation exits if HasPierSide() is FALSE, directly before it would read the position of the motorized focus motor. This PR reverses the order: first read the position of the focus motor, then perform the pier side handling. 

At least here, this fixes the problem: the motor position is reported correctly, thus enabling autofocus workflows.
