### PR TITLE
Add global ISGetProperties/ISNewXXX/ISSnoopDevice propagation functions for drivers

### DIFF
--- a/libs/indibase/defaultdevice_p.h
+++ b/libs/indibase/defaultdevice_p.h
@@ -27,13 +27,19 @@
 #include "indipropertynumber.h"
 #include "indipropertytext.h"
 
+#include <list>
+#include <mutex>
+#include <shared_mutex>
+
 namespace INDI
 {
 class DefaultDevicePrivate: public BaseDevicePrivate
 {
 public:
-    DefaultDevicePrivate();
+    DefaultDevicePrivate(DefaultDevice *defaultDevice);
     virtual ~DefaultDevicePrivate();
+
+    DefaultDevice *defaultDevice;
 
     bool isInit { false };
     bool isDebug { false };
@@ -63,6 +69,10 @@ public:
 
     bool defineDynamicProperties {true};
     bool deleteDynamicProperties {true};
+
+public:
+    static std::list<DefaultDevicePrivate*> devices;
+    static std::recursive_mutex             devicesLock;
 };
 
 }

--- a/libs/indibase/defaultdevice_p.h
+++ b/libs/indibase/defaultdevice_p.h
@@ -22,14 +22,12 @@
 #include "defaultdevice.h"
 
 #include <cstring>
+#include <list>
+#include <mutex>
 
 #include "indipropertyswitch.h"
 #include "indipropertynumber.h"
 #include "indipropertytext.h"
-
-#include <list>
-#include <mutex>
-#include <shared_mutex>
 
 namespace INDI
 {


### PR DESCRIPTION
Hi!

Currently, each driver must support the functions:
```c++
void ISGetProperties(const char *dev)
{
    mydriver->ISGetProperties(dev);
}

void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
{
    mydriver->ISNewSwitch(dev, name, states, names, n);
}

void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
{
    mydriver->ISNewText(dev, name, texts, names, n);
}

void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
{
    mydriver->ISNewNumber(dev, name, values, names, n);
}

void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
               char *formats[], char *names[], int n)
{
    mydriver->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
}

void ISSnoopDevice(XMLEle *root)
{
    mydriver->ISSnoopDevice(root);
}
```
It always comes down to the same thing.
My suggestion is to do this on the indi library side.

The proposed PR is backward compatible. If the driver has already implemented these functions, the functions in indilib are not used (not linked).

When removing a function from drivers, you need to make sure that the methods in the class have an override specifier - it's not everywhere.
In the next PR, I will fix the override specifier for all drivers.

Edit: ahh yes, not all drivers inherit from DefaultDevice ... ;( 