### PR TITLE
Use __APPLE__ for macOS

### DIFF
--- a/libs/indicom.c
+++ b/libs/indicom.c
@@ -322,7 +322,7 @@ void IDLog(const char *fmt, ...)
 double time_ns()
 {
     struct timespec ts;
-#ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
+#ifdef __APPLE__ // OS X does not have clock_gettime, use clock_get_time
     clock_serv_t cclock;
     mach_timespec_t mts;
     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);


### PR DESCRIPTION
`__MACH__` indicates any Mach-based OS, which does not mean only macOS.