### PR TITLE
Fix/streammanager - fix recording long exposure time

### DIFF
--- a/libs/stream/fpsmeter.cpp
+++ b/libs/stream/fpsmeter.cpp
@@ -36,7 +36,11 @@ bool FPSMeter::newFrame()
     
     ++mTotalFrames;
     ++mFramesPerElapsedTime;
-    mElapsedTime += deltaTime();
+
+    double dt = deltaTime();
+
+    mElapsedTime += dt;
+    mTotalTime   += dt;
 
     if (mElapsedTime >= mTimeWindow)
     {            
@@ -74,6 +78,11 @@ uint64_t FPSMeter::totalFrames() const
     return mTotalFrames;
 }
 
+double FPSMeter::totalTime() const
+{
+    return mTotalTime;
+}
+
 void FPSMeter::reset()
 {
     mFramesPerElapsedTime = 0;
@@ -82,6 +91,7 @@ void FPSMeter::reset()
     mFrameTime2 = 0;
     mFramesPerSecond = 0;
     mTotalFrames = 0;
+    mTotalTime = 0;
 }
 
 

--- a/libs/stream/fpsmeter.h
+++ b/libs/stream/fpsmeter.h
@@ -68,6 +68,13 @@ public:
      */
     uint64_t totalFrames() const;
 
+    /**
+     * @brief Total time
+     * @return Total time of counted frames
+     */
+    double totalTime() const;
+
+
 
 public:
     /**
@@ -85,6 +92,8 @@ private:
     
     double mFramesPerSecond = 0;
 
+    double mTotalTime = 0;
     uint64_t mTotalFrames = 0;
+
 };
 }

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -273,9 +273,6 @@ class StreamManager
         std::atomic<bool> m_isRecordingAboutToClose { false };
         bool m_hasStreamingExposure { true };
 
-        uint32_t m_RecordingFrameTotal {0};
-        double m_RecordingFrameDuration {0};
-
         // Recorder
         RecorderManager *recorderManager = nullptr;
         RecorderInterface *recorder = nullptr;
@@ -290,6 +287,7 @@ class StreamManager
         FPSMeter m_FPSAverage;
         FPSMeter m_FPSFast;
         FPSMeter m_FPSPreview;
+        FPSMeter m_FPSRecorder;
 
         INDI_PIXEL_FORMAT m_PixelFormat = INDI_MONO;
         uint8_t m_PixelDepth = 8;
@@ -307,6 +305,7 @@ class StreamManager
         std::list<TimeFrame>     m_framesBuffer;   // buffer for incoming frames
         std::condition_variable  m_framesIncoming; // wakeup thread, new frames in framesBuffer
         std::atomic<bool>        m_framesThreadTerminate;
+        std::condition_variable  m_framesBufferEmpty;
 
         std::mutex m_recordMutex;
 


### PR DESCRIPTION
Hi!

Waiting for the frame to close its stream is annoying due to the long exposure times.
I moved the counting of time and frame rate from the processing thread to be able to stop the stream.

:)