### PR TITLE
 Sesto Senso 2: Log & display firmware version

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -381,7 +381,7 @@
         </device>
         <device label="Sesto Senso 2" manufacturer="Primaluce Lab">
             <driver name="Sesto Senso 2">indi_sestosenso2_focus</driver>
-            <version>0.5</version>
+            <version>0.6</version>
         </device>
         <device label="Esatto" manufacturer="Primaluce Lab">
             <driver name="Sesto Senso 2">indi_sestosenso2_focus</driver>

--- a/drivers.xml
+++ b/drivers.xml
@@ -385,7 +385,7 @@
         </device>
         <device label="Esatto" manufacturer="Primaluce Lab">
             <driver name="Sesto Senso 2">indi_sestosenso2_focus</driver>
-            <version>0.4</version>
+            <version>0.6</version>
         </device>
         <device label="Lakeside">
             <driver name="Lakeside">indi_lakeside_focus</driver>

--- a/drivers.xml
+++ b/drivers.xml
@@ -381,7 +381,7 @@
         </device>
         <device label="Sesto Senso 2" manufacturer="Primaluce Lab">
             <driver name="Sesto Senso 2">indi_sestosenso2_focus</driver>
-            <version>0.4</version>
+            <version>0.5</version>
         </device>
         <device label="Esatto" manufacturer="Primaluce Lab">
             <driver name="Sesto Senso 2">indi_sestosenso2_focus</driver>

--- a/drivers/focuser/sestosenso2.cpp
+++ b/drivers/focuser/sestosenso2.cpp
@@ -76,7 +76,7 @@ void ISSnoopDevice(XMLEle *root)
 
 SestoSenso2::SestoSenso2()
 {
-    setVersion(0, 4);
+    setVersion(0, 5);
     // Can move in Absolute & Relative motions, can AbortFocuser motion.
     FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_CAN_ABORT);
 
@@ -92,6 +92,11 @@ bool SestoSenso2::initProperties()
     // Firmware Information
     IUFillText(&FirmwareT[0], "VERSION", "Version", "");
     IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "FOCUS_FIRMWARE", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0,
+                     IPS_IDLE);
+
+    // Voltage Information
+    IUFillNumber(&VoltageInN[0], "VOLTAGEIN", "Volts", "%.2f", 0, 100, 0., 0.);
+    IUFillNumberVector(&VoltageInNP, VoltageInN, 1, getDeviceName(), "VOLTAGE_IN", "Voltage in", MAIN_CONTROL_TAB, IP_RO, 0,
                      IPS_IDLE);
 
     // Focuser temperature
@@ -168,6 +173,8 @@ bool SestoSenso2::updateProperties()
             defineNumber(&TemperatureNP);
         defineNumber(&SpeedNP);
         defineText(&FirmwareTP);
+        if (updateVoltageIn())
+            defineNumber(&VoltageInNP);
 
         //        if (m_IsSestoSenso2)
         //        {
@@ -186,6 +193,7 @@ bool SestoSenso2::updateProperties()
         if (TemperatureNP.s == IPS_OK)
             deleteProperty(TemperatureNP.name);
         deleteProperty(FirmwareTP.name);
+        deleteProperty(VoltageInNP.name);
         deleteProperty(CalibrationMessageTP.name);
         deleteProperty(CalibrationSP.name);
         deleteProperty(SpeedNP.name);
@@ -334,6 +342,35 @@ bool SestoSenso2::updatePosition()
         FocusAbsPosNP.s = IPS_ALERT;
         return false;
     }
+}
+
+bool SestoSenso2::updateVoltageIn()
+{
+    char res[SESTO_LEN] = {0};
+    double voltageIn = 0;
+
+    if (isSimulation())
+        strncpy(res, "12.00", SESTO_LEN);
+    else if (command->getVoltageIn(res) == false)
+        return false;
+
+    try
+    {
+        voltageIn = std::stod(res);
+    }
+    catch(...)
+    {
+        LOGF_WARN("Failed to process voltage response: %s (%d bytes)", res, strlen(res));
+        return false;
+    }
+
+    if (voltageIn > 24)
+        return false;
+
+    VoltageInN[0].value = voltageIn;
+    VoltageInNP.s = (voltageIn >= 11.0) ? IPS_OK : IPS_ALERT;
+
+    return true;
 }
 
 bool SestoSenso2::setupRunPreset()
@@ -788,6 +825,23 @@ void SestoSenso2::TimerHit()
                 lastTemperature = TemperatureN[0].value;
             }
         }
+
+        // Also use temparature poll rate for tracking input voltage
+        rc = updateVoltageIn();
+        if (rc)
+        {
+            if (fabs(lastVoltageIn - VoltageInN[0].value) >= 0.1)
+            {
+                IDSetNumber(&VoltageInNP, nullptr);
+                lastVoltageIn = VoltageInN[0].value;
+
+                if (VoltageInN[0].value < 11.0)
+                {
+                    LOG_WARN("Please check 12v DC power supply is connected.");
+                }
+            }
+        }
+
         m_TemperatureCounter = 0;   // Reset the counter
     }
 
@@ -1036,4 +1090,9 @@ bool CommandSet::getMotorTemp(char *res)
 bool CommandSet::getExternalTemp(char *res)
 {
     return sendCmd("{\"req\":{\"get\":{\"EXT_T\":\"\"}}}", "EXT_T", res);
+}
+
+bool CommandSet::getVoltageIn(char *res)
+{
+    return sendCmd("{\"req\":{\"get\":{\"VIN_12V\":\"\"}}}", "VIN_12V", res);
 }

--- a/drivers/focuser/sestosenso2.h
+++ b/drivers/focuser/sestosenso2.h
@@ -35,6 +35,7 @@ class CommandSet
         int PortFD;
         bool stop();
         bool getSerialNumber(char *res);
+        bool getFirmwareVersion(char *res);
         bool abort();
         bool go(uint32_t targetTicks, char *res);
         bool goHome(char *res);
@@ -136,8 +137,13 @@ class SestoSenso2 : public INDI::Focuser
         INumber SpeedN[1];
         INumberVectorProperty SpeedNP;
 
-        IText FirmwareT[1] {};
         ITextVectorProperty FirmwareTP;
+        IText FirmwareT[2];
+        enum
+        {
+            FIRMWARE_SN,
+            FIRMWARE_VERSION,
+        };
 
         INumber VoltageInN[1] {};
         INumberVectorProperty VoltageInNP;

--- a/drivers/focuser/sestosenso2.h
+++ b/drivers/focuser/sestosenso2.h
@@ -51,6 +51,7 @@ class CommandSet
         bool loadSlowPreset(char *res);
         bool getMotorTemp(char *res);
         bool getExternalTemp(char *res);
+        bool getVoltageIn(char *res);
         std::string deviceName;
 
         const char *getDeviceName()
@@ -105,6 +106,7 @@ class SestoSenso2 : public INDI::Focuser
 
         bool updateTemperature();
         bool updatePosition();
+        bool updateVoltageIn();
         void setConnectionParams();
         bool initCommandSet();
         void checkMotionProgressCallback();
@@ -119,6 +121,7 @@ class SestoSenso2 : public INDI::Focuser
 
         uint32_t targetPos { 0 };
         uint32_t lastPos { 0 };
+        double lastVoltageIn { 0 };
         double lastTemperature { 0 };
         uint16_t m_TemperatureCounter { 0 };
 
@@ -135,6 +138,9 @@ class SestoSenso2 : public INDI::Focuser
 
         IText FirmwareT[1] {};
         ITextVectorProperty FirmwareTP;
+
+        INumber VoltageInN[1] {};
+        INumberVectorProperty VoltageInNP;
 
         ISwitch CalibrationS[2];
         ISwitchVectorProperty CalibrationSP;


### PR DESCRIPTION
Also moved firmware info to Info tab to declutter main controls tab a little.