### PR TITLE
Use size_t to fix compilation on 32-bit ARM

### DIFF
--- a/libs/indibase/dsp/convolution.cpp
+++ b/libs/indibase/dsp/convolution.cpp
@@ -75,7 +75,7 @@ bool Convolution::ISNewBLOB(const char *dev, const char *name, int sizes[], int 
                     if(!strcmp(formats[i], "fits")) {
                         fitsfile *fptr;
                         int status;
-                        unsigned long size = sizes[i];
+                        size_t size = sizes[i];
                         ffimem(&fptr, &buf, &size, sizes[i], realloc, &status);
                         char value[MAXINDINAME];
                         char comment[MAXINDINAME];


### PR DESCRIPTION
Compiler gives an error from incompatible pointer type for ffimem, which expects size_t. Happens to work on 64-bit where types are the same.