### PR TITLE
Weather: adds checkParameterState()

### DIFF
--- a/libs/indibase/indiweatherinterface.cpp
+++ b/libs/indibase/indiweatherinterface.cpp
@@ -187,6 +187,43 @@ bool WeatherInterface::setCriticalParameter(std::string param)
     return false;
 }
 
+IPState WeatherInterface::checkParameterState(INumber parameter)
+{
+    double warn = *(static_cast<double *>(parameter.aux0));
+    double rangeWarn = (parameter.max - parameter.min) * (warn / 100);
+
+    if ((parameter.value < parameter.min) || (parameter.value > parameter.max))
+    {
+        return IPS_ALERT;
+    }
+    //else if (parameter.value < (parameter.min + rangeWarn) || parameter.value > (parameter.max - rangeWarn))
+    // FIXME This is a hack to prevent warnings parameters which minimum values are zero (e.g. Wind)
+    else if (   ((parameter.value < (parameter.min + rangeWarn)) && parameter.min != 0)
+                || ((parameter.value > (parameter.max - rangeWarn)) && parameter.max != 0))
+    {
+        return IPS_BUSY;
+    }
+    else
+    {
+        return IPS_OK;
+    }
+
+    return IPS_IDLE;
+}
+
+IPState WeatherInterface::checkParameterState(std::string param)
+{
+    for (int i = 0; i < ParametersNP.nnp; i++)
+    {
+        if (!strcmp(ParametersN[i].name, param.c_str()))
+        {
+            return checkParameterState(ParametersN[i]);
+        }
+    }
+
+    return IPS_IDLE;
+}
+
 bool WeatherInterface::syncCriticalParameters()
 {
     if (critialParametersL == nullptr)
@@ -204,30 +241,25 @@ bool WeatherInterface::syncCriticalParameters()
         {
             if (!strcmp(critialParametersL[i].name, ParametersN[j].name))
             {
-                double warn = *(static_cast<double *>(ParametersN[j].aux0));
-
-                double rangeWarn = (ParametersN[j].max - ParametersN[j].min) * (warn / 100);
-
-                if ((ParametersN[j].value < ParametersN[j].min) || (ParametersN[j].value > ParametersN[j].max))
+                IPState state = checkParameterState(ParametersN[j]);
+                switch (state)
                 {
-                    critialParametersL[i].s = IPS_ALERT;
-                    DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_WARNING, "Caution: Parameter %s value (%g) is in the danger zone!",
-                                 ParametersN[j].label, ParametersN[j].value);
-                }
-                //else if (ParametersN[j].value < (ParametersN[j].min + rangeWarn) || ParametersN[j].value > (ParametersN[j].max - rangeWarn))
-                // FIXME This is a hack to prevent warnings parameters which minimum values are zero (e.g. Wind)
-                else if (   ((ParametersN[j].value < (ParametersN[j].min + rangeWarn)) && ParametersN[j].min != 0)
-                            || ((ParametersN[j].value > (ParametersN[j].max - rangeWarn)) && ParametersN[j].max != 0))
-                {
+                case IPS_BUSY:
                     critialParametersL[i].s = IPS_BUSY;
                     DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_WARNING, "Warning: Parameter %s value (%g) is in the warning zone!",
                                  ParametersN[j].label, ParametersN[j].value);
-                }
-                else
-                {
+                    break;
+
+                case IPS_ALERT:
+                    critialParametersL[i].s = IPS_ALERT;
+                    DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_WARNING, "Caution: Parameter %s value (%g) is in the danger zone!",
+                                 ParametersN[j].label, ParametersN[j].value);
+                    break;
+
+                case IPS_IDLE:
+                case IPS_OK:
                     critialParametersL[i].s = IPS_OK;
                 }
-                break;
             }
         }
 

--- a/libs/indibase/indiweatherinterface.cpp
+++ b/libs/indibase/indiweatherinterface.cpp
@@ -187,7 +187,7 @@ bool WeatherInterface::setCriticalParameter(std::string param)
     return false;
 }
 
-IPState WeatherInterface::checkParameterState(INumber parameter)
+IPState WeatherInterface::checkParameterState(const INumber &parameter) const
 {
     double warn = *(static_cast<double *>(parameter.aux0));
     double rangeWarn = (parameter.max - parameter.min) * (warn / 100);
@@ -211,7 +211,7 @@ IPState WeatherInterface::checkParameterState(INumber parameter)
     return IPS_IDLE;
 }
 
-IPState WeatherInterface::checkParameterState(std::string param)
+IPState WeatherInterface::checkParameterState(const std::string &param) const
 {
     for (int i = 0; i < ParametersNP.nnp; i++)
     {

--- a/libs/indibase/indiweatherinterface.h
+++ b/libs/indibase/indiweatherinterface.h
@@ -128,9 +128,9 @@ class WeatherInterface
          * @returns IPS_BUSY:  The given parameter is in the warning zone.
          * @returns IPS_ALERT: The given parameter is in the danger zone.
          */
-        IPState checkParameterState(std::string param);
+        IPState checkParameterState(const std::string &param) const;
 
-        IPState checkParameterState(INumber parameter);
+        IPState checkParameterState(const INumber &parameter) const;
 
         /**
          * @brief updateWeatherState Send update weather state to client

--- a/libs/indibase/indiweatherinterface.h
+++ b/libs/indibase/indiweatherinterface.h
@@ -121,6 +121,18 @@ class WeatherInterface
         void setParameterValue(std::string name, double value);
 
         /**
+         * @brief checkParameterState Checks the given parameter against the defined bounds
+         * @param param Name of parameter to check.
+         * @returns IPS_IDLE:  The given parameter name is not valid.
+         * @returns IPS_OK:    The given parameter is within the safe zone.
+         * @returns IPS_BUSY:  The given parameter is in the warning zone.
+         * @returns IPS_ALERT: The given parameter is in the danger zone.
+         */
+        IPState checkParameterState(std::string param);
+
+        IPState checkParameterState(INumber parameter);
+
+        /**
          * @brief updateWeatherState Send update weather state to client
          * @returns true if any parameters changed from last update. False if no states changed.
          */


### PR DESCRIPTION
This comes from the discussion at https://github.com/indilib/indi-3rdparty/issues/83

This extracts the check of a parameter (added with addParameter) against
the user defined limits.

    IPState checkParameterState(std::string param);
    IPState checkParameterState(INumber parameter);

Returns:

  - IPS_IDLE:  The given parameter name is not valid.
  - IPS_OK:    The given parameter is within the safe zone.
  - IPS_BUSY:  The given parameter is in the warning zone.
  - IPS_ALERT: The given parameter is in the danger zone.