### PR TITLE
Fix for #1270, use d m s.f with f being tenths for LX200_GEO_LONGER_FORMAT

### DIFF
--- a/drivers/telescope/ioptronHC8406.cpp
+++ b/drivers/telescope/ioptronHC8406.cpp
@@ -351,7 +351,7 @@ bool ioptronHC8406::isSlewComplete()
 
 void ioptronHC8406::getBasicData()
 {
-    checkLX200Format(PortFD);
+    checkLX200EquatorialFormat(PortFD);
     sendScopeLocation();
     sendScopeTime();
 }

--- a/drivers/telescope/lx200_10micron.cpp
+++ b/drivers/telescope/lx200_10micron.cpp
@@ -271,7 +271,7 @@ void LX200_10MICRON::getBasicData()
         getMountInfo();
 
         getAlignment();
-        checkLX200Format(fd);
+        checkLX200EquatorialFormat(fd);
         timeFormat = LX200_24;
 
         if (getTrackFreq(PortFD, &TrackFreqN[0].value) < 0)

--- a/drivers/telescope/lx200_TeenAstro.cpp
+++ b/drivers/telescope/lx200_TeenAstro.cpp
@@ -977,6 +977,7 @@ bool LX200_TeenAstro::sendScopeTime()
 bool LX200_TeenAstro::sendScopeLocation()
 {
     int dd = 0, mm = 0, elev = 0;
+    double ssf = 0.0;
 
     LOG_INFO("Send location");
     return true;
@@ -991,7 +992,7 @@ bool LX200_TeenAstro::sendScopeLocation()
         return true;
     }
 
-    if (getSiteLatitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLatitude(PortFD, &dd, &mm, &ssf) < 0)
     {
         LOG_WARN("Failed to get site latitude from device.");
         return false;
@@ -1003,7 +1004,7 @@ bool LX200_TeenAstro::sendScopeLocation()
         else
             LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0;
     }
-    if (getSiteLongitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLongitude(PortFD, &dd, &mm, &ssf) < 0)
     {
         LOG_WARN("Failed to get site longitude from device.");
         return false;
@@ -1094,8 +1095,9 @@ bool LX200_TeenAstro::setSiteElevation(double elevation)
 bool LX200_TeenAstro::getLocation()
 {
     int dd = 0, mm = 0, elev = 0;
+    double ssf = 0.0;
 
-    if (getSiteLatitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLatitude(PortFD, &dd, &mm, &ssf) < 0)
     {
         LOG_WARN("Failed to get site latitude from device.");
         return false;
@@ -1108,7 +1110,7 @@ bool LX200_TeenAstro::getLocation()
             LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0;
     }
 
-    if (getSiteLongitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLongitude(PortFD, &dd, &mm, &ssf) < 0)
     {
         LOG_WARN("Failed to get site longitude from device.");
         return false;

--- a/drivers/telescope/lx200_TeenAstro.cpp
+++ b/drivers/telescope/lx200_TeenAstro.cpp
@@ -636,7 +636,7 @@ void LX200_TeenAstro::getBasicData()
 
     if (!isSimulation())
     {
-        checkLX200Format(PortFD);
+        checkLX200EquatorialFormat(PortFD);
         char buffer[128];
         getVersionDate(PortFD, buffer);
         IUSaveText(&VersionT[0], buffer);

--- a/drivers/telescope/lx200ap.cpp
+++ b/drivers/telescope/lx200ap.cpp
@@ -551,7 +551,7 @@ bool LX200AstroPhysics::setBasicDataPart0()
     }
 
     // Detect and set fomat. It should be LONG.
-    checkLX200Format(PortFD);
+    checkLX200EquatorialFormat(PortFD);
 
     return true;
 }

--- a/drivers/telescope/lx200ap_experimental.cpp
+++ b/drivers/telescope/lx200ap_experimental.cpp
@@ -933,7 +933,8 @@ bool LX200AstroPhysicsExperimental::ReadScopeStatus()
     }
     int ddd = 0;
     int fmm = 0;
-    if (getSiteLongitude(PortFD, &ddd, &fmm) < 0)
+    double ssf = 0.0;
+    if (getSiteLongitude(PortFD, &ddd, &fmm, &ssf) < 0)
     {
         LOG_DEBUG("Reading longitude failed :Gg %d");
     }

--- a/drivers/telescope/lx200ap_experimental.cpp
+++ b/drivers/telescope/lx200ap_experimental.cpp
@@ -1557,7 +1557,7 @@ bool LX200AstroPhysicsExperimental::Handshake()
     disclaimerMessage();
 
     // Detect and set fomat. It should be LONG.
-    return (checkLX200Format(PortFD) == 0);
+    return (checkLX200EquatorialFormat(PortFD) == 0);
 }
 
 bool LX200AstroPhysicsExperimental::Disconnect()

--- a/drivers/telescope/lx200ap_gtocp2.cpp
+++ b/drivers/telescope/lx200ap_gtocp2.cpp
@@ -573,7 +573,7 @@ bool LX200AstroPhysicsGTOCP2::Handshake()
     }
 
     // Detect and set fomat. It should be LONG.
-    return (checkLX200Format(PortFD) == 0);
+    return (checkLX200EquatorialFormat(PortFD) == 0);
 }
 
 bool LX200AstroPhysicsGTOCP2::Disconnect()

--- a/drivers/telescope/lx200basic.cpp
+++ b/drivers/telescope/lx200basic.cpp
@@ -384,7 +384,7 @@ bool LX200Basic::Abort()
 void LX200Basic::getBasicData()
 {
     // Make sure short
-    checkLX200Format(PortFD);
+    checkLX200EquatorialFormat(PortFD);
 
     // Get current RA/DEC
     getLX200RA(PortFD, &currentRA);

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -1026,9 +1026,24 @@ int setSiteLongitude(int fd, double Long)
 /* Add mutex */
 /*    std::unique_lock<std::mutex> guard(lx200CommsLock); */
 
-    getSexComponents(Long, &d, &m, &s);
-
-    snprintf(read_buffer, sizeof(read_buffer), ":Sg%03d:%02d#", d, m);
+    switch (controller_format) {
+    case LX200_SHORT_FORMAT: // d m
+        getSexComponents(Long, &d, &m, &s);
+        snprintf(read_buffer, sizeof(read_buffer), ":Sg%03d:%02d#", d, m);
+        break;
+    case LX200_LONG_FORMAT: // d m s
+        getSexComponents(Long, &d, &m, &s);
+        snprintf(read_buffer, sizeof(read_buffer), ":Sg%03d:%02d:%02d#", d, m, s);
+        break;
+    case LX200_LONGER_FORMAT: // d m s.f with f being tenths of arcsecond
+        double s_f;
+        getSexComponentsIID(Long, &d, &m, &s_f);
+        snprintf(read_buffer, sizeof(read_buffer), ":Sg%03d:%02d:%04.01f#", d, m, s_f);
+        break;
+    default:
+        DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Unknown controller_format <%d>", controller_format);
+        return -1;
+    }
 
     return (setStandardProcedure(fd, read_buffer));
 }
@@ -1042,9 +1057,24 @@ int setSiteLatitude(int fd, double Lat)
 /* Add mutex */
 /*    std::unique_lock<std::mutex> guard(lx200CommsLock); */
 
-    getSexComponents(Lat, &d, &m, &s);
-
-    snprintf(read_buffer, sizeof(read_buffer), ":St%+03d:%02d:%02d#", d, m, s);
+    switch (controller_format) {
+    case LX200_SHORT_FORMAT: // d m
+        getSexComponents(Lat, &d, &m, &s);
+        snprintf(read_buffer, sizeof(read_buffer), ":St%+03d:%02d#", d, m);
+        break;
+    case LX200_LONG_FORMAT: // d m s
+        getSexComponents(Lat, &d, &m, &s);
+        snprintf(read_buffer, sizeof(read_buffer), ":St%+03d:%02d:%02d#", d, m, s);
+        break;
+    case LX200_LONGER_FORMAT: // d m s.f with f being tenths of arcsecond
+        double s_f;
+        getSexComponentsIID(Lat, &d, &m, &s_f);
+        snprintf(read_buffer, sizeof(read_buffer), ":St%+03d:%02d:%04.01f#", d, m, s_f);
+        break;
+    default:
+        DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Unknown controller_format <%d>", controller_format);
+        return -1;
+    }
 
     return (setStandardProcedure(fd, read_buffer));
 }

--- a/drivers/telescope/lx200driver.h
+++ b/drivers/telescope/lx200driver.h
@@ -44,12 +44,19 @@ enum TDirection
     LX200_SOUTH,
     LX200_ALL
 };
-/* Formats of Right Ascension and Declination */
-enum TFormat
+/* Formats of Equatorial Right Ascension and Declination */
+enum TEquatorialFormat
 {
-    LX200_SHORT_FORMAT,
-    LX200_LONG_FORMAT,
-    LX200_LONGER_FORMAT
+    LX200_EQ_SHORT_FORMAT,
+    LX200_EQ_LONG_FORMAT,
+    LX200_EQ_LONGER_FORMAT
+};
+/* Formats of Geographic Latitude and Longitude */
+enum TGeographicFormat
+{
+    LX200_GEO_SHORT_FORMAT,
+    LX200_GEO_LONG_FORMAT,
+    LX200_GEO_LONGER_FORMAT
 };
 /* Time Format */
 enum TTimeFormat
@@ -292,9 +299,9 @@ int SendPulseCmd(int fd, int direction, int duration_msec);
  Other Commands
  **************************************************************************/
 /* Determines LX200 RA/DEC format, tries to set to long if found short */
-int checkLX200Format(int fd);
+int checkLX200EquatorialFormat(int fd);
 /* return the controller_format enum value */
-int getLX200Format();
+int getLX200EquatorialFormat();
 /* Select a site from the LX200 controller */
 int selectSite(int fd, int siteNum);
 /* Select a catalog object */

--- a/drivers/telescope/lx200driver.h
+++ b/drivers/telescope/lx200driver.h
@@ -201,9 +201,9 @@ int getCommandInt(int fd, int *value, const char *cmd);
 /* Get tracking frequency */
 int getTrackFreq(int fd, double *value);
 /* Get site Latitude */
-int getSiteLatitude(int fd, int *dd, int *mm);
+int getSiteLatitude(int fd, int *dd, int *mm, double *ssf);
 /* Get site Longitude */
-int getSiteLongitude(int fd, int *ddd, int *mm);
+int getSiteLongitude(int fd, int *ddd, int *mm, double *ssf);
 /* Get Calender data */
 int getCalendarDate(int fd, char *date);
 /* Get site Name */

--- a/drivers/telescope/lx200ss2000pc.cpp
+++ b/drivers/telescope/lx200ss2000pc.cpp
@@ -157,7 +157,7 @@ bool LX200SS2000PC::updateTime(ln_date *utc, double utc_offset)
 void LX200SS2000PC::getBasicData(void)
 {
     if (!isSimulation())
-        checkLX200Format(PortFD);
+        checkLX200EquatorialFormat(PortFD);
     sendScopeLocation();
     sendScopeTime();
 }

--- a/drivers/telescope/lx200telescope.cpp
+++ b/drivers/telescope/lx200telescope.cpp
@@ -330,13 +330,13 @@ bool LX200Telescope::Goto(double ra, double dec)
     char RAStr[64] = {0}, DecStr[64] = {0};
     int fracbase = 0;
 
-    switch (getLX200Format())
+    switch (getLX200EquatorialFormat())
     {
-        case LX200_LONGER_FORMAT:
+        case LX200_EQ_LONGER_FORMAT:
             fracbase = 360000;
             break;
-        case LX200_LONG_FORMAT:
-        case LX200_SHORT_FORMAT:
+        case LX200_EQ_LONG_FORMAT:
+        case LX200_EQ_SHORT_FORMAT:
         default:
             fracbase = 3600;
             break;
@@ -1146,7 +1146,7 @@ void LX200Telescope::getBasicData()
 {
     if (!isSimulation())
     {
-        checkLX200Format(PortFD);
+        checkLX200EquatorialFormat(PortFD);
 
         if (genericCapability & LX200_HAS_ALIGNMENT_TYPE)
             getAlignment();

--- a/drivers/telescope/lx200telescope.cpp
+++ b/drivers/telescope/lx200telescope.cpp
@@ -640,7 +640,7 @@ bool LX200Telescope::updateLocation(double latitude, double longitude, double el
     if (isSimulation())
         return true;
 
-    if (!isSimulation() && setSiteLongitude(PortFD, 360.0 - longitude) < 0)
+    if (!isSimulation() && setSiteLongitude(PortFD, longitude) < 0)
     {
         LOG_ERROR("Error setting site longitude coordinates");
         return false;
@@ -653,10 +653,11 @@ bool LX200Telescope::updateLocation(double latitude, double longitude, double el
     }
 
     char l[MAXINDINAME] = {0}, L[MAXINDINAME] = {0};
-    fs_sexa(l, latitude, 3, 3600);
-    fs_sexa(L, longitude, 4, 3600);
+    fs_sexa(l, latitude, 2, 36000);
+    fs_sexa(L, longitude, 2, 36000);
 
-    LOGF_INFO("Site location updated to Lat %.32s - Long %.32s", l, L);
+    // Choose WGS 84, also known as EPSG:4326 for latitude/longitude ordering
+    LOGF_INFO("Site location in the mount updated to Latitude %.12s (%g) Longitude %.12s (%g) (Longitude sign in carthography format)", l, latitude, L, longitude);
 
     return true;
 }
@@ -1356,7 +1357,10 @@ bool LX200Telescope::sendScopeTime()
 
 bool LX200Telescope::sendScopeLocation()
 {
-    int dd = 0, mm = 0;
+    int lat_dd = 0, lat_mm = 0, long_dd = 0, long_mm = 0;
+    double lat_ssf = 0.0, long_ssf = 0.0;
+    char lat_sexagesimal[MAXINDIFORMAT];
+    char lng_sexagesimal[MAXINDIFORMAT];
 
     if (isSimulation())
     {
@@ -1368,35 +1372,33 @@ bool LX200Telescope::sendScopeLocation()
         return true;
     }
 
-    if (getSiteLatitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLatitude(PortFD, &lat_dd, &lat_mm, &lat_ssf) < 0)
     {
         LOG_WARN("Failed to get site latitude from device.");
         return false;
     }
     else
     {
-        if (dd > 0)
-            LocationNP.np[0].value = dd + mm / 60.0;
-        else
-            LocationNP.np[0].value = dd - mm / 60.0;
+        snprintf(lat_sexagesimal, MAXINDIFORMAT,"%02d:%02d:%02.1lf", lat_dd, lat_mm, lat_ssf);
+        f_scansexa(lat_sexagesimal, &(LocationNP.np[LOCATION_LATITUDE].value));
     }
 
-    if (getSiteLongitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLongitude(PortFD, &long_dd, &long_mm, &long_ssf) < 0)
     {
         LOG_WARN("Failed to get site longitude from device.");
         return false;
     }
     else
     {
-        if (dd > 0)
-            LocationNP.np[1].value = 360.0 - (dd + mm / 60.0);
-        else
-            LocationNP.np[1].value = (dd - mm / 60.0) * -1.0;
-
+        snprintf(lng_sexagesimal, MAXINDIFORMAT,"%02d:%02d:%02.1lf", long_dd, long_mm, long_ssf);
+        f_scansexa(lng_sexagesimal, &(LocationNP.np[LOCATION_LONGITUDE].value));
     }
 
-    LOGF_DEBUG("Mount Controller Latitude: %g Longitude: %g", LocationN[LOCATION_LATITUDE].value,
-               LocationN[LOCATION_LONGITUDE].value);
+    LOGF_INFO("Mount has Latitude %s (%g) Longitude %s (%g) (Longitude sign in carthography format)",
+              lat_sexagesimal,
+              LocationN[LOCATION_LATITUDE].value,
+              lng_sexagesimal,
+              LocationN[LOCATION_LONGITUDE].value);
 
     IDSetNumber(&LocationNP, nullptr);
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1387,6 +1387,7 @@ bool Rainbow::sendScopeTime()
 bool Rainbow::sendScopeLocation()
 {
     int dd = 0, mm = 0;
+    double ssf = 0.0;
 
     if (isSimulation())
     {
@@ -1398,7 +1399,7 @@ bool Rainbow::sendScopeLocation()
         return true;
     }
 
-    if (getSiteLatitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLatitude(PortFD, &dd, &mm, &ssf) < 0)
     {
         LOG_WARN("Failed to get site latitude from device.");
         return false;
@@ -1411,7 +1412,7 @@ bool Rainbow::sendScopeLocation()
             LocationNP.np[0].value = dd - mm / 60.0;
     }
 
-    if (getSiteLongitude(PortFD, &dd, &mm) < 0)
+    if (getSiteLongitude(PortFD, &dd, &mm, &ssf) < 0)
     {
         LOG_WARN("Failed to get site longitude from device.");
         return false;

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -104,7 +104,7 @@ bool Telescope::initProperties()
     IUFillTextVector(&TimeTP, TimeT, 2, getDeviceName(), "TIME_UTC", "UTC", SITE_TAB, IP_RW, 60, IPS_IDLE);
 
     IUFillNumber(&LocationN[LOCATION_LATITUDE], "LAT", "Lat (dd:mm:ss.s)", "%012.8m", -90, 90, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", -180, 360, 0, 0.0);
+    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", 0, 360, 0, 0.0);
     IUFillNumber(&LocationN[LOCATION_ELEVATION], "ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
     IUFillNumberVector(&LocationNP, LocationN, 3, getDeviceName(), "GEOGRAPHIC_COORD", "Scope Location", SITE_TAB,
                        IP_RW, 60, IPS_IDLE);

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -103,8 +103,8 @@ bool Telescope::initProperties()
     IUFillText(&TimeT[1], "OFFSET", "UTC Offset", nullptr);
     IUFillTextVector(&TimeTP, TimeT, 2, getDeviceName(), "TIME_UTC", "UTC", SITE_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillNumber(&LocationN[LOCATION_LATITUDE], "LAT", "Lat (dd:mm:ss)", "%010.6m", -90, 90, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss)", "%010.6m", 0, 360, 0, 0.0);
+    IUFillNumber(&LocationN[LOCATION_LATITUDE], "LAT", "Lat (dd:mm:ss.s)", "%012.8m", -90, 90, 0, 0.0);
+    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", 0, 360, 0, 0.0);
     IUFillNumber(&LocationN[LOCATION_ELEVATION], "ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
     IUFillNumberVector(&LocationNP, LocationN, 3, getDeviceName(), "GEOGRAPHIC_COORD", "Scope Location", SITE_TAB,
                        IP_RW, 60, IPS_IDLE);
@@ -1666,6 +1666,7 @@ bool Telescope::processLocationInfo(double latitude, double longitude, double el
     {
         LocationNP.s = IPS_OK;
         IDSetNumber(&LocationNP, nullptr);
+        return true;
     }
     else if (latitude == 0 && longitude == 0)
     {
@@ -1719,14 +1720,18 @@ bool Telescope::updateLocation(double latitude, double longitude, double elevati
 void Telescope::updateObserverLocation(double latitude, double longitude, double elevation)
 {
     INDI_UNUSED(elevation);
-    // JM: INDI Longitude is 0 to 360 increasing EAST. libnova East is Positive, West is negative
     lnobserver.lng = longitude;
-
+    // JM: INDI Longitude is 0 to 360 increasing EAST. libnova East is Positive, West is negative
     if (lnobserver.lng > 180)
         lnobserver.lng -= 360;
     lnobserver.lat = latitude;
 
-    LOGF_INFO("Observer location updated: Longitude (%g) Latitude (%g)", lnobserver.lng, lnobserver.lat);
+    char lat_str[MAXINDIFORMAT];
+    char lng_str[MAXINDIFORMAT];
+    fs_sexa(lat_str, lnobserver.lat, 2, 36000);
+    fs_sexa(lng_str, lnobserver.lng, 2, 36000);
+    // Choose WGS 84, also known as EPSG:4326 for latitude/longitude ordering
+    LOGF_INFO("Observer location updated: Latitude %.12s (%g) Longitude %.12s (%g)", lat_str, lnobserver.lat, lng_str, lnobserver.lng);
 }
 
 bool Telescope::SetParkPosition(double Axis1Value, double Axis2Value)

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -104,7 +104,7 @@ bool Telescope::initProperties()
     IUFillTextVector(&TimeTP, TimeT, 2, getDeviceName(), "TIME_UTC", "UTC", SITE_TAB, IP_RW, 60, IPS_IDLE);
 
     IUFillNumber(&LocationN[LOCATION_LATITUDE], "LAT", "Lat (dd:mm:ss.s)", "%012.8m", -90, 90, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", 0, 360, 0, 0.0);
+    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", -180, 180, 0, 0.0);
     IUFillNumber(&LocationN[LOCATION_ELEVATION], "ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
     IUFillNumberVector(&LocationNP, LocationN, 3, getDeviceName(), "GEOGRAPHIC_COORD", "Scope Location", SITE_TAB,
                        IP_RW, 60, IPS_IDLE);

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -104,7 +104,7 @@ bool Telescope::initProperties()
     IUFillTextVector(&TimeTP, TimeT, 2, getDeviceName(), "TIME_UTC", "UTC", SITE_TAB, IP_RW, 60, IPS_IDLE);
 
     IUFillNumber(&LocationN[LOCATION_LATITUDE], "LAT", "Lat (dd:mm:ss.s)", "%012.8m", -90, 90, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", -180, 180, 0, 0.0);
+    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", -180, 360, 0, 0.0);
     IUFillNumber(&LocationN[LOCATION_ELEVATION], "ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
     IUFillNumberVector(&LocationNP, LocationN, 3, getDeviceName(), "GEOGRAPHIC_COORD", "Scope Location", SITE_TAB,
                        IP_RW, 60, IPS_IDLE);


### PR DESCRIPTION
This allows to set the higher precision on the mount : 
```
#:Gg#
-005*32#

#:U1#
#:Gg#
-005*31:46#

#:U2#
#:Gg#
-005:31:46.2#
```
These values however are not shown yet on the Site Management (seconds are, fractions of seconds are not).
I'll add this later and update this PR.