### PR TITLE
DDW shutter state fix

### DIFF
--- a/drivers/dome/ddw_dome.cpp
+++ b/drivers/dome/ddw_dome.cpp
@@ -301,17 +301,24 @@ void DDW::parseGINF(const char *response)
 
         DomeAbsPosN[0].value = 360.0 * azimuth / ticksPerRev;
 
+        ShutterState newState;
         switch (shutter)
         {
             case 1:
-                setShutterState(SHUTTER_CLOSED);
+                newState = SHUTTER_CLOSED;
                 break;
             case 2:
-                setShutterState(SHUTTER_OPENED);
+                newState = SHUTTER_OPENED;
                 break;
             default:
-                setShutterState(SHUTTER_UNKNOWN);
+                newState = SHUTTER_UNKNOWN;
                 break;
+        }
+
+        // Only send if changed to avoid spam
+        if (getShutterState() != newState)
+        {
+            setShutterState(newState);
         }
     }
 }


### PR DESCRIPTION
Avoid spamming shutter state updates if the state hasn't changed.

At first looked like there was some issue with the shutter status value, but it seems to have been just a testing issue that the user didn't open the shutter fully so it reported as indeterminate.