### PR TITLE
Cleaning up the examples - Remove global 'IS' functions.

### DIFF
--- a/examples/tutorial_eight/simple_spectrograph.cpp
+++ b/examples/tutorial_eight/simple_spectrograph.cpp
@@ -29,44 +29,6 @@
 
 std::unique_ptr<SimpleSpectrograph> simpleSpectrograph(new SimpleSpectrograph());
 
-void ISGetProperties(const char *dev)
-{
-    simpleSpectrograph->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    simpleSpectrograph->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    simpleSpectrograph->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    simpleSpectrograph->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    INDI_UNUSED(dev);
-    INDI_UNUSED(name);
-    INDI_UNUSED(sizes);
-    INDI_UNUSED(blobsizes);
-    INDI_UNUSED(blobs);
-    INDI_UNUSED(formats);
-    INDI_UNUSED(names);
-    INDI_UNUSED(n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    simpleSpectrograph->ISSnoopDevice(root);
-}
-
 /**************************************************************************************
 ** Client is asking us to establish connection to the device
 ***************************************************************************************/

--- a/examples/tutorial_eight/simple_spectrograph.h
+++ b/examples/tutorial_eight/simple_spectrograph.h
@@ -26,25 +26,26 @@
 
 class SimpleSpectrograph : public INDI::Spectrograph
 {
-  public:
+public:
     SimpleSpectrograph() = default;
 
-  protected:
+protected:
     // General device functions
-    bool Connect();
-    bool Disconnect();
-    const char *getDefaultName();
-    bool initProperties();
-    bool updateProperties();
+    bool Connect() override;
+    bool Disconnect() override;
+    const char *getDefaultName() override;
+    bool initProperties() override;
+    bool updateProperties() override;
 
     // Spectrograph specific functions
-    bool StartIntegration(double duration);
-    bool paramsUpdated(float sr, float freq, float bps, float bw, float gain);
-    bool AbortIntegration();
-    int SetTemperature(double temperature);
-    void TimerHit();
+    bool StartIntegration(double duration) override;
+    bool AbortIntegration() override;
+    int SetTemperature(double temperature) override;
+    void TimerHit() override;
 
-  private:
+    bool paramsUpdated(float sr, float freq, float bps, float bw, float gain);
+
+private:
     // Utility functions
     float CalcTimeLeft();
     void setupParams();

--- a/examples/tutorial_five/dome.cpp
+++ b/examples/tutorial_five/dome.cpp
@@ -31,44 +31,6 @@
 
 std::unique_ptr<Dome> dome(new Dome());
 
-void ISGetProperties(const char *dev)
-{
-    dome->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    dome->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    dome->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    dome->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    INDI_UNUSED(dev);
-    INDI_UNUSED(name);
-    INDI_UNUSED(sizes);
-    INDI_UNUSED(blobsizes);
-    INDI_UNUSED(blobs);
-    INDI_UNUSED(formats);
-    INDI_UNUSED(names);
-    INDI_UNUSED(n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    dome->ISSnoopDevice(root);
-}
-
 /**************************************************************************************
 ** Client is asking us to establish connection to the device
 ***************************************************************************************/

--- a/examples/tutorial_five/dome.h
+++ b/examples/tutorial_five/dome.h
@@ -29,20 +29,20 @@
 
 class Dome : public INDI::DefaultDevice
 {
-  public:
+public:
     Dome() = default;
-    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
-    bool ISSnoopDevice(XMLEle *root);
 
-  protected:
+protected:
     // General device functions
-    bool Connect();
-    bool Disconnect();
-    const char *getDefaultName();
-    bool initProperties();
-    bool updateProperties();
+    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+    bool ISSnoopDevice(XMLEle *root) override;
+    bool Connect() override;
+    bool Disconnect() override;
+    const char *getDefaultName() override;
+    bool initProperties() override;
+    bool updateProperties() override;
 
-  private:
+private:
     void closeShutter();
 
     ISwitch ShutterS[2];

--- a/examples/tutorial_five/raindetector.cpp
+++ b/examples/tutorial_five/raindetector.cpp
@@ -22,44 +22,6 @@
 
 std::unique_ptr<RainDetector> rainDetector(new RainDetector());
 
-void ISGetProperties(const char *dev)
-{
-    rainDetector->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    rainDetector->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    rainDetector->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    rainDetector->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    INDI_UNUSED(dev);
-    INDI_UNUSED(name);
-    INDI_UNUSED(sizes);
-    INDI_UNUSED(blobsizes);
-    INDI_UNUSED(blobs);
-    INDI_UNUSED(formats);
-    INDI_UNUSED(names);
-    INDI_UNUSED(n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    rainDetector->ISSnoopDevice(root);
-}
-
 /**************************************************************************************
 ** Client is asking us to establish connection to the device
 ***************************************************************************************/

--- a/examples/tutorial_five/raindetector.h
+++ b/examples/tutorial_five/raindetector.h
@@ -24,19 +24,19 @@
 
 class RainDetector : public INDI::DefaultDevice
 {
-  public:
+public:
     RainDetector() = default;
-    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
 
-  protected:
+protected:
     // General device functions
-    bool Connect();
-    bool Disconnect();
-    const char *getDefaultName();
-    bool initProperties();
-    bool updateProperties();
+    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+    bool Connect() override;
+    bool Disconnect() override;
+    const char *getDefaultName() override;
+    bool initProperties() override;
+    bool updateProperties() override;
 
-  private:
+private:
     ILight RainL[1];
     ILightVectorProperty RainLP;
 

--- a/examples/tutorial_four/simpleskeleton.cpp
+++ b/examples/tutorial_four/simpleskeleton.cpp
@@ -48,54 +48,6 @@ std::unique_ptr<SimpleSkeleton> simpleSkeleton(new SimpleSkeleton());
 //const int POLLMS = 1000; // Period of update, 1 second.
 
 /**************************************************************************************
-**
-***************************************************************************************/
-void ISGetProperties(const char *dev)
-{
-    simpleSkeleton->ISGetProperties(dev);
-}
-
-/**************************************************************************************
-**
-***************************************************************************************/
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    simpleSkeleton->ISNewSwitch(dev, name, states, names, n);
-}
-
-/**************************************************************************************
-**
-***************************************************************************************/
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    simpleSkeleton->ISNewText(dev, name, texts, names, n);
-}
-
-/**************************************************************************************
-**
-***************************************************************************************/
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    simpleSkeleton->ISNewNumber(dev, name, values, names, n);
-}
-
-/**************************************************************************************
-**
-***************************************************************************************/
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    simpleSkeleton->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-/**************************************************************************************
-**
-***************************************************************************************/
-void ISSnoopDevice(XMLEle *root)
-{
-    INDI_UNUSED(root);
-}
-
-/**************************************************************************************
 ** Initialize all properties & set default values.
 **************************************************************************************/
 bool SimpleSkeleton::initProperties()

--- a/examples/tutorial_four/simpleskeleton.h
+++ b/examples/tutorial_four/simpleskeleton.h
@@ -34,20 +34,20 @@
 
 class SimpleSkeleton : public INDI::DefaultDevice
 {
-  public:
+public:
     SimpleSkeleton() = default;
     ~SimpleSkeleton() = default;
 
-    virtual void ISGetProperties(const char *dev) override;
-    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
-    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-    virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
+protected:
+    void ISGetProperties(const char *dev) override;
+    bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+    bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+    bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
                            char *formats[], char *names[], int n) override;
 
-  private:
-    const char *getDefaultName();
-    virtual bool initProperties() override;
-    virtual bool Connect();
-    virtual bool Disconnect();
+    const char *getDefaultName() override;
+    bool initProperties() override;
+    bool Connect() override;
+    bool Disconnect() override;
 };

--- a/examples/tutorial_one/simpledevice.cpp
+++ b/examples/tutorial_one/simpledevice.cpp
@@ -26,55 +26,6 @@
 std::unique_ptr<SimpleDevice> simpleDevice(new SimpleDevice());
 
 /**************************************************************************************
-** Return properties of device.
-***************************************************************************************/
-void ISGetProperties(const char *dev)
-{
-    simpleDevice->ISGetProperties(dev);
-}
-
-/**************************************************************************************
-** Process new switch from client
-***************************************************************************************/
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    simpleDevice->ISNewSwitch(dev, name, states, names, n);
-}
-
-/**************************************************************************************
-** Process new text from client
-***************************************************************************************/
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    simpleDevice->ISNewText(dev, name, texts, names, n);
-}
-
-/**************************************************************************************
-** Process new number from client
-***************************************************************************************/
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    simpleDevice->ISNewNumber(dev, name, values, names, n);
-}
-
-/**************************************************************************************
-** Process new blob from client
-***************************************************************************************/
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    simpleDevice->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-/**************************************************************************************
-** Process snooped property from another driver
-***************************************************************************************/
-void ISSnoopDevice(XMLEle *root)
-{
-    INDI_UNUSED(root);
-}
-
-/**************************************************************************************
 ** Client is asking us to establish connection to the device
 ***************************************************************************************/
 bool SimpleDevice::Connect()

--- a/examples/tutorial_one/simpledevice.h
+++ b/examples/tutorial_one/simpledevice.h
@@ -25,10 +25,10 @@
 
 class SimpleDevice : public INDI::DefaultDevice
 {
-  public:
+public:
     SimpleDevice() = default;
 
-  protected:
+protected:
     bool Connect() override;
     bool Disconnect() override;
     const char *getDefaultName() override;

--- a/examples/tutorial_one/simpledevice.h
+++ b/examples/tutorial_one/simpledevice.h
@@ -29,7 +29,7 @@ class SimpleDevice : public INDI::DefaultDevice
     SimpleDevice() = default;
 
   protected:
-    bool Connect();
-    bool Disconnect();
-    const char *getDefaultName();
+    bool Connect() override;
+    bool Disconnect() override;
+    const char *getDefaultName() override;
 };

--- a/examples/tutorial_seven/simple_telescope_simulator.cpp
+++ b/examples/tutorial_seven/simple_telescope_simulator.cpp
@@ -22,37 +22,6 @@ using namespace INDI::AlignmentSubsystem;
 // We declare an auto pointer to ScopeSim.
 std::unique_ptr<ScopeSim> telescope_sim(new ScopeSim());
 
-void ISGetProperties(const char *dev)
-{
-    telescope_sim->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    telescope_sim->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    telescope_sim->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    telescope_sim->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    telescope_sim->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    INDI_UNUSED(root);
-}
-
 ScopeSim::ScopeSim() :
     DBG_SIMULATOR(INDI::Logger::getInstance().addDebugLevel("Simulator Verbose", "SIMULATOR"))
 {

--- a/examples/tutorial_seven/simple_telescope_simulator.h
+++ b/examples/tutorial_seven/simple_telescope_simulator.h
@@ -7,29 +7,30 @@
 
 class ScopeSim : public INDI::Telescope, public INDI::AlignmentSubsystem::AlignmentSubsystemForDrivers
 {
-  public:
+public:
     ScopeSim();
 
-private:
-    virtual bool Abort() override;
+protected:
+    bool Abort() override;
     bool canSync();
-    virtual bool Connect() override;
-    virtual bool Disconnect() override;
-    virtual const char *getDefaultName() override;
-    virtual bool Goto(double ra, double dec) override;
-    virtual bool initProperties() override;
-    virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
+    bool Connect() override;
+    bool Disconnect() override;
+    const char *getDefaultName() override;
+    bool Goto(double ra, double dec) override;
+    bool initProperties() override;
+    bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
                            char *formats[], char *names[], int n) override;
-    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
-    virtual bool MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command) override;
-    virtual bool MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command) override;
-    virtual bool ReadScopeStatus() override;
-    virtual bool Sync(double ra, double dec) override;
-    virtual void TimerHit() override;
-    virtual bool updateLocation(double latitude, double longitude, double elevation) override;
+    bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+    bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+    bool MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command) override;
+    bool MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command) override;
+    bool ReadScopeStatus() override;
+    bool Sync(double ra, double dec) override;
+    void TimerHit() override;
+    bool updateLocation(double latitude, double longitude, double elevation) override;
 
+private:
     static constexpr long MICROSTEPS_PER_REVOLUTION { 1000000 };
     static constexpr double MICROSTEPS_PER_DEGREE { MICROSTEPS_PER_REVOLUTION / 360.0 };
     static constexpr double DEFAULT_SLEW_RATE { MICROSTEPS_PER_DEGREE * 2.0 };

--- a/examples/tutorial_seven/simple_telescope_simulator.h
+++ b/examples/tutorial_seven/simple_telescope_simulator.h
@@ -18,15 +18,10 @@ private:
     virtual const char *getDefaultName() override;
     virtual bool Goto(double ra, double dec) override;
     virtual bool initProperties() override;
-    friend void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-                          char *formats[], char *names[], int n);
     virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
                            char *formats[], char *names[], int n) override;
-    friend void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
     virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    friend void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
     virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-    friend void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n);
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
     virtual bool MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command) override;
     virtual bool MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command) override;

--- a/examples/tutorial_six/tutorial_client.h
+++ b/examples/tutorial_six/tutorial_client.h
@@ -38,27 +38,27 @@
 
 class MyClient : public INDI::BaseClient
 {
-  public:
+public:
     MyClient();
     ~MyClient() = default;
 
     void setTemperature();
     void takeExposure();
 
-  protected:
-    virtual void newDevice(INDI::BaseDevice *dp);
-    virtual void removeDevice(INDI::BaseDevice */*dp*/) {}
-    virtual void newProperty(INDI::Property *property);
-    virtual void removeProperty(INDI::Property */*property*/) {}
-    virtual void newBLOB(IBLOB *bp);
-    virtual void newSwitch(ISwitchVectorProperty */*svp*/) {}
-    virtual void newNumber(INumberVectorProperty *nvp);
-    virtual void newMessage(INDI::BaseDevice *dp, int messageID);
-    virtual void newText(ITextVectorProperty */*tvp*/) {}
-    virtual void newLight(ILightVectorProperty */*lvp*/) {}
-    virtual void serverConnected() {}
-    virtual void serverDisconnected(int /*exit_code*/) {}
+protected:
+    void newDevice(INDI::BaseDevice *dp) override;
+    void removeDevice(INDI::BaseDevice */*dp*/) override {}
+    void newProperty(INDI::Property *property) override;
+    void removeProperty(INDI::Property */*property*/) override {}
+    void newBLOB(IBLOB *bp) override;
+    void newSwitch(ISwitchVectorProperty */*svp*/) override {}
+    void newNumber(INumberVectorProperty *nvp) override;
+    void newMessage(INDI::BaseDevice *dp, int messageID) override;
+    void newText(ITextVectorProperty */*tvp*/) override {}
+    void newLight(ILightVectorProperty */*lvp*/) override {}
+    void serverConnected() override {}
+    void serverDisconnected(int /*exit_code*/) override {}
 
-  private:
+private:
     INDI::BaseDevice *ccd_simulator;
 };

--- a/examples/tutorial_three/simpleccd.cpp
+++ b/examples/tutorial_three/simpleccd.cpp
@@ -29,44 +29,6 @@
 
 std::unique_ptr<SimpleCCD> simpleCCD(new SimpleCCD());
 
-void ISGetProperties(const char *dev)
-{
-    simpleCCD->ISGetProperties(dev);
-}
-
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    simpleCCD->ISNewSwitch(dev, name, states, names, n);
-}
-
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    simpleCCD->ISNewText(dev, name, texts, names, n);
-}
-
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    simpleCCD->ISNewNumber(dev, name, values, names, n);
-}
-
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    INDI_UNUSED(dev);
-    INDI_UNUSED(name);
-    INDI_UNUSED(sizes);
-    INDI_UNUSED(blobsizes);
-    INDI_UNUSED(blobs);
-    INDI_UNUSED(formats);
-    INDI_UNUSED(names);
-    INDI_UNUSED(n);
-}
-
-void ISSnoopDevice(XMLEle *root)
-{
-    simpleCCD->ISSnoopDevice(root);
-}
-
 /**************************************************************************************
 ** Client is asking us to establish connection to the device
 ***************************************************************************************/

--- a/examples/tutorial_three/simpleccd.h
+++ b/examples/tutorial_three/simpleccd.h
@@ -31,17 +31,17 @@ class SimpleCCD : public INDI::CCD
 
   protected:
     // General device functions
-    bool Connect();
-    bool Disconnect();
-    const char *getDefaultName();
-    bool initProperties();
-    bool updateProperties();
+    bool Connect() override;
+    bool Disconnect() override;
+    const char *getDefaultName() override;
+    bool initProperties() override;
+    bool updateProperties() override;
 
     // CCD specific functions
-    bool StartExposure(float duration);
-    bool AbortExposure();
-    int SetTemperature(double temperature);
-    void TimerHit();
+    bool StartExposure(float duration) override;
+    bool AbortExposure() override;
+    int SetTemperature(double temperature) override;
+    void TimerHit() override;
 
   private:
     // Utility functions

--- a/examples/tutorial_three/simpleccd.h
+++ b/examples/tutorial_three/simpleccd.h
@@ -26,10 +26,10 @@
 
 class SimpleCCD : public INDI::CCD
 {
-  public:
+public:
     SimpleCCD() = default;
 
-  protected:
+protected:
     // General device functions
     bool Connect() override;
     bool Disconnect() override;
@@ -43,7 +43,7 @@ class SimpleCCD : public INDI::CCD
     int SetTemperature(double temperature) override;
     void TimerHit() override;
 
-  private:
+private:
     // Utility functions
     float CalcTimeLeft();
     void setupParams();

--- a/examples/tutorial_two/simplescope.cpp
+++ b/examples/tutorial_two/simplescope.cpp
@@ -28,55 +28,6 @@
 
 static std::unique_ptr<SimpleScope> simpleScope(new SimpleScope());
 
-/**************************************************************************************
-** Return properties of device.
-***************************************************************************************/
-void ISGetProperties(const char *dev)
-{
-    simpleScope->ISGetProperties(dev);
-}
-
-/**************************************************************************************
-** Process new switch from client
-***************************************************************************************/
-void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    simpleScope->ISNewSwitch(dev, name, states, names, n);
-}
-
-/**************************************************************************************
-** Process new text from client
-***************************************************************************************/
-void ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
-{
-    simpleScope->ISNewText(dev, name, texts, names, n);
-}
-
-/**************************************************************************************
-** Process new number from client
-***************************************************************************************/
-void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
-{
-    simpleScope->ISNewNumber(dev, name, values, names, n);
-}
-
-/**************************************************************************************
-** Process new blob from client
-***************************************************************************************/
-void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
-               char *names[], int n)
-{
-    simpleScope->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
-}
-
-/**************************************************************************************
-** Process snooped property from another driver
-***************************************************************************************/
-void ISSnoopDevice(XMLEle *root)
-{
-    simpleScope->ISSnoopDevice(root);
-}
-
 SimpleScope::SimpleScope()
 {
     // We add an additional debug level so we can log verbose scope status

--- a/examples/tutorial_two/simplescope.h
+++ b/examples/tutorial_two/simplescope.h
@@ -25,10 +25,10 @@
 
 class SimpleScope : public INDI::Telescope
 {
-  public:
+public:
     SimpleScope();
 
-  protected:
+protected:
     bool Handshake() override;
 
     const char *getDefaultName() override;
@@ -39,7 +39,7 @@ class SimpleScope : public INDI::Telescope
     bool Goto(double, double) override;
     bool Abort() override;
 
-  private:
+private:
     double currentRA {0};
     double currentDEC {90};
     double targetRA {0};


### PR DESCRIPTION
Hi!

I have removed the function implementations from the examples.
- ISGetProperties
- ISNewSwitch/Text/Number etc
- ISSnoopDevice

The role was successfully taken over by the implementation in DefaultDevice.
Additionally, I improved the formatting, override specifier and public/private/protected visibility.
I will try to upload the updated documentation today.