### PR TITLE
Fix QHYCFW3 driver handshake

### DIFF
--- a/drivers/filter_wheel/qhycfw3.cpp
+++ b/drivers/filter_wheel/qhycfw3.cpp
@@ -99,6 +99,19 @@ bool QHYCFW3::Handshake()
     if (isSimulation())
         return true;
 
+    LOG_DEBUG("HANDSHAKE");
+
+    if ( (rc = tty_read(PortFD, res, 1, 25, &nbytes_read)) != TTY_OK)
+    {
+        char error_message[ERRMSG_SIZE];
+        tty_error_msg(rc, error_message, ERRMSG_SIZE);
+
+        LOGF_ERROR("Handshake failed: %s. Firmware must be higher than 201409", error_message);
+        return false;
+    }
+
+    LOGF_DEBUG("RES <%s>", res);
+
     LOG_DEBUG("CMD <VRS>");
 
     if ( (rc = tty_write_string(PortFD, "VRS", &nbytes_written)) != TTY_OK)


### PR DESCRIPTION
The QHYCFW3 driver tries to issue the VRS command immediately
after connection, but the filter wheel protocol will first
do a full turn or sometimes more than that, and report
the current filter position before that.

The process takes considerable time and always causes a timeout,
but even if the timeout is increased, the initial position
report will desync commands if not read.

This adds a read to expect that initial report with a longer
timeout that lets it do a full initialization under most
conditions.

Tested with a QHYCFW3-S