### PR TITLE
Fix warnings, use strcpy/strcat for string literal

### DIFF
--- a/drivers/filter_wheel/ifwoptec.cpp
+++ b/drivers/filter_wheel/ifwoptec.cpp
@@ -666,7 +666,7 @@ bool FilterIFW::GetFilterNames()
                 p                                   = p + OPTEC_LEN_FLTNAME;
                 LOGF_DEBUG("filterNameIFW[%d] : %s", i, filterNameIFW[i]);
                 strncat(filterList, filterNameIFW[i], OPTEC_LEN_FLTNAME);
-                strncat(filterList, "/", 1);
+                strcat(filterList, "/");
             }
             filterList[strlen(filterList) - 1] = '\0'; //Remove last "/"
 

--- a/drivers/focuser/focuslynxbase.cpp
+++ b/drivers/focuser/focuslynxbase.cpp
@@ -1108,7 +1108,8 @@ bool FocusLynxBase::getFocusStatus()
         memset(response, 0, sizeof(response));
         if (isSimulation())
         {
-            strncpy(response, "Temp(C) = +21.7\n", 16);
+            //strncpy(response, "Temp(C) = +21.7\n", 16); // #PS: for string literal, use strcpy
+            strcpy(response, "Temp(C) = +21.7\n");
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1117,7 +1118,10 @@ bool FocusLynxBase::getFocusStatus()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        response[nbytes_read - 1] = '\0';
+
+        if (nbytes_read > 0)
+            response[nbytes_read - 1] = '\0'; // remove last character (new line)
+
         LOGF_DEBUG("RES (%s)", response);
 
         float temperature = 0;

--- a/drivers/rotator/gemini.cpp
+++ b/drivers/rotator/gemini.cpp
@@ -1921,7 +1921,8 @@ bool Gemini::getFocusStatus()
     memset(response, 0, sizeof(response));
     if (isSimulation())
     {
-        strncpy(response, "CurrTemp = +21.7\n", 16);
+        //strncpy(response, "CurrTemp = +21.7\n", 16); // #PS: incorrect, lost last character
+        strcpy(response, "CurrTemp = +21.7\n");
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1930,7 +1931,10 @@ bool Gemini::getFocusStatus()
         LOGF_ERROR("%s", errmsg);
         return false;
     }
-    response[nbytes_read - 1] = '\0';
+
+    if (nbytes_read > 0)
+        response[nbytes_read - 1] = '\0';
+
     DEBUGF(DBG_FOCUS, "RES (%s)", response);
 
     float temperature = 0;


### PR DESCRIPTION
Hi!

`char * strncat ( char * destination, const char * source, size_t num );`
_num - Maximum number of characters to be appended. size_t is an unsigned integral type._

There is no point in using this function for a known constant string.
It is overused in some places and the target buffer length is not checked.

I added an extra condition when removing the last character so there is no leakage for the empty string.

It is possible that when I replace with new widgets (Property), I will improve part of the implementation.
