### PR TITLE
meridian flip working for short polling intervals (again)

### DIFF
--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -388,7 +388,7 @@ bool ScopeSim::ReadScopeStatus()
                 {
                     // first step eastward if we start the meridian flip
                     // ensure that the first step is bigger than the standard step to ensure flipping
-                    dx    = dt;
+                    dx    = dt+0.5;
                     da_ra = GOTO_RATE*(dt+0.5);
                 }
             }


### PR DESCRIPTION
PR #1042 fixed the meridian flip behavior of the telescope simulator for long polling periods. Unfortunately, the PR created a regression for short polling intervals, which is fixed with this patch.