### PR TITLE
UDP support for skywatcherAPI

### DIFF
--- a/drivers/telescope/skywatcherAPI.cpp
+++ b/drivers/telescope/skywatcherAPI.cpp
@@ -770,7 +770,7 @@ bool SkywatcherAPI::TalkWithAxis(AXISID Axis, char Command, std::string &cmdData
         std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
         response[0] = '\0';
-        rc = skywatcher_tty_read_section(MyPortFD, response, 0x0A, 10, &bytesRead);
+        rc = skywatcher_tty_read_section(MyPortFD, response, 0x0D, 10, &bytesRead);
         if (rc != TTY_OK)
             return false;
         for (int i=0; i<bytesRead && !EndReading; i++)

--- a/drivers/telescope/skywatcherAPI.h
+++ b/drivers/telescope/skywatcherAPI.h
@@ -317,7 +317,7 @@ class SkywatcherAPI
         TTY_ERRNO        = -7
     };
     virtual int skywatcher_tty_read(int fd, char *buf, int nbytes, int timeout, int *nbytes_read) = 0;
-    //    virtual int skywatcher_tty_read_section(int fd, char *buf, char stop_char, int timeout, int *nbytes_read) = 0;
+    virtual int skywatcher_tty_read_section(int fd, char *buf, char stop_char, int timeout, int *nbytes_read) = 0;
     virtual int skywatcher_tty_write(int fd, const char *buffer, int nbytes, int *nbytes_written) = 0;
     //    virtual int skywatcher_tty_write_string(int fd, const char * buffer, int *nbytes_written) = 0;
     //    virtual int skywatcher_tty_connect(const char *device, int bit_rate, int word_size, int parity, int stop_bits, int *fd) = 0;

--- a/drivers/telescope/skywatcherAPIMount.h
+++ b/drivers/telescope/skywatcherAPIMount.h
@@ -75,8 +75,10 @@ private:
     void ResetGuidePulses();
     void ConvertGuideCorrection(double delta_ra, double delta_dec, double &delta_alt, double &delta_az);
     void UpdateScopeConfigSwitch();
+    int recover_tty_reconnect();
     // Overrides for the pure virtual functions in SkyWatcherAPI
     virtual int skywatcher_tty_read(int fd, char *buf, int nbytes, int timeout, int *nbytes_read) override;
+    virtual int skywatcher_tty_read_section(int fd, char *buf, char stop_char, int timeout, int *nbytes_read) override;
     virtual int skywatcher_tty_write(int fd, const char *buffer, int nbytes, int *nbytes_written) override;
 
     void SkywatcherMicrostepsFromTelescopeDirectionVector(

--- a/drivers/telescope/skywatcherAltAzSimple.h
+++ b/drivers/telescope/skywatcherAltAzSimple.h
@@ -67,8 +67,10 @@ class SkywatcherAltAzSimple : public SkywatcherAPI,
 private:
     void ResetGuidePulses();
     void UpdateScopeConfigSwitch();
+    int recover_tty_reconnect();
     // Overrides for the pure virtual functions in SkyWatcherAPI
     virtual int skywatcher_tty_read(int fd, char *buf, int nbytes, int timeout, int *nbytes_read) override;
+    virtual int skywatcher_tty_read_section(int fd, char *buf, char stop_char, int timeout, int *nbytes_read) override;
     virtual int skywatcher_tty_write(int fd, const char *buffer, int nbytes, int *nbytes_written) override;
     void UpdateDetailedMountInformation(bool InformClient);
     ln_hrz_posn GetAltAzPosition(double ra, double dec, double offset_in_sec = 0);


### PR DESCRIPTION
SkywatcherAPI::TalkWithAxis() changed to use tty_read_section() to read the response for a command. This way both Serial and UDP connection can work. Fix #1158