### PR TITLE
Add sync capability for all Optec focuser types

### DIFF
--- a/drivers/focuser/focuslynxbase.cpp
+++ b/drivers/focuser/focuslynxbase.cpp
@@ -67,10 +67,11 @@ FocusLynxBase::FocusLynxBase()
     focusMoveRequest = 0;
     simPosition      = 0;
 
-    // Can move in Absolute & Relative motions, can AbortFocuser motion, and has variable speed.
+    // Can move in Absolute & Relative motions, can AbortFocuser motion, can sync, and has variable speed.
     FI::SetCapability(FOCUSER_CAN_ABORT    |
                       FOCUSER_CAN_ABS_MOVE |
                       FOCUSER_CAN_REL_MOVE |
+                      FOCUSER_CAN_SYNC     |
                       FOCUSER_CAN_REVERSE  |
                       FOCUSER_HAS_BACKLASH);
 
@@ -3522,15 +3523,11 @@ bool FocusLynxBase::checkIfAbsoluteFocuser()
         LOG_DEBUG("Absolute focuser detected.");
         GotoSP.nsp = 2;
         isAbsolute = true;
-
-        FI::SetCapability(FI::GetCapability() | FOCUSER_CAN_SYNC);
     }
     else
     {
         LOG_DEBUG("Relative focuser detected.");
         GotoSP.nsp = 1;
-
-        FI::SetCapability(FI::GetCapability() & ~FOCUSER_CAN_SYNC);
 
         SyncMandatoryS[0].s = ISS_OFF;
         SyncMandatoryS[1].s = ISS_ON;


### PR DESCRIPTION
The sync capability has disappeared for relative focusers. At least my PDMS focuser accepts the sync command and I assume that all other relative focusers do this as well.