### PR TITLE
Refactoring - Typed property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,12 @@ SET(indiclient_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclient.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyswitch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertylight.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyblob.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyview_client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indistandardproperty.cpp)
 
@@ -240,6 +246,12 @@ SET(indiclientqt_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclientqt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyswitch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertylight.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyblob.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyview_client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indistandardproperty.cpp)
 IF (UNITY_BUILD)
@@ -405,6 +417,12 @@ SET(indidriver_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/defaultdevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyswitch.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertylight.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyblob.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyview_driver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indiutility.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indiccd.cpp
@@ -1932,6 +1950,12 @@ if (INDI_BUILD_DRIVERS OR INDI_BUILD_CLIENT OR INDI_BUILD_QT5_CLIENT)
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indifilterinterface.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indirotatorinterface.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyswitch.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertylight.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyblob.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertyview.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiwidgetview.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiwidgettraits.h

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -891,6 +891,24 @@ void BaseDevice::registerProperty(void *p, INDI_PROPERTY_TYPE type)
     }
 }
 
+void BaseDevice::registerProperty(INDI::Property &property)
+{
+    D_PTR(BaseDevice);
+
+    if (property.getType() == INDI_UNKNOWN)
+        return;
+
+    INDI::Property *pContainer = getProperty(property.getName(), property.getType());
+
+    if (pContainer != nullptr)
+        pContainer->setRegistered(true);
+    else
+    {
+        std::lock_guard<std::mutex> lock(d->m_Lock);
+        d->pAll.push_back(new INDI::Property(property));
+    }
+}
+
 const char *BaseDevice::getDriverName() const
 {
     ITextVectorProperty *driverInfo = getText("DRIVER_INFO");

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -128,6 +128,8 @@ public:
     void registerProperty(INDI::PropertyView<ILight> *property);
     void registerProperty(INDI::PropertyView<IBLOB> *property);
 
+    void registerProperty(INDI::Property &property);
+
     /** \brief Remove a property
      *  \param name name of property to be removed. Pass NULL to remove the whole device.
      *  \param errmsg buffer to store error message.

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -188,6 +188,7 @@ public:
     void defineBLOB(IBLOBVectorProperty *bvp) __attribute__((deprecated));
     void defineProperty(IBLOBVectorProperty *property);
 
+    void defineProperty(INDI::Property &property);
     /**
      * \brief Delete a property and unregister it. It will also be deleted from all clients.
      * \param propertyName name of property to be deleted.

--- a/libs/indibase/defaultdevice_p.h
+++ b/libs/indibase/defaultdevice_p.h
@@ -23,6 +23,10 @@
 
 #include <cstring>
 
+#include "indipropertyswitch.h"
+#include "indipropertynumber.h"
+#include "indipropertytext.h"
+
 namespace INDI
 {
 class DefaultDevicePrivate: public BaseDevicePrivate
@@ -41,24 +45,13 @@ public:
     uint16_t minorVersion { 0 };
     uint16_t interfaceDescriptor { 0 };
 
-    WidgetView<ISwitch> DebugS[2];
-    WidgetView<ISwitch> SimulationS[2];
-    WidgetView<ISwitch> ConfigProcessS[4];
-    WidgetView<ISwitch> ConnectionS[2];
-    WidgetView<INumber> PollPeriodN[1];
-
-    PropertyView<ISwitch> DebugSP;
-    PropertyView<ISwitch> SimulationSP;
-    PropertyView<ISwitch> ConfigProcessSP;
-    PropertyView<ISwitch> ConnectionSP;
-    PropertyView<INumber> PollPeriodNP;
-
-    WidgetView<IText> DriverInfoT[4] {};
-    PropertyView<IText> DriverInfoTP;
-
-    // Connection modes
-    WidgetView<ISwitch> *ConnectionModeS = nullptr;
-    PropertyView<ISwitch> ConnectionModeSP;
+    PropertySwitch SimulationSP     { 2 };
+    PropertySwitch DebugSP          { 2 };
+    PropertySwitch ConfigProcessSP  { 4 };
+    PropertySwitch ConnectionSP     { 2 };
+    PropertyNumber PollPeriodNP     { 1 };
+    PropertyText   DriverInfoTP     { 4 };
+    PropertySwitch ConnectionModeSP { 0 }; // dynamic count of switches
 
     std::vector<Connection::Interface *> connections;
     Connection::Interface *activeConnection = nullptr;

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -323,24 +323,24 @@ PropertyView<IBLOB> *Property::getBLOB() const
     return nullptr;
 }
 
-void Property::save(FILE *fp)
+void Property::save(FILE *fp) const
 {
-    D_PTR(Property);
+    D_PTR(const Property);
     PROPERTY_CASE( property->save(fp); )
 }
 
-void Property::apply(const char *format, ...)
+void Property::apply(const char *format, ...) const
 {
-    D_PTR(Property);
+    D_PTR(const Property);
     va_list ap;
     va_start(ap, format);
     PROPERTY_CASE( property->vapply(format, ap); )
     va_end(ap);
 }
 
-void Property::define(const char *format, ...)
+void Property::define(const char *format, ...) const
 {
-    D_PTR(Property);
+    D_PTR(const Property);
     va_list ap;
     va_start(ap, format);
     PROPERTY_CASE( property->vdefine(format, ap); )

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -278,6 +278,41 @@ IPerm Property::getPermission() const
     return IP_RO;
 }
 
+bool Property::isEmpty() const
+{
+    D_PTR(const Property);
+    PROPERTY_CASE( return property->isEmpty(); )
+    return true;
+}
+
+bool Property::isNameMatch(const char *otherName) const
+{
+    D_PTR(const Property);
+    PROPERTY_CASE( return property->isNameMatch(otherName); )
+    return false;
+}
+
+bool Property::isNameMatch(const std::string &otherName) const
+{
+    D_PTR(const Property);
+    PROPERTY_CASE( return property->isNameMatch(otherName); )
+    return false;
+}
+
+bool Property::isLabelMatch(const char *otherLabel) const
+{
+    D_PTR(const Property);
+    PROPERTY_CASE( return property->isLabelMatch(otherLabel); )
+    return false;
+}
+
+bool Property::isLabelMatch(const std::string &otherLabel) const
+{
+    D_PTR(const Property);
+    PROPERTY_CASE( return property->isLabelMatch(otherLabel); )
+    return false;
+}
+
 PropertyView<INumber> *Property::getNumber() const
 {
     D_PTR(const Property);

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -88,14 +88,14 @@ public: // Convenience Functions
     IPerm getPermission() const;
 
 public:
-    void save(FILE *fp);
+    void save(FILE *fp) const;
 
 public:
-    void apply(const char *format, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
-    void define(const char *format, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);
+    void apply(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
+    void define(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
 
-    void apply()  { apply(nullptr);  }
-    void define() { define(nullptr); }
+    void apply() const  { apply(nullptr);  }
+    void define() const { define(nullptr); }
 
 public:
     INDI::PropertyView<INumber> *getNumber() const;

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -88,6 +88,15 @@ public: // Convenience Functions
     IPerm getPermission() const;
 
 public:
+    bool isEmpty() const;
+
+    bool isNameMatch(const char *otherName) const;
+    bool isNameMatch(const std::string &otherName) const;
+
+    bool isLabelMatch(const char *otherLabel) const;
+    bool isLabelMatch(const std::string &otherLabel) const;
+
+public:
     void save(FILE *fp) const;
 
 public:

--- a/libs/indibase/property/indipropertybasic.cpp
+++ b/libs/indibase/property/indipropertybasic.cpp
@@ -1,0 +1,313 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "indipropertybasic.h"
+#include "indipropertybasic_p.h"
+
+namespace INDI
+{
+
+template <typename T>
+PropertyBasicPrivateTemplate<T>::PropertyBasicPrivateTemplate(size_t count)
+    : PropertyPrivate(&property)
+    , widgets(count)
+{
+    property.setWidgets(widgets.data(), widgets.size());
+}
+
+template <typename T>
+PropertyBasicPrivateTemplate<T>::~PropertyBasicPrivateTemplate()
+{ }
+
+template <typename T>
+PropertyBasic<T>::~PropertyBasic()
+{ }
+
+template <typename T>
+PropertyBasic<T>::PropertyBasic(PropertyBasicPrivate &dd)
+    : Property(dd)
+{ }
+
+template <typename T>
+void PropertyBasic<T>::setName(const char *name)
+{
+    D_PTR(PropertyBasic);
+    d->property.setName(name);
+}
+
+template <typename T>
+void PropertyBasic<T>::setName(const std::string &name)
+{
+    D_PTR(PropertyBasic);
+    d->property.setName(name);
+}
+
+template <typename T>
+void PropertyBasic<T>::setLabel(const char *label)
+{
+    D_PTR(PropertyBasic);
+    d->property.setLabel(label);
+}
+
+template <typename T>
+void PropertyBasic<T>::setLabel(const std::string &label)
+{
+    D_PTR(PropertyBasic);
+    d->property.setLabel(label);
+}
+
+template <typename T>
+void PropertyBasic<T>::setGroupName(const char *name)
+{
+    D_PTR(PropertyBasic);
+    d->property.setGroupName(name);
+}
+
+template <typename T>
+void PropertyBasic<T>::setGroupName(const std::string &name)
+{
+    D_PTR(PropertyBasic);
+    d->property.setGroupName(name);
+}
+
+template <typename T>
+void PropertyBasic<T>::setPermission(IPerm permission)
+{
+    D_PTR(PropertyBasic);
+    d->property.setPermission(permission);
+}
+
+template <typename T>
+void PropertyBasic<T>::setTimeout(double timeout)
+{
+    D_PTR(PropertyBasic);
+    d->property.setTimeout(timeout);
+}
+
+template <typename T>
+void PropertyBasic<T>::setState(IPState state)
+{
+    D_PTR(PropertyBasic);
+    d->property.setState(state);
+}
+
+template <typename T>
+void PropertyBasic<T>::setTimestamp(const char *timestamp)
+{
+    D_PTR(PropertyBasic);
+    d->property.setTimestamp(timestamp);
+}
+
+template <typename T>
+void PropertyBasic<T>::setTimestamp(const std::string &timestamp)
+{
+    D_PTR(PropertyBasic);
+    d->property.setTimestamp(timestamp);
+}
+
+template <typename T>
+const char *PropertyBasic<T>::getName() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getName();
+}
+
+template <typename T>
+const char *PropertyBasic<T>::getLabel() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getLabel();
+}
+
+template <typename T>
+const char *PropertyBasic<T>::getGroupName() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getGroupName();
+}
+
+template <typename T>
+IPerm PropertyBasic<T>::getPermission() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getPermission();
+}
+
+template <typename T>
+const char *PropertyBasic<T>::getPermissionAsString() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getPermissionAsString();
+}
+
+template <typename T>
+double PropertyBasic<T>::getTimeout() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getTimeout();
+}
+
+template <typename T>
+IPState PropertyBasic<T>::getState() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getState();
+}
+
+template <typename T>
+const char *PropertyBasic<T>::getStateAsString() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getStateAsString();
+}
+
+template <typename T>
+const char *PropertyBasic<T>::getTimestamp() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.getTimestamp();
+}
+
+template <typename T>
+bool PropertyBasic<T>::isEmpty() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.isEmpty();
+}
+
+template <typename T>
+bool PropertyBasic<T>::isNameMatch(const char *otherName) const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.isNameMatch(otherName);
+}
+
+template <typename T>
+bool PropertyBasic<T>::isNameMatch(const std::string &otherName) const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.isNameMatch(otherName);
+}
+
+template <typename T>
+bool PropertyBasic<T>::isLabelMatch(const char *otherLabel) const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.isLabelMatch(otherLabel);
+}
+
+template <typename T>
+bool PropertyBasic<T>::isLabelMatch(const std::string &otherLabel) const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.isLabelMatch(otherLabel);
+}
+
+template <typename T>
+void PropertyBasic<T>::save(FILE *f) const
+{
+    D_PTR(const PropertyBasic);
+    d->property.save(f);
+}
+
+template <typename T>
+void PropertyBasic<T>::vapply(const char *format, va_list args) const
+{
+    D_PTR(const PropertyBasic);
+    d->property.vapply(format, args);
+}
+
+template <typename T>
+void PropertyBasic<T>::vdefine(const char *format, va_list args) const
+{
+    D_PTR(const PropertyBasic);
+    d->property.vdefine(format, args);
+}
+
+template <typename T>
+void PropertyBasic<T>::apply(const char *format, ...) const
+{
+    D_PTR(const PropertyBasic);
+    va_list ap;
+    va_start(ap, format);
+    d->property.vapply(format, ap);
+    va_end(ap);
+}
+
+template <typename T>
+void PropertyBasic<T>::define(const char *format, ...) const
+{
+    D_PTR(const PropertyBasic);
+    va_list ap;
+    va_start(ap, format);
+    d->property.vdefine(format, ap);
+    va_end(ap);
+}
+
+template <typename T>
+void PropertyBasic<T>::apply() const
+{
+    D_PTR(const PropertyBasic);
+    d->property.apply();
+}
+
+template <typename T>
+void PropertyBasic<T>::define() const
+{
+    D_PTR(const PropertyBasic);
+    d->property.define();
+}
+
+template <typename T>
+WidgetView<T> *PropertyBasic<T>::findWidgetByName(const char *name)
+{
+    D_PTR(PropertyBasic);
+    return d->property.findWidgetByName(name);
+}
+
+
+template <typename T>
+void PropertyBasic<T>::resize(size_t size)
+{
+    D_PTR(PropertyBasic);
+    d->widgets.resize(size);
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());
+
+}
+
+template <typename T>
+WidgetView<T> &PropertyBasic<T>::operator[](size_t index) const
+{
+    D_PTR(const PropertyBasic);
+    return *d->property.at(index);
+}
+
+
+template class PropertyBasicPrivateTemplate<IText>;
+template class PropertyBasicPrivateTemplate<INumber>;
+template class PropertyBasicPrivateTemplate<ISwitch>;
+template class PropertyBasicPrivateTemplate<ILight>;
+template class PropertyBasicPrivateTemplate<IBLOB>;
+
+template class PropertyBasic<IText>;
+template class PropertyBasic<INumber>;
+template class PropertyBasic<ISwitch>;
+template class PropertyBasic<ILight>;
+template class PropertyBasic<IBLOB>;
+
+}

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -1,0 +1,102 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indiproperty.h"
+
+namespace INDI
+{
+
+template <typename>
+class PropertyBasicPrivateTemplate;
+
+template <typename T>
+class PropertyBasic : public INDI::Property
+{
+    using PropertyBasicPrivate = PropertyBasicPrivateTemplate<T>;
+    DECLARE_PRIVATE(PropertyBasic)
+public:
+    ~PropertyBasic();
+
+public:
+    void setName(const char *name);
+    void setName(const std::string &name);
+
+    void setLabel(const char *label);
+    void setLabel(const std::string &label);
+
+    void setGroupName(const char *name);
+    void setGroupName(const std::string &name);
+
+    void setPermission(IPerm permission);
+    void setTimeout(double timeout);
+    void setState(IPState state);
+
+    void setTimestamp(const char *timestamp);
+    void setTimestamp(const std::string &timestamp);
+
+public:
+    const char *getName()               const;
+    const char *getLabel()              const;
+    const char *getGroupName()          const;
+
+    IPerm       getPermission()         const;
+    const char *getPermissionAsString() const;
+
+    double      getTimeout()            const;
+    IPState     getState()              const;
+    const char *getStateAsString()      const;
+
+    const char *getTimestamp()          const;
+
+public:
+    bool isEmpty() const;
+
+    bool isNameMatch(const char *otherName) const;
+    bool isNameMatch(const std::string &otherName) const;
+
+    bool isLabelMatch(const char *otherLabel) const;
+    bool isLabelMatch(const std::string &otherLabel) const;
+
+public:
+    void save(FILE *f) const;
+
+    void vapply(const char *format, va_list args) const;
+    void vdefine(const char *format, va_list args) const;
+
+    void apply(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
+    void define(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
+
+    void apply() const;
+    void define() const;
+
+public:
+    void resize(size_t size);
+
+    WidgetView<T> &operator[](size_t index) const;
+    // #PS: TODO begin, end, cbegin, cend, etc
+
+public:
+    WidgetView<T> *findWidgetByName(const char *name);
+
+protected:
+    PropertyBasic(PropertyBasicPrivate &dd);
+};
+
+}

--- a/libs/indibase/property/indipropertybasic_p.h
+++ b/libs/indibase/property/indipropertybasic_p.h
@@ -1,0 +1,41 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indiproperty_p.h"
+#include "indipropertyview.h"
+
+#include <vector>
+
+namespace INDI
+{
+
+template <typename T>
+class PropertyBasicPrivateTemplate: public PropertyPrivate
+{
+public:
+    PropertyBasicPrivateTemplate(size_t count);
+    virtual ~PropertyBasicPrivateTemplate();
+
+public:
+    std::vector<WidgetView<T>>  widgets;
+    PropertyView<T>             property;
+};
+
+}

--- a/libs/indibase/property/indipropertyblob.cpp
+++ b/libs/indibase/property/indipropertyblob.cpp
@@ -1,0 +1,58 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "indipropertyblob.h"
+#include "indipropertyblob_p.h"
+
+namespace INDI
+{
+
+PropertyBlobPrivate::PropertyBlobPrivate(size_t count)
+    : PropertyBasicPrivateTemplate<IBLOB>(count)
+{ }
+
+PropertyBlobPrivate::~PropertyBlobPrivate()
+{ }
+
+PropertyBlob::PropertyBlob(size_t count)
+    : PropertyBasic<IBLOB>(*new PropertyBlobPrivate(count))
+{ }
+
+PropertyBlob::~PropertyBlob()
+{ }
+
+bool PropertyBlob::update(
+    const int sizes[], const int blobsizes[], const char * const blobs[], const char * const formats[],
+    const char * const names[], int n
+)
+{
+    D_PTR(PropertyBlob);
+    return d->property.update(sizes, blobsizes, blobs, formats, names, n);
+}
+
+void PropertyBlob::fill(
+    const char *device, const char *name, const char *label, const char *group,
+    IPerm permission, double timeout, IPState state
+)
+{
+    D_PTR(PropertyBlob);
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());
+    d->property.fill(device, name, label, group, permission, timeout, state);
+}
+
+}

--- a/libs/indibase/property/indipropertyblob.h
+++ b/libs/indibase/property/indipropertyblob.h
@@ -1,0 +1,46 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic.h"
+
+namespace INDI
+{
+
+class PropertyBlobPrivate;
+class PropertyBlob: public INDI::PropertyBasic<IBLOB>
+{
+    DECLARE_PRIVATE(PropertyBlob)
+public:
+    PropertyBlob(size_t count);
+    ~PropertyBlob();
+
+public:
+    bool update(
+        const int sizes[], const int blobsizes[], const char * const blobs[], const char * const formats[],
+        const char * const names[], int n
+    );
+
+    void fill(
+        const char *device, const char *name, const char *label, const char *group,
+        IPerm permission, double timeout, IPState state
+    );
+};
+
+}

--- a/libs/indibase/property/indipropertyblob_p.h
+++ b/libs/indibase/property/indipropertyblob_p.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic_p.h"
+#include "indipropertyview.h"
+
+namespace INDI
+{
+
+class PropertyBlobPrivate: public PropertyBasicPrivateTemplate<IBLOB>
+{
+public:
+    PropertyBlobPrivate(size_t count);
+    virtual ~PropertyBlobPrivate();
+
+public:
+
+};
+
+}

--- a/libs/indibase/property/indipropertylight.cpp
+++ b/libs/indibase/property/indipropertylight.cpp
@@ -1,0 +1,49 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "indipropertylight.h"
+#include "indipropertylight_p.h"
+
+namespace INDI
+{
+
+PropertyLightPrivate::PropertyLightPrivate(size_t count)
+    : PropertyBasicPrivateTemplate<ILight>(count)
+{ }
+
+PropertyLightPrivate::~PropertyLightPrivate()
+{ }
+
+PropertyLight::PropertyLight(size_t count)
+    : PropertyBasic<ILight>(*new PropertyLightPrivate(count))
+{ }
+
+PropertyLight::~PropertyLight()
+{ }
+
+void PropertyLight::fill(
+    const char *device, const char *name, const char *label, const char *group,
+    IPState state
+)
+{
+    D_PTR(PropertyLight);
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());
+    d->property.fill(device, name, label, group, state);
+}
+
+}

--- a/libs/indibase/property/indipropertylight.h
+++ b/libs/indibase/property/indipropertylight.h
@@ -1,0 +1,43 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic.h"
+
+namespace INDI
+{
+
+class PropertyLightPrivate;
+class PropertyLight: public INDI::PropertyBasic<ILight>
+{
+    DECLARE_PRIVATE(PropertyLight)
+public:
+    PropertyLight(size_t count);
+    ~PropertyLight();
+
+public:
+    // bool update(..., const char * const names[], int n);
+
+    void fill(
+        const char *device, const char *name, const char *label, const char *group,
+        IPState state
+    );
+};
+
+}

--- a/libs/indibase/property/indipropertylight_p.h
+++ b/libs/indibase/property/indipropertylight_p.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic_p.h"
+#include "indipropertyview.h"
+
+namespace INDI
+{
+
+class PropertyLightPrivate: public PropertyBasicPrivateTemplate<ILight>
+{
+public:
+    PropertyLightPrivate(size_t count);
+    virtual ~PropertyLightPrivate();
+
+public:
+
+};
+
+}

--- a/libs/indibase/property/indipropertynumber.cpp
+++ b/libs/indibase/property/indipropertynumber.cpp
@@ -1,0 +1,61 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "indipropertynumber.h"
+#include "indipropertynumber_p.h"
+
+namespace INDI
+{
+
+PropertyNumberPrivate::PropertyNumberPrivate(size_t count)
+    : PropertyBasicPrivateTemplate<INumber>(count)
+{ }
+
+PropertyNumberPrivate::~PropertyNumberPrivate()
+{ }
+
+PropertyNumber::PropertyNumber(size_t count)
+    : PropertyBasic<INumber>(*new PropertyNumberPrivate(count))
+{ }
+
+PropertyNumber::~PropertyNumber()
+{ }
+
+bool PropertyNumber::update(const double values[], const char * const names[], int n)
+{
+    D_PTR(PropertyNumber);
+    return d->property.update(values, names, n);
+}
+
+void PropertyNumber::fill(
+    const char *device, const char *name, const char *label, const char *group,
+    IPerm permission, double timeout, IPState state
+)
+{
+    D_PTR(PropertyNumber);
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());
+    d->property.fill(device, name, label, group, permission, timeout, state);
+}
+
+void PropertyNumber::updateMinMax()
+{
+    D_PTR(PropertyNumber);
+    d->property.updateMinMax();
+}
+
+}

--- a/libs/indibase/property/indipropertynumber.h
+++ b/libs/indibase/property/indipropertynumber.h
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic.h"
+
+namespace INDI
+{
+
+class PropertyNumberPrivate;
+class PropertyNumber: public INDI::PropertyBasic<INumber>
+{
+    DECLARE_PRIVATE(PropertyNumber)
+public:
+    PropertyNumber(size_t count);
+    ~PropertyNumber();
+
+public:
+    bool update(const double values[], const char * const names[], int n);
+
+    void fill(
+        const char *device, const char *name, const char *label, const char *group,
+        IPerm permission, double timeout, IPState state
+    );
+
+public:
+    void updateMinMax();
+
+};
+
+}

--- a/libs/indibase/property/indipropertynumber_p.h
+++ b/libs/indibase/property/indipropertynumber_p.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic_p.h"
+#include "indipropertyview.h"
+
+namespace INDI
+{
+
+class PropertyNumberPrivate: public PropertyBasicPrivateTemplate<INumber>
+{
+public:
+    PropertyNumberPrivate(size_t count);
+    virtual ~PropertyNumberPrivate();
+
+public:
+
+};
+
+}

--- a/libs/indibase/property/indipropertyswitch.cpp
+++ b/libs/indibase/property/indipropertyswitch.cpp
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "indipropertyswitch.h"
+#include "indipropertyswitch_p.h"
+
+namespace INDI
+{
+
+PropertySwitchPrivate::PropertySwitchPrivate(size_t count)
+    : PropertyBasicPrivateTemplate<ISwitch>(count)
+{ }
+
+PropertySwitchPrivate::~PropertySwitchPrivate()
+{ }
+
+PropertySwitch::PropertySwitch(size_t count)
+    : PropertyBasic<ISwitch>(*new PropertySwitchPrivate(count))
+{ }
+
+PropertySwitch::~PropertySwitch()
+{ }
+
+void PropertySwitch::reset()
+{
+    D_PTR(PropertySwitch);
+    d->property.reset();
+}
+
+int PropertySwitch::findOnSwitchIndex() const
+{
+    D_PTR(const PropertySwitch);
+    return d->property.findOnSwitchIndex();
+}
+
+INDI::WidgetView<ISwitch> *PropertySwitch::findOnSwitch() const
+{
+    D_PTR(const PropertySwitch);
+    return d->property.findOnSwitch();
+}
+
+bool PropertySwitch::update(const ISState states[], const char * const names[], int n)
+{
+    D_PTR(PropertySwitch);
+    return d->property.update(states, names, n);
+}
+
+void PropertySwitch::fill(
+    const char *device, const char *name, const char *label, const char *group,
+    IPerm permission, ISRule rule, double timeout, IPState state
+)
+{
+    D_PTR(PropertySwitch);
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());
+    d->property.fill(device, name, label, group, permission, rule, timeout, state);
+}
+
+}

--- a/libs/indibase/property/indipropertyswitch.h
+++ b/libs/indibase/property/indipropertyswitch.h
@@ -1,0 +1,48 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic.h"
+
+namespace INDI
+{
+
+class PropertySwitchPrivate;
+class PropertySwitch: public INDI::PropertyBasic<ISwitch>
+{
+    DECLARE_PRIVATE(PropertySwitch)
+public:
+    PropertySwitch(size_t count);
+    ~PropertySwitch();
+
+public:
+    bool update(const ISState states[], const char * const names[], int n);
+
+    void fill(
+        const char *device, const char *name, const char *label, const char *group,
+        IPerm permission, ISRule rule, double timeout, IPState state
+    );
+
+public:
+    void reset();
+    int findOnSwitchIndex() const;
+    INDI::WidgetView<ISwitch> *findOnSwitch() const;
+};
+
+}

--- a/libs/indibase/property/indipropertyswitch_p.h
+++ b/libs/indibase/property/indipropertyswitch_p.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic_p.h"
+#include "indipropertyview.h"
+
+namespace INDI
+{
+
+class PropertySwitchPrivate: public PropertyBasicPrivateTemplate<ISwitch>
+{
+public:
+    PropertySwitchPrivate(size_t count);
+    virtual ~PropertySwitchPrivate();
+
+public:
+
+};
+
+}

--- a/libs/indibase/property/indipropertytext.cpp
+++ b/libs/indibase/property/indipropertytext.cpp
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "indipropertytext.h"
+#include "indipropertytext_p.h"
+
+namespace INDI
+{
+
+PropertyTextPrivate::PropertyTextPrivate(size_t count)
+    : PropertyBasicPrivateTemplate<IText>(count)
+{ }
+
+PropertyTextPrivate::~PropertyTextPrivate()
+{ }
+
+PropertyText::PropertyText(size_t count)
+    : PropertyBasic<IText>(*new PropertyTextPrivate(count))
+{ }
+
+PropertyText::~PropertyText()
+{ }
+
+bool PropertyText::update(const char * const texts[], const char * const names[], int n)
+{
+    D_PTR(PropertyText);
+    return d->property.update(texts, names, n);
+}
+
+void PropertyText::fill(
+    const char *device, const char *name, const char *label, const char *group,
+    IPerm permission, double timeout, IPState state
+)
+{
+    D_PTR(PropertyText);
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());
+    d->property.fill(device, name, label, group, permission, timeout, state);
+}
+
+}

--- a/libs/indibase/property/indipropertytext.h
+++ b/libs/indibase/property/indipropertytext.h
@@ -1,0 +1,43 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic.h"
+
+namespace INDI
+{
+
+class PropertyTextPrivate;
+class PropertyText: public INDI::PropertyBasic<IText>
+{
+    DECLARE_PRIVATE(PropertyText)
+public:
+    PropertyText(size_t count);
+    ~PropertyText();
+
+public:
+    bool update(const char * const texts[], const char * const names[], int n);
+
+    void fill(
+        const char *device, const char *name, const char *label, const char *group,
+        IPerm permission, double timeout, IPState state
+    );
+};
+
+}

--- a/libs/indibase/property/indipropertytext_p.h
+++ b/libs/indibase/property/indipropertytext_p.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "indipropertybasic_p.h"
+#include "indipropertyview.h"
+
+namespace INDI
+{
+
+class PropertyTextPrivate: public PropertyBasicPrivateTemplate<IText>
+{
+public:
+    PropertyTextPrivate(size_t count);
+    virtual ~PropertyTextPrivate();
+
+public:
+
+};
+
+}

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -124,10 +124,10 @@ public: // only for ISwitch
     void reset()                                           { IUResetSwitch(this); }
 
     template <typename X = T, enable_if_is_same_t<X, ISwitch> = true>
-    WidgetType *findOnSwitch()                             { return static_cast<WidgetType *>(IUFindOnSwitch(this)); }
+    WidgetType *findOnSwitch() const                       { return static_cast<WidgetType *>(IUFindOnSwitch(this)); }
 
     template <typename X = T, enable_if_is_same_t<X, ISwitch> = true>
-    int findOnSwitchIndex()                                { return IUFindOnSwitchIndex(this); }
+    int findOnSwitchIndex() const                          { return IUFindOnSwitchIndex(this); }
 
 public: // only for INumber
     template <typename X = T, enable_if_is_same_t<X, INumber> = true>
@@ -155,10 +155,10 @@ public: //getters
     int count() const;                                     /* outside implementation */
     WidgetType *widget() const;                            /* outside implementation */
 
-    WidgetType *findWidgetByName(const char *name);        /* outside implementation */
+    WidgetType *findWidgetByName(const char *name) const;  /* outside implementation */
 
 public: //tests
-    bool isEmpty() const                                   { return widget() == nullptr; }
+    bool isEmpty() const                                   { return widget() == nullptr || count() == 0; }
 
     bool isNameMatch(const char *otherName) const          { return !strcmp(getName(), otherName); }
     bool isNameMatch(const std::string &otherName) const   { return getName() == otherName; }
@@ -167,16 +167,16 @@ public: //tests
     bool isLabelMatch(const std::string &otherLabel) const { return getLabel() == otherLabel; }
 
 public: // only driver side
-    void save(FILE *f);                                    /* outside implementation */
+    void save(FILE *f) const;                              /* outside implementation */
 
-    void vapply(const char *format, va_list args);         /* outside implementation - only driver side, see indipropertyview_driver.cpp */
-    void vdefine(const char *format, va_list args);        /* outside implementation - only driver side, see indipropertyview_driver.cpp */
+    void vapply(const char *format, va_list args) const;   /* outside implementation - only driver side, see indipropertyview_driver.cpp */
+    void vdefine(const char *format, va_list args) const;  /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
-    void apply(const char *format, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3);  /* outside implementation - only driver side, see indipropertyview_driver.cpp */
-    void define(const char *format, ...) ATTRIBUTE_FORMAT_PRINTF(2, 3); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
+    void apply(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);  /* outside implementation - only driver side, see indipropertyview_driver.cpp */
+    void define(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
-    void apply()                                           { apply(nullptr);  }
-    void define()                                          { define(nullptr); }
+    void apply() const                                     { apply(nullptr);  }
+    void define() const                                    { define(nullptr); }
 
 public:
     template <typename X = T, enable_if_is_same_t<X, IText> = true>
@@ -211,26 +211,26 @@ public:
 
 public:
     template <typename X = T, enable_if_is_same_t<X, IText> = true>
-    bool update(const char **texts, const char **names, int n);
+    bool update(const char * const texts[], const char * const names[], int n);
     /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
     template <typename X = T, enable_if_is_same_t<X, INumber> = true>
-    bool update(const double *values, const char **names, int n);
+    bool update(const double values[], const char * const names[], int n);
     /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
     template <typename X = T, enable_if_is_same_t<X, ISwitch> = true>
-    bool update(const ISState *states, const char **names, int n);
+    bool update(const ISState states[], const char * const names[], int n);
     /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
     /*
     template <typename X = T, enable_if_is_same_t<X, ILight> = true>
-    bool update(..., const char **names, int n);
+    bool update(..., const char * const names[], int n);
     */
 
     template <typename X = T, enable_if_is_same_t<X, IBLOB> = true>
     bool update(
-        const int sizes[], const int blobsizes[], const char *blobs[], const char *formats[],
-        const char *names[], int n
+        const int sizes[], const int blobsizes[], const char * const blobs[], const char * const formats[],
+        const char * const names[], int n
     ); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
 
@@ -297,8 +297,8 @@ public:
     void fill(const char *name, const char *label, const char *initialText)
     ; /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
-    //void fill(const std::string &name, const std::string &label, const std::string &initialText)
-    //{ fill(name.c_str(), label.c_str(), initialText.c_str()); }
+    void fill(const std::string &name, const std::string &label, const std::string &initialText)
+    { fill(name.c_str(), label.c_str(), initialText.c_str()); }
 };
 
 template <>
@@ -586,23 +586,23 @@ inline void PropertyView<T>::setAux(void *user)
 { this->aux = user; }
 
 template <>
-inline void PropertyView<IText>::save(FILE *f)
+inline void PropertyView<IText>::save(FILE *f) const
 { IUSaveConfigText(f, this); }
 
 template <>
-inline void PropertyView<INumber>::save(FILE *f)
+inline void PropertyView<INumber>::save(FILE *f) const
 { IUSaveConfigNumber(f, this); }
 
 template <>
-inline void PropertyView<ISwitch>::save(FILE *f)
+inline void PropertyView<ISwitch>::save(FILE *f) const
 { IUSaveConfigSwitch(f, this); }
 
 template <>
-inline void PropertyView<ILight>::save(FILE *f)
+inline void PropertyView<ILight>::save(FILE *f) const
 { (void)f; /* IUSaveConfigLight(f, this); */ }
 
 template <>
-inline void PropertyView<IBLOB>::save(FILE *f)
+inline void PropertyView<IBLOB>::save(FILE *f) const
 { IUSaveConfigBLOB(f, this); }
 
 template <typename T>
@@ -638,27 +638,27 @@ inline bool PropertyView<ISwitch>::setRule(const std::string &rule)
 { return crackISRule(rule.data(), &this->r) == 0; }
 
 template <typename T>
-inline WidgetView<T> *PropertyView<T>::findWidgetByName(const char *name)
+inline WidgetView<T> *PropertyView<T>::findWidgetByName(const char *name) const
 { return nullptr; }
 
 template <>
-inline WidgetView<IText> *PropertyView<IText>::findWidgetByName(const char *name)
+inline WidgetView<IText> *PropertyView<IText>::findWidgetByName(const char *name) const
 { return static_cast<WidgetView<IText> *>(IUFindText(this, name)); }
 
 template <>
-inline WidgetView<INumber> *PropertyView<INumber>::findWidgetByName(const char *name)
+inline WidgetView<INumber> *PropertyView<INumber>::findWidgetByName(const char *name) const
 { return static_cast<WidgetView<INumber> *>(IUFindNumber(this, name)); }
 
 template <>
-inline WidgetView<ISwitch> *PropertyView<ISwitch>::findWidgetByName(const char *name)
+inline WidgetView<ISwitch> *PropertyView<ISwitch>::findWidgetByName(const char *name) const
 { return static_cast<WidgetView<ISwitch> *>(IUFindSwitch(this, name)); }
 
 template <>
-inline WidgetView<ILight> *PropertyView<ILight>::findWidgetByName(const char *name)
+inline WidgetView<ILight> *PropertyView<ILight>::findWidgetByName(const char *name) const
 { return static_cast<WidgetView<ILight> *>(IUFindLight(this, name)); }
 
 template <>
-inline WidgetView<IBLOB> *PropertyView<IBLOB>::findWidgetByName(const char *name)
+inline WidgetView<IBLOB> *PropertyView<IBLOB>::findWidgetByName(const char *name) const
 { return static_cast<WidgetView<IBLOB> *>(IUFindBLOB(this, name)); }
 
 template <typename T>

--- a/libs/indibase/property/indipropertyview_client.cpp
+++ b/libs/indibase/property/indipropertyview_client.cpp
@@ -25,51 +25,51 @@ static void errorUnavailable(const char *function)
 { fprintf(stderr, "%s method available only on driver side\n", function); }
 
 template <>
-void PropertyView<IText>::vapply(const char *, va_list)
+void PropertyView<IText>::vapply(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<IText>::vdefine(const char *, va_list)
+void PropertyView<IText>::vdefine(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<INumber>::vapply(const char *, va_list)
+void PropertyView<INumber>::vapply(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<INumber>::vdefine(const char *, va_list)
+void PropertyView<INumber>::vdefine(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<ISwitch>::vapply(const char *, va_list)
+void PropertyView<ISwitch>::vapply(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<ISwitch>::vdefine(const char *, va_list)
+void PropertyView<ISwitch>::vdefine(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<ILight>::vapply(const char *, va_list)
+void PropertyView<ILight>::vapply(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<ILight>::vdefine(const char *, va_list)
+void PropertyView<ILight>::vdefine(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<IBLOB>::vapply(const char *, va_list)
+void PropertyView<IBLOB>::vapply(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <>
-void PropertyView<IBLOB>::vdefine(const char *, va_list)
+void PropertyView<IBLOB>::vdefine(const char *, va_list) const
 { errorUnavailable(__FUNCTION__); }
 
 template <typename T>
-void PropertyView<T>::apply(const char *, ...)
+void PropertyView<T>::apply(const char *, ...) const
 { errorUnavailable(__FUNCTION__); }
 
 template <typename T>
-void PropertyView<T>::define(const char *, ...)
+void PropertyView<T>::define(const char *, ...) const
 { errorUnavailable(__FUNCTION__); }
 
 template <> template <>
@@ -108,21 +108,21 @@ void PropertyView<IBLOB>::fill(
 { errorUnavailable(__FUNCTION__); }
 
 template <> template<>
-bool PropertyView<IText>::update(const char *[], const char *[], int)
+bool PropertyView<IText>::update(const char * const [], const char * const [], int)
 { errorUnavailable(__FUNCTION__); return false; }
 
 template <> template<>
-bool PropertyView<INumber>::update(const double [], const char *[], int)
+bool PropertyView<INumber>::update(const double [], const char * const [], int)
 { errorUnavailable(__FUNCTION__); return false; }
 
 template <> template<>
-bool PropertyView<ISwitch>::update(const ISState [], const char *[], int)
+bool PropertyView<ISwitch>::update(const ISState [], const char * const [], int)
 { errorUnavailable(__FUNCTION__); return false; }
 
 template <> template<>
 bool PropertyView<IBLOB>::update(
-    const int [], const int [], const char *[], const char *[],
-    const char *[], int
+    const int [], const int [], const char * const [], const char * const [],
+    const char * const [], int
 )
 { errorUnavailable(__FUNCTION__); return false; }
 

--- a/libs/indibase/property/indipropertyview_driver.cpp
+++ b/libs/indibase/property/indipropertyview_driver.cpp
@@ -23,51 +23,51 @@ namespace INDI
 {
 
 template <>
-void PropertyView<IText>::vapply(const char *format, va_list arg)
+void PropertyView<IText>::vapply(const char *format, va_list arg) const
 { IDSetTextVA(this, format, arg); }
 
 template <>
-void PropertyView<IText>::vdefine(const char *format, va_list arg)
+void PropertyView<IText>::vdefine(const char *format, va_list arg) const
 { IDDefTextVA(this, format, arg); }
 
 template <>
-void PropertyView<INumber>::vapply(const char *format, va_list arg)
+void PropertyView<INumber>::vapply(const char *format, va_list arg) const
 { IDSetNumberVA(this, format, arg); }
 
 template <>
-void PropertyView<INumber>::vdefine(const char *format, va_list arg)
+void PropertyView<INumber>::vdefine(const char *format, va_list arg) const
 { IDDefNumberVA(this, format, arg); }
 
 template <>
-void PropertyView<ISwitch>::vapply(const char *format, va_list arg)
+void PropertyView<ISwitch>::vapply(const char *format, va_list arg) const
 { IDSetSwitchVA(this, format, arg); }
 
 template <>
-void PropertyView<ISwitch>::vdefine(const char *format, va_list arg)
+void PropertyView<ISwitch>::vdefine(const char *format, va_list arg) const
 { IDDefSwitchVA(this, format, arg); }
 
 template <>
-void PropertyView<ILight>::vapply(const char *format, va_list arg)
+void PropertyView<ILight>::vapply(const char *format, va_list arg) const
 { IDSetLightVA(this, format, arg); }
 
 template <>
-void PropertyView<ILight>::vdefine(const char *format, va_list arg)
+void PropertyView<ILight>::vdefine(const char *format, va_list arg) const
 { IDDefLightVA(this, format, arg); }
 
 template <>
-void PropertyView<IBLOB>::vapply(const char *format, va_list arg)
+void PropertyView<IBLOB>::vapply(const char *format, va_list arg) const
 { IDSetBLOBVA(this, format, arg); }
 
 template <>
-void PropertyView<IBLOB>::vdefine(const char *format, va_list arg)
+void PropertyView<IBLOB>::vdefine(const char *format, va_list arg) const
 { IDDefBLOBVA(this, format, arg); }
 
 template <typename T>
-void PropertyView<T>::apply(const char *format, ...)
+void PropertyView<T>::apply(const char *format, ...) const
 { va_list ap; va_start(ap, format); this->vapply(format, ap); va_end(ap); }
 
 template <typename T>
-void PropertyView<T>::define(const char *format, ...)
+void PropertyView<T>::define(const char *format, ...) const
 { va_list ap; va_start(ap, format); this->vdefine(format, ap); va_end(ap); }
 
 template <> template <>
@@ -131,21 +131,21 @@ void PropertyView<IBLOB>::fill(
 }
 
 template <> template<>
-bool PropertyView<IText>::update(const char *texts[], const char *names[], int n)
+bool PropertyView<IText>::update(const char * const texts[], const char * const names[], int n)
 { return IUUpdateText(this, const_cast<char**>(texts), const_cast<char**>(names), n) == 0; }
 
 template <> template<>
-bool PropertyView<INumber>::update(const double values[], const char *names[], int n)
+bool PropertyView<INumber>::update(const double values[], const char * const names[], int n)
 { return IUUpdateNumber(this, const_cast<double*>(values), const_cast<char**>(names), n) == 0; }
 
 template <> template<>
-bool PropertyView<ISwitch>::update(const ISState states[], const char *names[], int n)
+bool PropertyView<ISwitch>::update(const ISState states[], const char * const names[], int n)
 { return IUUpdateSwitch(this, const_cast<ISState*>(states), const_cast<char**>(names), n) == 0; }
 
 template <> template<>
 bool PropertyView<IBLOB>::update(
-    const int sizes[], const int blobsizes[], const char *blobs[], const char *formats[],
-    const char *names[], int n
+    const int sizes[], const int blobsizes[], const char *const blobs[], const char *const formats[],
+    const char * const names[], int n
 )
 {
     return IUUpdateBLOB(


### PR DESCRIPTION
Hi!

As previously mentioned (#1361), I am moving to stage two.

My plan:
1. Implementation of PropertyView/WidgetView decorators (collection of used low-level functions)
2. **implementation of widgets (eg PropertyText...) which have methods from PropertyView/WidgetView and additionally inherit from INDI::Property.**
3. implementation of signals / slots for PropertyText...

In brief:
- minor PropertyView / WidgetView fixes
- For example, Merge ISwitch** and ISwitchVectorProperty** to PropertySwitch, see defaultdevice_p.h
- Ability to dynamically change the number of elements, see "ConnectionModeSP"

 ** ISwitch and ISwitchVectorProperty is the same as WidgetView <ISwitch> PropertyView <ISwitch> with additional method implementation.

I'm going to spend this night on additional testing. If there is anyone willing, I invite you to test ;)
