### PR TITLE
Fix for when observer location is less than 1 degree East

### DIFF
--- a/drivers/telescope/celestrondriver.cpp
+++ b/drivers/telescope/celestrondriver.cpp
@@ -793,7 +793,7 @@ bool CelestronDriver::set_location(double longitude, double latitude)
     cmd[5] = static_cast<char>(abs(long_d));       // not sure how the conversion from int to char will work for longtitudes > 127
     cmd[6] = static_cast<char>(long_m);
     cmd[7] = static_cast<char>(long_s);
-    cmd[8] = long_d >= 0 ? 0 : 1;	 //Error fixed here (was cmd[8] = long_d >= 0 ? 0 : 1;) which was wrong for < 1 degree East.
+    cmd[8] = longitude > 0 ? 0 : 1;	 //Error fixed here (was cmd[8] = long_d >= 0 ? 0 : 1;) which was wrong for < 1 degree East.
 
     set_sim_response("#");
     return send_command(cmd, 9, response, 1, false, true);


### PR DESCRIPTION
If the observer longitude was less than 1 degree East the code wrongly sent West to the mount because it checked to see if the degrees where > 0 not accounted for the case such as my location which is 000:07:24 East. Changing to >= fixes this issue.