### PR TITLE
LX200 classic fix Park issue in polar mode: Let mount settle (beep) after slew to park is completed

### DIFF
--- a/drivers/telescope/lx200classic.cpp
+++ b/drivers/telescope/lx200classic.cpp
@@ -406,7 +406,7 @@ bool LX200Classic::Park()
     EqNP.s     = IPS_BUSY;
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking is in progress...");
-    
+
     return true;
 }
 
@@ -502,7 +502,6 @@ bool LX200Classic::ReadScopeStatus()
     if ((TrackState == SCOPE_PARKED) && (settling == 0) && !isSimulation())
     {
         settling = -1;
-        LOG_INFO("Settling for park done");
         if (setAlignmentMode(PortFD, LX200_ALIGN_LAND) < 0)
         {
             LOG_ERROR("Parking Failed.");
@@ -512,7 +511,7 @@ bool LX200Classic::ReadScopeStatus()
         }
         //Update the UI
         LX200Generic::getAlignment();
-        LOG_INFO("Land mode set");
+        LOG_DEBUG("Mount Land mode set. Parking completed.");
     }
 
     if (LX200Generic::ReadScopeStatus())
@@ -523,7 +522,6 @@ bool LX200Classic::ReadScopeStatus()
             //otherwise changing to landmode slews the scope to same 
             //coordinates intepreted in landmode.
             //Between isSlewComplete() and the beep there is nearly 3 seconds!
-            LOG_INFO("Slew done parking");
             settling = 3; //n iterations of default 1000ms
         }
     }


### PR DESCRIPTION
In general the LX200 classic needs almost three seconds after the LX200Telescope::isSlewComlpete() until it beeps to indicated that it is done with positioning. In this time interval one can hear the motors still making some microcorrections.

For normal goto's this does not matter that much. Only occasional star traces in the alignment images. But for parking in polar mode it had the negative effect that changing to landmode while the scope was still busy it reinterprets the slew coordinates given in RaDec as land coordinates (AzAlt?) and rapidly slews to a completely different position.

Adding the settling time by making a few iterations through ReadScopeStatus() solves this.

I am not aware of any LX200 classic commands to detect whether the mount things slewing is really done.