### PR TITLE
Fix enabling/disabling DMFC properties and remove dead code

### DIFF
--- a/drivers/focuser/dmfc.cpp
+++ b/drivers/focuser/dmfc.cpp
@@ -89,35 +89,14 @@ bool DMFC::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    // Sync
-    //    IUFillNumber(&SyncN[0], "FOCUS_SYNC_OFFSET", "Offset", "%6.0f", 0, 60000., 0., 0.);
-    //    IUFillNumberVector(&SyncNP, SyncN, 1, getDeviceName(), "FOCUS_SYNC", "Sync", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
-
     // Focuser temperature
     IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
     IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    //    // Reverse direction
-    //    IUFillSwitch(&ReverseS[DIRECTION_NORMAL], "Normal", "", ISS_ON);
-    //    IUFillSwitch(&ReverseS[DIRECTION_REVERSED], "Reverse", "", ISS_OFF);
-    //    IUFillSwitchVector(&ReverseSP, ReverseS, 2, getDeviceName(), "Reverse", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY,
-    //                       0, IPS_IDLE);
-
     // Max Speed
     IUFillNumber(&MaxSpeedN[0], "Value", "", "%6.2f", 100, 1000., 100., 400.);
     IUFillNumberVector(&MaxSpeedNP, MaxSpeedN, 1, getDeviceName(), "MaxSpeed", "", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
-
-    //    // Enable/Disable backlash
-    //    IUFillSwitch(&BacklashCompensationS[BACKLASH_ENABLED], "Enable", "", ISS_OFF);
-    //    IUFillSwitch(&BacklashCompensationS[BACKLASH_DISABLED], "Disable", "", ISS_ON);
-    //    IUFillSwitchVector(&FocuserBacklashSP, BacklashCompensationS, 2, getDeviceName(), "Backlash Compensation", "",
-    //                       FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-
-    //    // Backlash Value
-    //    IUFillNumber(&BacklashN[0], "Value", "", "%.f", 0, 9999, 100., 0.);
-    //    IUFillNumberVector(&BacklashNP, BacklashN, 1, getDeviceName(), "Backlash", "", FOCUS_SETTINGS_TAB, IP_RW, 0,
-    //                       IPS_IDLE);
 
     // Encoders
     IUFillSwitch(&EncoderS[ENCODERS_ON], "On", "", ISS_ON);
@@ -166,11 +145,6 @@ bool DMFC::updateProperties()
     if (isConnected())
     {
         defineNumber(&TemperatureNP);
-        //defineNumber(&SyncNP);
-
-        //        defineSwitch(&ReverseSP);
-        //        defineSwitch(&FocuserBacklashSP);
-        //        defineNumber(&BacklashNP);
         defineSwitch(&EncoderSP);
         defineSwitch(&MotorTypeSP);
         defineNumber(&MaxSpeedNP);
@@ -180,11 +154,6 @@ bool DMFC::updateProperties()
     else
     {
         deleteProperty(TemperatureNP.name);
-        //deleteProperty(SyncNP.name);
-
-        //        deleteProperty(ReverseSP.name);
-        //        deleteProperty(FocuserBacklashSP.name);
-        //        deleteProperty(BacklashNP.name);
         deleteProperty(EncoderSP.name);
         deleteProperty(MotorTypeSP.name);
         deleteProperty(MaxSpeedNP.name);
@@ -305,22 +274,6 @@ bool DMFC::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         /////////////////////////////////////////////
-        // Backlash
-        /////////////////////////////////////////////
-        //        if (!strcmp(name, FocuserBacklashSP.name))
-        //        {
-        //            IUUpdateSwitch(&FocuserBacklashSP, states, names, n);
-        //            bool rc = false;
-        //            if (IUFindOnSwitchIndex(&FocuserBacklashSP) == BACKLASH_ENABLED)
-        //                rc = setBacklash(BacklashN[0].value);
-        //            else
-        //                rc = setBacklash(0);
-
-        //            FocuserBacklashSP.s = rc ? IPS_OK : IPS_ALERT;
-        //            IDSetSwitch(&FocuserBacklashSP, nullptr);
-        //            return true;
-        //        }
-        /////////////////////////////////////////////
         // Encoders
         /////////////////////////////////////////////
         if (!strcmp(name, EncoderSP.name))
@@ -343,17 +296,6 @@ bool DMFC::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
             return true;
         }
         /////////////////////////////////////////////
-        // Reverse
-        /////////////////////////////////////////////
-        //        else if (!strcmp(name, ReverseSP.name))
-        //        {
-        //            IUUpdateSwitch(&ReverseSP, states, names, n);
-        //            bool rc = setReverseEnabled(ReverseS[DIRECTION_REVERSED].s == ISS_ON);
-        //            ReverseSP.s = rc ? IPS_OK : IPS_ALERT;
-        //            IDSetSwitch(&ReverseSP, nullptr);
-        //            return true;
-        //        }
-        /////////////////////////////////////////////
         // Motor Type
         /////////////////////////////////////////////
         if (!strcmp(name, MotorTypeSP.name))
@@ -373,35 +315,6 @@ bool DMFC::ISNewNumber(const char *dev, const char *name, double values[], char 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        /////////////////////////////////////////////
-        // Sync
-        /////////////////////////////////////////////
-        //        if (strcmp(name, SyncNP.name) == 0)
-        //        {
-        //            IUUpdateNumber(&SyncNP, values, names, n);
-        //            bool rc = sync(SyncN[0].value);
-        //            SyncNP.s = rc ? IPS_OK : IPS_ALERT;
-        //            IDSetNumber(&SyncNP, nullptr);
-        //            return true;
-        //        }
-        /////////////////////////////////////////////
-        // Backlash
-        /////////////////////////////////////////////
-        //        else if (strcmp(name, BacklashNP.name) == 0)
-        //        {
-        //            IUUpdateNumber(&BacklashNP, values, names, n);
-        //            // Only updaet backlash value if compensation is enabled
-        //            if (BacklashCompensationS[BACKLASH_ENABLED].s == ISS_ON)
-        //            {
-        //                bool rc = setBacklash(BacklashN[0].value);
-        //                BacklashNP.s = rc ? IPS_OK : IPS_ALERT;
-        //            }
-        //            else
-        //                BacklashNP.s = IPS_OK;
-
-        //            IDSetNumber(&BacklashNP, nullptr);
-        //            return true;
-        //        }
         /////////////////////////////////////////////
         // MaxSpeed
         /////////////////////////////////////////////
@@ -489,7 +402,7 @@ bool DMFC::updateFocusParams()
     }
 
     int motorType = atoi(token);
-    if (motorType != IUFindOnSwitchIndex(&MotorTypeSP) && motorType >= 0 && motorType <= 1)
+    if (motorType >= 0 && motorType <= 1)
     {
         IUResetSwitch(&MotorTypeSP);
         MotorTypeS[motorType].s = ISS_ON;
@@ -559,7 +472,7 @@ bool DMFC::updateFocusParams()
     }
 
     int ledStatus = atoi(token);
-    if (ledStatus != IUFindOnSwitchIndex(&LEDSP) && ledStatus >= 0 && ledStatus <= 1)
+    if (ledStatus >= 0 && ledStatus <= 1)
     {
         IUResetSwitch(&LEDSP);
         LEDS[ledStatus].s = ISS_ON;
@@ -577,7 +490,7 @@ bool DMFC::updateFocusParams()
     }
 
     int reverseStatus = atoi(token);
-    if (reverseStatus != IUFindOnSwitchIndex(&FocusReverseSP) && reverseStatus >= 0 && reverseStatus <= 1)
+    if (reverseStatus >= 0 && reverseStatus <= 1)
     {
         IUResetSwitch(&FocusReverseSP);
         FocusReverseS[reverseStatus].s = ISS_ON;
@@ -595,7 +508,7 @@ bool DMFC::updateFocusParams()
     }
 
     int encoderStatus = atoi(token);
-    if (encoderStatus != IUFindOnSwitchIndex(&EncoderSP) && encoderStatus >= 0 && encoderStatus <= 1)
+    if (encoderStatus >= 0 && encoderStatus <= 1)
     {
         IUResetSwitch(&EncoderSP);
         EncoderS[encoderStatus].s = ISS_ON;
@@ -666,7 +579,6 @@ bool DMFC::setMaxSpeed(uint16_t speed)
     return true;
 }
 
-//bool DMFC::setReverseEnabled(bool enable)
 bool DMFC::ReverseFocuser(bool enabled)
 {
     int nbytes_written = 0, rc = -1;
@@ -738,8 +650,6 @@ bool DMFC::setEncodersEnabled(bool enable)
 
     return true;
 }
-
-//bool DMFC::setBacklash(uint16_t value)
 
 bool DMFC::SetFocuserBacklash(int32_t steps)
 {
@@ -875,9 +785,6 @@ bool DMFC::saveConfigItems(FILE *fp)
 {
     INDI::Focuser::saveConfigItems(fp);
 
-    //    IUSaveConfigSwitch(fp, &ReverseSP);
-    //    IUSaveConfigNumber(fp, &BacklashNP);
-    //    IUSaveConfigSwitch(fp, &FocuserBacklashSP);
     IUSaveConfigSwitch(fp, &EncoderSP);
     IUSaveConfigSwitch(fp, &MotorTypeSP);
     IUSaveConfigNumber(fp, &MaxSpeedNP);


### PR DESCRIPTION
When e.g. Reverse motor direction is disabled, that is,
DEBUG   1036.928082 sec : CMD <0X41>
DEBUG   1036.955548 sec : RES <OK_FC:1.2:1:19.7:4000:0:1:0:0:0>
                                                         ^
							 |
One cannot enable it, due to
reverseStatus != IUFindOnSwitchIndex(&FocusReverseSP)
check where e.g. reverseStatus := 1, however,
IUFillSwitch(&FocusReverseS[REVERSED_DISABLED], "DISABLED", "Disabled", ISS_ON);
also results in 1.

int IUFindOnSwitchIndex(const ISwitchVectorProperty *svp)
{
    int i;

    for (i = 0; i < svp->nsp; i++)
        if (svp->sp[i].s == ISS_ON)
            return i;
    return -1;
}

and

IUFillSwitch(&FocusReverseS[REVERSED_ENABLED], "ENABLED", "Enabled", ISS_OFF);
IUFillSwitch(&FocusReverseS[REVERSED_DISABLED], "DISABLED", "Disabled", ISS_ON);
IUFillSwitchVector(&FocusReverseSP, FocusReverseS, 2, m_defaultDevice->getDeviceName(), "FOCUS_REVERSE_MOTION", "Reverse Motion", groupName, IP_RW,
                   ISR_1OFMANY, 60, IPS_IDLE);