### PR TITLE
Fix out of bounds access in myfocuserpro2.cpp

### DIFF
--- a/drivers/focuser/myfocuserpro2.cpp
+++ b/drivers/focuser/myfocuserpro2.cpp
@@ -455,7 +455,7 @@ bool MyFocuserPro2::readTempeartureCoefficient()
     int rc = sscanf(res, "B%d#", &val);
 
     if (rc > 0)
-        TemperatureSettingN[1].value = val;
+        TemperatureSettingN[0].value = val;
     else
     {
         LOGF_ERROR("Unknown error: Temperature Coefficient value (%s)", res);
@@ -808,7 +808,7 @@ bool MyFocuserPro2::ISNewNumber(const char * dev, const char * name, double valu
         if (strcmp(name, TemperatureSettingNP.name) == 0)
         {
             IUUpdateNumber(&TemperatureSettingNP, values, names, n);
-            if (!setTemperatureCoefficient(TemperatureSettingN[1].value))
+            if (!setTemperatureCoefficient(TemperatureSettingN[0].value))
             {
                 TemperatureSettingNP.s = IPS_ALERT;
                 IDSetNumber(&TemperatureSettingNP, nullptr);


### PR DESCRIPTION
There seems to have been a small gaffe that TemperatureSettingN array is being accessed by index 1 even though there is only one value in the array. This causes compiler warning and is obviously bad otherwise too, so I wonder why no one noticed before :)

`
/home/pi/src/indi/drivers/focuser/myfocuserpro2.cpp: In member function ‘bool MyFocuserPro2::readTempeartureCoefficient()’:
/home/pi/src/indi/drivers/focuser/myfocuserpro2.cpp:458:30: warning: array subscript 1 is above array bounds of ‘INumber [1]’ [-Warray-bounds]
         TemperatureSettingN[1].value = val;
         ~~~~~~~~~~~~~~~~~~~~~^
/home/pi/src/indi/drivers/focuser/myfocuserpro2.cpp: In member function ‘virtual bool MyFocuserPro2::ISNewNumber(const char*, const char*, double*, char**, int)’:
/home/pi/src/indi/drivers/focuser/myfocuserpro2.cpp:811:65: warning: array subscript 1 is above array bounds of ‘INumber [1]’ [-Warray-bounds]
             if (!setTemperatureCoefficient(TemperatureSettingN[1].value))
                                            ~~~~~~~~~~~~~~~~~~~~~^
`