### PR TITLE
Debug/implement new Xagyl driver

### DIFF
--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -466,7 +466,7 @@ bool XAGYLWheel::SelectFilter(int f)
     if (!optionalResponse(opt))
         return false;
 
-    if (getFilterPosition())
+    if (!getFilterPosition())
         return false;
 
     SelectFilterDone(CurrentFilter);
@@ -772,7 +772,7 @@ bool XAGYLWheel::sendCommand(const char * cmd, char * res)
     // If the response starts with "ERROR" the command failed.
     if (0 == strncmp(res, "ERROR", 5))
     {
-        LOGF_WARN("Device error: <%s>", res);
+        LOGF_WARN("Device error: %s", res);
         return false;
     }
     else
@@ -811,7 +811,7 @@ bool XAGYLWheel::optionalResponse(char *res)
 
     // If the response starts with "ERROR" just warn.
     if (0 == strncmp(res, "ERROR", 5))
-        LOGF_WARN("Device warning: <%s>", res);
+        LOGF_WARN("Device warning: %s", res);
     else
         LOGF_DEBUG("RES (optional) <%s>", res);
 

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright(c) 2020 Jasem Mutlaq. All rights reserved.
+  Copyright(c) 2020 Justin Husted.
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -185,7 +185,8 @@ bool XAGYLWheel::Handshake()
         SettingsNP.nnp--;
 
     bool rc = getMaxFilterSlots();
-    if (!rc) {
+    if (!rc)
+    {
         LOG_ERROR("Unable to parse max filter slots.");
         return false;
     }
@@ -193,7 +194,8 @@ bool XAGYLWheel::Handshake()
     initOffset();
 
     rc = getFilterPosition();
-    if (!rc) {
+    if (!rc)
+    {
         LOG_ERROR("Unable to initialize filter position.");
         return false;
     }
@@ -419,7 +421,8 @@ bool XAGYLWheel::SelectFilter(int f)
 {
     // The wheel does not return a response when setting the value to the
     // current number.
-    if (CurrentFilter == f) {
+    if (CurrentFilter == f)
+    {
         SelectFilterDone(CurrentFilter);
         return true;
     }

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -669,7 +669,7 @@ bool XAGYLWheel::setOffset(int value)
 bool XAGYLWheel::getOffset(int filter)
 {
     char cmd[DRIVER_LEN] = {0}, res[DRIVER_LEN] = {0};
-    snprintf(cmd, DRIVER_LEN, "0%d", filter + 1);
+    snprintf(cmd, DRIVER_LEN, "O%d", filter + 1);
     if (!sendCommand(cmd, res))
         return false;
 

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -711,10 +711,7 @@ bool XAGYLWheel::sendCommand(const char * cmd, char * res, int cmd_len, int res_
     else
     {
         LOGF_DEBUG("CMD <%s>", cmd);
-
-        char formatted_command[DRIVER_LEN] = {0};
-        snprintf(formatted_command, DRIVER_LEN, "%s\r", cmd);
-        rc = tty_write_string(PortFD, formatted_command, &nbytes_written);
+        rc = tty_write_string(PortFD, cmd, &nbytes_written);
     }
 
     if (rc != TTY_OK)

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -196,8 +196,9 @@ bool XAGYLWheel::Handshake()
     m_FirmwareVersion = firmware_version;
 
     // We don't have pulse width for version < 3
+    SettingsNP.nnp = 4;
     if (m_FirmwareVersion < 3)
-        SettingsNP.nnp--;
+        SettingsNP.nnp = 3;
 
     bool rc = getMaxFilterSlots();
     if (!rc)

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -32,23 +32,26 @@ void ISGetProperties(const char *dev)
     xagylWheel->ISGetProperties(dev);
 }
 
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
+void ISNewSwitch(const char *dev, const char *name, ISState *states,
+                 char *names[], int n)
 {
     xagylWheel->ISNewSwitch(dev, name, states, names, n);
 }
 
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
+void ISNewText(const char *dev, const char *name, char *texts[], char *names[],
+               int n)
 {
     xagylWheel->ISNewText(dev, name, texts, names, n);
 }
 
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
+void ISNewNumber(const char *dev, const char *name, double values[],
+                 char *names[], int n)
 {
     xagylWheel->ISNewNumber(dev, name, values, names, n);
 }
 
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
+void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[],
+               char *blobs[], char *formats[], char *names[], int n)
 {
     INDI_UNUSED(dev);
     INDI_UNUSED(name);
@@ -100,26 +103,38 @@ bool XAGYLWheel::initProperties()
     INDI::FilterWheel::initProperties();
 
     // Firmware info
-    IUFillText(&FirmwareInfoT[FIRMWARE_PRODUCT], "FIRMWARE_PRODUCT", "Product", nullptr);
-    IUFillText(&FirmwareInfoT[FIRMWARE_VERSION], "FIRMWARE_VERSION", "Version", nullptr);
-    IUFillText(&FirmwareInfoT[FIRMWARE_SERIAL], "FIRMWARE_SERIAL", "Serial #", nullptr);
-    IUFillTextVector(&FirmwareInfoTP, FirmwareInfoT, 3, getDeviceName(), "Info", "Info", MAIN_CONTROL_TAB, IP_RO, 60,
-                     IPS_IDLE);
+    IUFillText(&FirmwareInfoT[FIRMWARE_PRODUCT], "FIRMWARE_PRODUCT", "Product",
+               nullptr);
+    IUFillText(&FirmwareInfoT[FIRMWARE_VERSION], "FIRMWARE_VERSION", "Version",
+               nullptr);
+    IUFillText(&FirmwareInfoT[FIRMWARE_SERIAL], "FIRMWARE_SERIAL", "Serial #",
+               nullptr);
+    IUFillTextVector(&FirmwareInfoTP, FirmwareInfoT, 3, getDeviceName(),
+                     "Info", "Info", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     // Settings
-    IUFillNumber(&SettingsN[SETTING_SPEED], "SETTING_SPEED", "Speed", "%.f", 0, 100, 10., 0.);
-    IUFillNumber(&SettingsN[SETTING_JITTER], "SETTING_JITTER", "Jitter", "%.f", 0, 10, 1., 0.);
-    IUFillNumber(&SettingsN[SETTING_THRESHOLD], "SETTING_THRESHOLD", "Threshold", "%.f", 0, 100, 10., 0.);
-    IUFillNumber(&SettingsN[SETTING_PW], "SETTING_PW", "Pulse", "%.f", 100, 10000, 100., 0.);
-    IUFillNumberVector(&SettingsNP, SettingsN, 4, getDeviceName(), "Settings", "Settings", SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
+    IUFillNumber(&SettingsN[SETTING_SPEED], "SETTING_SPEED", "Speed", "%.f",
+                 0, 100, 10., 0.);
+    IUFillNumber(&SettingsN[SETTING_JITTER], "SETTING_JITTER", "Jitter", "%.f",
+                 0, 10, 1., 0.);
+    IUFillNumber(&SettingsN[SETTING_THRESHOLD], "SETTING_THRESHOLD",
+                 "Threshold", "%.f", 0, 100, 10., 0.);
+    IUFillNumber(&SettingsN[SETTING_PW], "SETTING_PW", "Pulse", "%.f",
+                 100, 10000, 100., 0.);
+    IUFillNumberVector(&SettingsNP, SettingsN, 4, getDeviceName(), "Settings",
+                       "Settings", SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Reset
     IUFillSwitch(&ResetS[COMMAND_REBOOT], "COMMAND_REBOOT", "Reboot", ISS_OFF);
     IUFillSwitch(&ResetS[COMMAND_INIT], "COMMAND_INIT", "Initialize", ISS_OFF);
-    IUFillSwitch(&ResetS[COMMAND_CLEAR_CALIBRATION], "COMMAND_CLEAR_CALIBRATION Calibration", "Clear Calibration", ISS_OFF);
-    IUFillSwitch(&ResetS[COMMAND_PERFORM_CALIBRAITON], "COMMAND_PERFORM_CALIBRAITON", "Perform Calibration", ISS_OFF);
-    IUFillSwitchVector(&ResetSP, ResetS, 4, getDeviceName(), "Commands", "Commands", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
-                       IPS_IDLE);
+    IUFillSwitch(&ResetS[COMMAND_CLEAR_CALIBRATION],
+                 "COMMAND_CLEAR_CALIBRATION Calibration", "Clear Calibration",
+                 ISS_OFF);
+    IUFillSwitch(&ResetS[COMMAND_PERFORM_CALIBRAITON],
+                 "COMMAND_PERFORM_CALIBRAITON", "Perform Calibration", ISS_OFF);
+    IUFillSwitchVector(&ResetSP, ResetS, 4, getDeviceName(),
+                       "Commands", "Commands", MAIN_CONTROL_TAB, IP_RW,
+                       ISR_ATMOST1, 0, IPS_IDLE);
 
     addAuxControls();
 
@@ -208,7 +223,8 @@ bool XAGYLWheel::Handshake()
 /////////////////////////////////////////////////////////////////////////////
 ///
 /////////////////////////////////////////////////////////////////////////////
-bool XAGYLWheel::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
+bool XAGYLWheel::ISNewSwitch(const char *dev, const char *name, ISState *states,
+                             char *names[], int n)
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
@@ -258,7 +274,8 @@ bool XAGYLWheel::ISNewSwitch(const char *dev, const char *name, ISState *states,
 /////////////////////////////////////////////////////////////////////////////
 ///
 /////////////////////////////////////////////////////////////////////////////
-bool XAGYLWheel::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
+bool XAGYLWheel::ISNewNumber(const char *dev, const char *name, double values[],
+                             char *names[], int n)
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
@@ -287,7 +304,8 @@ bool XAGYLWheel::ISNewNumber(const char *dev, const char *name, double values[],
 
         if (strcmp(SettingsNP.name, name) == 0)
         {
-            double newSpeed = 0, newJitter = 0, newThreshold = 0, newPulseWidth = 0;
+            double newSpeed = 0, newJitter = 0, newThreshold = 0,
+                   newPulseWidth = 0;
             for (int i = 0; i < n; i++)
             {
                 if (!strcmp(names[i], SettingsN[SET_SPEED].name))
@@ -300,7 +318,8 @@ bool XAGYLWheel::ISNewNumber(const char *dev, const char *name, double values[],
                     newPulseWidth = values[i];
             }
 
-            bool rc_speed = true, rc_jitter = true, rc_threshold = true, rc_pulsewidth = true;
+            bool rc_speed = true, rc_jitter = true, rc_threshold = true,
+                 rc_pulsewidth = true;
 
             if (std::abs(newSpeed - SettingsN[SET_SPEED].value) > 0)
             {
@@ -339,7 +358,8 @@ bool XAGYLWheel::ISNewNumber(const char *dev, const char *name, double values[],
             }
 
             // Pulse width
-            if (m_FirmwareVersion >= 3 && std::abs(newPulseWidth - SettingsN[SET_PULSE_WITDH].value))
+            if (m_FirmwareVersion >= 3 && std::abs(
+                        newPulseWidth - SettingsN[SET_PULSE_WITDH].value))
             {
                 if (newPulseWidth > SettingsN[SET_PULSE_WITDH].value)
                 {
@@ -379,11 +399,12 @@ void XAGYLWheel::initOffset()
     {
         snprintf(offsetName, MAXINDINAME, "OFFSET_%d", i + 1);
         snprintf(offsetLabel, MAXINDINAME, "#%d Offset", i + 1);
-        IUFillNumber(OffsetN + i, offsetName, offsetLabel, "%.f", -99, 99, 10, 0);
+        IUFillNumber(OffsetN + i, offsetName, offsetLabel, "%.f",
+                     -99, 99, 10, 0);
     }
 
-    IUFillNumberVector(&OffsetNP, OffsetN, FilterSlotN[0].max, getDeviceName(), "Offsets", "", FILTER_TAB, IP_RW, 0,
-                       IPS_IDLE);
+    IUFillNumberVector(&OffsetNP, OffsetN, FilterSlotN[0].max, getDeviceName(),
+                       "Offsets", "", FILTER_TAB, IP_RW, 0, IPS_IDLE);
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -427,11 +448,14 @@ bool XAGYLWheel::SelectFilter(int f)
         return true;
     }
 
+    // The wheel moves to a new position, and responds with one line or two.
+    // On success, the first line will be P#.  On failure, it is an ERROR.
     char cmd[DRIVER_LEN] = {0}, res[DRIVER_LEN] = {0};
     snprintf(cmd, DRIVER_LEN, "G%X", f);
     if (!sendCommand(cmd, res))
         return false;
 
+    // On success, the wheel may also return an ERROR on a second line.
     char opt[DRIVER_LEN] = {0};
     if (!optionalResponse(opt))
         return false;
@@ -705,22 +729,14 @@ bool XAGYLWheel::saveConfigItems(FILE *fp)
 /////////////////////////////////////////////////////////////////////////////
 /// Send Command
 /////////////////////////////////////////////////////////////////////////////
-bool XAGYLWheel::sendCommand(const char * cmd, char * res, int cmd_len, int res_len)
+bool XAGYLWheel::sendCommand(const char * cmd, char * res)
 {
     int nbytes_written = 0, nbytes_read = 0, rc = -1;
 
-    if (cmd_len > 0)
-    {
-        char hex_cmd[DRIVER_LEN * 3] = {0};
-        hexDump(hex_cmd, cmd, cmd_len);
-        LOGF_DEBUG("CMD <%s>", hex_cmd);
-        rc = tty_write(PortFD, cmd, cmd_len, &nbytes_written);
-    }
-    else
-    {
-        LOGF_DEBUG("CMD <%s>", cmd);
-        rc = tty_write_string(PortFD, cmd, &nbytes_written);
-    }
+    assert(res);
+
+    LOGF_DEBUG("CMD <%s>", cmd);
+    rc = tty_write_string(PortFD, cmd, &nbytes_written);
 
     if (rc != TTY_OK)
     {
@@ -730,13 +746,8 @@ bool XAGYLWheel::sendCommand(const char * cmd, char * res, int cmd_len, int res_
         return false;
     }
 
-    if (res == nullptr)
-        return true;
-
-    if (res_len > 0)
-        rc = tty_read(PortFD, res, res_len, DRIVER_TIMEOUT, &nbytes_read);
-    else
-        rc = tty_nread_section(PortFD, res, DRIVER_LEN, DRIVER_STOP_CHAR, DRIVER_TIMEOUT, &nbytes_read);
+    rc = tty_nread_section(PortFD, res, DRIVER_LEN, DRIVER_STOP_CHAR,
+                           DRIVER_TIMEOUT, &nbytes_read);
 
     if (rc != TTY_OK)
     {
@@ -746,20 +757,11 @@ bool XAGYLWheel::sendCommand(const char * cmd, char * res, int cmd_len, int res_
         return false;
     }
 
-    if (res_len > 0)
-    {
-        char hex_res[DRIVER_LEN * 3] = {0};
-        hexDump(hex_res, res, res_len);
-        LOGF_DEBUG("RES <%s>", hex_res);
-    }
-    else
-    {
-        // Remove extra \r
-        assert(nbytes_read > 1);
+    // Remove extra \r
+    assert(nbytes_read > 1);
 
-        res[nbytes_read - 2] = 0;
-        LOGF_DEBUG("RES <%s>", res);
-    }
+    res[nbytes_read - 2] = 0;
+    LOGF_DEBUG("RES <%s>", res);
 
     return true;
 }
@@ -772,8 +774,8 @@ bool XAGYLWheel::optionalResponse(char *res)
 {
     int nbytes_read = 0, rc = -1;
 
-    rc = tty_nread_section(PortFD, res, DRIVER_LEN, DRIVER_STOP_CHAR, FLUSH_TIMEOUT,
-                           &nbytes_read);
+    rc = tty_nread_section(PortFD, res, DRIVER_LEN, DRIVER_STOP_CHAR,
+                           FLUSH_TIMEOUT, &nbytes_read);
     if (rc == TTY_TIME_OUT)
     {
         res[0] = '\0';
@@ -807,17 +809,4 @@ void XAGYLWheel::hexDump(char * buf, const char * data, int size)
 
     if (size > 0)
         buf[3 * size - 1] = '\0';
-}
-
-/////////////////////////////////////////////////////////////////////////////
-///
-/////////////////////////////////////////////////////////////////////////////
-std::vector<std::string> XAGYLWheel::split(const std::string &input, const std::string &regex)
-{
-    // passing -1 as the submatch index parameter performs splitting
-    std::regex re(regex);
-    std::sregex_token_iterator
-    first{input.begin(), input.end(), re, -1},
-          last;
-    return {first, last};
 }

--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -752,9 +752,9 @@ bool XAGYLWheel::sendCommand(const char * cmd, char * res, int cmd_len, int res_
     else
     {
         // Remove extra \r
-        assert(nbytes_read > 0);
+        assert(nbytes_read > 1);
 
-        res[nbytes_read - 1] = 0;
+        res[nbytes_read - 2] = 0;
         LOGF_DEBUG("RES <%s>", res);
     }
 
@@ -786,10 +786,10 @@ bool XAGYLWheel::optionalResponse(char *res)
     }
 
     // Remove extra \r
-    assert(nbytes_read > 0);
+    assert(nbytes_read > 1);
 
-    res[nbytes_read - 1] = 0;
-    LOGF_DEBUG("RES <%s>", res);
+    res[nbytes_read - 2] = 0;
+    LOGF_DEBUG("RES (optional) <%s>", res);
 
     return true;
 }

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright(c) 2020 Jasem Mutlaq. All rights reserved.
+  Copyright(c) 2020 Justin Husted.
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -134,8 +134,8 @@ class XAGYLWheel : public INDI::FilterWheel
         static constexpr const char * SETTINGS_TAB = "Settings";
         // 0xA is the stop char
         static const char DRIVER_STOP_CHAR { 0xA };
-        // Wait up to a maximum of 3 seconds for serial input
-        static constexpr const uint8_t DRIVER_TIMEOUT {3};
+        // Wait up to a maximum of 15 seconds for serial input
+        static constexpr const uint8_t DRIVER_TIMEOUT {15};
         // Maximum buffer for sending/receving.
         static constexpr const uint8_t DRIVER_LEN {64};
 };

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -61,7 +61,8 @@ class XAGYLWheel : public INDI::FilterWheel
         bool saveConfigItems(FILE *fp) override;
 
     private:
-        bool setCommand(SET_COMMAND command, int value);
+        bool setMaximumSpeed(int value);
+        bool setRelativeCommand(SET_COMMAND command, int value);
 
         void initOffset();
 
@@ -144,7 +145,7 @@ class XAGYLWheel : public INDI::FilterWheel
         static constexpr const int DRIVER_TIMEOUT {15};
 
         // Some commands optionally return an extra string.
-        static constexpr const int FLUSH_TIMEOUT {1};
+        static constexpr const int OPTIONAL_TIMEOUT {1};
 
         // Maximum buffer for sending/receving.
         static constexpr const int DRIVER_LEN {64};

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -87,8 +87,8 @@ class XAGYLWheel : public INDI::FilterWheel
         //////////////////////////////////////////////////////////////////////
         /// Communication Functions
         //////////////////////////////////////////////////////////////////////
+        bool receiveResponse(char * res, bool optional = false);
         bool sendCommand(const char * cmd, char * res);
-        bool optionalResponse(char * res);
         void hexDump(char * buf, const char * data, int size);
 
         //////////////////////////////////////////////////////////////////////

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -51,7 +51,6 @@ class XAGYLWheel : public INDI::FilterWheel
         const char *getDefaultName() override;
 
         bool Handshake() override;
-        void TimerHit() override;
 
         bool SelectFilter(int) override;
         bool saveConfigItems(FILE *fp) override;
@@ -83,6 +82,7 @@ class XAGYLWheel : public INDI::FilterWheel
         /// Communication Functions
         ///////////////////////////////////////////////////////////////////////////////
         bool sendCommand(const char * cmd, char * res = nullptr, int cmd_len = -1, int res_len = -1);
+        bool optionalResponse(char * res);
         void hexDump(char * buf, const char * data, int size);
         std::vector<std::string> split(const std::string &input, const std::string &regex);
 
@@ -132,10 +132,16 @@ class XAGYLWheel : public INDI::FilterWheel
         /// Static Helper Values
         /////////////////////////////////////////////////////////////////////////////
         static constexpr const char * SETTINGS_TAB = "Settings";
+
         // 0xA is the stop char
         static const char DRIVER_STOP_CHAR { 0xA };
-        // Wait up to a maximum of 15 seconds for serial input
-        static constexpr const uint8_t DRIVER_TIMEOUT {15};
+
+        // Wait up to a maximum of 15 seconds for normal serial input
+        static constexpr const int DRIVER_TIMEOUT {15};
+
+        // Some commands optionally return an extra string.
+        static constexpr const int FLUSH_TIMEOUT {1};
+
         // Maximum buffer for sending/receving.
-        static constexpr const uint8_t DRIVER_LEN {64};
+        static constexpr const int DRIVER_LEN {64};
 };

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -79,7 +79,7 @@ class XAGYLWheel : public INDI::FilterWheel
 
         // Calibration offset
         bool getOffset(int filter);
-        bool setOffset(int value);
+        bool setOffset(int filter, int shift);
 
         // Reset
         bool reset(int value);

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -36,7 +36,10 @@ class XAGYLWheel : public INDI::FilterWheel
             INFO_MAX_SLOTS,
             INFO_PULSE_WIDTH
         } GET_COMMAND;
-        typedef enum { SET_SPEED, SET_JITTER, SET_THRESHOLD, SET_PULSE_WITDH } SET_COMMAND;
+        typedef enum
+        {
+            SET_SPEED, SET_JITTER, SET_THRESHOLD, SET_PULSE_WITDH
+        } SET_COMMAND;
 
         XAGYLWheel();
         virtual ~XAGYLWheel() override;
@@ -44,8 +47,10 @@ class XAGYLWheel : public INDI::FilterWheel
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
 
-        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name,
+                                 ISState *states, char *names[], int n) override;
+        virtual bool ISNewNumber(const char *dev, const char *name,
+                                 double values[], char *names[], int n) override;
 
     protected:
         const char *getDefaultName() override;
@@ -78,17 +83,16 @@ class XAGYLWheel : public INDI::FilterWheel
         // Reset
         bool reset(int value);
 
-        ///////////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////
         /// Communication Functions
-        ///////////////////////////////////////////////////////////////////////////////
-        bool sendCommand(const char * cmd, char * res = nullptr, int cmd_len = -1, int res_len = -1);
+        //////////////////////////////////////////////////////////////////////
+        bool sendCommand(const char * cmd, char * res);
         bool optionalResponse(char * res);
         void hexDump(char * buf, const char * data, int size);
-        std::vector<std::string> split(const std::string &input, const std::string &regex);
 
-        ///////////////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////
         /// Properties
-        ///////////////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////
 
         // Firmware info
         ITextVectorProperty FirmwareInfoTP;
@@ -128,9 +132,9 @@ class XAGYLWheel : public INDI::FilterWheel
 
         uint8_t m_FirmwareVersion { 0 };
 
-        /////////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////
         /// Static Helper Values
-        /////////////////////////////////////////////////////////////////////////////
+        //////////////////////////////////////////////////////////////////////
         static constexpr const char * SETTINGS_TAB = "Settings";
 
         // 0xA is the stop char


### PR DESCRIPTION
This patch set fixes all issues I could find with Jasem's new Xagyl driver, when running against my physical wheel.

Major features:
1. Strict command/response with no timers or tcflush. The device firmware crashes on me when it receives commands out of sequence.
2. Relative commands like Jitter/Offset/etc. are implemented using loops.
3. Device error messages are reported to the user.
4. Device reboot/etc. work correctly and poll the device.

I'm not sure if offset etc. ever worked with the old driver (the device's command set seems to imply they're meant to be used interactively!) but they work now.

My device cannot use the v3+ Xagyl firmware, so I cannot verify that the Pulse Width command works as intended.