### PR TITLE
CCD Simulator focusing

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -178,7 +178,7 @@ bool CCDSim::initProperties()
                        SIMULATOR_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Simulate focusing
-    IUFillNumber(&FocusSimulationN[0], "SIM_FOCUS_POSITION", "Focus", "%.f", 0.0, 100000.0, 1.0, 45000.0);
+    IUFillNumber(&FocusSimulationN[0], "SIM_FOCUS_POSITION", "Focus", "%.f", 0.0, 100000.0, 1.0, 36700.0);
     IUFillNumber(&FocusSimulationN[1], "SIM_FOCUS_MAX", "Max. Position", "%.f", 0.0, 100000.0, 1.0, 100000.0);
     IUFillNumber(&FocusSimulationN[2], "SIM_SEEING", "Seeing (arcsec)", "%4.2f", 0, 60, 0, 3.5);
     IUFillNumberVector(&FocusSimulationNP, FocusSimulationN, 3, getDeviceName(), "SIM_FOCUSING", "Focus Simulation", SIMULATOR_TAB, IP_RW, 60, IPS_IDLE);
@@ -1236,8 +1236,8 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
                 double max         = FocusSimulationN[1].value;
                 double optimalFWHM = FocusSimulationN[2].value;
 
-                // limit to +/- 50
-                double ticks = 100 * (FocuserPos - focus) / max;
+                // limit to +/- 10
+                double ticks = 20 * (FocuserPos - focus) / max;
 
                 seeing = 0.5625 * ticks * ticks + optimalFWHM;
                 return true;

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -177,6 +177,12 @@ bool CCDSim::initProperties()
     IUFillSwitchVector(&SimulateRgbSP, SimulateRgbS, 2, getDeviceName(), "SIMULATE_RGB", "RGB",
                        SIMULATOR_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
+    // Simulate focusing
+    IUFillNumber(&FocusSimulationN[0], "SIM_FOCUS_POSITION", "Focus", "%.f", 0.0, 100000.0, 1.0, 45000.0);
+    IUFillNumber(&FocusSimulationN[1], "SIM_FOCUS_MAX", "Max. Position", "%.f", 0.0, 100000.0, 1.0, 100000.0);
+    IUFillNumber(&FocusSimulationN[2], "SIM_SEEING", "Seeing (arcsec)", "%4.2f", 0, 60, 0, 3.5);
+    IUFillNumberVector(&FocusSimulationNP, FocusSimulationN, 3, getDeviceName(), "SIM_FOCUSING", "Focus Simulation", SIMULATOR_TAB, IP_RW, 60, IPS_IDLE);
+
     // Simulate Crash
     IUFillSwitch(&CrashS[0], "CRASH", "Crash driver", ISS_OFF);
     IUFillSwitchVector(&CrashSP, CrashS, 1, getDeviceName(), "CCD_SIMULATE_CRASH", "Crash", SIMULATOR_TAB, IP_WO,
@@ -272,6 +278,7 @@ void CCDSim::ISGetProperties(const char * dev)
 
     defineNumber(&SimulatorSettingsNP);
     defineNumber(&EqPENP);
+    defineNumber(&FocusSimulationNP);
     defineSwitch(&SimulateRgbSP);
     defineSwitch(&CrashSP);
 }
@@ -1199,10 +1206,37 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
 {
     if (IUSnoopNumber(root, &FWHMNP) == 0)
     {
-        seeing = FWHMNP.np[0].value;
+        // we calculate the FWHM and do not snoop it from the focus simulator
+        // seeing = FWHMNP.np[0].value;
         return true;
     }
 
+    XMLEle * ep           = nullptr;
+    const char * propName = findXMLAttValu(root, "name");
+
+    if (!strcmp(propName, "ABS_FOCUS_POSITION"))
+    {
+        for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
+        {
+            const char * name = findXMLAttValu(ep, "name");
+
+            if (!strcmp(name, "FOCUS_ABSOLUTE_POSITION"))
+            {
+                FocuserPos = atol(pcdataXMLEle(ep));
+
+                // calculate FWHM
+                double focus       = FocusSimulationN[0].value;
+                double max         = FocusSimulationN[1].value;
+                double optimalFWHM = FocusSimulationN[2].value;
+
+                // limit to +/- 50
+                double ticks = 100 * (FocuserPos - focus) / max;
+
+                seeing = 0.5625 * ticks * ticks + optimalFWHM;
+                return true;
+            }
+        }
+    }
     // We try to snoop EQPEC first, if not found, we snoop regular EQNP
 #ifdef USE_EQUATORIAL_PE
     const char * propName = findXMLAttValu(root, "name");
@@ -1262,6 +1296,9 @@ bool CCDSim::saveConfigItems(FILE * fp)
 
     // RGB
     IUSaveConfigSwitch(fp, &SimulateRgbSP);
+
+    // Focus simulation
+    IUSaveConfigNumber(fp, &FocusSimulationNP);
 
     return true;
 }

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -1131,6 +1131,13 @@ bool CCDSim::ISNewNumber(const char * dev, const char * name, double values[], c
             INDI::FilterInterface::processNumber(dev, name, values, names, n);
             return true;
         }
+        else if (!strcmp(name, FocusSimulationNP.name))
+        {
+            // update focus simulation parameters
+            IUUpdateNumber(&FocusSimulationNP, values, names, n);
+            FocusSimulationNP.s = IPS_OK;
+            IDSetNumber(&FocusSimulationNP, nullptr);
+        }
     }
 
     return INDI::CCD::ISNewNumber(dev, name, values, names, n);

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -203,6 +203,15 @@ class CCDSim : public INDI::CCD, public INDI::FilterInterface
         INumberVectorProperty FWHMNP;
         INumber FWHMN[1];
 
+        // Focuser positions for focusing simulation
+        // FocuserPosition[0] is the position where the scope is in focus
+        // FocuserPosition[1] is the maximal position the focuser may move to (@see FOCUS_MAX in #indifocuserinterface.cpp)
+        // FocuserPosition[2] is the seeing (in arcsec)
+        // We need to have these values here, since we cannot snoop it from the focuser (the focuser does not
+        // publish these values)
+        INumberVectorProperty FocusSimulationNP;
+        INumber FocusSimulationN[3];
+
         INumberVectorProperty EqPENP;
         INumber EqPEN[2];
 

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -840,7 +840,7 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
 
             // JJ ed 2019-12-10
             if (strlen(ActiveDeviceT[ACTIVE_FOCUSER].text) > 0)
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FOCUS_ABSOLUTE_POSITION");
+                IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "ABS_FOCUS_POSITION");
             else
                 FocuserPos = std::numeric_limits<long>::quiet_NaN();
             //

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -118,7 +118,7 @@ CCD::CCD()
     MPSAS           = std::numeric_limits<double>::quiet_NaN();
     RotatorAngle    = std::numeric_limits<double>::quiet_NaN();
     // JJ ed 2019-12-10
-    FocusPos        = std::numeric_limits<long>::quiet_NaN();
+    FocuserPos      = std::numeric_limits<long>::quiet_NaN();
 
     Airmass         = std::numeric_limits<double>::quiet_NaN();
     Latitude        = std::numeric_limits<double>::quiet_NaN();
@@ -772,7 +772,7 @@ bool CCD::ISSnoopDevice(XMLEle * root)
 
             if (!strcmp(name, "FOCUS_ABSOLUTE_POSITION"))
             {
-                FocusPos = atol(pcdataXMLEle(ep));
+                FocuserPos = atol(pcdataXMLEle(ep));
                 break;
             }
         }
@@ -842,7 +842,7 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
             if (strlen(ActiveDeviceT[ACTIVE_FOCUSER].text) > 0)
                 IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FOCUS_ABSOLUTE_POSITION");
             else
-                FocusPos = std::numeric_limits<long>::quiet_NaN();
+                FocuserPos = std::numeric_limits<long>::quiet_NaN();
             //
 
 
@@ -1834,9 +1834,9 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
 
     // JJ ed 2020-03-28
     // If the focus position is set, add the information to the FITS header
-    if (!std::isnan(FocusPos))
+    if (!std::isnan(FocuserPos))
     {
-        fits_update_key_lng(fptr, "FOCUSPOS", FocusPos, "Focus position in steps", &status);
+        fits_update_key_lng(fptr, "FOCUSPOS", FocuserPos, "Focus position in steps", &status);
     }
 
     // SCALE assuming square-pixels

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -540,10 +540,10 @@ class CCD : public DefaultDevice, GuiderInterface
         // Rotator Angle
         double RotatorAngle;
 
-        // JJ ed 2019-12-10
-        long FocusPos;
+        // JJ ed 2019-12-10 current focuser position
+        long FocuserPos;
 
-        // Airmas
+        // Airmass
         double Airmass;
         double Latitude;
         double Longitude;


### PR DESCRIPTION
Currently, the CCD simulator supports focusing only in combination with the Focus Simulator. This change creates the option to attach a real (absolute) focuser and using the CCD simulator so that focusing can be tested during daytime.

**Test Plan**
Create a EKOS profile combining an absolute focuser with the CCD Simulator. Use the Simulator settings of the CCD Simulator to configure the focus position and the maximal focuser position. Using this setup, try different focuser positions and check, whether the stars change their FHWM values.