### PR TITLE
Add snoop device to joystick controller

### DIFF
--- a/libs/indibase/indicontroller.h
+++ b/libs/indibase/indicontroller.h
@@ -152,6 +152,9 @@ class Controller
     ISwitchVectorProperty UseJoystickSP;
     ISwitch UseJoystickS[2];
 
+    ITextVectorProperty JoystickDeviceTP;
+    IText JoystickDeviceT[1] {};
+
     ITextVectorProperty JoystickSettingTP;
     IText *JoystickSettingT = nullptr;
 };


### PR DESCRIPTION
Adds the ability to change the device name of the Joystick for the Controller. This will allow other devices not named "Joystick" to be used as a joystick. Defaults to "Joystick" so it is not a breaking change.