### PR TITLE
fix: add null pointer check to serial connect

### DIFF
--- a/libs/indibase/connectionplugins/connectionserial.cpp
+++ b/libs/indibase/connectionplugins/connectionserial.cpp
@@ -176,12 +176,16 @@ bool Serial::Connect()
 
     // If if the user port is one of the detected system ports.
     bool isSystemPort = false;
-    for (int i = 0; i < SystemPortSP.nsp; i++)
+
+    if (SystemPortS != nullptr)
     {
-        if (!strcmp(PortT[0].text, SystemPortS[i].name))
+        for (int i = 0; i < SystemPortSP.nsp; i++)
         {
-            isSystemPort = true;
-            break;
+            if (!strcmp(PortT[0].text, SystemPortS[i].name))
+            {
+                isSystemPort = true;
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Fix a SEGFAULT when there are no system ports defined.