### PR TITLE
Add missing fclose calls

### DIFF
--- a/libindi/libs/indibase/basedevice.cpp
+++ b/libindi/libs/indibase/basedevice.cpp
@@ -485,6 +485,7 @@ bool BaseDevice::buildSkeleton(const char *filename)
     }
 
     fproot = readXMLFile(fp, lp, errmsg);
+    fclose(fp);
 
     if (fproot == nullptr)
     {

--- a/libindi/libs/indibase/indidome.cpp
+++ b/libindi/libs/indibase/indidome.cpp
@@ -1467,6 +1467,7 @@ const char * Dome::LoadParkXML()
         delXMLEle(ParkdataXmlRoot);
 
     ParkdataXmlRoot = readXMLFile(fp, lp, errmsg);
+    fclose(fp);
 
     delLilXML(lp);
     if (!ParkdataXmlRoot)

--- a/libindi/libs/indibase/inditelescope.cpp
+++ b/libindi/libs/indibase/inditelescope.cpp
@@ -1912,6 +1912,7 @@ const char *Telescope::LoadParkXML()
         delXMLEle(ParkdataXmlRoot);
 
     ParkdataXmlRoot = readXMLFile(fp, lp, errmsg);
+    fclose(fp);
 
     delLilXML(lp);
     if (!ParkdataXmlRoot)
@@ -2038,6 +2039,7 @@ bool Telescope::PurgeParkData()
         delXMLEle(ParkdataXmlRoot);
 
     ParkdataXmlRoot = readXMLFile(fp, lp, errmsg);
+    fclose(fp);
 
     delLilXML(lp);
     if (!ParkdataXmlRoot)
@@ -2555,6 +2557,7 @@ bool Telescope::LoadScopeConfig()
     char ErrMsg[512];
 
     RootXmlNode = readXMLFile(FilePtr, XmlHandle, ErrMsg);
+    fclose(FilePtr);    
     delLilXML(XmlHandle);
     XmlHandle = nullptr;
     if (!RootXmlNode)
@@ -2694,6 +2697,7 @@ bool Telescope::HasDefaultScopeConfig()
     char ErrMsg[512];
 
     RootXmlNode = readXMLFile(FilePtr, XmlHandle, ErrMsg);
+    fclose(FilePtr);
     delLilXML(XmlHandle);
     XmlHandle = nullptr;
     if (!RootXmlNode)


### PR DESCRIPTION
As per thread at https://www.indilib.org/forum/development/5528-inditelescope-cpp-left-open-files.html I also checked a few other places which had left files open in my system and added the missing fclose calls.