### PR TITLE
Bugfix - Use const qualifier for const string

### DIFF
--- a/drivers/agent/agent_imager.cpp
+++ b/drivers/agent/agent_imager.cpp
@@ -162,7 +162,8 @@ void Imager::initiateNextCapture()
                 IDSetNumber(&ProgressNP, "CCD is not connected");
                 return;
             }
-            CCDImageBinN[0].value = CCDImageBinN[1].value = currentGroup()->binning();
+            CCDImageBinN[0].value = currentGroup()->binning();
+            CCDImageBinN[1].value = currentGroup()->binning();
             sendNewNumber(&CCDImageBinNP);
             CCDImageExposureN[0].value = currentGroup()->exposure();
             sendNewNumber(&CCDImageExposureNP);

--- a/drivers/agent/agent_imager.h
+++ b/drivers/agent/agent_imager.h
@@ -81,8 +81,8 @@ class Imager : public virtual INDI::DefaultDevice, public virtual INDI::BaseClie
         int maxGroup { 0 };
         int image { 0 };
         int maxImage { 0 };
-        char *controlledCCD { nullptr };
-        char *controlledFilterWheel { nullptr };
+        const char *controlledCCD { nullptr };
+        const char *controlledFilterWheel { nullptr };
 
         ITextVectorProperty ControlledDeviceTP;
         IText ControlledDeviceT[2] {};

--- a/drivers/weather/weather_safety_proxy.cpp
+++ b/drivers/weather/weather_safety_proxy.cpp
@@ -290,7 +290,7 @@ IPState WeatherSafetyProxy::updateWeather()
 
 IPState WeatherSafetyProxy::executeScript()
 {
-    char *cmd = ScriptsT[WSP_SCRIPT].text;
+    const char *cmd = ScriptsT[WSP_SCRIPT].text;
 
     if (access(cmd, F_OK|X_OK) == -1)
     {

--- a/libs/lx/Lx.cpp
+++ b/libs/lx/Lx.cpp
@@ -364,7 +364,7 @@ void Lx::closeserial(int fd)
         perror("closeserial()");
 }
 
-int Lx::openserial(char *devicename)
+int Lx::openserial(const char *devicename)
 {
     int fd;
     struct termios attr;

--- a/libs/lx/Lx.h
+++ b/libs/lx/Lx.h
@@ -65,7 +65,7 @@ class Lx
     int serialfd;
     struct termios oldterminfo;
     void closeserial(int fd);
-    int openserial(char *devicename);
+    int openserial(const char *devicename);
     int setRTS(int fd, int level);
     int setDTR(int fd, int level);
     bool startLxSerial();


### PR DESCRIPTION
Minor changes to prevent future refactoring problems.