### PR TITLE
Streammanager/chrono - Fix the 24h time limit.

### DIFF
--- a/libs/stream/fpsmeter.cpp
+++ b/libs/stream/fpsmeter.cpp
@@ -18,7 +18,6 @@
 
 */
 #include "fpsmeter.h"
-#include <cmath>
 
 namespace INDI
 {
@@ -32,7 +31,7 @@ FPSMeter::FPSMeter(double timeWindow)
 bool FPSMeter::newFrame()
 {
     mFrameTime2 = mFrameTime1;
-    mFrameTime1 = currentTime();
+    mFrameTime1 = std::chrono::steady_clock::now();
     
     ++mTotalFrames;
     ++mFramesPerElapsedTime;
@@ -65,12 +64,7 @@ double FPSMeter::framesPerSecond() const
 
 double FPSMeter::deltaTime() const
 {
-    return std::abs(mFrameTime1 - mFrameTime2);
-}
-
-double FPSMeter::frameTime() const
-{
-    return mFrameTime1;
+    return std::chrono::duration<double>(mFrameTime1 - mFrameTime2).count() * 1000;
 }
 
 uint64_t FPSMeter::totalFrames() const
@@ -87,19 +81,11 @@ void FPSMeter::reset()
 {
     mFramesPerElapsedTime = 0;
     mElapsedTime = 0;
-    mFrameTime1 = currentTime();
-    mFrameTime2 = 0;
+    mFrameTime1 = std::chrono::steady_clock::now();
+    mFrameTime2 = mFrameTime1;
     mFramesPerSecond = 0;
     mTotalFrames = 0;
     mTotalTime = 0;
-}
-
-
-double FPSMeter::currentTime()
-{
-    struct itimerval itime;
-    getitimer(ITIMER_REAL, &itime);
-    return (1000.0 * itime.it_value.tv_sec) + (itime.it_value.tv_usec / 1000.0);
 }
 
 }

--- a/libs/stream/fpsmeter.h
+++ b/libs/stream/fpsmeter.h
@@ -19,7 +19,7 @@
 */
 #pragma once
 
-#include <sys/time.h>
+#include <chrono>
 #include <cstdint>
 
 namespace INDI
@@ -58,11 +58,6 @@ public:
     double deltaTime() const;
 
     /**
-     * @brief Get last frame timestamp
-     */
-    double frameTime() const;
-
-    /**
      * @brief Total frames
      * @return Number of frames counted
      */
@@ -74,21 +69,13 @@ public:
      */
     double totalTime() const;
 
-
-
-public:
-    /**
-     * @brief get current system timestamp
-     */
-    static double currentTime();
-
 private:
     uint64_t mFramesPerElapsedTime = 0;
     double mElapsedTime = 0;
     double mTimeWindow = 1000;
 
-    double mFrameTime1 = 0;
-    double mFrameTime2 = 0;
+    std::chrono::steady_clock::time_point mFrameTime1;
+    std::chrono::steady_clock::time_point mFrameTime2;
     
     double mFramesPerSecond = 0;
 

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -1,4 +1,5 @@
 /*
+    Copyright (C) 2020 by Pawel Soja <kernel32.pl@gmail.com>
     Copyright (C) 2015 by Jasem Mutlaq <mutlaqja@ikarustech.com>
     Copyright (C) 2014 by geehalel <geehalel@gmail.com>
 

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -28,7 +28,6 @@
 #include "indilogger.h"
 
 #include <cerrno>
-#include <signal.h>
 #include <sys/stat.h>
 #include <cmath>
 
@@ -45,22 +44,6 @@ StreamManager::StreamManager(DefaultDevice *mainDevice)
     m_isRecording = false;
 
     prepareGammaLUT();
-
-    // Timer
-    // now use BSD setimer to avoi librt dependency
-    //sevp.sigev_notify=SIGEV_NONE;
-    //timer_create(CLOCK_MONOTONIC, &sevp, &fpstimer);
-    //fpssettings.it_interval.tv_sec=24*3600;
-    //fpssettings.it_interval.tv_nsec=0;
-    //fpssettings.it_value=fpssettings.it_interval;
-    //timer_settime(fpstimer, 0, &fpssettings, nullptr);
-
-    struct itimerval fpssettings;
-    fpssettings.it_interval.tv_sec  = 24 * 3600;
-    fpssettings.it_interval.tv_usec = 0;
-    fpssettings.it_value            = fpssettings.it_interval;
-    signal(SIGALRM, SIG_IGN); //portable
-    setitimer(ITIMER_REAL, &fpssettings, nullptr);
 
     m_FPSAverage.setTimeWindow(1000);
     m_FPSFast.setTimeWindow(50);

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -1,4 +1,5 @@
 /*
+    Copyright (C) 2020 by Pawel Soja <kernel32.pl@gmail.com>
     Copyright (C) 2015 by Jasem Mutlaq <mutlaqja@ikarustech.com>
     Copyright (C) 2014 by geehalel <geehalel@gmail.com>
 
@@ -34,7 +35,6 @@
 #include <thread>
 #include <atomic>
 #include <condition_variable>
-#include <sys/time.h>
 
 #include <stdint.h>
 


### PR DESCRIPTION
I moved all the "processing" of time to the fpsmeter class. I used [steady_clock](https://en.cppreference.com/w/cpp/chrono/steady_clock) (from the c ++ 11 standard) - monotonic clock that will never be adjusted.

The previous implementation had a counter counting down with an initial value:
`fpssettings.it_interval.tv_sec = 24 * 3600;`
After 24 hours, the application crashed.

I'm getting down to work on the streammanager class. I will keep simplifying the code and optimizing some parts of it.
Once libAsiCamera2Boost is stable, the Indi Library fragments will be ready to be linked.
I am adding myself as a co-author so that I can be found in case of confusion.
