### PR TITLE
Bug fix: meridian flip working for longer polling intervals

### DIFF
--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -386,8 +386,10 @@ bool ScopeSim::ReadScopeStatus()
                 dx = fabs(dx);
                 if (dx == 0)
                 {
-                    dx    = 1;
-                    da_ra = GOTO_LIMIT;
+                    // first step eastward if we start the meridian flip
+                    // ensure that the first step is bigger than the standard step to ensure flipping
+                    dx    = dt;
+                    da_ra = GOTO_RATE*(dt+0.5);
                 }
             }
 


### PR DESCRIPTION
The meridian flip currently works only for short polling intervals. With this fix the initial move is always big enough so that the next move is eastward and jumps not simply back.

Test case: select a polling interval of 2secs and slew to a position close, but east of the meridian. Wait until the target crosses the meridian so that a meridian flip is issued. Without this fix, the mount makes one step eastward and then jumps immediately back to the original position. With this this fix, the mount makes an entire round.