### PR TITLE
fix/performance/streammanager - Do not block the stream thread when sending FPS status, fix frames discarding.

### DIFF
--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -285,7 +285,8 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
     if (m_FPSFast.newFrame())
     {
         FpsN[0].value = m_FPSFast.framesPerSecond();
-        IDSetNumber(&FpsNP, nullptr);
+        if (m_fastFPSUpdate.try_lock()) // don't block stream thread / record thread
+            std::thread([&](){ IDSetNumber(&FpsNP, nullptr); m_fastFPSUpdate.unlock(); }).detach();
     }
 
     if (isStreaming() || isRecording())

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -273,6 +273,18 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
         return;
     }
 
+    // Discard every N frame.
+    // do not count it to fps statistics
+    // N is StreamExposureN[STREAM_DIVISOR].value
+    ++m_frameCountDivider;
+    if (
+        (StreamExposureN[STREAM_DIVISOR].value > 1) &&
+        (m_frameCountDivider % static_cast<int>(StreamExposureN[STREAM_DIVISOR].value)) == 0
+    )
+    {
+        return;
+    }
+
     if (m_FPSAverage.newFrame())
     {
         FpsN[1].value = m_FPSAverage.framesPerSecond();
@@ -284,10 +296,6 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
         if (m_fastFPSUpdate.try_lock()) // don't block stream thread / record thread
             std::thread([&](){ IDSetNumber(&FpsNP, nullptr); m_fastFPSUpdate.unlock(); }).detach();
     }
-
-    if (StreamExposureN[STREAM_DIVISOR].value > 1
-            && (m_FPSAverage.totalFrames() % static_cast<int>(StreamExposureN[STREAM_DIVISOR].value)) == 0)
-        return;
 
     if (isStreaming() || isRecording())
     {
@@ -717,6 +725,7 @@ bool StreamManager::startRecording()
     }
 #endif
     m_FPSRecorder.reset();
+    m_frameCountDivider = 0;
 
     if (m_isStreaming == false)
     {
@@ -1050,6 +1059,7 @@ bool StreamManager::setStream(bool enable)
             m_FPSFast.reset();
             m_FPSPreview.reset();
             m_FPSPreview.setTimeWindow(1000.0 / LimitsN[LIMITS_PREVIEW_FPS].value);
+            m_frameCountDivider = 0;
             
             if(currentDevice->getDriverInterface() & INDI::DefaultDevice::CCD_INTERFACE)
             {

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -273,10 +273,6 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
         return;
     }
 
-    if (StreamExposureN[STREAM_DIVISOR].value > 1
-            && (m_FPSAverage.totalFrames() % static_cast<int>(StreamExposureN[STREAM_DIVISOR].value)) == 0)
-        return;
-
     if (m_FPSAverage.newFrame())
     {
         FpsN[1].value = m_FPSAverage.framesPerSecond();
@@ -288,6 +284,10 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
         if (m_fastFPSUpdate.try_lock()) // don't block stream thread / record thread
             std::thread([&](){ IDSetNumber(&FpsNP, nullptr); m_fastFPSUpdate.unlock(); }).detach();
     }
+
+    if (StreamExposureN[STREAM_DIVISOR].value > 1
+            && (m_FPSAverage.totalFrames() % static_cast<int>(StreamExposureN[STREAM_DIVISOR].value)) == 0)
+        return;
 
     if (isStreaming() || isRecording())
     {

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -307,6 +307,8 @@ class StreamManager
         std::atomic<bool>        m_framesThreadTerminate;
         std::condition_variable  m_framesBufferEmpty;
 
+        std::mutex               m_fastFPSUpdate;
+
         std::mutex m_recordMutex;
 
         uint8_t *gammaLUT_16_8 = nullptr;

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -289,6 +289,8 @@ class StreamManager
         FPSMeter m_FPSPreview;
         FPSMeter m_FPSRecorder;
 
+        uint32_t m_frameCountDivider = 0;
+
         INDI_PIXEL_FORMAT m_PixelFormat = INDI_MONO;
         uint8_t m_PixelDepth = 8;
         uint16_t rawWidth = 0, rawHeight = 0;


### PR DESCRIPTION
I found another performance issue that has been around for a long time. I didn't notice him last time.

This simple fix sends the FPS value without blocking threads.
This is important when running the indi server remotely.