### PR TITLE
rework/streammanager - fix recording long exposure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ ENDIF(OGGTHEORA_FOUND)
 
     SET(libstream_CXX_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/streammanager.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/fpsmeter.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/recorderinterface.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/recordermanager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/serrecorder.cpp
@@ -1784,6 +1785,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libindi.pc DESTINATION ${PKGCONFIG_INS
 if (UNIX)
     INSTALL(FILES
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/streammanager.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/fpsmeter.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/jpegutils.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/ccvt.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/ccvt_types.h

--- a/libs/stream/fpsmeter.cpp
+++ b/libs/stream/fpsmeter.cpp
@@ -36,7 +36,11 @@ bool FPSMeter::newFrame()
     
     ++mTotalFrames;
     ++mFramesPerElapsedTime;
-    mElapsedTime += deltaTime();
+
+    double dt = deltaTime();
+
+    mElapsedTime += dt;
+    mTotalTime   += dt;
 
     if (mElapsedTime >= mTimeWindow)
     {            
@@ -74,6 +78,11 @@ uint64_t FPSMeter::totalFrames() const
     return mTotalFrames;
 }
 
+double FPSMeter::totalTime() const
+{
+    return mTotalTime;
+}
+
 void FPSMeter::reset()
 {
     mFramesPerElapsedTime = 0;
@@ -82,6 +91,7 @@ void FPSMeter::reset()
     mFrameTime2 = 0;
     mFramesPerSecond = 0;
     mTotalFrames = 0;
+    mTotalTime = 0;
 }
 
 

--- a/libs/stream/fpsmeter.cpp
+++ b/libs/stream/fpsmeter.cpp
@@ -1,0 +1,95 @@
+/*
+    Copyright (C) 2020 by Pawel Soja <kernel32.pl@gmail.com>
+    FPS Meter
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+#include "fpsmeter.h"
+#include <cmath>
+
+namespace INDI
+{
+
+FPSMeter::FPSMeter(double timeWindow)
+    : mTimeWindow(timeWindow)
+{
+    reset();
+}
+
+bool FPSMeter::newFrame()
+{
+    mFrameTime2 = mFrameTime1;
+    mFrameTime1 = currentTime();
+    
+    ++mTotalFrames;
+    ++mFramesPerElapsedTime;
+    mElapsedTime += deltaTime();
+
+    if (mElapsedTime >= mTimeWindow)
+    {            
+        mFramesPerSecond = mFramesPerElapsedTime / mElapsedTime * 1000;
+        mElapsedTime = 0;
+        mFramesPerElapsedTime = 0;
+        return true;
+    }
+
+    return false;
+}
+
+void FPSMeter::setTimeWindow(double timeWindow)
+{
+    mTimeWindow = timeWindow;
+}
+
+double FPSMeter::framesPerSecond() const
+{
+    return mFramesPerSecond;
+}
+
+double FPSMeter::deltaTime() const
+{
+    return std::abs(mFrameTime1 - mFrameTime2);
+}
+
+double FPSMeter::frameTime() const
+{
+    return mFrameTime1;
+}
+
+uint64_t FPSMeter::totalFrames() const
+{
+    return mTotalFrames;
+}
+
+void FPSMeter::reset()
+{
+    mFramesPerElapsedTime = 0;
+    mElapsedTime = 0;
+    mFrameTime1 = currentTime();
+    mFrameTime2 = 0;
+    mFramesPerSecond = 0;
+    mTotalFrames = 0;
+}
+
+
+double FPSMeter::currentTime()
+{
+    struct itimerval itime;
+    getitimer(ITIMER_REAL, &itime);
+    return (1000.0 * itime.it_value.tv_sec) + (itime.it_value.tv_usec / 1000.0);
+}
+
+}

--- a/libs/stream/fpsmeter.h
+++ b/libs/stream/fpsmeter.h
@@ -68,6 +68,13 @@ public:
      */
     uint64_t totalFrames() const;
 
+    /**
+     * @brief Total time
+     * @return Total time of counted frames
+     */
+    double totalTime() const;
+
+
 
 public:
     /**
@@ -85,6 +92,8 @@ private:
     
     double mFramesPerSecond = 0;
 
+    double mTotalTime = 0;
     uint64_t mTotalFrames = 0;
+
 };
 }

--- a/libs/stream/fpsmeter.h
+++ b/libs/stream/fpsmeter.h
@@ -1,0 +1,90 @@
+/*
+    Copyright (C) 2020 by Pawel Soja <kernel32.pl@gmail.com>
+    FPS Meter
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+#pragma once
+
+#include <sys/time.h>
+#include <cstdint>
+
+namespace INDI
+{
+class FPSMeter
+{
+public:
+    FPSMeter(double timeWindow = 1000);
+
+public:
+    /**
+     * @brief Reset all frame information
+     */
+    void reset();
+
+    /**
+     * @brief When you get a frame, call the function to count
+     * @return returns true if the time window has been reached
+     */
+    bool newFrame();
+
+    /**
+     * @brief Time window setup
+     * @param timeWindow Time window in milliseconds over which the frames are counted
+     */
+    void setTimeWindow(double timeWindow);
+
+public:
+    /**
+     * @brief Number of frames per second counted in the time window
+     */
+    double framesPerSecond() const;
+    /**
+     * @brief Time in milliseconds between last frames
+     */
+    double deltaTime() const;
+
+    /**
+     * @brief Get last frame timestamp
+     */
+    double frameTime() const;
+
+    /**
+     * @brief Total frames
+     * @return Number of frames counted
+     */
+    uint64_t totalFrames() const;
+
+
+public:
+    /**
+     * @brief get current system timestamp
+     */
+    static double currentTime();
+
+private:
+    uint64_t mFramesPerElapsedTime = 0;
+    double mElapsedTime = 0;
+    double mTimeWindow = 1000;
+
+    double mFrameTime1 = 0;
+    double mFrameTime2 = 0;
+    
+    double mFramesPerSecond = 0;
+
+    uint64_t mTotalFrames = 0;
+};
+}

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -85,6 +85,17 @@ StreamManager::StreamManager(DefaultDevice *mainDevice)
 
 StreamManager::~StreamManager()
 {
+    {
+        std::lock_guard<std::mutex> lock(m_framesMutex);
+        if (m_framesThread.joinable())
+        {
+            m_framesThreadTerminate = true;
+            m_framesBuffer.clear();
+            m_framesIncoming.notify_all();
+            m_framesThread.join();
+        }
+    }
+
     delete (recorderManager);
     delete (encoderManager);
     delete [] gammaLUT_16_8;

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -1112,7 +1112,7 @@ void StreamManager::getStreamFrame(uint16_t * x, uint16_t * y, uint16_t * w, uin
 
 bool StreamManager::uploadStream(const uint8_t * buffer, uint32_t nbytes)
 {
-// Send as is, already encoded.
+    // Send as is, already encoded.
     if (m_PixelFormat == INDI_JPG)
     {
         // Upload to client now

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -85,15 +85,15 @@ StreamManager::StreamManager(DefaultDevice *mainDevice)
 
 StreamManager::~StreamManager()
 {
+    if (m_framesThread.joinable())
     {
-        std::lock_guard<std::mutex> lock(m_framesMutex);
-        if (m_framesThread.joinable())
         {
+            std::lock_guard<std::mutex> lock(m_framesMutex);
             m_framesThreadTerminate = true;
             m_framesBuffer.clear();
             m_framesIncoming.notify_all();
-            m_framesThread.join();
         }
+        m_framesThread.join();
     }
 
     delete (recorderManager);

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "indidevapi.h"
+#include "fpsmeter.h"
 #include "recorder/recordermanager.h"
 #include "encoder/encodermanager.h"
 
@@ -288,8 +289,8 @@ class StreamManager
         EncoderInterface *encoder = nullptr;
 
         // Measure FPS
-        struct itimerval tframe1, tframe2;
-        uint32_t mssum = 0, m_FrameCounterPerSecond = 0;
+        FPSMeter m_FPSAverage;
+        FPSMeter m_FPSFast;
 
         INDI_PIXEL_FORMAT m_PixelFormat = INDI_MONO;
         uint8_t m_PixelDepth = 8;

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -157,11 +157,11 @@ class StreamManager
         }
         bool isRecording()
         {
-            return m_isRecording;
+            return m_isRecording && !m_isRecordingAboutToClose;
         }
         bool isBusy()
         {
-            return (isStreaming() || isRecording());
+            return (m_isStreaming || m_isRecording);
         }
         double getTargetFPS()
         {
@@ -268,8 +268,9 @@ class StreamManager
         INumberVectorProperty LimitsNP;
         enum { LIMITS_BUFFER_MAX, LIMITS_PREVIEW_FPS };
 
-        bool m_isStreaming { false };
-        bool m_isRecording { false };
+        std::atomic<bool> m_isStreaming { false };
+        std::atomic<bool> m_isRecording { false };
+        std::atomic<bool> m_isRecordingAboutToClose { false };
         bool m_hasStreamingExposure { true };
 
         uint32_t m_RecordingFrameTotal {0};

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -273,9 +273,6 @@ class StreamManager
         std::atomic<bool> m_isRecordingAboutToClose { false };
         bool m_hasStreamingExposure { true };
 
-        uint32_t m_RecordingFrameTotal {0};
-        double m_RecordingFrameDuration {0};
-
         // Recorder
         RecorderManager *recorderManager = nullptr;
         RecorderInterface *recorder = nullptr;
@@ -290,6 +287,7 @@ class StreamManager
         FPSMeter m_FPSAverage;
         FPSMeter m_FPSFast;
         FPSMeter m_FPSPreview;
+        FPSMeter m_FPSRecorder;
 
         INDI_PIXEL_FORMAT m_PixelFormat = INDI_MONO;
         uint8_t m_PixelDepth = 8;
@@ -307,6 +305,7 @@ class StreamManager
         std::list<TimeFrame>     m_framesBuffer;   // buffer for incoming frames
         std::condition_variable  m_framesIncoming; // wakeup thread, new frames in framesBuffer
         std::atomic<bool>        m_framesThreadTerminate;
+        std::condition_variable  m_framesBufferEmpty;
 
         std::mutex m_recordMutex;
 

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -308,9 +308,8 @@ class StreamManager
         std::condition_variable  m_framesIncoming; // wakeup thread, new frames in framesBuffer
         std::atomic<bool>        m_framesThreadTerminate;
 
+        std::mutex m_recordMutex;
 
         uint8_t *gammaLUT_16_8 = nullptr;
-
-        std::mutex recordMutex;
 };
 }


### PR DESCRIPTION
Hi!

Waiting for the frame to close its stream is annoying due to the long exposure times.
I moved the counting of time and frame rate from the processing thread to be able to stop the stream.
