### PR TITLE
Set switches correctly when parking dome

### DIFF
--- a/libindi/libs/indibase/indidome.cpp
+++ b/libindi/libs/indibase/indidome.cpp
@@ -1944,7 +1944,7 @@ IPState Dome::Park()
         SetParked(true);
     else if (ParkSP.s == IPS_BUSY)
     {
-        domeState = DOME_PARKING;
+        setDomeState(DOME_PARKING);
 
         if (CanAbsMove())
             DomeAbsPosNP.s = IPS_BUSY;


### PR DESCRIPTION
When parking, the Indi dome controller needs to set the switches correctly such that clients are informed about the parking action.