### PR TITLE
Goto mode selectable for Alt/Az mounts via an UI Switch.

### DIFF
--- a/drivers/telescope/synscandriver.h
+++ b/drivers/telescope/synscandriver.h
@@ -33,6 +33,7 @@ class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
         virtual const char * getDefaultName() override;
 
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
         static void guideTimeoutHelperNS(void *context);
         static void guideTimeoutHelperWE(void *context);
@@ -97,6 +98,8 @@ class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
         bool readFirmware();
         bool readModel();
         bool readTracking();
+        // Goto mode
+        bool SetAltAzMode(bool);
 
         // Slew
         bool slewFixedRate(SynscanDirection direction, uint8_t rate);
@@ -133,6 +136,8 @@ class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
 
         // Is mount type Alt-Az?
         bool m_isAltAz { false };
+        // Use Alt-Az Goto?
+        bool goto_AltAz { false };
 
         //////////////////////////////////////////////////////////////////
         /// Properties
@@ -153,6 +158,10 @@ class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
         // Horizontal Coords
         INumber HorizontalCoordsN[2];
         INumberVectorProperty HorizontalCoordsNP;
+
+        // Goto mode
+        ISwitch GotoModeS[2];
+        ISwitchVectorProperty GotoModeSP;
 
         // Mount Info
         enum MountInfo


### PR DESCRIPTION
There is a problem with using indi_synscan_telescope driver with Alt/Az mounts (like a Dobsonian Goto Mount). Sometimes the Goto command does not moves exactly where it was asked for. It turns out that the problem occures after issuing some sync operations to refine pointing accuracy. 
The problem is demonstrated in this forum topic: https://indilib.org/forum/mounts/6444-az-synscan-strange-behavior-can-someone-explain-please.html
It has turned out that the problem goes back to the fact that in case of AltAz mount the Goto operation falls back to GotoAltAz by calculating the Alt/Az coordinates from the requested Ra/Dec coordinates.
In the comment it says:
// For Alt/Az mounts, we must issue Goto Alt/Az
But it is not true, at least not for today's hand controller firmware versions.
The hand controller has two type of Goto commands: 'r' command for Goto Ra/Dec and 'b' command for Goto Alt/Az, and the hand controller happily accepts both for an Alt/Az mount.
Both command works the same as long as the mount is freshly and ideally aligned. But in real life sync operations are needed for correcting imperfect alignments. That works by offsetting the coordinates in the vicinity of the sync star.
And here starts the problems: the Goto command comes in Ra/Dec coordinates from Kstars. The driver converts it into Alt/Az, but the driver does not count for the offset. Sends the Goto to the telescope, the telescope slews to the given Alt/Az position, but the reported Ra/Dec coordinates are offset by the hand controller. So Kstar shows the cross hair for the telescope in an ofset position, which is actually where the telescope points, but not what has been requested to slew to.

I've added a UI switch to the driver by which I can force the driver to issue Ra/Dec goto even for Alt/Az mounts. This way the scope slews to the requested Ra/Dec coordinates, offseted by the sync offset, so it points to the actual right position in the sky, and reports the same Ra/Dec coordinates in the status message, so Kstars shows the cross hair for the telescope in the right position

The new switch only appears in case of an Alt/Az mount has connected, and defaults to using Ra/Dec goto but by flipping the switch one can get back the old way of operation.
