### PR TITLE
add new ccd rotation prop to ccd simulator

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -107,6 +107,7 @@ bool CCDSim::setupParameters()
     m_PEPeriod = SimulatorSettingsN[SIM_PE_PERIOD].value;
     m_PEMax = SimulatorSettingsN[SIM_PE_MAX].value;
     m_TimeFactor = SimulatorSettingsN[SIM_TIME_FACTOR].value;
+    RotatorAngle = SimulatorSettingsN[SIM_ROTATION].value;
 
     uint32_t nbuf = PrimaryCCD.getXRes() * PrimaryCCD.getYRes() * PrimaryCCD.getBPP() / 8;
     PrimaryCCD.setFrameBufferSize(nbuf);
@@ -161,6 +162,7 @@ bool CCDSim::initProperties()
     IUFillNumber(&SimulatorSettingsN[SIM_PE_PERIOD], "SIM_PEPERIOD", "PE Period (minutes)", "%4.1f", 0, 60, 5, 0);
     IUFillNumber(&SimulatorSettingsN[SIM_PE_MAX], "SIM_PEMAX", "PE Max (arcsec)", "%4.1f", 0, 6000, 500, 0);
     IUFillNumber(&SimulatorSettingsN[SIM_TIME_FACTOR], "SIM_TIME_FACTOR", "Time Factor (x)", "%.2f", 0.01, 100, 10, 1);
+    IUFillNumber(&SimulatorSettingsN[SIM_ROTATION], "SIM_ROTATION", "CCD Rotation", "%.2f", 0, 360, 10, 0);
 
     IUFillNumberVector(&SimulatorSettingsNP, SimulatorSettingsN, SIM_N, getDeviceName(), "SIMULATOR_SETTINGS",
                        "Settings", SIMULATOR_TAB, IP_RW, 60, IPS_IDLE);

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -60,6 +60,7 @@ class CCDSim : public INDI::CCD, public INDI::FilterInterface
             SIM_PE_PERIOD,
             SIM_PE_MAX,
             SIM_TIME_FACTOR,
+            SIM_ROTATION,
             SIM_N
         };
 


### PR DESCRIPTION
To make testing https://invent.kde.org/education/kstars/-/issues/56 easier, add a manual rotation prop to the ccd simulator.