### PR TITLE
Partially fix Xagyl wheel driver

### DIFF
--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -486,6 +486,8 @@ bool XAGYLWheel::setCommand(SET_COMMAND cmd, int value)
     }
 
     // Commands that have no reply
+    /*
+      Huh? Goto responds with a position or error on 1.99.
     switch (cmd)
     {
         case SET_POSITION:
@@ -495,6 +497,7 @@ bool XAGYLWheel::setCommand(SET_COMMAND cmd, int value)
         default:
             break;
     }
+    */
 
     char response[XAGYL_MAXBUF]={0};
 
@@ -502,6 +505,11 @@ bool XAGYLWheel::setCommand(SET_COMMAND cmd, int value)
     {
         switch (cmd)
         {
+            case SET_POSITION:
+                simData.position = value;
+                snprintf(response, XAGYL_MAXBUF, "P%d", simData.position);
+                break;
+
             case SET_SPEED:
                 simData.speed = value / 10;
                 snprintf(response, XAGYL_MAXBUF, "Speed=%3d%%", simData.speed * 10);

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -25,7 +25,7 @@
 
 #include <termios.h>
 
-#define XAGYL_MAXBUF 32
+#define XAGYL_MAXBUF 256
 #define SETTINGS_TAB "Settings"
 
 // We declare an auto pointer to XAGYLWheel.


### PR DESCRIPTION
My Xagyl wheel is an older model using the 1.99 firmware (and apparently can't be upgraded), so I can't verify that these changes work with the newer models.

On my unit, issuing a G command (Goto) produces a result: either the filter position, or an error. However, the indi driver apparently ignored this and did not wait for a result at all.

This caused it to issue a new command while the wheel was in the process of responding to the last command, causing the wheel and driver to get out of sync. The driver would then read a partial error message, fail to parse it, and issue another command. In the end, this crashed the device firmware, causing it to go into an infinite loop printing "ERROR 6 - Unknown command" forever.

This error state is still possible with this patch (especially reboot may cause it, and some other commands), but it seemed to be relatively stable at least with Goto and Jitter.

I additionally increased the response length to 256 as 32 seemed borderline with some of the error messages I've seen.