### PR TITLE
Add new helper methods to the AlignmentSubsystemForDrivers (Alt/Az)

### DIFF
--- a/libs/indibase/alignment/AlignmentSubsystemForDrivers.h
+++ b/libs/indibase/alignment/AlignmentSubsystemForDrivers.h
@@ -120,8 +120,8 @@ namespace INDI
       bool SkyToTelescopeEquatorial(double actualRA, double actualDec, double &mountRA, double &mountDec);
 
       /** \brief Converts a mount location to actual sky coordinates, usually called in ReadScopeStatus.
-       * \param[in] mountRA Right Ascension to send to the mount
-       * \param[in] mountDec Declination to send to the mount
+       * \param[in] mountRA Right Ascension where the mount thinks it is in decimal hours
+       * \param[in] mountDec Declination where the mount thinks it is in decimal degrees
        * \param[out] actualRA actual Right Ascension in decimal hours
        * \param[out] actualDec actual Declination in decimal degrees
        * \return true if we converted mountRa/mountDec to actualRA/actualDec, otherwise false
@@ -130,6 +130,43 @@ namespace INDI
        * is not set. Call UpdateLocation to set the current location.
        */
       bool TelescopeEquatorialToSky(double mountRA, double mountDec, double &actualRA, double &actualDec);
+
+      /** \brief Adds an alignment point to the model database, usually called from Sync.
+       * \param[in] actualRA actual Right Ascension in decimal hours
+       * \param[in] actualDec actual Declination in decimal degrees
+       * \param[in] mountAlt Altitude where the mount thinks it is in decimal degrees
+       * \param[in] mountAz Azimuth where the mount thinks it is in decimal degrees
+       * \return true if the alignment point was added to the database, otherwise false
+       *
+       * This will return false if either the alignment point was already added, or if the location
+       * is not set. Call UpdateLocation to set the current location.
+       */
+      bool AddAlignmentEntryAltAz(double actualRA, double actualDec, double mountAlt, double mountAz);
+
+      /** \brief Converts an actual sky location to coordinates to send to the mount, usually called
+       * in Goto.
+       * \param[in] actualRA actual Right Ascension in decimal hours
+       * \param[in] actualDec actual Declination in decimal degrees
+       * \param[out] mountAlt Altitude to send to the mount
+       * \param[out] mountAz Azimuth to send to the mount
+       * \return true if we converted actualRA/actualDec to mountAlt/mountAz, otherwise false
+       *
+       * This will return false if we have fewer than 2 alignment points added, or if the location
+       * is not set. Call UpdateLocation to set the current location.
+       */
+      bool SkyToTelescopeAltAz(double actualRA, double actualDec, double &mountAlt, double &mountAz);
+
+      /** \brief Converts a mount location to actual sky coordinates, usually called in ReadScopeStatus.
+       * \param[in] mountAlt Altitude where the mount thinks it is in decimal degrees
+       * \param[in] mountAz Azimuth where the mount thinks it is in decimal degrees
+       * \param[out] actualRA actual Right Ascension in decimal hours
+       * \param[out] actualDec actual Declination in decimal degrees
+       * \return true if we converted mountRa/mountDec to actualRA/actualDec, otherwise false
+       *
+       * This will return false if we have fewer than 2 alignment points added, or if the location
+       * is not set. Call UpdateLocation to set the current location.
+       */
+      bool TelescopeAltAzToSky(double mountAlt, double mountAz, double &actualRA, double &actualDec);
 
     private:
       /** \brief This static function is registered as a load database callback with

--- a/test/alignment/test_alignment.cpp
+++ b/test/alignment/test_alignment.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <stdio.h>
 
 #include <indilogger.h>
 
@@ -34,9 +35,9 @@ double round(double value, int decimal_places)
     return std::round(value * multiplier) / multiplier;
 }
 
-TEST(ALIGNMENT_TEST, Test_TDVRoundTrip)
+TEST(ALIGNMENT_TEST, Test_TDVRoundTripEquatorial)
 {
-    Scope s;
+    Scope s(INDI::AlignmentSubsystem::MathPluginManagement::EQUATORIAL);
 
     s.Handshake();
     s.SetAlignmentSubsystemActive(true);
@@ -60,9 +61,32 @@ TEST(ALIGNMENT_TEST, Test_TDVRoundTrip)
     ASSERT_DOUBLE_EQ(RaDec.dec, RaDecResult.dec);
 }
 
-TEST(ALIGNMENT_TEST, Test_ThreeSyncPoints)
+TEST(ALIGNMENT_TEST, Test_TDVRoundTripAltAz)
 {
-    Scope s;
+    Scope s(INDI::AlignmentSubsystem::MathPluginManagement::ALTAZ);
+
+    s.Handshake();
+    s.SetAlignmentSubsystemActive(true);
+
+    double alt = 35.7, az = 80.0;
+    struct ln_hrz_posn AltAz;
+    AltAz.alt = range360(alt);
+    AltAz.az = range360(az);
+
+    TelescopeDirectionVector TDV = s.TelescopeDirectionVectorFromAltitudeAzimuth(AltAz);
+    struct ln_hrz_posn AltAzResult;
+    s.AltitudeAzimuthFromTelescopeDirectionVector(TDV, AltAzResult);
+
+    AltAzResult.alt = range360(AltAzResult.alt);
+    AltAzResult.az = range360(AltAzResult.az);
+
+    ASSERT_DOUBLE_EQ(AltAz.alt, AltAzResult.alt);
+    ASSERT_DOUBLE_EQ(AltAz.az, AltAzResult.az);
+}
+
+TEST(ALIGNMENT_TEST, Test_ThreeSyncPointsEquatorial)
+{
+    Scope s(INDI::AlignmentSubsystem::MathPluginManagement::EQUATORIAL);
 
     s.Handshake();
     s.updateLocation(34.70, -80.54, 161);
@@ -93,6 +117,52 @@ TEST(ALIGNMENT_TEST, Test_ThreeSyncPoints)
     s.SkyToTelescopeEquatorial(VegaSkyRA, VegaSkyDec, VegaMountRA, VegaMountDec);
     ASSERT_DOUBLE_EQ(round(VegaJ2000RA, 1), round(VegaMountRA, 1));
     ASSERT_DOUBLE_EQ(round(VegaJ2000Dec, 6), round(VegaMountDec, 6));
+}
+
+TEST(ALIGNMENT_TEST, Test_ThreeSyncPointsAltAz)
+{
+    Scope s(INDI::AlignmentSubsystem::MathPluginManagement::ALTAZ);
+
+    s.Handshake();
+    ASSERT_TRUE(s.updateLocation(34.70, -80.54, 161));
+    s.SetAlignmentSubsystemActive(true);
+
+    double VegaJ2000RA = 18.6156972;
+    double VegaJ2000Dec = 38.7856944;
+
+    double ArcturusJ2000RA = 14.2612083;
+    double ArcturusJ2000Dec = 19.1872694;
+
+    double MizarJ2000RA = 13.3988500;
+    double MizarJ2000Dec = 54.9254167;
+
+    // The test scope will do a "perfect" sync with whatever we send it.
+    ASSERT_TRUE(s.Sync(VegaJ2000RA, VegaJ2000Dec));
+    ASSERT_TRUE(s.Sync(ArcturusJ2000RA, ArcturusJ2000Dec));
+    ASSERT_TRUE(s.Sync(MizarJ2000RA, MizarJ2000Dec));
+
+    double testPointAlt = 35.123456, testPointAz = 80.123456;
+    double skyRA, skyDec;
+    ASSERT_TRUE(s.TelescopeAltAzToSky(testPointAlt, testPointAz, skyRA, skyDec));
+
+    // convert the ra/dec we received to alt/az to compare
+    ln_lnlat_posn location;
+    s.GetDatabaseReferencePosition(location);
+    ln_equ_posn raDec;
+    raDec.dec = skyDec;
+    raDec.ra = skyRA * 360.0 / 24.0; // get_hrz_from_equ expects this in decimal degrees
+    ln_hrz_posn altAz;
+    get_hrz_from_equ(&raDec, &location, ln_get_julian_from_sys(), &altAz);
+
+    // I would expect these to be closer than 1 decimal apart, but it seems to work
+    ASSERT_DOUBLE_EQ(round(testPointAlt, 1), round(altAz.alt, 1));
+    ASSERT_DOUBLE_EQ(round(testPointAz, 1), round(altAz.az, 1));
+
+    double roundTripAlt, roundTripAz;
+    s.SkyToTelescopeAltAz(skyRA, skyDec, roundTripAlt, roundTripAz);
+
+    ASSERT_DOUBLE_EQ(round(testPointAlt, 1), round(roundTripAlt, 1));
+    ASSERT_DOUBLE_EQ(round(testPointAz, 1), round(roundTripAz, 1));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Now adding the helper methods for Alt/Az mounts. I would appreciate if someone with an Alt/Az mount could test this. The test cases I wrote seem to work well, though.

```cpp
      /** \brief Adds an alignment point to the model database, usually called from Sync.
       * \param[in] actualRA actual Right Ascension in decimal hours
       * \param[in] actualDec actual Declination in decimal degrees
       * \param[in] mountAlt Altitude where the mount thinks it is in decimal degrees
       * \param[in] mountAz Azimuth where the mount thinks it is in decimal degrees
       * \return true if the alignment point was added to the database, otherwise false
       *
       * This will return false if either the alignment point was already added, or if the location
       * is not set. Call UpdateLocation to set the current location.
       */
      bool AddAlignmentEntryAltAz(double actualRA, double actualDec, double mountAlt, double mountAz);

      /** \brief Converts an actual sky location to coordinates to send to the mount, usually called
       * in Goto.
       * \param[in] actualRA actual Right Ascension in decimal hours
       * \param[in] actualDec actual Declination in decimal degrees
       * \param[out] mountAlt Altitude to send to the mount
       * \param[out] mountAz Azimuth to send to the mount
       * \return true if we converted actualRA/actualDec to mountAlt/mountAz, otherwise false
       *
       * This will return false if we have fewer than 2 alignment points added, or if the location
       * is not set. Call UpdateLocation to set the current location.
       */
      bool SkyToTelescopeAltAz(double actualRA, double actualDec, double &mountAlt, double &mountAz);

      /** \brief Converts a mount location to actual sky coordinates, usually called in ReadScopeStatus.
       * \param[in] mountAlt Altitude where the mount thinks it is in decimal degrees
       * \param[in] mountAz Azimuth where the mount thinks it is in decimal degrees
       * \param[out] actualRA actual Right Ascension in decimal hours
       * \param[out] actualDec actual Declination in decimal degrees
       * \return true if we converted mountRa/mountDec to actualRA/actualDec, otherwise false
       *
       * This will return false if we have fewer than 2 alignment points added, or if the location
       * is not set. Call UpdateLocation to set the current location.
       */
      bool TelescopeAltAzToSky(double mountAlt, double mountAz, double &actualRA, double &actualDec);
```