### PR TITLE
modify libindi.spec to add a timestamp to the RPM package generated

### DIFF
--- a/spec/libindi.spec
+++ b/spec/libindi.spec
@@ -2,7 +2,7 @@
 
 Name: indi
 Version: 1.8.7.git
-Release: 1%{?dist}
+Release: %(date -u +%%Y%%m%%d%%H%%M%%S)%{?dist}
 Summary: Instrument Neutral Distributed Interface
 
 License: LGPLv2+ and GPLv2+


### PR DESCRIPTION
This PR adds a timestamp to the RPM filename for 2 reasons:

1. rpm updates can happen automatically as they key off the version in the file name to notice updates
2. the timestamp can be tied back to the git log