### PR TITLE
Compatibility fixed - the new firmware has more arguments.

### DIFF
--- a/drivers/focuser/steeldrive2.cpp
+++ b/drivers/focuser/steeldrive2.cpp
@@ -563,7 +563,7 @@ bool SteelDriveII::getSummary()
         return false;
 
     std::vector<std::string> params = split(res, ";");
-    if (params.size() != 10)
+    if (params.size() < 10)
         return false;
 
     for (int i = 0; i < 10; i++)


### PR DESCRIPTION
The condition should check the minimum number of arguments needed to work properly.
A newly purchased Baader SteelDrive II sends additional information, being backward compatible.
