### PR TITLE
Update of SmartFocus driver

### DIFF
--- a/drivers/focuser/smartfocus.cpp
+++ b/drivers/focuser/smartfocus.cpp
@@ -108,17 +108,17 @@ bool SmartFocus::initProperties()
     IUFillLightVector(&FlagsLP, FlagsL, STATUS_NUM_FLAGS, getDeviceName(), "FLAGS", "Status Flags", MAIN_CONTROL_TAB,
                       IPS_IDLE);
 
-    IUFillNumber(&MaxPositionN[0], "MAXPOSITION", "Maximum position", "%6.0f", 1., 100000., 0., 1833);
-    IUFillNumberVector(&MaxPositionNP, MaxPositionN, 1, getDeviceName(), "FOCUS_MAXPOSITION", "Max. position",
+    IUFillNumber(&MotionErrorN[0], "MOTION_ERROR", "Motion error", "%6.0f", -100., 100., 1., 0.);
+    IUFillNumberVector(&MotionErrorNP, MotionErrorN, 1, getDeviceName(), "MOTION_ERROR", "Motion error",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = MaxPositionN[0].value;
+    FocusRelPosN[0].max   = FocusMaxPosN[0].value; //MaxPositionN[0].value;
     FocusRelPosN[0].value = 10;
     FocusRelPosN[0].step  = 1;
 
     FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = MaxPositionN[0].value;
+    FocusAbsPosN[0].max   = FocusMaxPosN[0].value; //MaxPositionN[0].value;
     FocusAbsPosN[0].value = 0;
     FocusAbsPosN[0].step  = 1;
 
@@ -134,14 +134,14 @@ bool SmartFocus::updateProperties()
     if (isConnected())
     {
         defineLight(&FlagsLP);
-        defineNumber(&MaxPositionNP);
+        defineNumber(&MotionErrorNP);
         SFgetState();
         IDMessage(getDeviceName(), "SmartFocus focuser ready for use.");
     }
     else
     {
         deleteProperty(FlagsLP.name);
-        deleteProperty(MaxPositionNP.name);
+        deleteProperty(MotionErrorNP.name);
     }
     return true;
 }
@@ -170,20 +170,12 @@ bool SmartFocus::ISNewNumber(const char *dev, const char *name, double values[],
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, MaxPositionNP.name) == 0)
+        if (strcmp(name, MotionErrorNP.name) == 0)
         {
-            if (values[0] > 0)
-            {
-                IUUpdateNumber(&MaxPositionNP, values, names, n);
-                FocusAbsPosN[0].min = 0;
-                FocusAbsPosN[0].max = MaxPositionN[0].value;
-                IUUpdateMinMax(&FocusAbsPosNP);
-                MaxPositionNP.s = IPS_OK;
-                IDSetNumber(&MaxPositionNP, nullptr);
-                return true;
-            }
-            else
-                return false;
+            IUUpdateNumber(&MotionErrorNP, values, names, n);
+            MotionErrorNP.s = IPS_OK;
+            IDSetNumber(&MotionErrorNP, nullptr);
+            return true;
         }
     }
     return INDI::Focuser::ISNewNumber(dev, name, values, names, n);
@@ -207,8 +199,8 @@ bool SmartFocus::AbortFocuser()
 
 IPState SmartFocus::MoveAbsFocuser(uint32_t targetPosition)
 {
-    const Position destination = static_cast<Position>(targetPosition);
-    IPState result             = IPS_ALERT;
+    Position destination = static_cast<Position>(targetPosition);
+    IPState result       = IPS_ALERT;
     if (isSimulation())
     {
         position = destination;
@@ -217,28 +209,40 @@ IPState SmartFocus::MoveAbsFocuser(uint32_t targetPosition)
     }
     else
     {
-        char command[3];
-        command[0] = goto_position;
-        command[1] = ((destination >> 8) & 0xFF);
-        command[2] = (destination & 0xFF);
-        LOGF_DEBUG("MoveAbsFocuser: destination= %d", destination);
-        tcflush(PortFD, TCIOFLUSH);
-        if (send(command, sizeof(command), "MoveAbsFocuser"))
+        constexpr bool Correct_Positions = true;
+        if (Correct_Positions)
         {
-            char respons;
-            if (recv(&respons, sizeof(respons), "MoveAbsFocuser"))
+            const int error = MotionErrorN[0].value; // The NGF-S overshoots motions by 3 steps.
+            if (destination > position) destination -= error, destination = std::max(position,destination);
+            if (destination < position) destination += error, destination = std::min(position,destination);
+        }
+        if (destination != position)
+        {
+            char command[3];
+            command[0] = goto_position;
+            command[1] = ((destination >> 8) & 0xFF);
+            command[2] = (destination & 0xFF);
+            LOGF_DEBUG("MoveAbsFocuser: destination= %d", destination);
+            tcflush(PortFD, TCIOFLUSH);
+            if (send(command, sizeof(command), "MoveAbsFocuser"))
             {
-                LOGF_DEBUG("MoveAbsFocuser received echo: %c", respons);
-                if (respons != goto_position)
-                    LOGF_ERROR("MoveAbsFocuser received unexpected respons: %c (0x02x)", respons,
-                           respons);
-                else
+                char respons;
+                if (recv(&respons, sizeof(respons), "MoveAbsFocuser"))
                 {
-                    state  = MovingTo;
-                    result = IPS_BUSY;
+                    LOGF_DEBUG("MoveAbsFocuser received echo: %c", respons);
+                    if (respons != goto_position)
+                        LOGF_ERROR("MoveAbsFocuser received unexpected respons: %c (0x02x)", respons,
+                               respons);
+                    else
+                    {
+                        state  = MovingTo;
+                        result = IPS_BUSY;
+                    }
                 }
             }
-        }
+         }
+         else
+            result = IPS_OK;
     }
     return result;
 }
@@ -304,7 +308,8 @@ void SmartFocus::TimerHit()
 
 bool SmartFocus::saveConfigItems(FILE *fp)
 {
-    IUSaveConfigNumber(fp, &MaxPositionNP);
+    Focuser::saveConfigItems(fp);
+    IUSaveConfigNumber(fp, &MotionErrorNP);
     return true;
 }
 

--- a/drivers/focuser/smartfocus.h
+++ b/drivers/focuser/smartfocus.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
-  Copyright(c) 2015 Camiel Severijns. All rights reserved.
+  Copyright(c) 2015,2020 Camiel Severijns. All rights reserved.
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public
@@ -90,6 +90,6 @@ class SmartFocus : public INDI::Focuser
 
     ILight FlagsL[5];
     ILightVectorProperty FlagsLP;
-    INumber MaxPositionN[1];
-    INumberVectorProperty MaxPositionNP;
+    INumber MotionErrorN[1];
+    INumberVectorProperty MotionErrorNP;
 };


### PR DESCRIPTION
The MaxPosition property which is now a duplication of a similar property in INDI::Focuser, has been removed.
The SmartFocus unit has a systematic error when moving to a given target position. The MotionError property
was added. This property is used to correct for this systematic error so that the actual target position matches
the desired position.