### PR TITLE
Refactoring - Widget decorators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1918,6 +1918,9 @@ if (INDI_BUILD_DRIVERS OR INDI_BUILD_CLIENT OR INDI_BUILD_QT5_CLIENT)
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indifilterinterface.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indirotatorinterface.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyview.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiwidgetview.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiwidgettraits.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indiutility.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indistandardproperty.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indidome.h

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -61,6 +61,18 @@ PropertyPrivate::PropertyPrivate(IBLOBVectorProperty *property)
     , registered(property != nullptr)
 { }
 
+
+#define PROPERTY_CASE(CODE) \
+    switch (d->property != nullptr ? d->type : INDI_UNKNOWN) \
+    { \
+        case INDI_NUMBER: { auto property = static_cast<PropertyView<INumber> *>(d->property); CODE } break; \
+        case INDI_TEXT:   { auto property = static_cast<PropertyView<IText>   *>(d->property); CODE } break; \
+        case INDI_SWITCH: { auto property = static_cast<PropertyView<ISwitch> *>(d->property); CODE } break; \
+        case INDI_LIGHT:  { auto property = static_cast<PropertyView<ILight>  *>(d->property); CODE } break; \
+        case INDI_BLOB:   { auto property = static_cast<PropertyView<IBLOB>   *>(d->property); CODE } break; \
+        default:; \
+    }
+
 PropertyPrivate::~PropertyPrivate()
 {
     // Only delete properties if they were created dynamically via the buildSkeleton
@@ -68,59 +80,8 @@ PropertyPrivate::~PropertyPrivate()
     if (property == nullptr || !dynamic)
         return;
 
-    switch (type)
-    {
-        case INDI_NUMBER:
-        {
-            INumberVectorProperty *p = static_cast<INumberVectorProperty *>(property);
-            free(p->np);
-            delete p;
-            break;
-        }
-
-        case INDI_TEXT:
-        {
-            ITextVectorProperty *p = static_cast<ITextVectorProperty *>(property);
-            for (int i = 0; i < p->ntp; ++i)
-            {
-                free(p->tp[i].text);
-            }
-            free(p->tp);
-            delete p;
-            break;
-        }
-
-        case INDI_SWITCH:
-        {
-            ISwitchVectorProperty *p = static_cast<ISwitchVectorProperty *>(property);
-            free(p->sp);
-            delete p;
-            break;
-        }
-
-        case INDI_LIGHT:
-        {
-            ILightVectorProperty *p = static_cast<ILightVectorProperty *>(property);
-            free(p->lp);
-            delete p;
-            break;
-        }
-
-        case INDI_BLOB:
-        {
-            IBLOBVectorProperty *p = static_cast<IBLOBVectorProperty *>(property);
-            for (int i = 0; i < p->nbp; ++i)
-            {
-                free(p->bp[i].blob);
-            }
-            free(p->bp);
-            delete p;
-            break;
-        }
-
-        case INDI_UNKNOWN:
-            break;
-    }
+    auto d = this;
+    PROPERTY_CASE( delete property; )
 }
 
 Property::Property()
@@ -220,258 +181,144 @@ BaseDevice *Property::getBaseDevice() const
     return d->baseDevice;
 }
 
-
 void Property::setName(const char *name)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: strncpy(static_cast<INumberVectorProperty *>(d->property)->name, name, MAXINDINAME); break;
-        case INDI_TEXT:   strncpy(static_cast<ITextVectorProperty   *>(d->property)->name, name, MAXINDINAME); break;
-        case INDI_SWITCH: strncpy(static_cast<ISwitchVectorProperty *>(d->property)->name, name, MAXINDINAME); break;
-        case INDI_LIGHT:  strncpy(static_cast<ILightVectorProperty  *>(d->property)->name, name, MAXINDINAME); break;
-        case INDI_BLOB:   strncpy(static_cast<IBLOBVectorProperty   *>(d->property)->name, name, MAXINDINAME); break;
-        default:;
-    }
+    PROPERTY_CASE( property->setName(name); )
 }
 
 void Property::setLabel(const char *label)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: strncpy(static_cast<INumberVectorProperty *>(d->property)->label, label, MAXINDILABEL); break;
-        case INDI_TEXT:   strncpy(static_cast<ITextVectorProperty   *>(d->property)->label, label, MAXINDILABEL); break;
-        case INDI_SWITCH: strncpy(static_cast<ISwitchVectorProperty *>(d->property)->label, label, MAXINDILABEL); break;
-        case INDI_LIGHT:  strncpy(static_cast<ILightVectorProperty  *>(d->property)->label, label, MAXINDILABEL); break;
-        case INDI_BLOB:   strncpy(static_cast<IBLOBVectorProperty   *>(d->property)->label, label, MAXINDILABEL); break;
-        default:;
-    }
+    PROPERTY_CASE( property->setLabel(label); )
 }
 
 void Property::setGroupName(const char *group)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: strncpy(static_cast<INumberVectorProperty *>(d->property)->group, group, MAXINDIGROUP); break;
-        case INDI_TEXT:   strncpy(static_cast<ITextVectorProperty   *>(d->property)->group, group, MAXINDIGROUP); break;
-        case INDI_SWITCH: strncpy(static_cast<ISwitchVectorProperty *>(d->property)->group, group, MAXINDIGROUP); break;
-        case INDI_LIGHT:  strncpy(static_cast<ILightVectorProperty  *>(d->property)->group, group, MAXINDIGROUP); break;
-        case INDI_BLOB:   strncpy(static_cast<IBLOBVectorProperty   *>(d->property)->group, group, MAXINDIGROUP); break;
-        default:;
-    }
+    PROPERTY_CASE( property->setGroupName(group); )
 }
 
 void Property::setDeviceName(const char *device)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: strncpy(static_cast<INumberVectorProperty *>(d->property)->device, device, MAXINDIDEVICE); break;
-        case INDI_TEXT:   strncpy(static_cast<ITextVectorProperty   *>(d->property)->device, device, MAXINDIDEVICE); break;
-        case INDI_SWITCH: strncpy(static_cast<ISwitchVectorProperty *>(d->property)->device, device, MAXINDIDEVICE); break;
-        case INDI_LIGHT:  strncpy(static_cast<ILightVectorProperty  *>(d->property)->device, device, MAXINDIDEVICE); break;
-        case INDI_BLOB:   strncpy(static_cast<IBLOBVectorProperty   *>(d->property)->device, device, MAXINDIDEVICE); break;
-        default:;
-    }
+    PROPERTY_CASE( property->setDeviceName(device); )
 }
 
 void Property::setTimestamp(const char *timestamp)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: strncpy(static_cast<INumberVectorProperty *>(d->property)->timestamp, timestamp, MAXINDITSTAMP); break;
-        case INDI_TEXT:   strncpy(static_cast<ITextVectorProperty   *>(d->property)->timestamp, timestamp, MAXINDITSTAMP); break;
-        case INDI_SWITCH: strncpy(static_cast<ISwitchVectorProperty *>(d->property)->timestamp, timestamp, MAXINDITSTAMP); break;
-        case INDI_LIGHT:  strncpy(static_cast<ILightVectorProperty  *>(d->property)->timestamp, timestamp, MAXINDITSTAMP); break;
-        case INDI_BLOB:   strncpy(static_cast<IBLOBVectorProperty   *>(d->property)->timestamp, timestamp, MAXINDITSTAMP); break;
-        default:;
-    }
+    PROPERTY_CASE( property->setTimestamp(timestamp); )
 }
 
 void Property::setState(IPState state)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: static_cast<INumberVectorProperty *>(d->property)->s = state; break;
-        case INDI_TEXT:   static_cast<ITextVectorProperty   *>(d->property)->s = state; break;
-        case INDI_SWITCH: static_cast<ISwitchVectorProperty *>(d->property)->s = state; break;
-        case INDI_LIGHT:  static_cast<ILightVectorProperty  *>(d->property)->s = state; break;
-        case INDI_BLOB:   static_cast<IBLOBVectorProperty   *>(d->property)->s = state; break;
-        default:;
-    }
+    PROPERTY_CASE( property->setState(state); )
 }
 
 void Property::setPermission(IPerm permission)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: static_cast<INumberVectorProperty *>(d->property)->p = permission; break;
-        case INDI_TEXT:   static_cast<ITextVectorProperty   *>(d->property)->p = permission; break;
-        case INDI_SWITCH: static_cast<ISwitchVectorProperty *>(d->property)->p = permission; break;
-        //case INDI_LIGHT:  static_cast<ILightVectorProperty  *>(d->property)->p = permission; break;
-        case INDI_BLOB:   static_cast<IBLOBVectorProperty   *>(d->property)->p = permission; break;
-        default:;
-    }
+    PROPERTY_CASE( property->setPermission(permission); )
 }
 
 void Property::setTimeout(double timeout)
 {
     D_PTR(Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: static_cast<INumberVectorProperty *>(d->property)->timeout = timeout; break;
-        case INDI_TEXT:   static_cast<ITextVectorProperty   *>(d->property)->timeout = timeout; break;
-        case INDI_SWITCH: static_cast<ISwitchVectorProperty *>(d->property)->timeout = timeout; break;
-        //case INDI_LIGHT:  static_cast<ILightVectorProperty  *>(d->property)->timeout = timeout; break;
-        case INDI_BLOB:   static_cast<IBLOBVectorProperty   *>(d->property)->timeout = timeout; break;
-        default:;
-    }
+    PROPERTY_CASE( property->setTimeout(timeout); )
 }
 
 const char *Property::getName() const
 {
     D_PTR(const Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: return (static_cast<INumberVectorProperty *>(d->property)->name);
-        case INDI_TEXT:   return (static_cast<ITextVectorProperty   *>(d->property)->name);
-        case INDI_SWITCH: return (static_cast<ISwitchVectorProperty *>(d->property)->name);
-        case INDI_LIGHT:  return (static_cast<ILightVectorProperty  *>(d->property)->name);
-        case INDI_BLOB:   return (static_cast<IBLOBVectorProperty   *>(d->property)->name);
-        default: return nullptr;
-    }
+    PROPERTY_CASE( return property->getName(); )
+    return nullptr;
 }
 
 const char *Property::getLabel() const
 {
     D_PTR(const Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: return static_cast <INumberVectorProperty *>(d->property)->label;
-        case INDI_TEXT:   return static_cast <ITextVectorProperty   *>(d->property)->label;
-        case INDI_SWITCH: return static_cast <ISwitchVectorProperty *>(d->property)->label;
-        case INDI_LIGHT:  return static_cast <ILightVectorProperty  *>(d->property)->label;
-        case INDI_BLOB:   return static_cast <IBLOBVectorProperty   *>(d->property)->label;
-        default: return nullptr;
-    }
+    PROPERTY_CASE( return property->getLabel(); )
+    return nullptr;
 }
-
 
 const char *Property::getGroupName() const
 {
     D_PTR(const Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: return static_cast <INumberVectorProperty *>(d->property)->group;
-        case INDI_TEXT:   return static_cast <ITextVectorProperty   *>(d->property)->group;
-        case INDI_SWITCH: return static_cast <ISwitchVectorProperty *>(d->property)->group;
-        case INDI_LIGHT:  return static_cast <ILightVectorProperty  *>(d->property)->group;
-        case INDI_BLOB:   return static_cast <IBLOBVectorProperty   *>(d->property)->group;
-        default:          return nullptr;
-    }
+    PROPERTY_CASE( return property->getGroupName(); )
+    return nullptr;
 }
 
 const char *Property::getDeviceName() const
 {
     D_PTR(const Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: return static_cast <INumberVectorProperty *>(d->property)->device;
-        case INDI_TEXT:   return static_cast <ITextVectorProperty   *>(d->property)->device;
-        case INDI_SWITCH: return static_cast <ISwitchVectorProperty *>(d->property)->device;
-        case INDI_LIGHT:  return static_cast <ILightVectorProperty  *>(d->property)->device;
-        case INDI_BLOB:   return static_cast <IBLOBVectorProperty   *>(d->property)->device;
-        default:          return nullptr;
-    }
+    PROPERTY_CASE( return property->getDeviceName(); )
+    return nullptr;
 }
 
 const char *Property::getTimestamp() const
 {
     D_PTR(const Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: return static_cast <INumberVectorProperty *>(d->property)->timestamp;
-        case INDI_TEXT:   return static_cast <ITextVectorProperty   *>(d->property)->timestamp;
-        case INDI_SWITCH: return static_cast <ISwitchVectorProperty *>(d->property)->timestamp;
-        case INDI_LIGHT:  return static_cast <ILightVectorProperty  *>(d->property)->timestamp;
-        case INDI_BLOB:   return static_cast <IBLOBVectorProperty   *>(d->property)->timestamp;
-        default:          return nullptr;
-    }
+    PROPERTY_CASE( return property->getTimestamp(); )
+    return nullptr;
 }
 
 IPState Property::getState() const
 {
     D_PTR(const Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: return static_cast <INumberVectorProperty *>(d->property)->s;
-        case INDI_TEXT:   return static_cast <ITextVectorProperty   *>(d->property)->s;
-        case INDI_SWITCH: return static_cast <ISwitchVectorProperty *>(d->property)->s;
-        case INDI_LIGHT:  return static_cast <ILightVectorProperty  *>(d->property)->s;
-        case INDI_BLOB:   return static_cast <IBLOBVectorProperty   *>(d->property)->s;
-        default:          return IPS_ALERT;
-    }
+    PROPERTY_CASE( return property->getState(); )
+    return IPS_ALERT;
 }
 
 IPerm Property::getPermission() const
 {
     D_PTR(const Property);
-    switch (getType())
-    {
-        case INDI_NUMBER: return static_cast <INumberVectorProperty *>(d->property)->p;
-        case INDI_TEXT:   return static_cast <ITextVectorProperty   *>(d->property)->p;
-        case INDI_SWITCH: return static_cast <ISwitchVectorProperty *>(d->property)->p;
-        case INDI_BLOB:   return static_cast <IBLOBVectorProperty   *>(d->property)->p;
-        default:          return IP_RO;
-    }
+    PROPERTY_CASE( return property->getPermission(); )
+    return IP_RO;
 }
 
-INumberVectorProperty *Property::getNumber() const
+PropertyView<INumber> *Property::getNumber() const
 {
     D_PTR(const Property);
     if (d->type == INDI_NUMBER)
-        return static_cast <INumberVectorProperty * > (d->property);
+        return static_cast<PropertyView<INumber>*>(d->property);
 
     return nullptr;
 }
 
-ITextVectorProperty *Property::getText() const
+PropertyView<IText> *Property::getText() const
 {
     D_PTR(const Property);
     if (d->type == INDI_TEXT)
-        return static_cast <ITextVectorProperty * > (d->property);
+        return static_cast<PropertyView<IText>*>(d->property);
 
     return nullptr;
 }
 
-ILightVectorProperty *Property::getLight() const
+PropertyView<ILight> *Property::getLight() const
 {
     D_PTR(const Property);
     if (d->type == INDI_LIGHT)
-        return static_cast <ILightVectorProperty * > (d->property);
+        return static_cast<PropertyView<ILight>*>(d->property);
 
     return nullptr;
 }
 
-ISwitchVectorProperty *Property::getSwitch() const
+PropertyView<ISwitch> *Property::getSwitch() const
 {
     D_PTR(const Property);
     if (d->type == INDI_SWITCH)
-        return static_cast <ISwitchVectorProperty * > (d->property);
+        return static_cast<PropertyView<ISwitch>*>(d->property);
 
     return nullptr;
 }
 
-IBLOBVectorProperty *Property::getBLOB() const
+PropertyView<IBLOB> *Property::getBLOB() const
 {
     D_PTR(const Property);
     if (d->type == INDI_BLOB)
-        return static_cast <IBLOBVectorProperty * > (d->property);
+        return static_cast<PropertyView<IBLOB>*>(d->property);
 
     return nullptr;
 }

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -20,10 +20,14 @@
 
 #include "indibase.h"
 #include "indiutility.h"
-#include <memory>
 
-#include <cstdarg>
+#include "indipropertyview.h"
+
 #include "indidriver.h"
+
+#include <memory>
+#include <cstdarg>
+
 
 namespace INDI
 {
@@ -91,17 +95,16 @@ public:
     void define(const char *format = nullptr, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
 
 public:
-    INumberVectorProperty *getNumber() const;
-    ITextVectorProperty *getText() const;
-    ISwitchVectorProperty *getSwitch() const;
-    ILightVectorProperty *getLight() const;
-    IBLOBVectorProperty *getBLOB() const;
+    PropertyView<INumber> *getNumber() const;
+    PropertyView<IText>   *getText() const;
+    PropertyView<ISwitch> *getSwitch() const;
+    PropertyView<ILight>  *getLight() const;
+    PropertyView<IBLOB>   *getBLOB() const;
 
 protected:
     std::shared_ptr<PropertyPrivate> d_ptr;
     Property(PropertyPrivate &dd);
 };
-
 
 inline void Property::save(FILE *fp)
 {
@@ -116,6 +119,7 @@ inline void Property::save(FILE *fp)
     }
 }
 
+// TODO (move to server side)
 inline void Property::apply(const char *format, ...)
 {
     va_list ap;

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -1,0 +1,224 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indiapi.h"
+#include "indidevapi.h"
+#include "indiwidgettraits.h"
+
+#include "indiwidgetview.h"
+
+#include <string>
+#include <cstring>
+
+namespace INDI
+{
+
+/**
+ * \class INDI::PropertyView
+ * \brief Provides decorator for Low-Level INDI VectorProperty
+ */
+template <typename T>
+struct PropertyView: public WidgetTraits<T>::PropertyType
+{
+    using PropertyType = typename WidgetTraits<T>::PropertyType;
+    using WidgetType = WidgetView<T>;
+
+public:
+    PropertyView()                                  { memset(this, 0, sizeof(*this)); }
+    ~PropertyView()                                 { for(auto &p: *this) {p.clear();} free(widget()); }
+
+public: // setters
+    void setDeviceName(const char *name)            { strncpy(this->device, name, MAXINDIDEVICE); }
+    void setDeviceName(const std::string &name)     { setDeviceName(name.data()); }
+
+    void setName(const char *name)                  { strncpy(this->name, name, MAXINDINAME); }
+    void setName(const std::string &name)           { setName(name.data()); }
+
+    void setLabel(const char *label)                { strncpy(this->label, label, MAXINDILABEL); }
+    void setLabel(const std::string &label)         { setLabel(label.data()); }
+
+    void setGroupName(const char *name)             { strncpy(this->group, name, MAXINDIGROUP); }
+    void setGroupName(const std::string &name)      { setGroupName(name.data()); }
+
+    void setPermission(IPerm permission);
+    void setRule(ISRule rule);
+    bool setRule(const std::string &rule);
+
+    void setTimeout(double timeout);
+    void setState(IPState state)                    { this->s = state; }
+
+    void setTimestamp(const char *timestamp)        { strncpy(this->timestamp, timestamp, MAXINDITSTAMP); }
+    void setTimestamp(const std::string &timestamp) { setTimestamp(timestamp.data()); }
+
+    void setAux(void *user)                         { this->aux = user; }
+    void setWidgets(WidgetType *w, size_t count);
+
+public: //getters
+    const char *getDeviceName() const               { return this->device; }
+    const char *getName()       const               { return this->name; }
+    const char *getLabel()      const               { return this->label; }
+    const char *getGroupName()  const               { return this->group; }
+
+    IPerm getPermission()       const;
+    ISRule getRule()            const;
+    double getTimeout()         const;
+    IPState getState()          const               { return this->s; }
+
+    const char *getTimestamp()  const               { return this->timestamp; }
+    void *getAux()              const               { return this->aux; }
+
+    int count() const;
+    WidgetType *widget() const;
+
+public:
+    WidgetType *begin() const                       { return widget();           }
+    WidgetType *end()   const                       { return widget() + count(); }
+
+public:
+    void clear()
+    {
+        for(auto &p: *this) { p.clear(); }
+        free(widget());
+        memset(this, 0, sizeof(*this));
+    }
+
+};
+
+
+
+
+
+template <typename T>
+inline void PropertyView<T>::setTimeout(double timeout)
+{ this->timeout = timeout; }
+
+template <>
+inline void PropertyView<ILight>::setTimeout(double)
+{ }
+
+template <typename T>
+inline void PropertyView<T>::setPermission(IPerm permission)
+{ this->p = permission; }
+
+template <>
+inline void PropertyView<ILight>::setPermission(IPerm)
+{ }
+
+template <typename T>
+inline void PropertyView<T>::setRule(ISRule)
+{ }
+
+template <>
+inline void PropertyView<ISwitch>::setRule(ISRule rule)
+{ this->r = rule; }
+
+template <typename T>
+inline bool PropertyView<T>::setRule(const std::string &)
+{ return false; }
+
+template <>
+inline bool PropertyView<ISwitch>::setRule(const std::string &rule)
+{ return crackISRule(rule.data(), &this->r) == 0; }
+
+template <typename T>
+inline IPerm PropertyView<T>::getPermission() const
+{ return this->p; }
+
+template <>
+inline IPerm PropertyView<ILight>::getPermission() const
+{ return IP_RO; }
+
+template <typename T>
+inline ISRule PropertyView<T>::getRule() const
+{ return ISR_NOFMANY; }
+
+template <>
+inline ISRule PropertyView<ISwitch>::getRule() const
+{ return this->r; }
+
+template <typename T>
+inline double PropertyView<T>::getTimeout() const
+{ return this->timeout; }
+
+template <>
+inline double PropertyView<ILight>::getTimeout() const
+{ return 0; }
+
+template <>
+inline void PropertyView<IText>::setWidgets(WidgetType *w, size_t size)
+{ this->tp = w; this->ntp = size; }
+
+template <>
+inline void PropertyView<INumber>::setWidgets(WidgetType *w, size_t size)
+{ this->np = w; this->nnp = size; }
+
+template <>
+inline void PropertyView<ISwitch>::setWidgets(WidgetType *w, size_t size)
+{ this->sp = w; this->nsp = size; }
+
+template <>
+inline void PropertyView<ILight>::setWidgets(WidgetType *w, size_t size)
+{ this->lp = w; this->nlp = size; }
+
+template <>
+inline void PropertyView<IBLOB>::setWidgets(WidgetType *w, size_t size)
+{ this->bp = w; this->nbp = size; }
+
+template <>
+inline int PropertyView<IText>::count() const
+{ return this->ntp; }
+
+template <>
+inline int PropertyView<INumber>::count() const
+{ return this->nnp; }
+
+template <>
+inline int PropertyView<ISwitch>::count() const
+{ return this->nsp; }
+
+template <>
+inline int PropertyView<ILight>::count() const
+{ return this->nlp; }
+
+template <>
+inline int PropertyView<IBLOB>::count() const
+{ return this->nbp; }
+
+template <>
+inline PropertyView<IText>::WidgetType *PropertyView<IText>::widget() const
+{ return static_cast<WidgetType*>(this->tp); }
+
+template <>
+inline PropertyView<INumber>::WidgetType *PropertyView<INumber>::widget() const
+{ return static_cast<WidgetType*>(this->np); }
+
+template <>
+inline PropertyView<ISwitch>::WidgetType *PropertyView<ISwitch>::widget() const
+{ return static_cast<WidgetType*>(this->sp); }
+
+template <>
+inline PropertyView<ILight>::WidgetType *PropertyView<ILight>::widget() const
+{ return static_cast<WidgetType*>(this->lp); }
+
+template <>
+inline PropertyView<IBLOB>::WidgetType *PropertyView<IBLOB>::widget() const
+{ return static_cast<WidgetType*>(this->bp); }
+
+}

--- a/libs/indibase/property/indiwidgettraits.h
+++ b/libs/indibase/property/indiwidgettraits.h
@@ -1,0 +1,85 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indiapi.h"
+
+namespace INDI
+{
+
+template <typename>
+struct WidgetTraits;
+
+template<> struct WidgetTraits<IText>  
+{
+    using PropertyType = ITextVectorProperty;
+    struct UpdateArgs
+    {
+        char **texts;
+        char **names;
+        int n;
+    };
+};
+
+template<> struct WidgetTraits<INumber>
+{
+    using PropertyType = INumberVectorProperty;
+    struct UpdateArgs
+    {
+        double *values;
+        char **names;
+        int n;
+    };
+};
+
+template<> struct WidgetTraits<ISwitch>
+{
+    using PropertyType = ISwitchVectorProperty;
+    struct UpdateArgs
+    {
+        ISState *states;
+        char **names;
+        int n;
+    };
+};
+
+template<> struct WidgetTraits<ILight> 
+{
+    using PropertyType = ILightVectorProperty;
+    struct UpdateArgs
+    {
+
+    };
+};
+
+template<> struct WidgetTraits<IBLOB>  
+{
+    using PropertyType = IBLOBVectorProperty;
+    struct UpdateArgs
+    {
+        int *sizes;
+        int *blobsizes;
+        char **blobs;
+        char **formats;
+        char **names;
+        int n;
+    };
+};
+
+}

--- a/libs/indibase/property/indiwidgetview.h
+++ b/libs/indibase/property/indiwidgetview.h
@@ -1,0 +1,218 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indiapi.h"
+#include "indidevapi.h"
+#include "indiwidgettraits.h"
+
+#include <string>
+#include <cstring>
+
+namespace INDI
+{
+
+/**
+ * \class INDI::WidgetView
+ * \brief Provides decorator for Low-Level INDI widgets
+ */
+template <typename>
+struct WidgetView;
+
+template <>
+struct WidgetView<IText>: public IText
+{
+    using Type = IText;
+
+public:
+    WidgetView()                                  { memset(this, 0, sizeof(*this)); }
+    ~WidgetView()                                 { free(this->text); }
+    void clear()                                  { free(this->text); memset(this, 0, sizeof(*this)); }
+
+public: // setters
+    void setParent(ITextVectorProperty *parent)   { this->tvp = parent; }
+
+    void setName(const char *name)                { strncpy(this->name, name, MAXINDINAME); }
+    void setName(const std::string &name)         { setName(name.data()); }
+
+    void setLabel(const char *label)              { strncpy(this->label, label, MAXINDILABEL); }
+    void setLabel(const std::string &label)       { setLabel(label.data()); }
+
+    void setText(const char *text)                { free(this->text); this->text = strndup(text, strlen(text)); }
+    void setText(const std::string &text)         { setText(text.data()); }
+
+    void setAux(void *user)                       { this->aux0 = user; }
+    // don't use any other aux!
+
+public: //getters
+    const char *getName()  const                  { return this->name; }
+    const char *getLabel() const                  { return this->label; }
+    const char *getText()  const                  { return this->text; }
+
+    void *getAux() const                          { return this->aux0; }
+};
+
+template <>
+struct WidgetView<INumber>: public INumber
+{
+    using Type = INumber;
+
+public:
+    WidgetView()                                  { memset(this, 0, sizeof(*this)); }
+    ~WidgetView()                                 { }
+    void clear()                                  { memset(this, 0, sizeof(*this)); }
+
+public: // setters
+    void setParent(INumberVectorProperty *parent) { this->nvp = parent; }
+
+    void setName(const char *name)                { strncpy(this->name, name, MAXINDINAME); }
+    void setName(const std::string &name)         { setName(name.data()); }
+
+    void setLabel(const char *label)              { strncpy(this->label, label, MAXINDILABEL); }
+    void setLabel(const std::string &label)       { setLabel(label.data()); }
+
+    void setFormat(const char *format)            { strncpy(this->format, format, MAXINDIFORMAT); }
+    void setFormat(const std::string &format)     { setLabel(format.data()); }
+
+    void setMin(double min)                       { this->min = min; }
+    void setMax(double max)                       { this->max = max; }
+    void setStep(double step)                     { this->step = step; }
+    void setValue(double value)                   { this->value = value; }
+
+    void setAux(void *user)                       { this->aux0 = user; }
+    // don't use any other aux!
+
+public: //getters
+    const char *getName()   const                 { return this->name; }
+    const char *getLabel()  const                 { return this->label; }
+    const char *getFormat() const                 { return this->format; }
+
+    double getMin()   const                       { return this->min; }
+    double getMax()   const                       { return this->max; }
+    double getStep()  const                       { return this->step; }
+    double getValue() const                       { return this->value; }
+
+    void *getAux() const                          { return this->aux0; }
+};
+
+template <>
+struct WidgetView<ISwitch>: public ISwitch
+{
+    using Type = ISwitch;
+
+public:
+    WidgetView()                                  { memset(this, 0, sizeof(*this)); }
+    ~WidgetView()                                 { }
+    void clear()                                  { memset(this, 0, sizeof(*this)); }
+
+public: // setters
+    void setParent(ISwitchVectorProperty *parent) { this->svp = parent; }
+
+    void setName(const char *name)                { strncpy(this->name, name, MAXINDINAME); }
+    void setName(const std::string &name)         { setName(name.data()); }
+
+    void setLabel(const char *label)              { strncpy(this->label, label, MAXINDILABEL); }
+    void setLabel(const std::string &label)       { setLabel(label.data()); }
+
+    void setState(const ISState &state)           { this->s = state; }
+    bool setState(const std::string &state)       { return crackISState(state.data(), &this->s) == 0; }
+
+    void setAux(void *user)                       { this->aux = user; }
+    // don't use any other aux!
+
+public: //getters
+    const char *getName()   const                 { return this->name; }
+    const char *getLabel()  const                 { return this->label; }
+
+    ISState getState() const                      { return this->s; }
+
+    void *getAux() const                          { return this->aux; }
+};
+
+template <>
+struct WidgetView<ILight>: public ILight
+{
+    using Type = ILight;
+
+public:
+    WidgetView()                                  { memset(this, 0, sizeof(*this)); }
+    ~WidgetView()                                 { }
+    void clear()                                  { memset(this, 0, sizeof(*this)); }
+
+public: // setters
+    void setParent(ILightVectorProperty *parent)  { this->lvp = parent; }
+
+    void setName(const char *name)                { strncpy(this->name, name, MAXINDINAME); }
+    void setName(const std::string &name)         { setName(name.data()); }
+
+    void setLabel(const char *label)              { strncpy(this->label, label, MAXINDILABEL); }
+    void setLabel(const std::string &label)       { setLabel(label.data()); }
+
+    void setState(const IPState &state)           { this->s = state; }
+    bool setState(const std::string &state)       { return crackIPState(state.data(), &this->s) == 0; }
+
+    void setAux(void *user)                       { this->aux = user; }
+    // don't use any other aux!
+
+public: //getters
+    const char *getName()   const                 { return this->name; }
+    const char *getLabel()  const                 { return this->label; }
+
+    IPState getState() const                      { return this->s; }
+
+    void *getAux() const                          { return this->aux; }
+};
+
+template <>
+struct WidgetView<IBLOB>: public IBLOB
+{
+    using Type = IBLOB;
+
+public:
+    WidgetView()                                  { memset(this, 0, sizeof(*this)); }
+    ~WidgetView()                                 { free(this->blob); }
+    void clear()                                  { free(this->blob); memset(this, 0, sizeof(*this)); }
+
+public: // setters
+    void setParent(IBLOBVectorProperty *parent)   { this->bvp = parent; }
+
+    void setName(const char *name)                { strncpy(this->name, name, MAXINDINAME); }
+    void setName(const std::string &name)         { setName(name.data()); }
+
+    void setLabel(const char *label)              { strncpy(this->label, label, MAXINDILABEL); }
+    void setLabel(const std::string &label)       { setLabel(label.data()); }
+
+    void setFormat(const char *format)            { strncpy(this->format, format, MAXINDIBLOBFMT); }
+    void setFormat(const std::string &format)     { setLabel(format.data()); }
+
+    // TODO
+    //void setBlob(...);
+    
+    void setAux(void *user)                       { this->aux0 = user; }
+    // don't use any other aux!
+
+public: //getters
+    const char *getName()   const                 { return this->name; }
+    const char *getLabel()  const                 { return this->label; }
+    const char *getFormat() const                 { return this->format; }
+
+    void *getAux() const                          { return this->aux0; }
+};
+
+}


### PR DESCRIPTION
I have decided to split my work as milestones that will be extended.

This pull request includes the creation of decorators for existing IXXXVectorProperty/IXXX structures.

Additionally, I used "#define" for switch-case to avoid confusion when referencing structure fields.

Decorators, hereinafter called views, will enable implementation in C++ in the future.
Decorators to help get rid of direct calls to low-level functions.
Structures from indiapi.h can be projected onto decorators at any time for easy manipulation.
Everything about a given "Widget" in one place.

These classes will be the basis for the further implementation of Qt-Like widgets.
