### PR TITLE
PMC8 Driver update

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -209,17 +209,17 @@
             <driver name="Digital Setting Circle">indi_dsc_telescope</driver>
             <version>1.0</version>
         </device>
-        <device label="Explore Scientific PMC-Eight" manufacturer="Explore Scientific">
+        <device label="ES G-11 PMC-Eight" manufacturer="Explore Scientific">
             <driver name="PMC8">indi_pmc8_telescope</driver>
-            <version>0.2</version>
+            <version>0.3</version>
         </device>
-        <device label="Explore Scientific EXOS2" manufacturer="Explore Scientific">
+        <device label="ES EXOS2-GT PMC-Eight" manufacturer="Explore Scientific">
             <driver name="PMC8">indi_pmc8_telescope</driver>
-            <version>0.2</version>
+            <version>0.3</version>
         </device>
-        <device label="Explore Scientific iEXOS100" manufacturer="Explore Scientific">
+        <device label="ES iEXOS100 PMC-Eight" manufacturer="Explore Scientific">
             <driver name="PMC8">indi_pmc8_telescope</driver>
-            <version>0.2</version>
+            <version>0.3</version>
         </device>
     </devGroup>
     <devGroup group="Focusers">

--- a/drivers/telescope/pmc8.cpp
+++ b/drivers/telescope/pmc8.cpp
@@ -3,6 +3,10 @@
 
     Copyright (C) 2017 Michael Fulbright
 
+    Additional contributors: 
+        Thomas Olson, Copyright (C) 2019
+        Karl Rees, Copyright (C) 2019
+
     Based on IEQPro driver.
 
     This library is free software; you can redistribute it and/or

--- a/drivers/telescope/pmc8.cpp
+++ b/drivers/telescope/pmc8.cpp
@@ -27,6 +27,7 @@
 
 #include <indicom.h>
 #include <connectionplugins/connectionserial.h>
+#include <connectionplugins/connectiontcp.h>
 
 #include <libnova/sidereal_time.h>
 
@@ -39,6 +40,9 @@
 #define SLEWRATE 3          /* slew rate, degrees/s */
 
 #define MOUNTINFO_TAB "Mount Info"
+
+#define PMC8_DEFAULT_PORT 54372
+#define PMC8_DEFAULT_IP_ADDRESS "192.168.47.1"
 
 static std::unique_ptr<PMC8> scope(new PMC8());
 
@@ -93,7 +97,7 @@ PMC8::PMC8()
                            TELESCOPE_HAS_LOCATION,
                            4);
 
-    setVersion(0, 2);
+    setVersion(0, 3);
 }
 
 PMC8::~PMC8()
@@ -109,6 +113,14 @@ bool PMC8::initProperties()
 {
     INDI::Telescope::initProperties();
 
+    // My understanding is that all mounts communicate at 115200, so set this early and make it easier for newbies?
+    serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
+
+
+    //TO DO: Figure out how to set default Ethernet address and port (without overriding user config)
+    tcpConnection->setDefaultHost(PMC8_DEFAULT_IP_ADDRESS);
+    tcpConnection->setDefaultPort(PMC8_DEFAULT_PORT);
+
     // Mount Type
     IUFillSwitch(&MountTypeS[MOUNT_G11], "MOUNT_G11", "G11", ISS_OFF);
     IUFillSwitch(&MountTypeS[MOUNT_EXOS2], "MOUNT_EXOS2", "EXOS2", ISS_OFF);
@@ -116,13 +128,13 @@ bool PMC8::initProperties()
     IUFillSwitchVector(&MountTypeSP, MountTypeS, 3, getDeviceName(), "MOUNT_TYPE", "Mount Type", CONNECTION_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    // Guess type from device name
-    if (strstr(getDeviceName(), "EXOS2"))
+    // No need to guess mount type from device name here, can wait until after we get firmware
+    /*if (strstr(getDeviceName(), "EXOS2"))
         MountTypeS[MOUNT_EXOS2].s = ISS_ON;
     else if (strstr(getDeviceName(), "iEXOS100"))
         MountTypeS[MOUNT_iEXOS100].s = ISS_ON;
     else
-        MountTypeS[MOUNT_G11].s = ISS_ON;
+        MountTypeS[MOUNT_G11].s = ISS_ON;*/
 
 
     /* Tracking Mode */
@@ -208,6 +220,39 @@ void PMC8::getStartupData()
         FirmwareTP.s = IPS_OK;
         c = firmwareInfo.MainBoardFirmware.c_str();
         LOGF_INFO("firmware = %s.", c);
+
+        // not sure if there's really a point to the mount switch anymore if we know the mount from the firmware - perhaps remove as newer firmware becomes standard?
+        // populate mount type switch in interface from firmware if possible
+        if (firmwareInfo.MountType == MOUNT_EXOS2) {
+            MountTypeS[MOUNT_EXOS2].s = ISS_ON;
+            LOG_INFO("Detected mount type as Exos2.");
+        }
+        else if (firmwareInfo.MountType == MOUNT_G11) {
+            MountTypeS[MOUNT_G11].s = ISS_ON;
+            LOG_INFO("Detected mount type as G11.");
+        }
+        else if (firmwareInfo.MountType == MOUNT_iEXOS100) {
+            MountTypeS[MOUNT_iEXOS100].s = ISS_ON;
+            LOG_INFO("Detected mount type as iExos100.");
+        }
+        else {
+            LOG_INFO("Cannot detect mount type--perhaps this is older firmware?");
+            if (strstr(getDeviceName(), "EXOS2")) {
+                MountTypeS[MOUNT_EXOS2].s = ISS_ON;
+                LOG_INFO("Guessing mount is EXOS2 from device name.");
+            }
+            else if (strstr(getDeviceName(), "iEXOS100")) {
+                MountTypeS[MOUNT_iEXOS100].s = ISS_ON;
+                LOG_INFO("Guessing mount is iEXOS100 from device name.");
+            }
+            else {
+                MountTypeS[MOUNT_G11].s = ISS_ON;
+                LOG_INFO("Guessing mount is G11.");
+            }
+        }
+        MountTypeSP.s = IPS_OK;
+        IDSetSwitch(&MountTypeSP,nullptr);
+
         IUSaveText(&FirmwareT[0], c);
         IDSetText(&FirmwareTP, nullptr);
     }
@@ -305,10 +350,13 @@ bool PMC8::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
             LOGF_INFO("Selected mount is %s", MountTypeS[currentMountIndex].label);
 
             // Set iEXOS100 baud rate to 115200
-            if (!isConnected() && currentMountIndex == MOUNT_iEXOS100)
-                serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
+            // Not sure why we were only doing this for iEXOS100?  It's the same for everybody, right?
+            // So I moved this to initProperties()
+            //if (!isConnected()) && currentMountIndex == MOUNT_iEXOS100)
+            //    serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
 
-            set_pmc8_myMount(currentMountIndex);
+            //right now, this lets the user override the parameters for the detected mount.  Perhaps we should prevent the user from doing so?
+            set_pmc8_mountParameters(currentMountIndex);
             MountTypeSP.s = IPS_OK;
             IDSetSwitch(&MountTypeSP, nullptr);
             //		defineSwitch(&MountTypeSP);

--- a/drivers/telescope/pmc8.h
+++ b/drivers/telescope/pmc8.h
@@ -117,7 +117,9 @@ class PMC8 : public INDI::Telescope, public INDI::GuiderInterface
         /* Mount Types */
         ISwitch MountTypeS[3];
         ISwitchVectorProperty MountTypeSP;
-        enum { MOUNT_G11, MOUNT_EXOS2, MOUNT_iEXOS100 };
+
+        //Moved to driver
+        //enum { MOUNT_G11, MOUNT_EXOS2, MOUNT_iEXOS100 };
 
         /* Tracking Mode */
         //ISwitchVectorProperty TrackModeSP;

--- a/drivers/telescope/pmc8.h
+++ b/drivers/telescope/pmc8.h
@@ -2,7 +2,10 @@
     INDI Explore Scientific PMC8 driver
 
     Copyright (C) 2017 Michael Fulbright
-
+    Additional contributors: 
+        Thomas Olson, Copyright (C) 2019
+        Karl Rees, Copyright (C) 2019
+        
     Based on IEQPro driver.
 
     This library is free software; you can redistribute it and/or

--- a/drivers/telescope/pmc8driver.cpp
+++ b/drivers/telescope/pmc8driver.cpp
@@ -2,7 +2,10 @@
     INDI Explore Scientific PMC8 driver
 
     Copyright (C) 2017 Michael Fulbright
-
+    Additional contributors: 
+        Thomas Olson, Copyright (C) 2019
+        Karl Rees, Copyright (C) 2019
+	
     Based on IEQPro driver.
 
     This library is free software; you can redistribute it and/or

--- a/drivers/telescope/pmc8driver.cpp
+++ b/drivers/telescope/pmc8driver.cpp
@@ -51,8 +51,9 @@
 #define PMC8_iEXOS100_AXIS0_SCALE 4147200.0
 #define PMC8_iEXOS100_AXIS1_SCALE 4147200.0
 
-double PMC8_AXIS0_SCALE;
-double PMC8_AXIS1_SCALE;
+// Need to initialize to some value, or certain clients (e.g., KStars Lite) freak out
+double PMC8_AXIS0_SCALE = PMC8_EXOS2_AXIS0_SCALE;
+double PMC8_AXIS1_SCALE = PMC8_EXOS2_AXIS1_SCALE;
 
 #define ARCSEC_IN_CIRCLE 1296000.0
 
@@ -80,6 +81,8 @@ double PMC8_AXIS1_SCALE;
 
 // dont send pulses if already moving faster than this
 #define PMC8_PULSE_GUIDE_MAX_CURRATE 120
+
+#define PMC8_MAX_RETRIES 3 /*number of times to retry getting a response */
 
 bool pmc8_debug                 = false;
 bool pmc8_simulation            = false;
@@ -123,13 +126,13 @@ struct
 } simPMC8Data;
 
 
-void set_pmc8_myMount(int index)
+void set_pmc8_mountParameters(int index)
 {
 	switch(index)
 	{
 	case 0: // LosMandy G11
 		PMC8_AXIS0_SCALE = PMC8_G11_AXIS0_SCALE;
-		PMC8_AXIS1_SCALE = PMC8_G11_AXIS1_SCALE;
+        PMC8_AXIS1_SCALE = PMC8_G11_AXIS1_SCALE;
 		break;
 	case 1: // EXOS2
 		PMC8_AXIS0_SCALE = PMC8_EXOS2_AXIS0_SCALE;
@@ -246,30 +249,22 @@ bool check_pmc8_connection(int fd)
                 continue;
             }
 
-            if ((errcode = tty_read_section(fd, response, '!', PMC8_TIMEOUT, &nbytes_read)))
+			if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGv")))
             {
-                tty_error_msg(errcode, errmsg, MAXRBUF);
-
-                DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "check_pmc8_connection(): Error connecting - %s. "
+                DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "check_pmc8_connection(): Error connecting. "
                                                                    "Please read the instructions at: "
                                                                    "http://indilib.org/devices/telescopes/explore-scientific-g11-pmc-eight/ "
                                                                    "before using this driver!"
-                                                                   "A special USB SERIAL cable setup is REQUIRED for it work currently.",
-                                                                   errmsg);
+                                                                   "For serial connections, a special USB SERIAL cable setup is REQUIRED.");
 
                 usleep(50000);
                 continue;
             }
         }
 
-        if (nbytes_read > 0)
-        {
-            response[nbytes_read] = '\0';
-            DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
-
-            // FIXME - need to put in better check for a valid firmware version response
-            if (!strncmp(response, "ESGvES", 6))
-                return true;
+        // FIXME - need to put in better check for a valid firmware version response
+        if (!strncmp(response, "ESGvES", 6)) {
+            return true;
         }
 
         usleep(50000);
@@ -315,33 +310,41 @@ bool get_pmc8_main_firmware(int fd, FirmwareInfo *info)
             return false;
         }
 
-        if ((errcode = tty_read_section(fd, response, '!', PMC8_TIMEOUT, &nbytes_read)))
+		if ((errcode = get_pmc8_response(fd, response, &nbytes_read,"ESG")))
         {
-            tty_error_msg(errcode, errmsg, MAXRBUF);
-            DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "get_pmc8_main_firmware(): Error reading response - %s", errmsg);
+            DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "get_pmc8_main_firmware(): Error reading response.");
             return false;
         }
     }
 
-    if (nbytes_read > 0)
+    //minimum size firmware string is 12 (for iExos100), 14 for others, but can be up to 20 thus far
+    if (nbytes_read >= 12)
     {
-        response[nbytes_read] = '\0';
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
-        if (nbytes_read == 14)
-        {
-            response[13] = '\0';
-            strncpy(board, response+6, 6);
+        //strip ESGvES from string when getting firmware version
+        strncpy(board, response+6, nbytes_read-7);
+        info->MainBoardFirmware.assign(board, nbytes_read-7);
 
-            info->MainBoardFirmware.assign(board, 6);
-
-            tcflush(fd, TCIFLUSH);
-
-            return true;
+        // Set the mount type from firmware if we can (instead of relying on interface)
+        if (strstr(board,"G11")) {
+            info->MountType = MOUNT_G11;
         }
+        else if (strstr(board,"EXOS2")) {
+            info->MountType = MOUNT_EXOS2;
+        }
+        //not sure if this is a reliable way to detect iexos 100 going forward?
+        else if (strstr(board,"ES1A")) {
+            info->MountType = MOUNT_iEXOS100;
+        }
+        // update mount parameters
+        set_pmc8_mountParameters(info->MountType);
+
+        tcflush(fd, TCIFLUSH);
+
+        return true;
     }
 
-    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Only received #%d bytes, expected 14.", nbytes_read);
+    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Only received #%d bytes, expected at least 12.", nbytes_read);
     return false;
 }
 
@@ -395,16 +398,11 @@ bool get_pmc8_tracking_rate_axis(int fd, PMC8_AXIS axis, int &rate)
         return false;
     }
 
-    if ((errcode = tty_read(fd, response, 10, PMC8_TIMEOUT, &nbytes_read)))
+	if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGr")))
     {
-        tty_error_msg(errcode, errmsg, MAXRBUF);
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+        DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error getting Tracking Rate");
         return false;
     }
-
-    response[nbytes_read] = '\0';
-
-    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
     if (nbytes_read != 10)
     {
@@ -456,16 +454,11 @@ bool get_pmc8_direction_axis(int fd, PMC8_AXIS axis, int &dir)
         return false;
     }
 
-    if ((errcode = tty_read(fd, response, 7, PMC8_TIMEOUT, &nbytes_read)))
-    {
-        tty_error_msg(errcode, errmsg, MAXRBUF);
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+	if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGd")))    
+	{
+        DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error getting direction axis");
         return false;
     }
-
-    response[nbytes_read] = '\0';
-
-    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
     if (nbytes_read != 7)
     {
@@ -520,21 +513,17 @@ bool set_pmc8_direction_axis(int fd, PMC8_AXIS axis, int dir, bool fast)
         return false;
     }
 
-    if (fast)
+    if (fast) {
         return true;
+    }
 
-    if ((errcode = tty_read(fd, response, 7, PMC8_TIMEOUT, &nbytes_read)))
+	if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGd")))   
     {
-        tty_error_msg(errcode, errmsg, MAXRBUF);
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+        DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error setting direction axis");
         return false;
     }
 
-    response[nbytes_read] = '\0';
-
     snprintf(expresp, sizeof(expresp), "ESGd%d%d!", axis, dir);
-
-    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
     if (nbytes_read != 7 || strcmp(response, expresp))
     {
@@ -786,21 +775,18 @@ bool set_pmc8_axis_motor_rate(int fd, PMC8_AXIS axis, int mrate, bool fast)
         return false;
     }
 
-    if (fast)
+    if (fast) {
         return true;
+    }
 
-    if ((errcode = tty_read(fd, response, strlen(cmd), PMC8_TIMEOUT, &nbytes_read)))
+	if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGr")))     
     {
-        tty_error_msg(errcode, errmsg, MAXRBUF);
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+        DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error setting axis motor rate");
         return false;
     }
 
     if (nbytes_read == 10)
     {
-        response[nbytes_read] = '\0';
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
-
         tcflush(fd, TCIFLUSH);
         return true;
     }
@@ -936,10 +922,9 @@ bool set_pmc8_custom_ra_track_rate(int fd, double rate)
             return false;
         }
 
-        if ((errcode = tty_read(fd, response, strlen(cmd), PMC8_TIMEOUT, &nbytes_read)))
+        if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGx")))
         {
-            tty_error_msg(errcode, errmsg, MAXRBUF);
-            DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+            DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error setting custom RA track rate");
             return false;
         }
     }
@@ -949,9 +934,6 @@ bool set_pmc8_custom_ra_track_rate(int fd, double rate)
         DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Only received #%d bytes, expected 9.", nbytes_read);
         return false;
     }
-
-    response[nbytes_read] = '\0';
-    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
     tcflush(fd, TCIFLUSH);
 
@@ -1515,17 +1497,11 @@ bool set_pmc8_target_position_axis(int fd, PMC8_AXIS axis, int point)
         return false;
     }
 
-    if ((errcode = tty_read(fd, response, strlen(cmd), PMC8_TIMEOUT, &nbytes_read)))
+	if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGt")))   
     {
-        tty_error_msg(errcode, errmsg, MAXRBUF);
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+        DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error setting target position axis");
         return false;
     }
-
-    response[nbytes_read] = '\0';
-
-    if (nbytes_read > 0)
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
     // compare to expected response
     snprintf(expresp, sizeof(expresp), "ESGt%d%s!", axis, hexpt);
@@ -1588,17 +1564,11 @@ bool set_pmc8_position_axis(int fd, PMC8_AXIS axis, int point)
         return false;
     }
 
-    if ((errcode = tty_read(fd, response, strlen(cmd), PMC8_TIMEOUT, &nbytes_read)))
+	if ((errcode = get_pmc8_response(fd, response, &nbytes_read,"ESGp")))   
     {
-        tty_error_msg(errcode, errmsg, MAXRBUF);
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+        DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error setting position axis");
         return false;
     }
-
-    response[nbytes_read] = '\0';
-
-    if (nbytes_read > 0)
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
     // compare to expected response
     snprintf(expresp, sizeof(expresp), "ESGp%d%s!", axis, hexpt);
@@ -1659,16 +1629,11 @@ bool get_pmc8_position_axis(int fd, PMC8_AXIS axis, int &point)
         return false;
     }
 
-    if ((errcode = tty_read(fd, response, 12, PMC8_TIMEOUT, &nbytes_read)))
+	if ((errcode = get_pmc8_response(fd, response, &nbytes_read, "ESGp")))   
     {
-        tty_error_msg(errcode, errmsg, MAXRBUF);
-        DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "%s", errmsg);
+        DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_ERROR, "Error getting position axis");
         return false;
     }
-
-    response[nbytes_read] = '\0';
-
-    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", response);
 
     if (nbytes_read != 12)
     {
@@ -1976,4 +1941,55 @@ bool get_pmc8_coords(int fd, double &ra, double &dec)
 //    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "dec motor_counts=%d  DEC = %f", deccounts, dec);
 
     return rc;
+}
+
+//PMC8 connection is not entirely reliable when using Ethernet instead of Serial connection.
+//So, wrap tty_read statements in a get_pmc8_response call to handle common problems
+bool get_pmc8_response(int fd, char* buf, int *nbytes_read, const char* expected = NULL )
+{
+	
+	int err_code = 1;
+	int cnt = 0;
+	
+	//repeat a few times, after that, let's assume we're in an irrecoverable state
+    while ((err_code) && (cnt++ < PMC8_MAX_RETRIES))
+	{ 
+		//Read until exclamation point to get response
+        if ((err_code = tty_read_section(fd, buf, '!', PMC8_TIMEOUT, nbytes_read))) {
+            char errmsg[MAXRBUF];
+            tty_error_msg(err_code, errmsg, MAXRBUF);
+            DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_ERROR,"Read error: %s",errmsg);
+        }
+        if (*nbytes_read > 0) {
+            buf[*nbytes_read] = '\0';
+            DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "RES (%s)", buf);
+
+            //One problem is we get the string *HELLO* when we connect or disconnect, so discard that
+            if (buf[0]=='*') {
+                buf=buf+7;
+                *nbytes_read = *nbytes_read-7;
+            }
+
+            //Another problem is random extraneous ESGp! reponses during slew, so when we see those, drop them and try again
+            if (strncmp(buf, "ESGp!",5)==0) {
+                err_code = 1;
+                DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "Invalid response ESGp!");
+            }
+            //If a particular response was expected, make sure we got it
+            else if (expected) {
+                if (strncmp(buf, expected,strlen(expected))!=0) {
+                    err_code = 1;
+                    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_EXTRA_1, "No Match for %s", expected);
+                }
+                else {
+                    DEBUGFDEVICE(pmc8_device, INDI::Logger::DBG_EXTRA_1, "Matches %s", expected);
+                }
+            }
+        }
+        else {
+            DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_DEBUG, "No Response");
+            err_code = 1;
+        }
+	}
+	return err_code;
 }

--- a/drivers/telescope/pmc8driver.h
+++ b/drivers/telescope/pmc8driver.h
@@ -2,7 +2,10 @@
     INDI Explore Scientific PMC8 driver
 
     Copyright (C) 2017 Michael Fulbright
-
+    Additional contributors: 
+        Thomas Olson, Copyright (C) 2019
+        Karl Rees, Copyright (C) 2019
+        
     Based on IEQPro driver.
 
     This library is free software; you can redistribute it and/or

--- a/drivers/telescope/pmc8driver.h
+++ b/drivers/telescope/pmc8driver.h
@@ -50,6 +50,8 @@ typedef enum { PMC8_MOVE_4X, PMC8_MOVE_16X, PMC8_MOVE_64X, PMC8_MOVE_256X } PMC8
 typedef enum { PMC8_AXIS_RA=0, PMC8_AXIS_DEC=1 } PMC8_AXIS;
 typedef enum { PMC8_N, PMC8_S, PMC8_W, PMC8_E } PMC8_DIRECTION;
 
+typedef enum { MOUNT_G11 = 0, MOUNT_EXOS2 = 1, MOUNT_iEXOS100 = 2 } PMC8_MOUNT_TYPES;
+
 typedef struct
 {
     PMC8_SYSTEM_STATUS systemStatus;
@@ -61,6 +63,7 @@ typedef struct
 {
     std::string Model;
     std::string MainBoardFirmware;
+    PMC8_MOUNT_TYPES MountType;
 } FirmwareInfo;
 
 /**************************************************************************
@@ -70,7 +73,8 @@ typedef struct
 void set_pmc8_debug(bool enable);
 void set_pmc8_simulation(bool enable);
 void set_pmc8_device(const char *name);
-void set_pmc8_myMount(int index);
+void set_pmc8_mountParameters(int index);
+bool get_pmc8_response(int fd, char* buf, int* nbytes_read, const char* expected);
 
 /**************************************************************************
  Simulation
@@ -153,4 +157,6 @@ void set_pmc8_location(double latitude, double longitude);
 //bool set_ieqpro_local_time(int fd, int hh, int mm, int ss);
 //bool set_ieqpro_utc_offset(int fd, double offset_hours);
 //bool set_ieqpro_daylight_saving(int fd, bool enabled);
+
+
 


### PR DESCRIPTION
PMC8 driver update to better support Ethernet/WiFi connections, simplify mount communication, and more intelligently determine mount type and associated parameters

- Wrapped all tty_reads in a get_pmc8_response function that performs various associated actions such as error checking, debug output, and compensation for certain errors/events that can occur when communicating over WiFi
- Auto detect mount type from firmware
- Added variable for detected mountType to firmwareInfo so that we can access it without relying on the UI switches
- Changed set_myMount function name to set_mountParameters to be more consistent with its purpose
- Set mount parameters from driver if we can auto-detect mount type, instead of waiting for UI to do it
- Moved mount type guessing code to else loop after we check firmware (to continue to support older firmware that does not specify mount type)
- Set default Ethernet address/port for mounts to OEM default
- Moved default serial baud rate assignment to initProperties and made it applicable to all mounts
- Initialized axis scales to a default value to avoid crash in KStars Lite
- Updated version number to 0.3
- Updated drivers.xml to reflect changes and improve labels