### PR TITLE
Baader SteelDrive II - feature, Adjustable holding and move current for stepper drive

### DIFF
--- a/drivers/focuser/steeldrive2.cpp
+++ b/drivers/focuser/steeldrive2.cpp
@@ -122,6 +122,13 @@ bool SteelDriveII::initProperties()
     IUFillNumber(&TemperatureSensorN[TEMP_AVG], "TEMP_AVG", "Average (C)", "%.2f", -60, 60, 0, 0);
     IUFillNumberVector(&TemperatureSensorNP, TemperatureSensorN, 3, getDeviceName(), "TC_SENSOR", "Sensor", COMPENSATION_TAB, IP_RO, 60, IPS_IDLE);
 
+    // Stepper Drive
+    IUFillNumber(&StepperDriveN[CURRENT_MOVE], "STEPPER_DRIVE_CURRENT_MOVE", "Inverse Current Move", "%.f", 0, 127, 1, 25);
+    IUFillNumber(&StepperDriveN[CURRENT_HOLD], "STEPPER_DRIVE_CURRENT_HOLD", "Inverse Current Hold", "%.f", 0, 127, 1, 100);
+    IUFillNumberVector(
+        &StepperDriveNP, StepperDriveN, NARRAY(StepperDriveN),
+        getDeviceName(), "STEPPER_DRIVE", "Stepper Drive", OPTIONS_TAB, IP_RW, 60, IPS_IDLE
+    );
 
     addAuxControls();
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
@@ -148,6 +155,7 @@ bool SteelDriveII::updateProperties()
         defineSwitch(&TemperatureStateSP);
         defineNumber(&TemperatureSettingsNP);
         defineNumber(&TemperatureSensorNP);
+        defineNumber(&StepperDriveNP);
     }
     else
     {
@@ -158,6 +166,7 @@ bool SteelDriveII::updateProperties()
         deleteProperty(TemperatureStateSP.name);
         deleteProperty(TemperatureSettingsNP.name);
         deleteProperty(TemperatureSensorNP.name);
+        deleteProperty(StepperDriveNP.name);
     }
 
     return true;
@@ -334,6 +343,31 @@ bool SteelDriveII::ISNewNumber(const char *dev, const char *name, double values[
             IDSetNumber(&TemperatureSettingsNP, nullptr);
             return true;
         }
+
+        if (!strcmp(StepperDriveNP.name, name))
+        {
+            StepperDriveNP.s = IPS_OK;
+
+            if (StepperDriveN[CURRENT_MOVE].value != values[CURRENT_MOVE])
+            {
+                if (setParameter("CURRENT_MOVE", to_string(values[CURRENT_MOVE], 0)))
+                    StepperDriveN[CURRENT_MOVE].value = values[CURRENT_MOVE];
+                else
+                    StepperDriveNP.s = IPS_ALERT;
+            }
+
+            if (StepperDriveN[CURRENT_HOLD].value != values[CURRENT_HOLD])
+            {
+                if (setParameter("CURRENT_HOLD", to_string(values[CURRENT_HOLD], 0)))
+                    StepperDriveN[CURRENT_HOLD].value = values[CURRENT_HOLD];
+                else
+                    StepperDriveNP.s = IPS_ALERT;
+            }
+
+            IDSetNumber(&StepperDriveNP, nullptr);
+            return true;
+        }
+
     }
 
     return INDI::Focuser::ISNewNumber(dev, name, values, names, n);
@@ -540,6 +574,17 @@ void SteelDriveII::getStartupValues()
         TemperatureStateS[TC_ACTIVE].s = (value == "0") ? ISS_ON : ISS_OFF;
         TemperatureStateS[TC_PAUSED].s = (value == "0") ? ISS_OFF : ISS_ON;
     }
+
+    StepperDriveNP.s = IPS_OK;
+    if (getParameter("CURRENT_MOVE", value))
+        StepperDriveN[CURRENT_MOVE].value = std::stod(value);
+    else
+        StepperDriveNP.s = IPS_ALERT;
+
+    if (getParameter("CURRENT_HOLD", value))
+        StepperDriveN[CURRENT_HOLD].value = std::stod(value);
+    else
+        StepperDriveNP.s = IPS_ALERT;
 
     getSummary();
 

--- a/drivers/focuser/steeldrive2.h
+++ b/drivers/focuser/steeldrive2.h
@@ -139,6 +139,15 @@ class SteelDriveII : public INDI::Focuser
             TEMP_AVG
         };
 
+        // Stepper Drive
+        INumberVectorProperty StepperDriveNP;
+        INumber StepperDriveN[2];
+        enum
+        {
+            CURRENT_MOVE,
+            CURRENT_HOLD
+        };
+
         /////////////////////////////////////////////////////////////////////////////
         /// Private variables
         /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Implementation of current regulation based on technical documentation.
Now in the Options tab you can set:
- Inverse Current Move, Set the digital potentiometer whiper setting controlling the reference voltage VREF, which is inversly
proportional to the stepper driver current for movement. I ∝ 1/V (uint8 [0-127], DEFAULT = 25, safety limit = 10). This is an expert setting and should only be changed if one wants to use a different stepper motor or lift even heavier loads.

- Inverse Current Hold - The motor current while in holding position (not moving). The CURRENT HOLD value is the digital
potentiometer whiper setting controlling the reference voltage, which is inversly proportional to the stepper driver current in STOPPED state. I ∝1/V (uint8 [0-127], DEFAULT = 100, Safetly limit=10).

Fun fact about safety and limits:
I bought the "Steeldrive II motor focuser with Controller" kit.
Despite the change in the CURRENT_HOLD value, in the idle state, the current consumption was 2A and the stepper motor was very hot. I decided to take a closer look at the problem.
The problem was in electronics. At the "Digital POT" output, the voltage was 5V, despite changing the CURRENT_HOLD.
The reason was the lack of GND on the potentiometer. One of the resistors (0 ohm) was not soldered properly.
After the resistor was repaired, everything was back to normal.
By setting the maximum current via software, such high currents are not achievable as during an electronic fault.

So if you like heat you can set value to 1 without fear of damage ;)
The value of 0 is not allowed by firmware.
