### PR TITLE
Streammanager/refactoring - move queue and gamma lut to anothers files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,6 +339,7 @@ ENDIF(OGGTHEORA_FOUND)
     SET(libstream_CXX_SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/streammanager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/fpsmeter.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/gammalut16.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/recorderinterface.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/recordermanager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/recorder/serrecorder.cpp
@@ -1798,6 +1799,7 @@ if (UNIX)
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/streammanager.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/fpsmeter.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/uniquequeue.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/gammalut16.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/jpegutils.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/ccvt.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/ccvt_types.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1797,6 +1797,7 @@ if (UNIX)
     INSTALL(FILES
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/streammanager.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/fpsmeter.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/uniquequeue.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/jpegutils.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/ccvt.h
             ${CMAKE_CURRENT_SOURCE_DIR}/libs/stream/ccvt_types.h

--- a/libs/stream/gammalut16.cpp
+++ b/libs/stream/gammalut16.cpp
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2020 by Pawel Soja <kernel32.pl@gmail.com>
+    Copyright (C) 2015 by Jasem Mutlaq <mutlaqja@ikarustech.com>
+    Copyright (C) 2014 by geehalel <geehalel@gmail.com>
+
+    Stream Recorder
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+#include "gammalut16.h"
+#include <cmath>
+
+GammaLut16::GammaLut16(double gamma, double a, double b, double Ii)
+{
+    mLookUpTable.resize(65536);
+    
+    unsigned int i = 0;
+    for (auto &value: mLookUpTable)
+    {
+        double I = static_cast<double>(i++) / 65535.0;
+        double p;
+        if (I <= Ii)
+            p = a * I;
+        else
+            p = (1 + b) * powf(I, 1.0 / gamma) - b;
+        value = round(255.0 * p);
+    }
+}
+
+void GammaLut16::apply(const uint16_t *source, size_t count, uint8_t *destination) const
+{
+    apply(source, source + count, destination);
+}
+
+
+void GammaLut16::apply(const uint16_t *first, const uint16_t *last, uint8_t *destination) const
+{
+    const uint16_t *lookUpTable = mLookUpTable.data();
+
+    while (first != last)
+        *destination++ = lookUpTable[*first++];
+}

--- a/libs/stream/gammalut16.h
+++ b/libs/stream/gammalut16.h
@@ -24,6 +24,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <cstddef>
 
 class GammaLut16
 {

--- a/libs/stream/gammalut16.h
+++ b/libs/stream/gammalut16.h
@@ -1,0 +1,39 @@
+/*
+    Copyright (C) 2020 by Pawel Soja <kernel32.pl@gmail.com>
+    Copyright (C) 2015 by Jasem Mutlaq <mutlaqja@ikarustech.com>
+    Copyright (C) 2014 by geehalel <geehalel@gmail.com>
+
+    Stream Recorder
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+#pragma once
+
+#include <vector>
+#include <cstdint>
+
+class GammaLut16
+{
+public:
+    GammaLut16(double gamma = 2.4, double a = 12.92, double b = 0.055, double Ii = 0.00304);
+
+public:
+    void apply(const uint16_t *source, size_t count, uint8_t *destination) const;
+    void apply(const uint16_t *first, const uint16_t *last, uint8_t *destination) const;
+
+protected:
+    std::vector<uint16_t> mLookUpTable;
+};

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -36,6 +36,8 @@
 #include <atomic>
 #include <condition_variable>
 
+#include "uniquequeue.h"
+
 #include <stdint.h>
 
 /**
@@ -127,8 +129,8 @@ class StreamManager
         virtual bool saveConfigItems(FILE *fp);
 
         /**
-             * @brief newFrame CCD drivers call this function when a new frame is received. It is then streamed, or recorded, or both according to the settings in the streamer.
-             */
+         * @brief newFrame CCD drivers call this function when a new frame is received. It is then streamed, or recorded, or both according to the settings in the streamer.
+         */
         void newFrame(const uint8_t *buffer, uint32_t nbytes);
 
         /**
@@ -137,10 +139,10 @@ class StreamManager
         void asyncStreamThread();
 
         /**
-             * @brief setStream Enables (starts) or disables (stops) streaming.
-             * @param enable True to enable, false to disable
-             * @return True if operation is successful, false otherwise.
-             */
+         * @brief setStream Enables (starts) or disables (stops) streaming.
+         * @param enable True to enable, false to disable
+         * @return True if operation is successful, false otherwise.
+         */
         bool setStream(bool enable);
 
         RecorderInterface *getRecorder()
@@ -303,15 +305,11 @@ class StreamManager
         } TimeFrame;
 
         std::thread              m_framesThread;   // async incoming frames processing
-        std::mutex               m_framesMutex;    // protect read/write framesBuffer
-        std::list<TimeFrame>     m_framesBuffer;   // buffer for incoming frames
-        std::condition_variable  m_framesIncoming; // wakeup thread, new frames in framesBuffer
         std::atomic<bool>        m_framesThreadTerminate;
-        std::condition_variable  m_framesBufferEmpty;
+        UniqueQueue<TimeFrame>   m_framesIncoming;
 
         std::mutex               m_fastFPSUpdate;
-
-        std::mutex m_recordMutex;
+        std::mutex               m_recordMutex;
 
         uint8_t *gammaLUT_16_8 = nullptr;
 };

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -37,6 +37,7 @@
 #include <condition_variable>
 
 #include "uniquequeue.h"
+#include "gammalut16.h"
 
 #include <stdint.h>
 
@@ -216,8 +217,6 @@ class StreamManager
              */
         bool recordStream(const uint8_t *buffer, uint32_t nbytes, double deltams);
 
-        void prepareGammaLUT(double gamma = 2.4, double a = 12.92, double b = 0.055, double Ii = 0.00304);
-
         /* Stream switch */
         ISwitch StreamS[2];
         ISwitchVectorProperty StreamSP;
@@ -311,6 +310,6 @@ class StreamManager
         std::mutex               m_fastFPSUpdate;
         std::mutex               m_recordMutex;
 
-        uint8_t *gammaLUT_16_8 = nullptr;
+        GammaLut16               m_gammaLut16;
 };
 }

--- a/libs/stream/uniquequeue.h
+++ b/libs/stream/uniquequeue.h
@@ -1,0 +1,174 @@
+/*
+    Copyright (C) 2020 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <chrono>
+
+/**
+ * \class UniqueQueue template
+ * \brief The UniqueQueue class is a thread-safe FIFO container adapter.
+ * 
+ * Data is move to the queue, which ensures high efficiency when collecting data, e.g. for processing.
+ * This class ensures that threads are wake up waiting for data.
+ * It also provides a convenient "abort" method to wake up those waiting if there is no more data to process.
+ * Don't use it for large class/arrays (sizeof T). Provide an interface that allows data to be swapped/moved as pointers,
+ * like std::vector or simple pointers.
+ */
+template <typename T>
+class UniqueQueue
+{
+public:
+    /**
+     * @brief Move data to queue
+     * @param data the data will be moved using std::move
+     */
+    void push(T && data);
+    
+    /**
+     * @brief Pop data from queue
+     * @param dest the data will be swapped and destroyed
+     * @return returns false if the abort function was called while waiting for data
+     */
+    bool pop(T & dest);
+
+    /**
+     * @brief Pop data from queue
+     * @param dest the data will be swapped and destroyed
+     * @param msecs timeout in milliseconds
+     * @return returns false if timeout or the abort function was called while waiting for data
+     */
+    bool pop(T & dest, uint msecs);
+    
+    /**
+     * @brief Wait for an empty queue
+     */
+    void waitForEmpty() const;
+
+    /**
+     * @brief Wait for an empty queue
+     * @param msecs timeout in milliseconds
+     * @return returns false if timeout
+     */
+    bool waitForEmpty(uint msecs) const;
+    
+    /**
+     * @brief Clear queue
+     */
+    void clear();
+
+    /**
+     * @brief Clear queue and exit pop methods with false return
+     */
+    void abort();
+
+    /**
+     * @brief Return the number of items in the queue
+     * @return count of elements
+     */
+    size_t size() const;
+
+protected:
+    std::queue<T>      queue;
+    mutable std::mutex mutex;
+
+    mutable std::condition_variable decrease;
+    mutable std::condition_variable increase;  
+};
+
+// implementation
+template <typename T>
+inline void UniqueQueue<T>::push(T && data)
+{
+    std::lock_guard<std::mutex> lock(mutex);
+    queue.push(std::move(data));
+    increase.notify_all();
+}
+
+template <typename T>
+inline bool UniqueQueue<T>::pop(T & dest)
+{
+    std::unique_lock<std::mutex> lock(mutex);
+    if (queue.empty())
+        increase.wait(lock);
+
+    if (queue.empty())
+        return false; // abort
+
+    std::swap(dest, queue.front());
+    queue.pop();
+    decrease.notify_all();
+    return true;
+}
+
+template <typename T>
+inline bool UniqueQueue<T>::pop(T & dest, uint msecs)
+{
+    std::unique_lock<std::mutex> lock(mutex);
+
+    if (queue.empty() && increase.wait_for(lock, std::chrono::milliseconds(msecs)) == std::cv_status::timeout)
+        return false; // timeout
+
+    if (queue.empty())
+        return false; // abort
+
+    std::swap(dest, queue.front());
+    queue.pop();
+    decrease.notify_all();
+    return true;
+}
+
+template <typename T>
+inline size_t UniqueQueue<T>::size() const
+{
+    std::unique_lock<std::mutex> lock(mutex);
+    return queue.size();
+}
+
+template <typename T>
+inline void UniqueQueue<T>::clear()
+{
+    std::queue<T> empty;
+    std::unique_lock<std::mutex> lock(mutex);
+    std::swap(queue, empty);
+    decrease.notify_all();
+}
+
+template <typename T>
+inline void UniqueQueue<T>::waitForEmpty() const
+{
+    std::unique_lock<std::mutex> lock(mutex);
+    decrease.wait(lock, [this](){ return queue.empty(); });
+}
+
+template <typename T>
+inline bool UniqueQueue<T>::waitForEmpty(uint msecs) const
+{
+    std::unique_lock<std::mutex> lock(mutex);
+    return decrease.wait_for(lock, std::chrono::milliseconds(msecs), [this](){ return queue.empty(); });
+}
+
+template <typename T>
+inline void UniqueQueue<T>::abort()
+{
+    std::queue<T> empty;
+    std::unique_lock<std::mutex> lock(mutex);
+    std::swap(queue, empty);
+    increase.notify_all();
+    decrease.notify_all();
+}


### PR DESCRIPTION
Hi!
I am request in another cleaned version of the StreamManager class.

Additionally, I replaced the queue logic from std::list with std::queue (UniqueQueue).
std::list always allocates an extra header to create a node when adding an element.
std::queue is optimized not to allocate every time.

GammaLut16 class, you do not need to watch out to free memory, I try not to use new / delete operators, when the standard library offers its proven solutions for this.

I am trying to make the code more error-tolerant without sacrificing performance.
By the way, it would be nice to do d-pointers for common classes. In particular, shared with Indi 3rd Lib.
