### PR TITLE
Add methods to set polling rate limits in DefaultDevice

### DIFF
--- a/libindi/libs/indibase/defaultdevice.cpp
+++ b/libindi/libs/indibase/defaultdevice.cpp
@@ -1098,4 +1098,15 @@ void DefaultDevice::setDefaultPollingPeriod(uint32_t period)
     POLLMS = period;
 }
 
+void DefaultDevice::setMinimumPollingPeriod(uint32_t period)
+{
+    PollPeriodN[0].min = period;
+    IUUpdateMinMax(&PollPeriodNP);
+}
+
+void DefaultDevice::setMaximumPollingPeriod(uint32_t period)
+{
+    PollPeriodN[0].max = period;
+    IUUpdateMinMax(&PollPeriodNP);
+}
 }

--- a/libindi/libs/indibase/defaultdevice.cpp
+++ b/libindi/libs/indibase/defaultdevice.cpp
@@ -1098,15 +1098,11 @@ void DefaultDevice::setDefaultPollingPeriod(uint32_t period)
     POLLMS = period;
 }
 
-void DefaultDevice::setMinimumPollingPeriod(uint32_t period)
+void DefaultDevice::setPollingPeriodRange(uint32_t minimum, uint32_t maximum)
 {
-    PollPeriodN[0].min = period;
+    PollPeriodN[0].min = minimum;
+    PollPeriodN[0].max = maximum;
     IUUpdateMinMax(&PollPeriodNP);
 }
 
-void DefaultDevice::setMaximumPollingPeriod(uint32_t period)
-{
-    PollPeriodN[0].max = period;
-    IUUpdateMinMax(&PollPeriodNP);
-}
 }

--- a/libindi/libs/indibase/defaultdevice.h
+++ b/libindi/libs/indibase/defaultdevice.h
@@ -463,8 +463,7 @@ class INDI::DefaultDevice : public INDI::BaseDevice
         }
 
         void setDefaultPollingPeriod(uint32_t period);
-        void setMinimumPollingPeriod(uint32_t period);
-        void setMaximumPollingPeriod(uint32_t period);
+        void setPollingPeriodRange(uint32_t minimum, uint32_t maximum);
         uint32_t getPollingPeriod()
         {
             return static_cast<uint32_t>(PollPeriodN[0].value);

--- a/libindi/libs/indibase/defaultdevice.h
+++ b/libindi/libs/indibase/defaultdevice.h
@@ -463,6 +463,8 @@ class INDI::DefaultDevice : public INDI::BaseDevice
         }
 
         void setDefaultPollingPeriod(uint32_t period);
+        void setMinimumPollingPeriod(uint32_t period);
+        void setMaximumPollingPeriod(uint32_t period);
         uint32_t getPollingPeriod()
         {
             return static_cast<uint32_t>(PollPeriodN[0].value);


### PR DESCRIPTION
As discussed in thread at https://www.indilib.org/forum/development/5694-override-focuser-polling-period-control.html it would be useful to have methods to set device specific minimum and maximum polling rates. Some devices don't work with too frequent polling and some need to be polled often enough (at least ScopeDome is such, it resets the serial connection if there isn't traffic for a certain time). I haven't actually tested these functions yet, but they seemed straight forward enough to implement and at least it compiles :)