### PR TITLE
Fix skywatcher altaz crash

### DIFF
--- a/drivers/telescope/skywatcherAPIMount.cpp
+++ b/drivers/telescope/skywatcherAPIMount.cpp
@@ -564,7 +564,17 @@ bool SkywatcherAPIMount::ISNewNumber(const char *dev, const char *name, double v
 
 bool SkywatcherAPIMount::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
 {
-    IUUpdateSwitch(getSwitch(name), states, names, n);
+    ISwitchVectorProperty *svp;
+    svp = getSwitch(name);
+    if (svp == nullptr)
+    {
+        LOGF_WARN("getSwitch failed for %s", name);
+    }
+    else
+    {
+        LOGF_DEBUG("getSwitch OK %s", name);
+        IUUpdateSwitch(svp, states, names, n);
+    }
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // It is for us

--- a/drivers/telescope/skywatcherAltAzSimple.cpp
+++ b/drivers/telescope/skywatcherAltAzSimple.cpp
@@ -501,7 +501,17 @@ bool SkywatcherAltAzSimple::ISNewNumber(const char *dev, const char *name, doubl
 
 bool SkywatcherAltAzSimple::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
 {
-    IUUpdateSwitch(getSwitch(name), states, names, n);
+    ISwitchVectorProperty *svp;
+    svp = getSwitch(name);
+    if (svp == nullptr)
+    {
+        LOGF_WARN("getSwitch failed for %s", name);
+    }
+    else
+    {
+        LOGF_DEBUG("getSwitch OK %s", name);
+        IUUpdateSwitch(svp, states, names, n);
+    }
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // It is for us

--- a/indidriver.c
+++ b/indidriver.c
@@ -41,6 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <assert.h>
 
 pthread_mutex_t stdout_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -236,7 +237,10 @@ int IUUpdateSwitch(ISwitchVectorProperty *svp, ISState *states, char *names[], i
 
     if (svp == 0) {
     	IDLog("IUUpdateSwitch svp is NULL\n");
+        assert(svp != 0);
     	return -1;
+    } else {
+        IDLog("IUUpdateSwitch svp: %s\n", svp->name);
     }
     /* store On switch name */
     if (svp->r == ISR_1OFMANY)

--- a/indidriver.c
+++ b/indidriver.c
@@ -234,6 +234,10 @@ int IUUpdateSwitch(ISwitchVectorProperty *svp, ISState *states, char *names[], i
     ISwitch *sp;
     char sn[MAXINDINAME];
 
+    if (svp == 0) {
+    	IDLog("IUUpdateSwitch svp is NULL\n");
+    	return -1;
+    }
     /* store On switch name */
     if (svp->r == ISR_1OFMANY)
     {


### PR DESCRIPTION
Reissuing PR #1150 (fix for bug #1097), now issuing assert() on debug builds.
Also prevent calling IUUpdateSwitch() with svp==nullprt from drivers/telescope/skywatcherAPIMount.cpp and drivers/telescope/skywatcherAltAzSimple.cpp.
The root cause is still unknown, but it is related to how .indi/*_congif.xml is created when .indi is empty. After one successful driver open/close the config.xml changes so that the error does not occur  anymore.