### PR TITLE
parking to HA/Dec frame

### DIFF
--- a/drivers/telescope/scopesim_helper.h
+++ b/drivers/telescope/scopesim_helper.h
@@ -432,9 +432,10 @@ public:
     ///
     void apparentHaDecToMount(Angle apparentHa, Angle apparentDec, Angle *primary, Angle *secondary);
 
+    Angle lst();            // returns the current LST as an angle
 private:
 
-    Angle lst();            // returns the current LST as an angle
+
 
 
     Angle flipHourAngle = 0;


### PR DESCRIPTION
Still not satisfied with unpark/park of lx200ap driver I studied the process with the mount simulator. 

The current version parks to RA/Dec frame which is rotating for an earth bound observer. The simulator parks now to HA/Dec frame.

I changed the Angle method lst() from private to public. It comes in handy.