### PR TITLE
fix: inline methods that use unlinked functions

### DIFF
--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -122,9 +122,11 @@ Property::Property(IBLOBVectorProperty   *property)
 { }
 
 Property::~Property()
-{
+{ }
 
-}
+Property::Property(PropertyPrivate &dd)
+    : d_ptr(&dd)
+{ }
 
 void Property::setProperty(void *p)
 {

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -31,6 +31,36 @@ PropertyPrivate::PropertyPrivate(void *property, INDI_PROPERTY_TYPE type)
     , registered(property != nullptr)
 { }
 
+PropertyPrivate::PropertyPrivate(ITextVectorProperty *property)
+    : property(property)
+    , type(property ? INDI_TEXT : INDI_UNKNOWN)
+    , registered(property != nullptr)
+{ }
+
+PropertyPrivate::PropertyPrivate(INumberVectorProperty *property)
+    : property(property)
+    , type(property ? INDI_NUMBER : INDI_UNKNOWN)
+    , registered(property != nullptr)
+{ }
+
+PropertyPrivate::PropertyPrivate(ISwitchVectorProperty *property)
+    : property(property)
+    , type(property ? INDI_SWITCH : INDI_UNKNOWN)
+    , registered(property != nullptr)
+{ }
+
+PropertyPrivate::PropertyPrivate(ILightVectorProperty *property)
+    : property(property)
+    , type(property ? INDI_LIGHT : INDI_UNKNOWN)
+    , registered(property != nullptr)
+{ }
+
+PropertyPrivate::PropertyPrivate(IBLOBVectorProperty *property)
+    : property(property)
+    , type(property ? INDI_BLOB : INDI_UNKNOWN)
+    , registered(property != nullptr)
+{ }
+
 PropertyPrivate::~PropertyPrivate()
 {
     // Only delete properties if they were created dynamically via the buildSkeleton
@@ -102,23 +132,23 @@ Property::Property(void *property, INDI_PROPERTY_TYPE type)
 { }
 
 Property::Property(INumberVectorProperty *property)
-    : d_ptr(new PropertyPrivate(property, INDI_NUMBER))
+    : d_ptr(new PropertyPrivate(property))
 { }
 
 Property::Property(ITextVectorProperty   *property)
-    : d_ptr(new PropertyPrivate(property, INDI_TEXT))
+    : d_ptr(new PropertyPrivate(property))
 { }
 
 Property::Property(ISwitchVectorProperty *property)
-    : d_ptr(new PropertyPrivate(property, INDI_SWITCH))
+    : d_ptr(new PropertyPrivate(property))
 { }
 
 Property::Property(ILightVectorProperty  *property)
-    : d_ptr(new PropertyPrivate(property, INDI_LIGHT))
+    : d_ptr(new PropertyPrivate(property))
 { }
 
 Property::Property(IBLOBVectorProperty   *property)
-    : d_ptr(new PropertyPrivate(property, INDI_BLOB))
+    : d_ptr(new PropertyPrivate(property))
 { }
 
 Property::~Property()

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -17,25 +17,13 @@
 *******************************************************************************/
 
 #include "indiproperty.h"
+#include "indiproperty_p.h"
 
 #include <cstdlib>
 #include <cstring>
 
 namespace INDI
 {
-
-class PropertyPrivate
-{
-public:
-    void *property = nullptr;
-    BaseDevice *baseDevice = nullptr;
-    INDI_PROPERTY_TYPE type = INDI_UNKNOWN;
-    bool registered = false;
-    bool dynamic = false;
-
-    PropertyPrivate(void *property = nullptr, INDI_PROPERTY_TYPE type = INDI_UNKNOWN);
-    virtual ~PropertyPrivate();
-};
 
 PropertyPrivate::PropertyPrivate(void *property, INDI_PROPERTY_TYPE type)
     : property(property)
@@ -106,7 +94,7 @@ PropertyPrivate::~PropertyPrivate()
 }
 
 Property::Property()
-    : d_ptr(new PropertyPrivate())
+    : d_ptr(new PropertyPrivate(nullptr, INDI_UNKNOWN))
 { }
 
 Property::Property(void *property, INDI_PROPERTY_TYPE type)

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -20,31 +20,6 @@
 
 #include <cstdlib>
 #include <cstring>
-#include <cstdarg>
-
-extern "C" void indi_property_weak_function_throw(...)
-{
-    fprintf(stderr, "Unsupported function call. Please add indidriver to linker.\n");
-}
-
-#define WEAK_FUNCTION(FUNCTION) extern "C" FUNCTION __attribute__((weak, alias("indi_property_weak_function_throw")));
-
-WEAK_FUNCTION(void IUSaveConfigNumber(FILE *, const INumberVectorProperty *))
-WEAK_FUNCTION(void IUSaveConfigText(FILE *, const ITextVectorProperty *))
-WEAK_FUNCTION(void IUSaveConfigSwitch(FILE *, const ISwitchVectorProperty *))
-WEAK_FUNCTION(void IUSaveConfigBLOB(FILE *, const IBLOBVectorProperty *))
-
-WEAK_FUNCTION(void IDDefTextVA(const ITextVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDDefNumberVA(const INumberVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDDefSwitchVA(const ISwitchVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDDefLightVA(const ILightVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDDefBLOBVA(const IBLOBVectorProperty *, const char *, va_list))
-
-WEAK_FUNCTION(void IDSetTextVA(const ITextVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDSetNumberVA(const INumberVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDSetSwitchVA(const ISwitchVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDSetLightVA(const ILightVectorProperty *, const char *, va_list))
-WEAK_FUNCTION(void IDSetBLOBVA(const IBLOBVectorProperty *, const char *, va_list))
 
 namespace INDI
 {
@@ -225,18 +200,6 @@ BaseDevice *Property::getBaseDevice() const
     return d->baseDevice;
 }
 
-void Property::save(FILE *fp)
-{
-    switch (getType())
-    {
-        case INDI_NUMBER: IUSaveConfigNumber (fp, getNumber()); break;
-        case INDI_TEXT:   IUSaveConfigText   (fp, getText());   break;
-        case INDI_SWITCH: IUSaveConfigSwitch (fp, getSwitch()); break;
-        //case INDI_LIGHT:  IUSaveConfigLight  (fp, getLight());  break;
-        case INDI_BLOB:   IUSaveConfigBLOB   (fp, getBLOB());   break;
-        default:;;
-    }
-}
 
 void Property::setName(const char *name)
 {
@@ -491,38 +454,6 @@ IBLOBVectorProperty *Property::getBLOB() const
         return static_cast <IBLOBVectorProperty * > (d->property);
 
     return nullptr;
-}
-
-void Property::apply(const char *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    switch (getType())
-    {
-        case INDI_NUMBER: IDSetNumberVA(getNumber(), format, ap); break;
-        case INDI_TEXT:   IDSetTextVA(getText(),     format, ap); break;
-        case INDI_SWITCH: IDSetSwitchVA(getSwitch(), format, ap); break;
-        case INDI_LIGHT:  IDSetLightVA(getLight(),   format, ap); break;
-        case INDI_BLOB:   IDSetBLOBVA(getBLOB(),     format, ap); break;
-        default:;;
-    }
-    va_end(ap);
-}
-
-void Property::define(const char *format, ...)
-{
-    va_list ap;
-    va_start(ap, format);
-    switch (getType())
-    {
-        case INDI_NUMBER: IDDefNumberVA(getNumber(), format, ap); break;
-        case INDI_TEXT:   IDDefTextVA(getText(),     format, ap); break;
-        case INDI_SWITCH: IDDefSwitchVA(getSwitch(), format, ap); break;
-        case INDI_LIGHT:  IDDefLightVA(getLight(),   format, ap); break;
-        case INDI_BLOB:   IDDefBLOBVA(getBLOB(),     format, ap); break;
-        default:;;
-    }
-    va_end(ap);
 }
 
 }

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -99,6 +99,7 @@ public:
 
 protected:
     std::shared_ptr<PropertyPrivate> d_ptr;
+    Property(PropertyPrivate &dd);
 };
 
 

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -22,6 +22,9 @@
 #include "indiutility.h"
 #include <memory>
 
+#include <cstdarg>
+#include "indidriver.h"
+
 namespace INDI
 {
 class BaseDevice;
@@ -97,5 +100,51 @@ public:
 protected:
     std::shared_ptr<PropertyPrivate> d_ptr;
 };
+
+
+inline void Property::save(FILE *fp)
+{
+    switch (getType())
+    {
+        case INDI_NUMBER: IUSaveConfigNumber (fp, getNumber()); break;
+        case INDI_TEXT:   IUSaveConfigText   (fp, getText());   break;
+        case INDI_SWITCH: IUSaveConfigSwitch (fp, getSwitch()); break;
+        //case INDI_LIGHT:  IUSaveConfigLight  (fp, getLight());  break;
+        case INDI_BLOB:   IUSaveConfigBLOB   (fp, getBLOB());   break;
+        default:;;
+    }
+}
+
+inline void Property::apply(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    switch (getType())
+    {
+        case INDI_NUMBER: IDSetNumberVA(getNumber(), format, ap); break;
+        case INDI_TEXT:   IDSetTextVA(getText(),     format, ap); break;
+        case INDI_SWITCH: IDSetSwitchVA(getSwitch(), format, ap); break;
+        case INDI_LIGHT:  IDSetLightVA(getLight(),   format, ap); break;
+        case INDI_BLOB:   IDSetBLOBVA(getBLOB(),     format, ap); break;
+        default:;;
+    }
+    va_end(ap);
+}
+
+inline void Property::define(const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    switch (getType())
+    {
+        case INDI_NUMBER: IDDefNumberVA(getNumber(), format, ap); break;
+        case INDI_TEXT:   IDDefTextVA(getText(),     format, ap); break;
+        case INDI_SWITCH: IDDefSwitchVA(getSwitch(), format, ap); break;
+        case INDI_LIGHT:  IDDefLightVA(getLight(),   format, ap); break;
+        case INDI_BLOB:   IDDefBLOBVA(getBLOB(),     format, ap); break;
+        default:;;
+    }
+    va_end(ap);
+}
 
 } // namespace INDI

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -34,6 +34,12 @@ public:
     bool dynamic = false;
 
     PropertyPrivate(void *property, INDI_PROPERTY_TYPE type);
+    PropertyPrivate(ITextVectorProperty *property);
+    PropertyPrivate(INumberVectorProperty *property);
+    PropertyPrivate(ISwitchVectorProperty *property);
+    PropertyPrivate(ILightVectorProperty *property);
+    PropertyPrivate(IBLOBVectorProperty *property);
+
     virtual ~PropertyPrivate();
 };
 

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -1,0 +1,40 @@
+/*******************************************************************************
+  Copyright(c) 2011 Jasem Mutlaq. All rights reserved.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Library General Public
+ License version 2 as published by the Free Software Foundation.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Library General Public License for more details.
+
+ You should have received a copy of the GNU Library General Public License
+ along with this library; see the file COPYING.LIB.  If not, write to
+ the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ Boston, MA 02110-1301, USA.
+*******************************************************************************/
+
+#pragma once
+
+#include "indibase.h"
+
+namespace INDI
+{
+
+class BaseDevice;
+class PropertyPrivate
+{
+public:
+    void *property = nullptr;
+    BaseDevice *baseDevice = nullptr;
+    INDI_PROPERTY_TYPE type = INDI_UNKNOWN;
+    bool registered = false;
+    bool dynamic = false;
+
+    PropertyPrivate(void *property, INDI_PROPERTY_TYPE type);
+    virtual ~PropertyPrivate();
+};
+
+}


### PR DESCRIPTION
Is it possible to add automated tests for OS X?

I think I fixed the weak linking problem.
If the methods are not used (apply / define / save), there will be no reference to functions that are compiled only for drivers.

Additionally, I prepared the class for inheritance.
In some places, strongly typed, it is unnecessarily reduced to the INDI::Property type.
Later I will add another layer as template for IText/INumber/ISwitch/ILight/IBLOB that inherits from INDI::Property.


