### PR TITLE
Change unsigned int (32 bit) to unsigned long long (64 bit).  The 32 …

### DIFF
--- a/3rdparty/indi-beefocus/driver/beesimfirmware.h
+++ b/3rdparty/indi-beefocus/driver/beesimfirmware.h
@@ -71,13 +71,13 @@ class BeeSimFirmware
   private:
 
   /// @brief Current simulated time in ms.
-  unsigned int time; 
+  unsigned long long time; 
 
   /// @brief The Simulated Focuser firmware class
   std::unique_ptr<FS::Focuser> simulatedFocuser;
 
   /// @brief When's the next time when we can call the loop function on the
   ///        simulatedFocuser class (in microseconds).
-  unsigned long simulatedFocuserNextUpdate; 
+  unsigned long long simulatedFocuserNextUpdate; 
 };
  


### PR DESCRIPTION
Change 32 bit unsigned int time values to 64 bit unsigned int time values.  The 32 values overflow after 2^32/1000000 seconds, or ~71 minutes, causing the driver to hang.