### PR TITLE
Fix select motortype, reverse status and enable focuser backslash

### DIFF
--- a/drivers/focuser/dmfc.cpp
+++ b/drivers/focuser/dmfc.cpp
@@ -405,7 +405,8 @@ bool DMFC::updateFocusParams()
     if (motorType >= 0 && motorType <= 1)
     {
         IUResetSwitch(&MotorTypeSP);
-        MotorTypeS[motorType].s = ISS_ON;
+        MotorTypeS[MOTOR_DC].s = (motorType == 0) ? ISS_ON : ISS_OFF;
+        MotorTypeS[MOTOR_STEPPER].s = (motorType == 1) ? ISS_ON : ISS_OFF;
         MotorTypeSP.s = IPS_OK;
         IDSetSwitch(&MotorTypeSP, nullptr);
     }
@@ -493,7 +494,8 @@ bool DMFC::updateFocusParams()
     if (reverseStatus >= 0 && reverseStatus <= 1)
     {
         IUResetSwitch(&FocusReverseSP);
-        FocusReverseS[reverseStatus].s = ISS_ON;
+        FocusReverseS[REVERSED_ENABLED].s = (reverseStatus == 1) ? ISS_ON : ISS_OFF;
+        FocusReverseS[REVERSED_DISABLED].s = (reverseStatus == 0) ? ISS_ON : ISS_OFF;
         FocusReverseSP.s = IPS_OK;
         IDSetSwitch(&FocusReverseSP, nullptr);
     }
@@ -675,13 +677,18 @@ bool DMFC::SetFocuserBacklash(int32_t steps)
     return true;
 }
 
+bool DMFC::SetFocuserBacklashEnabled(bool enabled)
+{
+    return SetFocuserBacklash(enabled ? 1 : 0);
+}
+
 bool DMFC::setMotorType(uint8_t type)
 {
     int nbytes_written = 0, rc = -1;
     char errstr[MAXRBUF];
     char cmd[16] = {0};
 
-    snprintf(cmd, 16, "E:%d", (type == MOTOR_STEPPER) ? 1 : 0);
+    snprintf(cmd, 16, "R:%d", (type == MOTOR_STEPPER) ? 1 : 0);
     cmd[strlen(cmd)] = 0xA;
 
     LOGF_DEBUG("CMD <%s>", cmd);

--- a/drivers/focuser/dmfc.h
+++ b/drivers/focuser/dmfc.h
@@ -44,17 +44,15 @@ class DMFC : public INDI::Focuser
         virtual bool SyncFocuser(uint32_t ticks) override;
         virtual bool ReverseFocuser(bool enabled) override;
         virtual bool SetFocuserBacklash(int32_t steps) override;
+        virtual bool SetFocuserBacklashEnabled(bool enabled) override;
         virtual bool saveConfigItems(FILE *fp) override;
 
     private:
         bool updateFocusParams();
-        //bool sync(uint32_t newPosition);
         bool move(uint32_t newPosition);
         bool setMaxSpeed(uint16_t speed);
-        //bool setReverseEnabled(bool enable);
         bool setLedEnabled(bool enable);
         bool setEncodersEnabled(bool enable);
-        //bool setBacklash(uint16_t value);
         bool setMotorType(uint8_t type);
         bool ack();
 


### PR DESCRIPTION
According to DMFC serial command table:
http://pegasusastro.com/wp-content/uploads/2015/01/DMFC-Serial-Command-Table.pdf
the command to select the motortype is: "R:X", where X := 0 is DC and X := 1 is stepper.

In addition, the reverse motor direction is read out as N:0 (normal) or N:1 (reverse),
however, the enum is defined as follows:
enum { REVERSED_ENABLED = 0, REVERSED_DISABLED = 1 }.
So it is vice versa to the enum.

The focuser backslash cannot be activated because the command to
enable it, is issued as "C:0" (Disables compensation).