### PR TITLE
Tracking can now be switched on/off

### DIFF
--- a/drivers/telescope/synscandriver.cpp
+++ b/drivers/telescope/synscandriver.cpp
@@ -383,7 +383,7 @@ bool SynscanDriver::readTracking()
         m_TrackingFlag = res[0];
 
         // Track mode?
-        if ((m_TrackingFlag - 1) != IUFindOnSwitchIndex(&TrackModeSP))
+        if (((m_TrackingFlag - 1) != IUFindOnSwitchIndex(&TrackModeSP)) && (m_TrackingFlag))
         {
             IUResetSwitch(&TrackModeSP);
             TrackModeS[m_TrackingFlag - 1].s = ISS_ON;


### PR DESCRIPTION
Track mode was read from the properties and send as the track mode to be used to the handset, however since the track mode was periodically read from the handset and updated in the properties. If tracking was off, then the property was always off too ... which prevented tracking to be switched on.

Now the mode is only updated from the handset if we are not already tracking and the track mode has changed.