### PR TITLE
Bugfix - test_ccd_simulator with incorrect library, missing override

### DIFF
--- a/drivers/focuser/onfocus.h
+++ b/drivers/focuser/onfocus.h
@@ -32,8 +32,8 @@ public:
     const char * getDefaultName();
     virtual bool initProperties() override;
     virtual bool updateProperties() override;
-    virtual bool ISNewNumber (const char *dev, const char *name, double values[], char *names[], int n);
-    virtual bool ISNewSwitch (const char *dev, const char *name, ISState *states, char *names[], int n);
+    virtual bool ISNewNumber (const char *dev, const char *name, double values[], char *names[], int n) override;
+    virtual bool ISNewSwitch (const char *dev, const char *name, ISState *states, char *names[], int n) override;
     virtual IPState MoveAbsFocuser(uint32_t ticks);
     virtual IPState MoveRelFocuser(FocusDirection dir, uint32_t ticks);
     virtual bool AbortFocuser();

--- a/drivers/rotator/integra.h
+++ b/drivers/rotator/integra.h
@@ -49,8 +49,8 @@ class Integra : public INDI::Focuser, public INDI::RotatorInterface
         const char * getDefaultName();
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
-        virtual bool ISNewNumber (const char * dev, const char * name, double values[], char * names[], int n);
-        virtual bool ISNewSwitch (const char * dev, const char * name, ISState * states, char * names[], int n);
+        virtual bool ISNewNumber (const char * dev, const char * name, double values[], char * names[], int n) override;
+        virtual bool ISNewSwitch (const char * dev, const char * name, ISState * states, char * names[], int n) override;
 
     protected:
         // Focuser

--- a/drivers/rotator/nightcrawler.h
+++ b/drivers/rotator/nightcrawler.h
@@ -36,8 +36,8 @@ class NightCrawler : public INDI::Focuser, public INDI::RotatorInterface
         const char * getDefaultName();
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
-        virtual bool ISNewNumber (const char * dev, const char * name, double values[], char * names[], int n);
-        virtual bool ISNewSwitch (const char * dev, const char * name, ISState * states, char * names[], int n);
+        virtual bool ISNewNumber (const char * dev, const char * name, double values[], char * names[], int n) override;
+        virtual bool ISNewSwitch (const char * dev, const char * name, ISState * states, char * names[], int n) override;
 
         static void abnormalDisconnectCallback(void *userpointer);
 

--- a/test/drivers/CMakeLists.txt
+++ b/test/drivers/CMakeLists.txt
@@ -7,7 +7,6 @@ ADD_EXECUTABLE(test_ccd_simulator
 )
 
 TARGET_LINK_LIBRARIES(test_ccd_simulator
-    indiclient
     indidriver
     ${GTEST_BOTH_LIBRARIES}
     ${GMOCK_LIBRARIES}


### PR DESCRIPTION
Hi!

**Add missing overide specifier** - no comment.

**Remove indiclient from ccd driver test** - The library should not be included with driver side programs.
Causes an incorrect operation ("fill method available only on driver side") when using INDI::PropertyView<> because the priority is the source indipropertyview_client.cpp.