### PR TITLE
1st fix for CEM25p Slewing to home position while parked

### DIFF
--- a/drivers/telescope/ieqpro.cpp
+++ b/drivers/telescope/ieqpro.cpp
@@ -416,7 +416,13 @@ bool IEQPro::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                     return true;
 
                 case IEQ_GOTO_HOME:
-                    if (driver->gotoHome() == false)
+    		   if (TrackState == SCOPE_PARKED)
+    		   {
+		       LOG_ERROR("Please unpark the mount before issuing any motion commands.");
+        	       return false;
+    		   }
+
+		    if (driver->gotoHome() == false)
                     {
                         HomeSP.s = IPS_ALERT;
                         IDSetSwitch(&HomeSP, nullptr);


### PR DESCRIPTION
Hi,

From my forum post 
https://indilib.org/forum/mounts/7902-cem25p-slewing-to-home-position-park-bug-or-missing-feature
I have now added a stop to the "slewing to home position" while mount is parked.

Stephane