### PR TITLE
Freebsd 12.0 compilation fixes and webcamd support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,6 +497,13 @@ install(TARGETS indidriver LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 set(PKG_CONFIG_LIBS "${PKG_CONFIG_LIBS} -lindidriver -lindiAlignmentDriver")
 endif(CYGWIN)
 
+IF (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    # FreeBSD needs to find the correct GNU iconv library.
+    find_package(Iconv REQUIRED)
+    # The indidriver library is defined earlier in the file before the
+    # find has been run. Add an explicit link to avoid runtime errors.
+    target_link_libraries(indidriver ${ICONV_LIBRARIES})
+ENDIF(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
 
 ##################################################
 ########### INDI Alignment Subsystem #############
@@ -617,7 +624,11 @@ IF (UNITY_BUILD)
 ENDIF ()
 
 add_executable(indi_lx200generic ${lx200generic_SRCS})
-target_compile_definitions(indi_lx200generic PRIVATE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200809L)
+if (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+    target_compile_definitions(indi_lx200generic PRIVATE -D_XOPEN_SOURCE=700)
+ELSE()
+    target_compile_definitions(indi_lx200generic PRIVATE -D_XOPEN_SOURCE=600 -D_POSIX_C_SOURCE=200809L)
+ENDIF()
 target_link_libraries(indi_lx200generic indidriver)
 
 install(TARGETS indi_lx200generic RUNTIME DESTINATION bin )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,9 +309,9 @@ include_directories( ${NOVA_INCLUDE_DIR})
 include_directories( ${USB1_INCLUDE_DIRS})
 include_directories( ${GSL_INCLUDE_DIRS})
 include_directories( ${JPEG_INCLUDE_DIR} )
-IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
     include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/libs/webcam)
-ENDIF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+ENDIF (${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config-usb.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-usb.h)
 
@@ -354,7 +354,7 @@ ENDIF(OGGTHEORA_FOUND)
         ENABLE_UNITY_BUILD(libstream libstream_CXX_SRC 10 cpp)
     ENDIF ()
 
-    IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
         SET(libwebcam_C_SRC
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/webcam/v4l2_colorspace.c)
         SET(libwebcam_CXX_SRC
@@ -366,7 +366,7 @@ ENDIF(OGGTHEORA_FOUND)
             ENABLE_UNITY_BUILD(libwebcam libwebcam_C_SRC 10 c)
             ENABLE_UNITY_BUILD(libwebcam libwebcam_CXX_SRC 10 cpp)
         ENDIF (UNITY_BUILD)
-     ENDIF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    ENDIF (${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
 ENDIF(UNIX)
 
 SET(libdsp_C_SRC
@@ -1322,7 +1322,7 @@ install(TARGETS indi_script_dome RUNTIME DESTINATION bin)
 #########################################
 
 ########### INDI::CCD V4L Driver ###############
-IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+IF (${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
     SET(v4l2driverccd_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/lx/Lx.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/drivers/video/v4l2driver.cpp
@@ -1743,7 +1743,7 @@ if (UNIX)
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/recorderinterface.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/serrecorder.h
             DESTINATION ${INCLUDE_INSTALL_DIR}/libindi/stream/recorder COMPONENT Devel)
-    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
     INSTALL(FILES
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/webcam/v4l2_decode/v4l2_decode.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/webcam/v4l2_decode/v4l2_builtin_decoder.h

--- a/cmake_modules/FindIconv.cmake
+++ b/cmake_modules/FindIconv.cmake
@@ -28,6 +28,13 @@ ELSEIF(APPLE)
                /usr/lib/
                NO_CMAKE_SYSTEM_PATH)
     SET(ICONV_EXTERNAL TRUE)
+ELSEIF(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+  # Force paths to GNU version of iconv to avoid clashes with
+  # the libc version.
+  find_library(ICONV_LIBRARIES NAMES iconv libiconv PATHS
+               /usr/local/lib
+               NO_CMAKE_SYSTEM_PATH)
+  SET(ICONV_EXTERNAL TRUE)
 ELSE()
   find_library(ICONV_LIBRARIES NAMES iconv libiconv libiconv-2)
   IF(ICONV_LIBRARIES)

--- a/drivers/auxiliary/skysafari.cpp
+++ b/drivers/auxiliary/skysafari.cpp
@@ -39,6 +39,10 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 
+#ifdef __FreeBSD__
+#include <netinet/in.h>
+#endif
+
 // We declare unique pointer to my lovely German Shephard Tommy (http://indilib.org/images/juli_tommy.jpg)
 // Rest in Peace Tommy 2013-2018
 static std::unique_ptr<SkySafari> tommyGoodBoy(new SkySafari());

--- a/drivers/telescope/celestrondriver.h
+++ b/drivers/telescope/celestrondriver.h
@@ -28,6 +28,11 @@
 #include <string>
 #include "indicom.h"
 
+#ifdef __FreeBSD__
+#include <stdint.h>
+typedef uint8_t u_int8_t;
+#endif
+
 //#include <thread>
 //#include <condition_variable>
 //#include <atomic>

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -34,6 +34,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 #include <termios.h>
 #endif
 
+#ifdef __FreeBSD__
+#include <string.h>
+#endif
+
 /* Add mutex */
 
 #include <mutex>

--- a/drivers/video/v4l2driver.h
+++ b/drivers/video/v4l2driver.h
@@ -39,6 +39,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 
 #define TEMPFILE_LEN 16
 
+#ifdef __FreeBSD__
+typedef unsigned long ulong;
+#endif
+
 class Lx;
 
 class V4L2_Driver : public INDI::CCD

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -26,6 +26,12 @@
 #include <cstring>
 #include <unistd.h>
 
+#ifdef __FreeBSD__
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#endif
+
 namespace Connection
 {
 extern const char *CONNECTION_TAB;

--- a/libs/indibase/hid_libusb.c
+++ b/libs/indibase/hid_libusb.c
@@ -267,24 +267,6 @@ static int get_usage(uint8_t *report_descriptor, size_t size, unsigned short *us
 }
 #endif // INVASIVE_GET_USAGE
 
-#ifdef __FreeBSD__
-/* The FreeBSD version of libusb doesn't have this funciton. In mainline
-   libusb, it's inlined in libusb.h. This function will bear a striking
-   resemblence to that one, because there's about one way to code it.
-
-   Note that the data parameter is Unicode in UTF-16LE encoding.
-   Return value is the number of bytes in data, or LIBUSB_ERROR_*.
- */
-static inline int libusb_get_string_descriptor(libusb_device_handle *dev, uint8_t descriptor_index, uint16_t lang_id,
-                                               unsigned char *data, int length)
-{
-    return libusb_control_transfer(dev, LIBUSB_ENDPOINT_IN | 0x0, /* Endpoint 0 IN */
-                                   LIBUSB_REQUEST_GET_DESCRIPTOR, (LIBUSB_DT_STRING << 8) | descriptor_index, lang_id,
-                                   data, (uint16_t)length, 1000);
-}
-
-#endif
-
 /* Get the first language the device says it reports. This comes from
    USB string #0. */
 static uint16_t get_first_language(libusb_device_handle *dev)
@@ -341,11 +323,7 @@ static wchar_t *get_usb_string(libusb_device_handle *dev, uint8_t idx)
     size_t inbytes;
     size_t outbytes;
     size_t res;
-#ifdef __FreeBSD__
-    const char *inptr;
-#else
     char *inptr;
-#endif
     char *outptr;
 
     /* Determine which language to use. */

--- a/libs/webcam/pwc-ioctl.h
+++ b/libs/webcam/pwc-ioctl.h
@@ -51,7 +51,13 @@
 
 #pragma once
 
+#ifndef __FreeBSD__
 #include <linux/types.h>
+#else
+#include <stdint.h>
+typedef uint16_t __le16;
+typedef uint8_t __u8;
+#endif
 
 /* Enumeration of image sizes */
 #define PSZ_SQCIF 0x00

--- a/libs/webcam/v4l2_base.cpp
+++ b/libs/webcam/v4l2_base.cpp
@@ -42,13 +42,18 @@
 #include <cerrno>
 #include <sys/mman.h>
 #include <cstring>
-#include <asm/types.h> /* for videodev2.h */
 #include <ctime>
 #include <cmath>
 #include <sys/time.h>
 
+#ifdef __linux__
+#include <asm/types.h> /* for videodev2.h */
 /* Kernel headers version */
 #include <linux/version.h>
+#elif __FreeBSD__
+#define LINUX_VERSION_CODE 1
+#define KERNEL_VERSION(...) 1
+#endif
 
 #define ERRMSGSIZ 1024
 


### PR DESCRIPTION
This makes libindi compile on FreeBSD 12.0. It also adds support for webcamd. webcamd is essentially a a port Video 4 Linux to FreeBSD user space. Using a few defines, it is possible to compile the indi support for v4l2 for FreeBSD.

I don't know if it still compiled on earlier FreeBSD versions, but I did not try to maintain backwards compatibility, meaning I haven't tried compiling it on anything other than 12.0.

I tested the v4l2 support by forwarding the client over SSH to my Linux machine running OpenPHD2 and could capture images from the FreeBSD machine.

A build and test run has been performed on Linux and it still seems to work fine.