### PR TITLE
Avoid DDW communication watchdog

### DIFF
--- a/drivers/dome/ddw_dome.cpp
+++ b/drivers/dome/ddw_dome.cpp
@@ -334,10 +334,17 @@ void DDW::TimerHit()
         int rc = tty_read(PortFD, response, 1, 0, &nr);
         if (rc != TTY_OK || nr != 1)
         {
-            // All read
+            // Nothing more to read
+            if (++watchdog * getCurrentPollingPeriod() > 60 * 1000)
+            {
+                // If we haven't heard from the controller for 60s, send GINF command to keep DDW watchdog from triggering
+                writeCmd("GINF");
+                watchdog = 0; // prevent from triggering immediately again
+            }
             break;
         }
 
+        watchdog = 0;
         switch (response[0])
         {
             case 'L':

--- a/drivers/dome/ddw_dome.h
+++ b/drivers/dome/ddw_dome.h
@@ -76,6 +76,7 @@ class DDW : public INDI::Dome
 
         int ticksPerRev { 100 };
         double homeAz { 0 };
+        int watchdog { 0 };
 
         int fwVersion{ -1 };
 


### PR DESCRIPTION
Poll DDW controller status every 60s if there is no other traffic to keep communication watchdog from triggering and parking the dome. In reference to https://www.indilib.org/forum/general/447-digital-dome-works-does-this-work.html?start=48#66806