### PR TITLE
fix: IUUpdateSwitch crashes when ISwitchVectorProperty *svp is null p…

### DIFF
--- a/indidriver.c
+++ b/indidriver.c
@@ -234,6 +234,10 @@ int IUUpdateSwitch(ISwitchVectorProperty *svp, ISState *states, char *names[], i
     ISwitch *sp;
     char sn[MAXINDINAME];
 
+    if (svp == 0) {
+    	IDLog("IUUpdateSwitch svp is NULL\n");
+    	return -1;
+    }
     /* store On switch name */
     if (svp->r == ISR_1OFMANY)
     {


### PR DESCRIPTION
…ointer
This is for issue #1097.
It does not solve the root cause (why does not the swithc properties found in the first place?)
But anyways it is nicer to return from the function when getting a null pointer than crashing the driver.