### PR TITLE
Update CCD and Guide simulators to improve image accuracy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ IF (UNITY_BUILD)
 ENDIF ()
 
 SET(indiclient_C_SRC ${indiclient_C_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.c)
 
 add_library(indiclient STATIC ${indiclient_C_SRC} ${indiclient_CXX_SRC})
@@ -244,6 +245,7 @@ IF (UNITY_BUILD)
 ENDIF ()
 
 SET(indiclientqt_C_SRC ${indiclientqt_C_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.c)
 
 add_library(indiclientqt STATIC ${indiclientqt_C_SRC} ${indiclientqt_CXX_SRC})
@@ -441,6 +443,7 @@ SET(indidriver_C_SRC
     ${indidriver_C_SRC}
     ${libdsp_C_SRC}
     ${fpack_C_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.c)
 
 ##################################################
@@ -1665,6 +1668,7 @@ IF (UNITY_BUILD)
 ENDIF ()
 
 SET(indi_get_SRC ${indi_get_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.c)
 
 add_executable(indi_getprop ${indi_get_SRC})
@@ -1687,6 +1691,7 @@ IF (UNITY_BUILD)
 ENDIF ()
 
 SET(indi_set_SRC ${indi_set_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.c)
 
 add_executable(indi_setprop ${indi_set_SRC})
@@ -1710,6 +1715,7 @@ IF (UNITY_BUILD)
 ENDIF ()
 
 SET(indi_eval_SRC ${indi_eval_SRC}
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.c)
 
 add_executable(indi_eval ${indi_eval_SRC})
@@ -1823,6 +1829,7 @@ if (INDI_BUILD_DRIVERS OR INDI_BUILD_CLIENT OR INDI_BUILD_QT5_CLIENT)
         ${CMAKE_CURRENT_SOURCE_DIR}/indidevapi.h
         ${CMAKE_CURRENT_SOURCE_DIR}/base64.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.h
         ${CMAKE_CURRENT_SOURCE_DIR}/eventloop.h
         ${CMAKE_CURRENT_SOURCE_DIR}/indidriver.h

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -23,7 +23,7 @@
 #include "locale_compat.h"
 
 #include <libnova/julian_day.h>
-#include <libnova/precession.h>
+#include <libastro.h>
 
 #include <cmath>
 #include <unistd.h>
@@ -642,14 +642,21 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
 
             ln_equ_posn epochPos { 0, 0 }, J2000Pos { 0, 0 };
 
+            double jd = ln_get_julian_from_sys();
+
             epochPos.ra  = currentRA * 15.0;
             epochPos.dec = currentDE;
 
             // Convert from JNow to J2000
-            ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
+            LibAstro::ObservedToJ2000(&epochPos, jd, &J2000Pos);
 
             currentRA  = J2000Pos.ra / 15.0;
             currentDE = J2000Pos.dec;
+
+            LOGF_DEBUG("DrawCcdFrame JNow %f, %f J2000 %f, %f", epochPos.ra, epochPos.dec, J2000Pos.ra, J2000Pos.dec);
+            ln_equ_posn jnpos;
+            LibAstro::J2000toObserved(&J2000Pos, jd, &jnpos);
+            LOGF_DEBUG("J2000toObserved JNow %f, %f J2000 %f, %f", jnpos.ra, jnpos.dec, J2000Pos.ra, J2000Pos.dec);
 
             currentDE += guideNSOffset;
             currentRA += guideWEOffset;
@@ -1226,7 +1233,8 @@ bool CCDSim::ISNewNumber(const char * dev, const char * name, double values[], c
             RA = EqPEN[AXIS_RA].value;
             Dec = EqPEN[AXIS_DE].value;
 
-            ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
+            LibAstro::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
+            //ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
             currentRA  = J2000Pos.ra / 15.0;
             currentDE = J2000Pos.dec;
             usePE = true;
@@ -1502,3 +1510,4 @@ void CCDSim::addFITSKeywords(fitsfile *fptr, INDI::CCDChip *targetChip)
     int status = 0;
     fits_update_key_dbl(fptr, "Gain", GainN[0].value, 3, "Gain", &status);
 }
+

--- a/drivers/ccd/guide_simulator.cpp
+++ b/drivers/ccd/guide_simulator.cpp
@@ -23,7 +23,7 @@
 #include "locale_compat.h"
 
 #include <libnova/julian_day.h>
-#include <libnova/precession.h>
+#include <libastro.h>
 
 #include <cmath>
 #include <unistd.h>
@@ -624,7 +624,8 @@ int GuideSim::DrawCcdFrame(INDI::CCDChip * targetChip)
             epochPos.dec = currentDE;
 
             // Convert from JNow to J2000
-            ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
+            LibAstro::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
+            //ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
 
             currentRA  = J2000Pos.ra / 15.0;
             currentDE = J2000Pos.dec;
@@ -1187,7 +1188,8 @@ bool GuideSim::ISNewNumber(const char * dev, const char * name, double values[],
             RA = EqPEN[AXIS_RA].value;
             Dec = EqPEN[AXIS_DE].value;
 
-            ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
+            LibAstro::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
+            //ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
             currentRA  = J2000Pos.ra / 15.0;
             currentDE = J2000Pos.dec;
             usePE = true;

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -300,6 +300,11 @@ bool ScopeSim::ReadScopeStatus()
                 SetTrackEnabled(true);
                 EqNP.s = IPS_IDLE;
                 LOG_INFO("Telescope slew is complete. Tracking...");
+
+               // check the slew accuracy
+                auto dRa = targetRA - currentRA;
+                auto dDec = targetDEC - currentDEC;
+                LOGF_DEBUG("slew accuracy %f, %f", dRa * 15 * 3600, dDec * 3600);
             }
             break;
         default:

--- a/libs/libastro.cpp
+++ b/libs/libastro.cpp
@@ -1,0 +1,89 @@
+// file libastro.c
+//
+// holds extensions to the libnova library to provide useful functions for INDI
+//
+// Chris Rowland April 2020
+//
+
+#include "libastro.h"
+
+#include <math.h>
+
+#include <libnova/precession.h>
+#include <libnova/aberration.h>
+#include <libnova/nutation.h>
+
+// converts the Observed (JNow) position to a J2000 catalogue position by removing
+// aberration, nutation and precession using the libnova library
+void LibAstro::ObservedToJ2000(ln_equ_posn * observed, double jd, ln_equ_posn * J2000pos)
+{
+    ln_equ_posn tempPos;
+    // remove the aberration
+    ln_get_equ_aber(observed, jd, &tempPos);
+    // this conversion has added the aberration, we want to subtract it
+    tempPos.ra = observed->ra - (tempPos.ra - observed->ra);
+    tempPos.dec = observed->dec * 2 - tempPos.dec;
+
+
+    // remove the nutation
+    ln_get_equ_nut(&tempPos, jd, true);
+
+    // precess from now to J2000
+    ln_get_equ_prec2(&tempPos, jd, JD2000, J2000pos);
+}
+
+///
+/// \brief LibAstro::J2000toObserved converts catalogue to observed
+/// \param J2000pos catalogue position
+/// \param jd julian day for the observed epoch
+/// \param observed returns observed position
+///
+void LibAstro::J2000toObserved(ln_equ_posn *J2000pos, double jd, ln_equ_posn * observed)
+{
+	ln_equ_posn tempPosn;
+	
+    // apply precession from J2000 to jd
+    ln_get_equ_prec2(J2000pos, JD2000, jd, &tempPosn);
+
+	// apply nutation
+    ln_get_equ_nut(&tempPosn, jd, false);
+
+	// apply aberration
+    ln_get_equ_aber(&tempPosn, jd, observed);
+}
+
+// apply or remove nutation
+void LibAstro::ln_get_equ_nut(ln_equ_posn *posn, double jd, bool reverse)
+{
+    // code lifted from libnova ln_get_equ_nut
+    // with the option to add or remove nutation
+    struct ln_nutation nut;
+    ln_get_nutation (jd, &nut);
+
+    double mean_ra, mean_dec, delta_ra, delta_dec;
+
+    mean_ra = ln_deg_to_rad(posn->ra);
+    mean_dec = ln_deg_to_rad(posn->dec);
+
+    // Equ 22.1
+
+    double nut_ecliptic = ln_deg_to_rad(nut.ecliptic + nut.obliquity);
+    double sin_ecliptic = sin(nut_ecliptic);
+
+    double sin_ra = sin(mean_ra);
+    double cos_ra = cos(mean_ra);
+
+    double tan_dec = tan(mean_dec);
+
+    delta_ra = (cos (nut_ecliptic) + sin_ecliptic * sin_ra * tan_dec) * nut.longitude - cos_ra * tan_dec * nut.obliquity;
+    delta_dec = (sin_ecliptic * cos_ra) * nut.longitude + sin_ra * nut.obliquity;
+
+    // the sign changed to remove nutation
+    if (reverse)
+    {
+		delta_ra = -delta_ra;
+		delta_dec = -delta_dec;
+	}
+    posn->ra += delta_ra;
+    posn->dec += delta_dec;
+}

--- a/libs/libastro.cpp
+++ b/libs/libastro.cpp
@@ -1,3 +1,26 @@
+/*
+    libastro
+
+    functions used for coordinate conversions, based on libnova
+    
+    Copyright (C) 2020 Chris Rowland    
+
+    This library is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+*/
+
 // file libastro.c
 //
 // holds extensions to the libnova library to provide useful functions for INDI

--- a/libs/libastro.h
+++ b/libs/libastro.h
@@ -1,3 +1,26 @@
+/*
+    libastro
+
+    functions used for coordinate conversions, based on libnova
+    
+    Copyright (C) 2020 Chris Rowland    
+
+    This library is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+    License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library; if not, write to the Free Software Foundation,
+    Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+
+*/
+
 // file libsatro.h
 
 // functions used for coordinate conversions, based on libnova

--- a/libs/libastro.h
+++ b/libs/libastro.h
@@ -1,0 +1,42 @@
+// file libsatro.h
+
+// functions used for coordinate conversions, based on libnova
+
+#include <libnova/utility.h>
+
+///
+/// \brief The LibAstro class, this provides astrometric helper functions
+/// based on the libnova library
+///
+class LibAstro
+{
+public:
+	
+    ///
+    /// \brief ObservedToJ2000 converts an observed position to a J2000 catalogue position
+    ///  removes aberration, nutation and precession
+    /// \param observed position
+    /// \param jd Julian day epoch of observed position
+    /// \param J2000pos returns catalogue position
+    ///
+    static void ObservedToJ2000(ln_equ_posn * observed, double jd, ln_equ_posn * J2000pos);
+		
+    ///
+    /// \brief J2000toObserved converts a J2000 catalogue position to an observed position for the epoch jd
+    ///    applies precession, nutation and aberration
+    /// \param J2000pos J2000 catalogue position
+    /// \param jd Julian day epoch of observed position
+    /// \param observed returns observed position for the JD epoch
+    ///
+    static void J2000toObserved(ln_equ_posn *J2000pos, double jd, ln_equ_posn * observed);
+	
+protected:
+	
+    ///
+    /// \brief ln_get_equ_nut applies or removes nutation in place for the epoch JD
+    /// \param posn position, nutation is applied or removed in place
+    /// \param jd
+    /// \param reverse  set to true to remove nutation
+    ///
+    static void ln_get_equ_nut(ln_equ_posn *posn, double jd, bool reverse = false);
+};


### PR DESCRIPTION
The conversion of the JNow position to a J2000 catalogue position for
the GSC catalogue was  not done correctly, only the Precession was
removed, leaving aberration and nutation.

This adds libastro.cpp,.h files which contain converters to and from
J2000 catalogue and apparent positions.  When converting apparent to
J2000 the aberration, nutation and precession are all removed.  These
converters may be useful elsewhere, this isn't the only place
conversion from aparrent to J2000 is needed.