### PR TITLE
Improving Dome slave to telescope regarding telescope pier side

### DIFF
--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -1019,9 +1019,9 @@ bool Dome::ISSnoopDevice(XMLEle * root)
             const char * elemName = findXMLAttValu(ep, "name");
 
             if (!strcmp(elemName, "PIER_EAST") && !strcmp(pcdataXMLEle(ep), "On"))
-                mountOTASide = 1;
-            else if (!strcmp(elemName, "PIER_WEST") && !strcmp(pcdataXMLEle(ep), "On"))
                 mountOTASide = -1;
+            else if (!strcmp(elemName, "PIER_WEST") && !strcmp(pcdataXMLEle(ep), "On"))
+                mountOTASide = 1;
         }
         
         return true;
@@ -1307,20 +1307,20 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
 
     LOGF_DEBUG("HA: %g  Lng: %g RA: %g", hourAngle, observer.lng, mountEquatorialCoords.ra);
 
-    int OTASide = 0; // Side of the telescope with respect of the mount, 1: east, -1: west, 0: use the mid point
+    int OTASide = 0; // Side of the telescope with respect of the mount, 1: west, -1: east, 0: use the mid point
     
     if (OTASideSP.s == IPS_OK)
     {
         int OTASideS_Idx = -1;
         
-        if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = 1;
-        else if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = -1;
+        if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = -1;
+        else if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = 1;
         else if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = mountOTASide;
         else if(OTASideS[++OTASideS_Idx].s == ISS_ON)
         {
             // Note if the telescope points West, OTA is at east of the pier, and viceversa.
-            if(hourAngle > 0) OTASide = 1;
-            else OTASide = -1;
+            if(hourAngle > 0) OTASide = -1;
+            else OTASide = 1;
         }
         else
             ++OTASideS_Idx;

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -1059,6 +1059,7 @@ bool Dome::saveConfigItems(FILE * fp)
     IUSaveConfigNumber(fp, &DomeMeasurementsNP);
     //IUSaveConfigSwitch(fp, &AutoParkSP);
     IUSaveConfigSwitch(fp, &DomeAutoSyncSP);
+    IUSaveConfigSwitch(fp, &OTASideSP);
 
     if (HasBacklash())
     {

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -532,14 +532,14 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             if (DomeAutoSyncS[0].s == ISS_ON)
             {
                 IDSetSwitch(&DomeAutoSyncSP, "Dome will now be synced to mount azimuth position.");
-                LOGF_DEBUG("Dome will now be synced to mount azimuth position.");
+                LOG_WARN("Dome will now be synced to mount azimuth position.");
                 //UpdateAutoSync();
                 m_HorizontalUpdateTimerID = IEAddTimer(10, &Dome::updateMountCoordsHelper, this);
             }
             else
             {
                 IDSetSwitch(&DomeAutoSyncSP, "Dome is no longer synced to mount azimuth position.");
-                LOGF_DEBUG("Dome is no longer synced to mount azimuth position.");
+                LOG_WARN("Dome is no longer synced to mount azimuth position.");
                 if (m_HorizontalUpdateTimerID > 0)
                 {
                     IERmTimer(m_HorizontalUpdateTimerID);
@@ -563,31 +563,31 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             if (OTASideS[0].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at east of meridian");
-                LOGF_DEBUG("Dome will be synced for telescope been at east of meridian");
+                LOG_WARN("Dome will be synced for telescope been at east of meridian");
                 UpdateAutoSync();
             }
             else if (OTASideS[1].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at west of meridian");
-                LOGF_DEBUG("Dome will be synced for telescope been at west of meridian");
+                LOG_WARN("Dome will be synced for telescope been at west of meridian");
                 UpdateAutoSync();
             }
             else if (OTASideS[2].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier reported by mount");
-                LOGF_DEBUG("Dome will be synced for telescope been at the side of the pier reported by mount");
+                LOG_WARN("Dome will be synced for telescope been at the side of the pier reported by mount");
                 UpdateAutoSync();
             }
             else if (OTASideS[3].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier as of Hour Angle");
-                LOGF_DEBUG("Dome will be synced for telescope been at the side of the pier as of Hour Angle");
+                LOG_WARN("Dome will be synced for telescope been at the side of the pier as of Hour Angle");
                 UpdateAutoSync();
             }
             else if (OTASideS[4].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
-                LOGF_DEBUG("Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
+                LOG_WARN("Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
                 UpdateAutoSync();
             }
 

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -532,12 +532,14 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             if (DomeAutoSyncS[0].s == ISS_ON)
             {
                 IDSetSwitch(&DomeAutoSyncSP, "Dome will now be synced to mount azimuth position.");
+                LOGF_INFO("Dome will now be synced to mount azimuth position.");
                 //UpdateAutoSync();
                 m_HorizontalUpdateTimerID = IEAddTimer(10, &Dome::updateMountCoordsHelper, this);
             }
             else
             {
                 IDSetSwitch(&DomeAutoSyncSP, "Dome is no longer synced to mount azimuth position.");
+                LOGF_INFO("Dome is no longer synced to mount azimuth position.");
                 if (m_HorizontalUpdateTimerID > 0)
                 {
                     IERmTimer(m_HorizontalUpdateTimerID);
@@ -561,26 +563,31 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             if (OTASideS[0].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at east of meridian");
+                LOGF_INFO("Dome will be synced for telescope been at east of meridian");
                 UpdateAutoSync();
             }
             else if (OTASideS[1].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at west of meridian");
+                LOGF_INFO("Dome will be synced for telescope been at west of meridian");
                 UpdateAutoSync();
             }
             else if (OTASideS[2].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier reported by mount");
+                LOGF_INFO("Dome will be synced for telescope been at the side of the pier reported by mount");
                 UpdateAutoSync();
             }
             else if (OTASideS[3].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier as of Hour Angle");
+                LOGF_INFO("Dome will be synced for telescope been at the side of the pier as of Hour Angle");
                 UpdateAutoSync();
             }
             else if (OTASideS[4].s == ISS_ON)
             {
-                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope igniring the side of the pier as ina a fork mount");
+                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
+                LOGF_INFO("Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
                 UpdateAutoSync();
             }
 

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -1311,15 +1311,21 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
     
     if (OTASideSP.s == IPS_OK)
     {
-        if(OTASideS[0].s == ISS_ON) OTASide = 1;
-        else if(OTASideS[1].s == ISS_ON) OTASide = -1;
-        else if(OTASideS[2].s == ISS_ON) OTASide = mountOTASide;
-        else if(OTASideS[3].s == ISS_ON)
+        int OTASideS_Idx = -1;
+        
+        if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = 1;
+        else if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = -1;
+        else if(OTASideS[++OTASideS_Idx].s == ISS_ON) OTASide = mountOTASide;
+        else if(OTASideS[++OTASideS_Idx].s == ISS_ON)
         {
             // Note if the telescope points West, OTA is at east of the pier, and viceversa.
             if(hourAngle > 0) OTASide = 1;
             else OTASide = -1;
         }
+        else
+            ++OTASideS_Idx;
+        
+        LOGF_DEBUG("OTA_SIDE selection: %d", OTASideS_Idx);
     }
 
     OpticalCenter(MountCenter, OTASide * DomeMeasurementsN[DM_OTA_OFFSET].value, observer.lat, hourAngle, OptCenter);

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -532,14 +532,14 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             if (DomeAutoSyncS[0].s == ISS_ON)
             {
                 IDSetSwitch(&DomeAutoSyncSP, "Dome will now be synced to mount azimuth position.");
-                LOGF_INFO("Dome will now be synced to mount azimuth position.");
+                LOGF_DEBUG("Dome will now be synced to mount azimuth position.");
                 //UpdateAutoSync();
                 m_HorizontalUpdateTimerID = IEAddTimer(10, &Dome::updateMountCoordsHelper, this);
             }
             else
             {
                 IDSetSwitch(&DomeAutoSyncSP, "Dome is no longer synced to mount azimuth position.");
-                LOGF_INFO("Dome is no longer synced to mount azimuth position.");
+                LOGF_DEBUG("Dome is no longer synced to mount azimuth position.");
                 if (m_HorizontalUpdateTimerID > 0)
                 {
                     IERmTimer(m_HorizontalUpdateTimerID);
@@ -563,31 +563,31 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             if (OTASideS[0].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at east of meridian");
-                LOGF_INFO("Dome will be synced for telescope been at east of meridian");
+                LOGF_DEBUG("Dome will be synced for telescope been at east of meridian");
                 UpdateAutoSync();
             }
             else if (OTASideS[1].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at west of meridian");
-                LOGF_INFO("Dome will be synced for telescope been at west of meridian");
+                LOGF_DEBUG("Dome will be synced for telescope been at west of meridian");
                 UpdateAutoSync();
             }
             else if (OTASideS[2].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier reported by mount");
-                LOGF_INFO("Dome will be synced for telescope been at the side of the pier reported by mount");
+                LOGF_DEBUG("Dome will be synced for telescope been at the side of the pier reported by mount");
                 UpdateAutoSync();
             }
             else if (OTASideS[3].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier as of Hour Angle");
-                LOGF_INFO("Dome will be synced for telescope been at the side of the pier as of Hour Angle");
+                LOGF_DEBUG("Dome will be synced for telescope been at the side of the pier as of Hour Angle");
                 UpdateAutoSync();
             }
             else if (OTASideS[4].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
-                LOGF_INFO("Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
+                LOGF_DEBUG("Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
                 UpdateAutoSync();
             }
 

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -1316,8 +1316,9 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
         else if(OTASideS[2].s == ISS_ON) OTASide = mountOTASide;
         else if(OTASideS[3].s == ISS_ON)
         {
-            if(hourAngle > 0) OTASide = -1;
-            else OTASide = 1;
+            // Note if the telescope points West, OTA is at east of the pier, and viceversa.
+            if(hourAngle > 0) OTASide = 1;
+            else OTASide = -1;
         }
     }
 

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -1300,14 +1300,14 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
 
     LOGF_DEBUG("HA: %g  Lng: %g RA: %g", hourAngle, observer.lng, mountEquatorialCoords.ra);
 
-    int OTASide = 0; /* Side of the telescope with respect of the mount, 1: east, -1: west, 0: use the mid point*/
+    int OTASide = 0; // Side of the telescope with respect of the mount, 1: east, -1: west, 0: use the mid point
     
     if (OTASideSP.s == IPS_OK)
     {
         if(OTASideS[0].s == ISS_ON) OTASide = 1;
         else if(OTASideS[1].s == ISS_ON) OTASide = -1;
-        else if(OTASideS[2].s == ISS_ON && mountOTASide <> 0) OTASide = mountOTASide;
-        else
+        else if(OTASideS[2].s == ISS_ON) OTASide = mountOTASide;
+        else if(OTASideS[3].s == ISS_ON)
         {
             if(hourAngle > 0) OTASide = -1;
             else OTASide = 1;

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -563,31 +563,31 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             if (OTASideS[0].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at east of meridian");
-                LOG_WARN("Dome will be synced for telescope been at east of meridian");
+                LOG_WARN("Dome will be synced for telescope tube been at east of pier");
                 UpdateAutoSync();
             }
             else if (OTASideS[1].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at west of meridian");
-                LOG_WARN("Dome will be synced for telescope been at west of meridian");
+                LOG_WARN("Dome will be synced for telescope tube been at west of pier");
                 UpdateAutoSync();
             }
             else if (OTASideS[2].s == ISS_ON)
             {
-                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier reported by mount");
-                LOG_WARN("Dome will be synced for telescope been at the side of the pier reported by mount");
+                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope tube been at the side of the pier reported by mount");
+                LOG_WARN("Dome will be synced for telescope tube been at the side of the pier reported by mount");
                 UpdateAutoSync();
             }
             else if (OTASideS[3].s == ISS_ON)
             {
                 IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at the side of the pier as of Hour Angle");
-                LOG_WARN("Dome will be synced for telescope been at the side of the pier as of Hour Angle");
+                LOG_WARN("Dome will be synced for telescope tube been at the side of the pier derived from Hour Angle");
                 UpdateAutoSync();
             }
             else if (OTASideS[4].s == ISS_ON)
             {
-                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
-                LOG_WARN("Dome will be synced for telescope ign0ring the side of the pier as in a fork mount");
+                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope ignoring the side of the pier as in a fork mount");
+                LOG_WARN("Dome will be synced for telescope ignoring the side of the pier as in a fork mount");
                 UpdateAutoSync();
             }
 

--- a/libs/indibase/indidome.h
+++ b/libs/indibase/indidome.h
@@ -587,7 +587,8 @@ class Dome : public DefaultDevice
         INumber DomeMeasurementsN[6];
         INumberVectorProperty DomeMeasurementsNP;
         ISwitchVectorProperty OTASideSP;
-        ISwitch OTASideS[2];
+        ISwitch OTASideS[5]; // 0 is East, 1 is West, 2 is as reported by mout, 3 as deducted by Hour Angle, 4 ignore pier side and perform as in a fork mount
+        int mountOTASide = 0; // Side of the telescope with respect of the mount, 1: east, -1: west, 0 not defined
         ISwitchVectorProperty DomeAutoSyncSP;
         ISwitch DomeAutoSyncS[2];
 

--- a/libs/indibase/indidome.h
+++ b/libs/indibase/indidome.h
@@ -588,7 +588,7 @@ class Dome : public DefaultDevice
         INumberVectorProperty DomeMeasurementsNP;
         ISwitchVectorProperty OTASideSP;
         ISwitch OTASideS[5]; // 0 is East, 1 is West, 2 is as reported by mout, 3 as deducted by Hour Angle, 4 ignore pier side and perform as in a fork mount
-        int mountOTASide = 0; // Side of the telescope with respect of the mount, 1: east, -1: west, 0 not defined
+        int mountOTASide = 0; // Side of the telescope with respect of the mount, 1: west, -1: east, 0 not reported
         ISwitchVectorProperty DomeAutoSyncSP;
         ISwitch DomeAutoSyncS[2];
 


### PR DESCRIPTION
Looking for a solution of this bug (https://github.com/indilib/indi/issues/1364) I improved how Dome drivers deal with the side of the pier where the telescope is in GEM mounts.

Before this change, user can inform to Dome driver which side was the telescope, but if the mount has this information, then it takes from the mount. However, in some circuntances (when telescope was moving) it's not clear what side must be taken.

To make the dome driver behaviour more predictable and clear, now the user can choose from 5 diferent options:

**East** : Dome always positions as if telescope tube was at the east of the pier
**West**:  Dome always positions as if telescope tube was at the west of the pier
**Mount**: Dome positions as if the telescope tube was at the side the mount reports. If the mount didn't report the side, the dome behave as with a fork mount.
**Hour Angle**: Dome positions as if the telescope tube was at the side deducted by the hour angle of the target coordinates. For positive hour angle (telescope point to west of the meridian) the tube was in the east side.
**Ignore**: Dome positios as with a fork mount.

A final note: When configured as **Mount** and the telescope slews from one side  to the other side of the pier, the dome positions to the "wrong" side when the telescope begins moving, and then repositions to the correct side when the telescope end slewing. I have not found any solution for this  behaviour, so I left for a future change if a solution is found.