### PR TITLE
spec_updates: set the build directory the new way for F33 and rawhide

### DIFF
--- a/spec/libindi.spec
+++ b/spec/libindi.spec
@@ -1,4 +1,5 @@
 %global forgeurl https://github.com/indilib/indi.git
+%define __cmake_in_source_build %{_vpath_builddir}
 
 Name: indi
 Version: 1.8.7.git


### PR DESCRIPTION
F33 and F-rawhide changed the way cmake uses a build directory. By declaring it, we make sure that old distributions and new distributions both build.

Successful builds from this branch are here: https://copr.fedorainfracloud.org/coprs/xsnrg/libindi-bleeding/build/1701422/