### PR TITLE
Updates to DDW driver

### DIFF
--- a/drivers/dome/ddw_dome.h
+++ b/drivers/dome/ddw_dome.h
@@ -80,6 +80,9 @@ class DDW : public INDI::Dome
 
         int fwVersion{ -1 };
 
+        double gotoTarget { 0 };
+        bool gotoPending { false };
+
         enum
         {
             IDLE,


### PR DESCRIPTION
- restrict to serial connection as the controller only support that to avoid confusion
- if dome is currently moving when a new command to move arrives (from slaving or similar), latch the command and issue the goto after current one completes
- the state of DomeAbsPosNP was set to IPS_OK too early in a few places causing client to think move is over, corrected those so the state stays IPS_BUSY correctly until the move is actually finished