### PR TITLE
Add focuser temperature to FITS header

### DIFF
--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -118,7 +118,8 @@ CCD::CCD()
     MPSAS           = std::numeric_limits<double>::quiet_NaN();
     RotatorAngle    = std::numeric_limits<double>::quiet_NaN();
     // JJ ed 2019-12-10
-    FocuserPos      = std::numeric_limits<long>::quiet_NaN();
+    FocuserPos      = -1;
+    FocuserTemp     = std::numeric_limits<double>::quiet_NaN();
 
     Airmass         = std::numeric_limits<double>::quiet_NaN();
     Latitude        = std::numeric_limits<double>::quiet_NaN();
@@ -441,8 +442,9 @@ bool CCD::initProperties()
     IDSnoopDevice(ActiveDeviceT[ACTIVE_ROTATOR].text, "ABS_ROTATOR_ANGLE");
 
     // JJ ed 2019-12-10
-    // Snoop Rotator
+    // Snoop Focuser
     IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "ABS_FOCUS_POSITION");
+    IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FOCUS_TEMPERATURE");
     //
 
     // Snoop Filter Wheel
@@ -777,6 +779,19 @@ bool CCD::ISSnoopDevice(XMLEle * root)
             }
         }
     }
+    else if (!strcmp(propName, "FOCUS_TEMPERATURE"))
+    {
+        for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
+        {
+            const char * name = findXMLAttValu(ep, "name");
+
+            if (!strcmp(name, "TEMPERATURE"))
+            {
+                FocuserTemp = atof(pcdataXMLEle(ep));
+                break;
+            }
+        }
+    }
     //
 
     else if (!strcmp(propName, "GEOGRAPHIC_COORD"))
@@ -840,9 +855,15 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
 
             // JJ ed 2019-12-10
             if (strlen(ActiveDeviceT[ACTIVE_FOCUSER].text) > 0)
+            {
                 IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "ABS_FOCUS_POSITION");
+                IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FOCUS_TEMPERATURE");
+            }
             else
-                FocuserPos = std::numeric_limits<long>::quiet_NaN();
+            {
+                FocuserPos = -1;
+                FocuserTemp = std::numeric_limits<double>::quiet_NaN();
+            }
             //
 
 
@@ -1834,10 +1855,14 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
     }
 
     // JJ ed 2020-03-28
-    // If the focus position is set, add the information to the FITS header
-    if (!std::isnan(FocuserPos))
+    // If the focus position or temperature is set, add the information to the FITS header
+    if (FocuserPos != -1)
     {
         fits_update_key_lng(fptr, "FOCUSPOS", FocuserPos, "Focus position in steps", &status);
+    }
+    if (!std::isnan(FocuserTemp))
+    {
+        fits_update_key_dbl(fptr, "FOCUSTEM", FocuserTemp, 3, "Focuser temperature in degrees C", &status);
     }
 
     // SCALE assuming square-pixels

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -542,6 +542,7 @@ class CCD : public DefaultDevice, GuiderInterface
 
         // JJ ed 2019-12-10 current focuser position
         long FocuserPos;
+        double FocuserTemp;
 
         // Airmass
         double Airmass;


### PR DESCRIPTION
According to https://diffractionlimited.com/help/maximdl/FITS_File_Header_Definitions.htm there is a FITS extension field called FOCUSTEM which contains the focuser temperature so add that to the FITS header if available. This makes it possible to later correlate focus position with temperature for temperature compensation and other analytics purposes.

I also changed the "snooped focus position not valid" value to -1 instead of NaN as long type doesn't have NaN defined and std::numeric_limits<long>::quiet_Nan() returns 0 which is a valid focuser position where as -1 currently isn't.
