### PR TITLE
[myFocuserPro2] Fix coil power command

### DIFF
--- a/drivers/focuser/myfocuserpro2.cpp
+++ b/drivers/focuser/myfocuserpro2.cpp
@@ -775,7 +775,7 @@ bool MyFocuserPro2::setBacklashOutEnabled(bool enabled)
 bool MyFocuserPro2::setCoilPowerState(CoilPower enable)
 {
     char cmd[ML_RES] = {0};
-    snprintf(cmd, ML_RES, ":12%02d#", static_cast<int>(enable));
+    snprintf(cmd, ML_RES, ":12%01d#", static_cast<int>(enable));
     return sendCommand(cmd);
 }
 


### PR DESCRIPTION
According to the [latest documentation I could find](https://sourceforge.net/projects/arduinoascomfocuserpro2diy/files/Documentation/Comms%20Protocol%20v241.txt/download), the "coil power" command needs only one digit and not two as the current INDI driver implementation assumes. This means coil power will never be switched on (only the first digit will be read by the firmware, hence 0).