### PR TITLE
Improve on deadlocks and integrity

### DIFF
--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -56,6 +56,7 @@
 #endif
 
 #define MAXINDIBUF 49152
+#define DISCONNECTION_DELAY_US 500000
 
 INDI::BaseClient::BaseClient() : cServer("localhost"), cPort(7624)
 {
@@ -276,6 +277,12 @@ bool INDI::BaseClient::disconnectServer()
         return true;
 
     sConnected = false;
+
+    // Insert a disconnection delay for running threads to finish and
+    // new threads to spot the disconnection state. This mitigates most deadlocks
+    // without causing loss of functionality, but will suffer from real-time
+    // performance of the clients as the timeout is arbitrary.
+    usleep(DISCONNECTION_DELAY_US);
 
 #ifdef _WINDOWS
     net_close(sockfd);

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -363,6 +363,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 nvp = static_cast<INumberVectorProperty *>(pPtr);
                 if (!strcmp(name, nvp->name))
                 {
+                    if (mediator)
+                        mediator->removeProperty(*orderi);
                     delete *orderi;
                     orderi = pAll.erase(orderi);
                     return 0;
@@ -372,6 +374,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 tvp = static_cast<ITextVectorProperty *>(pPtr);
                 if (!strcmp(name, tvp->name))
                 {
+                    if (mediator)
+                        mediator->removeProperty(*orderi);
                     delete *orderi;
                     orderi = pAll.erase(orderi);
                     return 0;
@@ -381,6 +385,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 svp = static_cast<ISwitchVectorProperty *>(pPtr);
                 if (!strcmp(name, svp->name))
                 {
+                    if (mediator)
+                        mediator->removeProperty(*orderi);
                     delete *orderi;
                     orderi = pAll.erase(orderi);
                     return 0;
@@ -390,6 +396,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 lvp = static_cast<ILightVectorProperty *>(pPtr);
                 if (!strcmp(name, lvp->name))
                 {
+                    if (mediator)
+                        mediator->removeProperty(*orderi);
                     delete *orderi;
                     orderi = pAll.erase(orderi);
                     return 0;
@@ -399,6 +407,8 @@ int BaseDevice::removeProperty(const char *name, char *errmsg)
                 bvp = static_cast<IBLOBVectorProperty *>(pPtr);
                 if (!strcmp(name, bvp->name))
                 {
+                    if (mediator)
+                        mediator->removeProperty(*orderi);
                     (*orderi)->setRegistered(false);
                     delete *orderi;
                     orderi = pAll.erase(orderi);

--- a/libs/indibase/indiproperty.cpp
+++ b/libs/indibase/indiproperty.cpp
@@ -209,6 +209,9 @@ const char *INDI::Property::getDeviceName() const
 
 const char *INDI::Property::getTimestamp() const
 {
+    if (pPtr == nullptr)
+        return nullptr;
+
     switch (pType)
     {
         case INDI_NUMBER:
@@ -228,6 +231,9 @@ const char *INDI::Property::getTimestamp() const
 
 IPState INDI::Property::getState() const
 {
+    if (pPtr == nullptr)
+        return IPS_ALERT;
+
     switch (pType)
     {
         case INDI_NUMBER:
@@ -247,6 +253,9 @@ IPState INDI::Property::getState() const
 
 IPerm INDI::Property::getPermission() const
 {
+    if (pPtr == nullptr)
+        return IP_RO;
+
     switch (pType)
     {
         case INDI_NUMBER:
@@ -264,40 +273,45 @@ IPerm INDI::Property::getPermission() const
 
 INumberVectorProperty *INDI::Property::getNumber() const
 {
-    if (pType == INDI_NUMBER)
-        return static_cast <INumberVectorProperty * > (pPtr);
+    if (pPtr != nullptr)
+        if (pType == INDI_NUMBER)
+            return static_cast <INumberVectorProperty * > (pPtr);
 
     return nullptr;
 }
 
 ITextVectorProperty *INDI::Property::getText() const
 {
-    if (pType == INDI_TEXT)
-        return static_cast <ITextVectorProperty * > (pPtr);
+    if (pPtr != nullptr)
+        if (pType == INDI_TEXT)
+            return static_cast <ITextVectorProperty * > (pPtr);
 
     return nullptr;
 }
 
 ILightVectorProperty *INDI::Property::getLight() const
 {
-    if (pType == INDI_LIGHT)
-        return static_cast <ILightVectorProperty * > (pPtr);
+    if (pPtr != nullptr)
+        if (pType == INDI_LIGHT)
+            return static_cast <ILightVectorProperty * > (pPtr);
 
     return nullptr;
 }
 
 ISwitchVectorProperty *INDI::Property::getSwitch() const
 {
-    if (pType == INDI_SWITCH)
-        return static_cast <ISwitchVectorProperty * > (pPtr);
+    if (pPtr != nullptr)
+        if (pType == INDI_SWITCH)
+            return static_cast <ISwitchVectorProperty * > (pPtr);
 
     return nullptr;
 }
 
 IBLOBVectorProperty *INDI::Property::getBLOB() const
 {
-    if (pType == INDI_BLOB)
-        return static_cast <IBLOBVectorProperty * > (pPtr);
+    if (pPtr != nullptr)
+        if (pType == INDI_BLOB)
+            return static_cast <IBLOBVectorProperty * > (pPtr);
 
     return nullptr;
 }

--- a/libs/indibase/indiproperty.cpp
+++ b/libs/indibase/indiproperty.cpp
@@ -32,7 +32,7 @@ INDI::Property::~Property()
 {
     // Only delete properties if they were created dynamically via the buildSkeleton
     // function. Other drivers are responsible for their own memory allocation.
-    if (pDynamic)
+    if (pDynamic && pPtr != nullptr)
     {
         switch (pType)
         {

--- a/libs/indibase/indiproperty.cpp
+++ b/libs/indibase/indiproperty.cpp
@@ -92,7 +92,8 @@ INDI::Property::~Property()
 
 void INDI::Property::setProperty(void *p)
 {
-    pRegistered = true;
+    pType       = p ? pType : INDI_UNKNOWN;
+    pRegistered = p != nullptr;
     pPtr        = p;
 }
 

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -3,19 +3,29 @@
 SET (test_base64_SRCS
 	test_base64.cpp
 )
-
-
 ADD_EXECUTABLE(test_base64
-	${test_base64_SRCS}
+    ${test_base64_SRCS}
 )
 TARGET_LINK_LIBRARIES(test_base64
+    indiclient
+    ${GTEST_BOTH_LIBRARIES}
+    ${GMOCK_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+ADD_TEST(test_base64 test_base64)
+
+SET (test_property_class_SRCS
+    test_property_class.cpp
+)
+ADD_EXECUTABLE(test_property_class
+    ${test_property_class_SRCS}
+)
+TARGET_LINK_LIBRARIES(test_property_class
 	indiclient
 	${GTEST_BOTH_LIBRARIES}
 	${GMOCK_LIBRARIES}
 	${CMAKE_THREAD_LIBS_INIT}
 )
-
-
-ADD_TEST(test_base64 test_base64)
+ADD_TEST(test_property_class test_property_class)
 
 

--- a/test/core/test_property_class.cpp
+++ b/test/core/test_property_class.cpp
@@ -62,7 +62,7 @@ TEST(CORE_PROPERTY_CLASS, Test_PropertySetters)
         "label field",
         "group field",
         IP_RW, 42, IPS_BUSY,
-        {}, 0,
+        nullptr, 0,
         "timestamp field",
         nullptr };
 

--- a/test/core/test_property_class.cpp
+++ b/test/core/test_property_class.cpp
@@ -1,0 +1,183 @@
+/*******************************************************************************
+ Copyright(c) 2020 Eric Dejouhanet. All rights reserved.
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Library General Public
+ License version 2 as published by the Free Software Foundation.
+ .
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Library General Public License for more details.
+ .
+ You should have received a copy of the GNU Library General Public License
+ along with this library; see the file COPYING.LIB.  If not, write to
+ the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ Boston, MA 02110-1301, USA.
+*******************************************************************************/
+
+#include <gtest/gtest.h>
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <cstdlib>
+#include <cstring>
+
+#include "indiproperty.h"
+
+TEST(CORE_PROPERTY_CLASS, Test_EmptyProperty)
+{
+    INDI::Property p;
+
+    ASSERT_EQ(p.getProperty(), nullptr);
+    ASSERT_EQ(p.getBaseDevice(), nullptr);
+    ASSERT_EQ(p.getType(), INDI_UNKNOWN);
+    ASSERT_EQ(p.getRegistered(), false);
+    ASSERT_EQ(p.isDynamic(), false);
+
+    ASSERT_EQ(p.getName(), nullptr);
+    ASSERT_EQ(p.getLabel(), nullptr);
+    ASSERT_EQ(p.getGroupName(), nullptr);
+    ASSERT_EQ(p.getDeviceName(), nullptr);
+    ASSERT_EQ(p.getTimestamp(), nullptr);
+
+    ASSERT_EQ(p.getState(), IPS_ALERT);
+    ASSERT_EQ(p.getPermission(), IP_RO);
+
+    ASSERT_EQ(p.getNumber(), nullptr);
+    ASSERT_EQ(p.getText(), nullptr);
+    ASSERT_EQ(p.getSwitch(), nullptr);
+    ASSERT_EQ(p.getLight(), nullptr);
+    ASSERT_EQ(p.getBLOB(), nullptr);
+}
+
+TEST(CORE_PROPERTY_CLASS, Test_PropertySetters)
+{
+    INDI::Property p;
+
+    INumberVectorProperty nvp {
+        "device field",
+        "name field",
+        "label field",
+        "group field",
+        IP_RW, 42, IPS_BUSY,
+        {}, 0,
+        "timestamp field",
+        nullptr };
+
+    // Setting a property makes it registered but NOT meaningful
+    p.setProperty(&nvp);
+    ASSERT_EQ(p.getProperty(), &nvp);
+    ASSERT_EQ(p.getType(), INDI_UNKNOWN);
+    ASSERT_EQ(p.getNumber(), nullptr);
+
+    // Property fields remain unpropagated
+    ASSERT_EQ(p.getName(), nullptr);
+    ASSERT_EQ(p.getLabel(), nullptr);
+    ASSERT_EQ(p.getGroupName(), nullptr);
+    ASSERT_EQ(p.getDeviceName(), nullptr);
+    ASSERT_EQ(p.getTimestamp(), nullptr);
+
+     // Other fields remain unchanged
+    ASSERT_EQ(p.getRegistered(), true);
+    ASSERT_EQ(p.isDynamic(), false);
+    ASSERT_EQ(p.getBaseDevice(), nullptr);
+    ASSERT_EQ(p.getState(), IPS_ALERT);
+    ASSERT_EQ(p.getPermission(), IP_RO);
+
+    // Other specific conversions return nothing
+    ASSERT_EQ(p.getText(), nullptr);
+    ASSERT_EQ(p.getSwitch(), nullptr);
+    ASSERT_EQ(p.getLight(), nullptr);
+    ASSERT_EQ(p.getBLOB(), nullptr);
+
+    // Setting a property type gives a meaning to the property
+    // Note the possible desync between property value and type
+    p.setType(INDI_NUMBER);
+    ASSERT_EQ(p.getProperty(), &nvp);
+    ASSERT_EQ(p.getNumber(), &nvp);
+    ASSERT_EQ(p.getType(), INDI_NUMBER);
+
+    // Property fields are propagated
+    ASSERT_STREQ(p.getName(), "name field");
+    ASSERT_STREQ(p.getLabel(), "label field");
+    ASSERT_STREQ(p.getGroupName(), "group field");
+    ASSERT_STREQ(p.getDeviceName(), "device field");
+    ASSERT_STREQ(p.getTimestamp(), "timestamp field");
+
+    // And previously set fields remain unchanged
+    ASSERT_EQ(p.getRegistered(), true);
+    ASSERT_EQ(p.isDynamic(), false);
+    ASSERT_EQ(p.getBaseDevice(), nullptr);
+
+    // Other specific conversions still return nothing
+    ASSERT_EQ(p.getText(), nullptr);
+    ASSERT_EQ(p.getSwitch(), nullptr);
+    ASSERT_EQ(p.getLight(), nullptr);
+    ASSERT_EQ(p.getBLOB(), nullptr);
+
+    // Clearing a property brings it back to the unregistered state
+    p.setProperty(nullptr);
+    ASSERT_EQ(p.getProperty(), nullptr);
+    ASSERT_EQ(p.getType(), INDI_UNKNOWN);
+    ASSERT_EQ(p.getRegistered(), false);
+
+    // Property fields are not propagated anymore
+    ASSERT_EQ(p.getName(), nullptr);
+    ASSERT_EQ(p.getLabel(), nullptr);
+    ASSERT_EQ(p.getGroupName(), nullptr);
+    ASSERT_EQ(p.getDeviceName(), nullptr);
+    ASSERT_EQ(p.getTimestamp(), nullptr);
+
+    // And other fields are reset
+    ASSERT_EQ(p.isDynamic(), false);
+    ASSERT_EQ(p.getBaseDevice(), nullptr);
+    ASSERT_EQ(p.getState(), IPS_ALERT);
+    ASSERT_EQ(p.getPermission(), IP_RO);
+
+     // Again, conversions return nothing
+    ASSERT_EQ(p.getNumber(), nullptr);
+    ASSERT_EQ(p.getText(), nullptr);
+    ASSERT_EQ(p.getSwitch(), nullptr);
+    ASSERT_EQ(p.getLight(), nullptr);
+    ASSERT_EQ(p.getBLOB(), nullptr);
+}
+
+TEST(CORE_PROPERTY_CLASS, DISABLED_Test_Integrity)
+{
+    INDI::Property p;
+
+    INumberVectorProperty * corrupted_property = (INumberVectorProperty*) (void*) 0x12345678;
+    INDI::BaseDevice * corrupted_device = (INDI::BaseDevice*) (void*) 0x87654321;
+
+    p.setProperty(corrupted_property);
+
+    // A magic header should protect the property from returning garbage
+    EXPECT_EQ(p.getProperty(), nullptr);
+    EXPECT_EQ(p.getRegistered(), false);
+
+    // A verification mechanism should protect the property from getting an incorrect type
+    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
+    p.setType(INDI_NUMBER);
+    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
+    p.setType(INDI_TEXT);
+    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
+    p.setType(INDI_SWITCH);
+    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
+    p.setType(INDI_LIGHT);
+    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
+    p.setType(INDI_BLOB);
+    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
+
+    // A verification mechanism should protect the property from being converted to an incorrect type
+    EXPECT_EQ(p.getNumber(), nullptr);
+    EXPECT_EQ(p.getText(), nullptr);
+    EXPECT_EQ(p.getSwitch(), nullptr);
+    EXPECT_EQ(p.getLight(), nullptr);
+    EXPECT_EQ(p.getBLOB(), nullptr);
+
+    // A verification mechanism should protect the property from being associated to an invalid device
+    p.setBaseDevice(corrupted_device);
+    EXPECT_EQ(p.getBaseDevice(), nullptr);
+}


### PR DESCRIPTION
These fixes were tested to help resolve deadlock and sigsegv issues with KStars.

They are not expected to change any functionality from the specification.

The first commit - the delay after setting the disconnection state - is the most fragile. It embeds an arbitrary duration and requires clients to check the `isConnected()` flag before trying to interact with properties. However, it resolves most if not all deadlock situations with little side-effect (waiting a bit more for disconnection is non-critical).

Note that KStars also requires a few fixes to successfully manage its own shortcomings (part of another pull request).

Although the `INDI::Property` API is very light, those changes include a few unitary tests. Integrity tests are skipped because it is not obvious yet that we do want integrity checks embedded in INDI.