### PR TITLE
Remove not existing (previous) source directory.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,8 +3,6 @@
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/cmake.mk
 
-DEB_SRCDIR=libindi
-
 export CFLAGS := $(shell dpkg-buildflags --get CFLAGS)
 export CXXFLAGS := $(shell dpkg-buildflags --get CXXFLAGS)
 export LDFLAGS := $(shell dpkg-buildflags --get LDFLAGS)


### PR DESCRIPTION
Building indi Debian packages with command:

DEB_BUILD_OPTIONS='parallel=$(nproc --all)' debuild -i -us -uc -b

results in error:

CMake Error: The source directory "/home/indi/dev/astronomy/indi/indi/libindi" does not exist.
Specify --help for usage, or press the help button on the CMake GUI.
make: *** [/usr/share/cdbs/1/class/cmake.mk:75: obj-x86_64-linux-gnu/CMakeCache.txt] Error 1
dpkg-buildpackage: error: debian/rules build subprocess returned exit status 2
debuild: fatal error at line 1182:
dpkg-buildpackage -us -uc -ui -i -b failed

due to not existing libindi directory. Thus remove it.