### PR TITLE
Fix spurious error in new Xagyl driver

### DIFF
--- a/drivers/filter_wheel/xagyl_wheel.cpp
+++ b/drivers/filter_wheel/xagyl_wheel.cpp
@@ -818,7 +818,8 @@ bool XAGYLWheel::receiveResponse(char * res, bool optional)
     if (0 == strncmp(res, "ERROR", 5))
     {
         LOGF_WARN("Device error: %s", res);
-        return false;
+        if (!optional)
+            return false;
     }
     else
         LOGF_DEBUG("RES <%s>", res);


### PR DESCRIPTION
This bug was introduced after being handled correctly in the middle of
my previous patch.

When issuing a (G)oto command, the device firmware will sometimes return
the message: "ERROR 7 - Magnet weak" after returning the successful
position response.

In this case, the error should be printed and ignored rather than
treated as a failure.