### PR TITLE
Refactoring - use INDI::PropertyXXX - Stage 1 - Conflict check

### DIFF
--- a/drivers/agent/agent_imager.cpp
+++ b/drivers/agent/agent_imager.cpp
@@ -85,17 +85,17 @@ Imager::Imager()
 
 bool Imager::isRunning()
 {
-    return ProgressNP.s == IPS_BUSY;
+    return ProgressNP.getState() == IPS_BUSY;
 }
 
 bool Imager::isCCDConnected()
 {
-    return StatusL[0].s == IPS_OK;
+    return StatusLP[0].getState() == IPS_OK;
 }
 
 bool Imager::isFilterConnected()
 {
-    return StatusL[1].s == IPS_OK;
+    return StatusLP[1].getState() == IPS_OK;
 }
 
 std::shared_ptr<Group> Imager::getGroup(int index) const {
@@ -127,8 +127,8 @@ void Imager::initiateNextFilter()
         {
             if (filterSlot != 0)
             {
-                ProgressNP.s = IPS_ALERT;
-                IDSetNumber(&ProgressNP, "Filter wheel is not connected");
+                ProgressNP.setState(IPS_ALERT);
+                ProgressNP.apply("Filter wheel is not connected");
                 return;
             }
             else
@@ -136,12 +136,12 @@ void Imager::initiateNextFilter()
                 initiateNextCapture();
             }
         }
-        else if (filterSlot != 0 && FilterSlotN[0].value != filterSlot)
+        else if (filterSlot != 0 && FilterSlotNP[0].getValue() != filterSlot)
         {
-            FilterSlotN[0].value = filterSlot;
+            FilterSlotNP[0].setValue(filterSlot);
             sendNewNumber(&FilterSlotNP);
             LOGF_DEBUG("Group %d of %d, image %d of %d, filer %d, filter set initiated on %s",
-                   group, maxGroup, image, maxImage, (int)FilterSlotN[0].value, FilterSlotNP.device);
+                   group, maxGroup, image, maxImage, (int)FilterSlotNP[0].getValue(), FilterSlotNP.getDeviceName());
         }
         else
         {
@@ -158,22 +158,22 @@ void Imager::initiateNextCapture()
         {
             if (!isCCDConnected())
             {
-                ProgressNP.s = IPS_ALERT;
-                IDSetNumber(&ProgressNP, "CCD is not connected");
+                ProgressNP.setState(IPS_ALERT);
+                ProgressNP.apply("CCD is not connected");
                 return;
             }
-            CCDImageBinN[0].value = currentGroup()->binning();
-            CCDImageBinN[1].value = currentGroup()->binning();
+            CCDImageBinNP[0].setValue(currentGroup()->binning());
+            CCDImageBinNP[1].setValue(currentGroup()->binning());
             sendNewNumber(&CCDImageBinNP);
-            CCDImageExposureN[0].value = currentGroup()->exposure();
+            CCDImageExposureNP[0].setValue(currentGroup()->exposure());
             sendNewNumber(&CCDImageExposureNP);
-            IUSaveText(&CCDUploadSettingsT[0], ImageNameT[0].text);
-            IUSaveText(&CCDUploadSettingsT[1], "_TMP_");
+            CCDUploadSettingsTP[0].setText(ImageNameTP[0].getText());
+            CCDUploadSettingsTP[1].setText("_TMP_");
             sendNewSwitch(&CCDUploadSP);
             sendNewText(&CCDUploadSettingsTP);
             LOGF_DEBUG("Group %d of %d, image %d of %d, duration %.1fs, binning %d, capture initiated on %s", group,
-                   maxGroup, image, maxImage, CCDImageExposureN[0].value, (int)CCDImageBinN[0].value,
-                   CCDImageExposureNP.device);
+                   maxGroup, image, maxImage, CCDImageExposureNP[0].getValue(), (int)CCDImageBinNP[0].getValue(),
+                   CCDImageExposureNP.getDeviceName());
         }
     }
 }
@@ -181,40 +181,40 @@ void Imager::initiateNextCapture()
 void Imager::startBatch()
 {
     LOG_DEBUG("Batch started");
-    ProgressN[0].value = group = 1;
-    ProgressN[1].value = image = 1;
+    ProgressNP[0].setValue(group = 1);
+    ProgressNP[1].setValue(image = 1);
     maxImage                   = currentGroup()->count();
-    ProgressNP.s               = IPS_BUSY;
-    IDSetNumber(&ProgressNP, nullptr);
+    ProgressNP.setState(IPS_BUSY);
+    ProgressNP.apply();
     initiateNextFilter();
 }
 
 void Imager::abortBatch()
 {
-    ProgressNP.s = IPS_ALERT;
-    IDSetNumber(&ProgressNP, "Batch aborted");
+    ProgressNP.setState(IPS_ALERT);
+    ProgressNP.apply("Batch aborted");
 }
 
 void Imager::batchDone()
 {
-    ProgressNP.s = IPS_OK;
-    IDSetNumber(&ProgressNP, "Batch done");
+    ProgressNP.setState(IPS_OK);
+    ProgressNP.apply("Batch done");
 }
 
 void Imager::initiateDownload()
 {
-    int group = (int)DownloadN[0].value;
-    int image = (int)DownloadN[1].value;
+    int group = (int)DownloadNP[0].getValue();
+    int image = (int)DownloadNP[1].getValue();
     char name[128]={0};
     std::ifstream file;
 
     if (group == 0 || image == 0)
         return;
 
-    sprintf(name, IMAGE_NAME, ImageNameT[0].text, ImageNameT[1].text, group, image, format);
+    sprintf(name, IMAGE_NAME, ImageNameTP[0].getText(), ImageNameTP[1].getText(), group, image, format);
     file.open(name, std::ios::in | std::ios::binary | std::ios::ate);
-    DownloadN[0].value = 0;
-    DownloadN[1].value = 0;
+    DownloadNP[0].setValue(0);
+    DownloadNP[1].setValue(0);
     if (file.is_open())
     {
         long size  = file.tellg();
@@ -225,20 +225,20 @@ void Imager::initiateDownload()
         file.close();
         remove(name);
         LOGF_DEBUG("Group %d, image %d, download initiated", group, image);
-        DownloadNP.s = IPS_BUSY;
-        IDSetNumber(&DownloadNP, "Download initiated");
+        DownloadNP.setState(IPS_BUSY);
+        DownloadNP.apply("Download initiated");
         strncpy(FitsB[0].format, format, MAXINDIBLOBFMT);
         FitsB[0].blob    = data;
         FitsB[0].bloblen = FitsB[0].size = size;
         FitsBP.s                         = IPS_OK;
         IDSetBLOB(&FitsBP, nullptr);
-        DownloadNP.s = IPS_OK;
-        IDSetNumber(&DownloadNP, "Download finished");
+        DownloadNP.setState(IPS_OK);
+        DownloadNP.apply("Download finished");
     }
     else
     {
-        DownloadNP.s = IPS_ALERT;
-        IDSetNumber(&DownloadNP, "Download failed");
+        DownloadNP.setState(IPS_ALERT);
+        DownloadNP.apply("Download failed");
         LOGF_DEBUG("Group %d, image %d, upload failed", group, image);
     }
 }
@@ -256,76 +256,76 @@ bool Imager::initProperties()
 
     addDebugControl();
 
-    IUFillNumber(&GroupCountN[0], "GROUP_COUNT", "Image group count", "%3.0f", 1, MAX_GROUP_COUNT, 1, maxGroup = 1);
-    IUFillNumberVector(&GroupCountNP, GroupCountN, 1, getDefaultName(), "GROUPS", "Image groups", MAIN_CONTROL_TAB, IP_RW,
+    GroupCountNP[0].fill("GROUP_COUNT", "Image group count", "%3.0f", 1, MAX_GROUP_COUNT, 1, maxGroup = 1);
+    GroupCountNP.fill(getDefaultName(), "GROUPS", "Image groups", MAIN_CONTROL_TAB, IP_RW,
                        60, IPS_IDLE);
 
-    IUFillText(&ControlledDeviceT[0], "CCD", "CCD", "CCD Simulator");
-    IUFillText(&ControlledDeviceT[1], "FILTER", "Filter wheel", "Filter Simulator");
-    IUFillTextVector(&ControlledDeviceTP, ControlledDeviceT, 2, getDefaultName(), "DEVICES", "Controlled devices",
+    ControlledDeviceTP[0].fill("CCD", "CCD", "CCD Simulator");
+    ControlledDeviceTP[1].fill("FILTER", "Filter wheel", "Filter Simulator");
+    ControlledDeviceTP.fill(getDefaultName(), "DEVICES", "Controlled devices",
                      MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
-    controlledCCD         = ControlledDeviceT[0].text;
-    controlledFilterWheel = ControlledDeviceT[1].text;
+    controlledCCD         = ControlledDeviceTP[0].getText();
+    controlledFilterWheel = ControlledDeviceTP[1].getText();
 
-    IUFillLight(&StatusL[0], "CCD", controlledCCD, IPS_IDLE);
-    IUFillLight(&StatusL[1], "FILTER", controlledFilterWheel, IPS_IDLE);
-    IUFillLightVector(&StatusLP, StatusL, 2, getDefaultName(), "STATUS", "Controlled devices", MAIN_CONTROL_TAB, IPS_IDLE);
+    StatusLP[0].fill("CCD", controlledCCD, IPS_IDLE);
+    StatusLP[1].fill("FILTER", controlledFilterWheel, IPS_IDLE);
+    StatusLP.fill(getDefaultName(), "STATUS", "Controlled devices", MAIN_CONTROL_TAB, IPS_IDLE);
 
-    IUFillNumber(&ProgressN[0], "GROUP", "Current group", "%3.0f", 1, MAX_GROUP_COUNT, 1, 0);
-    IUFillNumber(&ProgressN[1], "IMAGE", "Current image", "%3.0f", 1, 100, 1, 0);
-    IUFillNumber(&ProgressN[2], "REMAINING_TIME", "Remaining time", "%5.2f", 0, 36000, 0, 0.0);
-    IUFillNumberVector(&ProgressNP, ProgressN, 3, getDefaultName(), "PROGRESS", "Batch execution progress", MAIN_CONTROL_TAB,
+    ProgressNP[0].fill("GROUP", "Current group", "%3.0f", 1, MAX_GROUP_COUNT, 1, 0);
+    ProgressNP[1].fill("IMAGE", "Current image", "%3.0f", 1, 100, 1, 0);
+    ProgressNP[2].fill("REMAINING_TIME", "Remaining time", "%5.2f", 0, 36000, 0, 0.0);
+    ProgressNP.fill(getDefaultName(), "PROGRESS", "Batch execution progress", MAIN_CONTROL_TAB,
                        IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&BatchS[0], "START", "Start batch", ISS_OFF);
-    IUFillSwitch(&BatchS[1], "ABORT", "Abort batch", ISS_OFF);
-    IUFillSwitchVector(&BatchSP, BatchS, 2, getDefaultName(), "BATCH", "Batch control", MAIN_CONTROL_TAB, IP_RW, ISR_NOFMANY,
+    BatchSP[0].fill("START", "Start batch", ISS_OFF);
+    BatchSP[1].fill("ABORT", "Abort batch", ISS_OFF);
+    BatchSP.fill(getDefaultName(), "BATCH", "Batch control", MAIN_CONTROL_TAB, IP_RW, ISR_NOFMANY,
                        60, IPS_IDLE);
 
-    IUFillText(&ImageNameT[0], "IMAGE_FOLDER", "Image folder", "/tmp");
-    IUFillText(&ImageNameT[1], "IMAGE_PREFIX", "Image prefix", "IMG");
-    IUFillTextVector(&ImageNameTP, ImageNameT, 2, getDefaultName(), "IMAGE_NAME", "Image name", OPTIONS_TAB, IP_RW, 60,
+    ImageNameTP[0].fill("IMAGE_FOLDER", "Image folder", "/tmp");
+    ImageNameTP[1].fill("IMAGE_PREFIX", "Image prefix", "IMG");
+    ImageNameTP.fill(getDefaultName(), "IMAGE_NAME", "Image name", OPTIONS_TAB, IP_RW, 60,
                      IPS_IDLE);
 
-    IUFillNumber(&DownloadN[0], "GROUP", "Group", "%3.0f", 1, MAX_GROUP_COUNT, 1, 1);
-    IUFillNumber(&DownloadN[1], "IMAGE", "Image", "%3.0f", 1, 100, 1, 1);
-    IUFillNumberVector(&DownloadNP, DownloadN, 2, getDefaultName(), "DOWNLOAD", "Download image", DOWNLOAD_TAB, IP_RW, 60,
+    DownloadNP[0].fill("GROUP", "Group", "%3.0f", 1, MAX_GROUP_COUNT, 1, 1);
+    DownloadNP[1].fill("IMAGE", "Image", "%3.0f", 1, 100, 1, 1);
+    DownloadNP.fill(getDefaultName(), "DOWNLOAD", "Download image", DOWNLOAD_TAB, IP_RW, 60,
                        IPS_IDLE);
 
     IUFillBLOB(&FitsB[0], "IMAGE", "Image", "");
     IUFillBLOBVector(&FitsBP, FitsB, 1, getDefaultName(), "IMAGE", "Image Data", DOWNLOAD_TAB, IP_RO, 60, IPS_IDLE);
 
-    defineProperty(&GroupCountNP);
-    defineProperty(&ControlledDeviceTP);
-    defineProperty(&ImageNameTP);
+    defineProperty(GroupCountNP);
+    defineProperty(ControlledDeviceTP);
+    defineProperty(ImageNameTP);
 
-    for (int i = 0; i < GroupCountN[0].value; i++)
+    for (int i = 0; i < GroupCountNP[0].getValue(); i++)
     {
         groups[i]->defineProperties();
     }
 
-    IUFillNumber(&CCDImageExposureN[0], "CCD_EXPOSURE_VALUE", "Duration (s)", "%5.2f", 0, 36000, 0, 1.0);
-    IUFillNumberVector(&CCDImageExposureNP, CCDImageExposureN, 1, ControlledDeviceT[0].text, "CCD_EXPOSURE", "Expose",
+    CCDImageExposureNP[0].fill("CCD_EXPOSURE_VALUE", "Duration (s)", "%5.2f", 0, 36000, 0, 1.0);
+    CCDImageExposureNP.fill(ControlledDeviceTP[0].getText(), "CCD_EXPOSURE", "Expose",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillNumber(&CCDImageBinN[0], "HOR_BIN", "X", "%2.0f", 1, 4, 1, 1);
-    IUFillNumber(&CCDImageBinN[1], "VER_BIN", "Y", "%2.0f", 1, 4, 1, 1);
-    IUFillNumberVector(&CCDImageBinNP, CCDImageBinN, 2, ControlledDeviceT[0].text, "CCD_BINNING", "Binning",
+    CCDImageBinNP[0].fill("HOR_BIN", "X", "%2.0f", 1, 4, 1, 1);
+    CCDImageBinNP[1].fill("VER_BIN", "Y", "%2.0f", 1, 4, 1, 1);
+    CCDImageBinNP.fill(ControlledDeviceTP[0].getText(), "CCD_BINNING", "Binning",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillSwitch(&CCDUploadS[0], "UPLOAD_CLIENT", "Client", ISS_OFF);
-    IUFillSwitch(&CCDUploadS[1], "UPLOAD_LOCAL", "Local", ISS_ON);
-    IUFillSwitch(&CCDUploadS[2], "UPLOAD_BOTH", "Both", ISS_OFF);
-    IUFillSwitchVector(&CCDUploadSP, CCDUploadS, 3, ControlledDeviceT[0].text, "UPLOAD_MODE", "Upload", OPTIONS_TAB,
+    CCDUploadSP[0].fill("UPLOAD_CLIENT", "Client", ISS_OFF);
+    CCDUploadSP[1].fill("UPLOAD_LOCAL", "Local", ISS_ON);
+    CCDUploadSP[2].fill("UPLOAD_BOTH", "Both", ISS_OFF);
+    CCDUploadSP.fill(ControlledDeviceTP[0].getText(), "UPLOAD_MODE", "Upload", OPTIONS_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillText(&CCDUploadSettingsT[0], "UPLOAD_DIR", "Dir", "");
-    IUFillText(&CCDUploadSettingsT[1], "UPLOAD_PREFIX", "Prefix", IMAGE_PREFIX);
-    IUFillTextVector(&CCDUploadSettingsTP, CCDUploadSettingsT, 2, ControlledDeviceT[0].text, "UPLOAD_SETTINGS",
+    CCDUploadSettingsTP[0].fill("UPLOAD_DIR", "Dir", "");
+    CCDUploadSettingsTP[1].fill("UPLOAD_PREFIX", "Prefix", IMAGE_PREFIX);
+    CCDUploadSettingsTP.fill(ControlledDeviceTP[0].getText(), "UPLOAD_SETTINGS",
                      "Upload Settings", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillNumber(&FilterSlotN[0], "FILTER_SLOT_VALUE", "Filter", "%3.0f", 1.0, 12.0, 1.0, 1.0);
-    IUFillNumberVector(&FilterSlotNP, FilterSlotN, 1, ControlledDeviceT[1].text, "FILTER_SLOT", "Filter Slot",
+    FilterSlotNP[0].fill("FILTER_SLOT_VALUE", "Filter", "%3.0f", 1.0, 12.0, 1.0, 1.0);
+    FilterSlotNP.fill(ControlledDeviceTP[1].getText(), "FILTER_SLOT", "Filter Slot",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     return true;
@@ -335,26 +335,26 @@ bool Imager::updateProperties()
 {
     if (isConnected())
     {
-        defineProperty(&StatusLP);
-        ProgressN[0].value = group = 0;
-        ProgressN[1].value = image = 0;
-        ProgressNP.s               = IPS_IDLE;
-        defineProperty(&ProgressNP);
-        BatchSP.s = IPS_IDLE;
-        defineProperty(&BatchSP);
-        DownloadN[0].value = 0;
-        DownloadN[1].value = 0;
-        DownloadNP.s       = IPS_IDLE;
-        defineProperty(&DownloadNP);
+        defineProperty(StatusLP);
+        ProgressNP[0].setValue(group = 0);
+        ProgressNP[1].setValue(image = 0);
+        ProgressNP.setState(IPS_IDLE);
+        defineProperty(ProgressNP);
+        BatchSP.setState(IPS_IDLE);
+        defineProperty(BatchSP);
+        DownloadNP[0].setValue(0);
+        DownloadNP[1].setValue(0);
+        DownloadNP.setState(IPS_IDLE);
+        defineProperty(DownloadNP);
         FitsBP.s = IPS_IDLE;
         defineProperty(&FitsBP);
     }
     else
     {
-        deleteProperty(StatusLP.name);
-        deleteProperty(ProgressNP.name);
-        deleteProperty(BatchSP.name);
-        deleteProperty(DownloadNP.name);
+        deleteProperty(StatusLP.getName());
+        deleteProperty(ProgressNP.getName());
+        deleteProperty(BatchSP.getName());
+        deleteProperty(DownloadNP.getName());
         deleteProperty(FitsBP.name);
     }
     return true;
@@ -369,29 +369,29 @@ bool Imager::ISNewNumber(const char *dev, const char *name, double values[], cha
 {
     if (Imager::DEVICE_NAME == dev)
     {
-        if (std::string{name} == std::string{GroupCountNP.name})
+        if (GroupCountNP.isNameMatch(name))
         {
             for (int i = 0; i < maxGroup; i++)
                 groups[i]->deleteProperties();
-            IUUpdateNumber(&GroupCountNP, values, names, n);
-            maxGroup = (int)GroupCountN[0].value;
+            GroupCountNP.update(values, names, n);
+            maxGroup = (int)GroupCountNP[0].getValue();
             if (maxGroup > MAX_GROUP_COUNT)
-                GroupCountN[0].value = maxGroup = MAX_GROUP_COUNT;
+                GroupCountNP[0].setValue(maxGroup = MAX_GROUP_COUNT);
             for (int i = 0; i < maxGroup; i++)
                 groups[i]->defineProperties();
-            GroupCountNP.s = IPS_OK;
-            IDSetNumber(&GroupCountNP, nullptr);
+            GroupCountNP.setState(IPS_OK);
+            GroupCountNP.apply();
             return true;
         }
-        if (std::string{name} == std::string{DownloadNP.name})
+        if (DownloadNP.isNameMatch(name))
         {
-            IUUpdateNumber(&DownloadNP, values, names, n);
+            DownloadNP.update(values, names, n);
             initiateDownload();
             return true;
         }
         if (strncmp(name, GROUP_PREFIX, GROUP_PREFIX_LEN) == 0)
         {
-            for (int i = 0; i < GroupCountN[0].value; i++)
+            for (int i = 0; i < GroupCountNP[0].getValue(); i++)
                 if (groups[i]->ISNewNumber(dev, name, values, names, n))
                 {
                     return true;
@@ -406,23 +406,23 @@ bool Imager::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
 {
     if (Imager::DEVICE_NAME == dev)
     {
-        if (std::string{name} == std::string{BatchSP.name})
+        if (BatchSP.isNameMatch(name))
         {
             for (int i = 0; i < n; i++)
             {
-                if (strcmp(names[i], BatchS[0].name) == 0 && states[i] == ISS_ON)
+                if (strcmp(names[i], BatchSP[0].getName()) == 0 && states[i] == ISS_ON)
                 {
                     if (!isRunning())
                         startBatch();
                 }
-                if (strcmp(names[i], BatchS[1].name) == 0 && states[i] == ISS_ON)
+                if (strcmp(names[i], BatchSP[1].getName()) == 0 && states[i] == ISS_ON)
                 {
                     if (isRunning())
                         abortBatch();
                 }
             }
-            BatchSP.s = IPS_OK;
-            IDSetSwitch(&BatchSP, nullptr);
+            BatchSP.setState(IPS_OK);
+            BatchSP.apply();
             return true;
         }
     }
@@ -433,21 +433,21 @@ bool Imager::ISNewText(const char *dev, const char *name, char *texts[], char *n
 {
     if (Imager::DEVICE_NAME == dev)
     {
-        if (std::string{name} == std::string{ControlledDeviceTP.name})
+        if (ControlledDeviceTP.isNameMatch(name))
         {
-            IUUpdateText(&ControlledDeviceTP, texts, names, n);
-            IDSetText(&ControlledDeviceTP, nullptr);
-            strncpy(StatusL[0].label, ControlledDeviceT[0].text, sizeof(StatusL[0].label));
-            strncpy(CCDImageExposureNP.device, ControlledDeviceT[0].text, sizeof(CCDImageExposureNP.device));
-            strncpy(CCDImageBinNP.device, ControlledDeviceT[0].text, sizeof(CCDImageBinNP.device));
-            strncpy(StatusL[1].label, ControlledDeviceT[1].text, sizeof(StatusL[1].label));
-            strncpy(FilterSlotNP.device, ControlledDeviceT[1].text, sizeof(FilterSlotNP.device));
+            ControlledDeviceTP.update(texts, names, n);
+            ControlledDeviceTP.apply();
+            StatusLP[0].setLabel(ControlledDeviceTP[0].getText());
+            CCDImageExposureNP.setDeviceName(ControlledDeviceTP[0].getText());
+            CCDImageBinNP.setDeviceName(ControlledDeviceTP[0].getText());
+            StatusLP[1].setLabel(ControlledDeviceTP[1].getText());
+            FilterSlotNP.setDeviceName(ControlledDeviceTP[1].getText());
             return true;
         }
-        if (std::string{name} == std::string{ImageNameTP.name})
+        if (ImageNameTP.isNameMatch(name))
         {
-            IUUpdateText(&ImageNameTP, texts, names, n);
-            IDSetText(&ImageNameTP, nullptr);
+            ImageNameTP.update(texts, names, n);
+            ImageNameTP.apply();
             return true;
         }
     }
@@ -489,9 +489,9 @@ bool Imager::Disconnect()
 void Imager::serverConnected()
 {
     LOG_DEBUG("Server connected");
-    StatusL[0].s = IPS_ALERT;
-    StatusL[1].s = IPS_ALERT;
-    IDSetLight(&StatusLP, nullptr);
+    StatusLP[0].setState(IPS_ALERT);
+    StatusLP[1].setState(IPS_ALERT);
+    StatusLP.apply();
 }
 
 void Imager::newDevice(INDI::BaseDevice *dp)
@@ -500,11 +500,11 @@ void Imager::newDevice(INDI::BaseDevice *dp)
 
     LOGF_DEBUG("Device %s detected", deviceName.c_str());
     if (deviceName == controlledCCD)
-        StatusL[0].s = IPS_BUSY;
+        StatusLP[0].setState(IPS_BUSY);
     if (deviceName == controlledFilterWheel)
-        StatusL[1].s = IPS_BUSY;
+        StatusLP[1].setState(IPS_BUSY);
 
-    IDSetLight(&StatusLP, nullptr);
+    StatusLP.apply();
 }
 
 void Imager::newProperty(INDI::Property *property)
@@ -518,7 +518,7 @@ void Imager::newProperty(INDI::Property *property)
         {
             if (state)
             {
-                StatusL[0].s = IPS_OK;
+                StatusLP[0].setState(IPS_OK);
             }
             else
             {
@@ -530,7 +530,7 @@ void Imager::newProperty(INDI::Property *property)
         {
             if (state)
             {
-                StatusL[1].s = IPS_OK;
+                StatusLP[1].setState(IPS_OK);
             }
             else
             {
@@ -538,7 +538,7 @@ void Imager::newProperty(INDI::Property *property)
                 LOGF_DEBUG("Connecting %s", controlledFilterWheel);
             }
         }
-        IDSetLight(&StatusLP, nullptr);
+        StatusLP.apply();
     }
 }
 
@@ -554,13 +554,13 @@ void Imager::removeDevice(INDI::BaseDevice *dp)
 
 void Imager::newBLOB(IBLOB *bp)
 {
-    if (ProgressNP.s == IPS_BUSY)
+    if (ProgressNP.getState() == IPS_BUSY)
     {
         char name[128]={0};
         std::ofstream file;
 
         strncpy(format, bp->format, 16);
-        sprintf(name, IMAGE_NAME, ImageNameT[0].text, ImageNameT[1].text, group, image, format);
+        sprintf(name, IMAGE_NAME, ImageNameTP[0].getText(), ImageNameTP[1].getText(), group, image, format);
         file.open(name, std::ios::out | std::ios::binary | std::ios::trunc);
         file.write(static_cast<char *>(bp->blob), bp->bloblen);
         file.close();
@@ -575,16 +575,16 @@ void Imager::newBLOB(IBLOB *bp)
             else
             {
                 maxImage           = nextGroup()->count();
-                ProgressN[0].value = group = group + 1;
-                ProgressN[1].value = image = 1;
-                IDSetNumber(&ProgressNP, nullptr);
+                ProgressNP[0].setValue(group = group + 1);
+                ProgressNP[1].setValue(image = 1);
+                ProgressNP.apply();
                 initiateNextFilter();
             }
         }
         else
         {
-            ProgressN[1].value = image = image + 1;
-            IDSetNumber(&ProgressNP, nullptr);
+            ProgressNP[1].setValue(image = image + 1);
+            ProgressNP.apply();
             initiateNextFilter();
         }
     }
@@ -601,25 +601,25 @@ void Imager::newSwitch(ISwitchVectorProperty *svp)
         {
             if (state)
             {
-                StatusL[0].s = IPS_OK;
+                StatusLP[0].setState(IPS_OK);
             }
             else
             {
-                StatusL[0].s = IPS_BUSY;
+                StatusLP[0].setState(IPS_BUSY);
             }
         }
         if (deviceName == controlledFilterWheel)
         {
             if (state)
             {
-                StatusL[1].s = IPS_OK;
+                StatusLP[1].setState(IPS_OK);
             }
             else
             {
-                StatusL[1].s = IPS_BUSY;
+                StatusLP[1].setState(IPS_BUSY);
             }
         }
-        IDSetLight(&StatusLP, nullptr);
+        StatusLP.apply();
     }
 }
 
@@ -631,15 +631,15 @@ void Imager::newNumber(INumberVectorProperty *nvp)
     {
         if (strcmp(nvp->name, "CCD_EXPOSURE") == 0)
         {
-            ProgressN[2].value = nvp->np[0].value;
-            IDSetNumber(&ProgressNP, nullptr);
+            ProgressNP[2].setValue(nvp->np[0].value);
+            ProgressNP.apply();
         }
     }
     if (deviceName == controlledFilterWheel)
     {
         if (strcmp(nvp->name, "FILTER_SLOT") == 0)
         {
-            FilterSlotN[0].value = nvp->np->value;
+            FilterSlotNP[0].setValue(nvp->np->value);
             if (nvp->s == IPS_OK)
                 initiateNextCapture();
         }
@@ -657,7 +657,7 @@ void Imager::newText(ITextVectorProperty *tvp)
             char name[128]={0};
 
             strncpy(format, strrchr(tvp->tp[0].text, '.'), sizeof(format));
-            sprintf(name, IMAGE_NAME, ImageNameT[0].text, ImageNameT[1].text, group, image, format);
+            sprintf(name, IMAGE_NAME, ImageNameTP[0].getText(), ImageNameTP[1].getText(), group, image, format);
             rename(tvp->tp[0].text, name);
             LOGF_DEBUG("Group %d of %d, image %d of %d, saved to %s", group, maxGroup, image,
                    maxImage, name);
@@ -670,16 +670,16 @@ void Imager::newText(ITextVectorProperty *tvp)
                 else
                 {
                     maxImage           = nextGroup()->count();
-                    ProgressN[0].value = group = group + 1;
-                    ProgressN[1].value = image = 1;
-                    IDSetNumber(&ProgressNP, nullptr);
+                    ProgressNP[0].setValue(group = group + 1);
+                    ProgressNP[1].setValue(image = 1);
+                    ProgressNP.apply();
                     initiateNextFilter();
                 }
             }
             else
             {
-                ProgressN[1].value = image = image + 1;
-                IDSetNumber(&ProgressNP, nullptr);
+                ProgressNP[1].setValue(image = image + 1);
+                ProgressNP.apply();
                 initiateNextFilter();
             }
         }
@@ -701,8 +701,8 @@ void Imager::serverDisconnected(int exit_code)
 {
     INDI_UNUSED(exit_code);
     LOG_DEBUG("Server disconnected");
-    StatusL[0].s = IPS_ALERT;
-    StatusL[1].s = IPS_ALERT;
+    StatusLP[0].setState(IPS_ALERT);
+    StatusLP[1].setState(IPS_ALERT);
 }
 
 

--- a/drivers/agent/agent_imager.h
+++ b/drivers/agent/agent_imager.h
@@ -21,6 +21,12 @@
 
 #include "baseclient.h"
 #include "defaultdevice.h"
+
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
 #define MAX_GROUP_COUNT 16
 
 class Group;
@@ -83,35 +89,20 @@ class Imager : public virtual INDI::DefaultDevice, public virtual INDI::BaseClie
         int maxImage { 0 };
         const char *controlledCCD { nullptr };
         const char *controlledFilterWheel { nullptr };
-
-        ITextVectorProperty ControlledDeviceTP;
-        IText ControlledDeviceT[2] {};
-        INumberVectorProperty GroupCountNP;
-        INumber GroupCountN[1];
-        INumberVectorProperty ProgressNP;
-        INumber ProgressN[3];
-        ISwitchVectorProperty BatchSP;
-        ISwitch BatchS[2];
-        ILightVectorProperty StatusLP;
-        ILight StatusL[2];
-        ITextVectorProperty ImageNameTP;
-        IText ImageNameT[2];
-        INumberVectorProperty DownloadNP;
-        INumber DownloadN[2];
+        INDI::PropertyText ControlledDeviceTP {2};
+        INDI::PropertyNumber GroupCountNP {1};
+        INDI::PropertyNumber ProgressNP {3};
+        INDI::PropertySwitch BatchSP {2};
+        INDI::PropertyLight StatusLP {2};
+        INDI::PropertyText ImageNameTP {2};
+        INDI::PropertyNumber DownloadNP {2};
         IBLOBVectorProperty FitsBP;
         IBLOB FitsB[1];
-
-        INumberVectorProperty CCDImageExposureNP;
-        INumber CCDImageExposureN[1];
-        INumberVectorProperty CCDImageBinNP;
-        INumber CCDImageBinN[2];
-        ISwitch CCDUploadS[3];
-        ISwitchVectorProperty CCDUploadSP;
-        IText CCDUploadSettingsT[2] {};
-        ITextVectorProperty CCDUploadSettingsTP;
-
-        INumberVectorProperty FilterSlotNP;
-        INumber FilterSlotN[1];
+        INDI::PropertyNumber CCDImageExposureNP {1};
+        INDI::PropertyNumber CCDImageBinNP {2};
+        INDI::PropertySwitch CCDUploadSP {3};
+        INDI::PropertyText CCDUploadSettingsTP {2};
+        INDI::PropertyNumber FilterSlotNP {1};
 
         std::vector<std::shared_ptr<Group>> groups;
         std::shared_ptr<Group> currentGroup() const;

--- a/drivers/auxiliary/astrometrydriver.cpp
+++ b/drivers/auxiliary/astrometrydriver.cpp
@@ -79,33 +79,33 @@ bool AstrometryDriver::initProperties()
     /**********************************************/
 
     // Solver Enable/Disable
-    IUFillSwitch(&SolverS[SOLVER_ENABLE], "ASTROMETRY_SOLVER_ENABLE", "Enable", ISS_OFF);
-    IUFillSwitch(&SolverS[SOLVER_DISABLE], "ASTROMETRY_SOLVER_DISABLE", "Disable", ISS_ON);
-    IUFillSwitchVector(&SolverSP, SolverS, 2, getDeviceName(), "ASTROMETRY_SOLVER", "Solver", MAIN_CONTROL_TAB, IP_RW,
+    SolverSP[SOLVER_ENABLE].fill("ASTROMETRY_SOLVER_ENABLE", "Enable", ISS_OFF);
+    SolverSP[SOLVER_DISABLE].fill("ASTROMETRY_SOLVER_DISABLE", "Disable", ISS_ON);
+    SolverSP.fill(getDeviceName(), "ASTROMETRY_SOLVER", "Solver", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Solver Settings
-    IUFillText(&SolverSettingsT[ASTROMETRY_SETTINGS_BINARY], "ASTROMETRY_SETTINGS_BINARY", "Solver",
+    SolverSettingsTP[ASTROMETRY_SETTINGS_BINARY].fill("ASTROMETRY_SETTINGS_BINARY", "Solver",
                "/usr/bin/solve-field");
-    IUFillText(&SolverSettingsT[ASTROMETRY_SETTINGS_OPTIONS], "ASTROMETRY_SETTINGS_OPTIONS", "Options",
+    SolverSettingsTP[ASTROMETRY_SETTINGS_OPTIONS].fill("ASTROMETRY_SETTINGS_OPTIONS", "Options",
                "--no-verify --no-plots --no-fits2fits --resort --downsample 2 -O");
-    IUFillTextVector(&SolverSettingsTP, SolverSettingsT, 2, getDeviceName(), "ASTROMETRY_SETTINGS", "Settings",
+    SolverSettingsTP.fill(getDeviceName(), "ASTROMETRY_SETTINGS", "Settings",
                      MAIN_CONTROL_TAB, IP_WO, 0, IPS_IDLE);
 
     // Solver Results
-    IUFillNumber(&SolverResultN[ASTROMETRY_RESULTS_PIXSCALE], "ASTROMETRY_RESULTS_PIXSCALE", "Pixscale (arcsec/pixel)",
+    SolverResultNP[ASTROMETRY_RESULTS_PIXSCALE].fill("ASTROMETRY_RESULTS_PIXSCALE", "Pixscale (arcsec/pixel)",
                  "%g", 0, 10000, 1, 0);
-    IUFillNumber(&SolverResultN[ASTROMETRY_RESULTS_ORIENTATION], "ASTROMETRY_RESULTS_ORIENTATION",
+    SolverResultNP[ASTROMETRY_RESULTS_ORIENTATION].fill("ASTROMETRY_RESULTS_ORIENTATION",
                  "Orientation (E of N) °", "%g", -360, 360, 1, 0);
-    IUFillNumber(&SolverResultN[ASTROMETRY_RESULTS_RA], "ASTROMETRY_RESULTS_RA", "RA (J2000)", "%g", 0, 24, 1, 0);
-    IUFillNumber(&SolverResultN[ASTROMETRY_RESULTS_DE], "ASTROMETRY_RESULTS_DE", "DE (J2000)", "%g", -90, 90, 1, 0);
-    IUFillNumber(&SolverResultN[ASTROMETRY_RESULTS_PARITY], "ASTROMETRY_RESULTS_PARITY", "Parity", "%g", -1, 1, 1, 0);
-    IUFillNumberVector(&SolverResultNP, SolverResultN, 5, getDeviceName(), "ASTROMETRY_RESULTS", "Results",
+    SolverResultNP[ASTROMETRY_RESULTS_RA].fill("ASTROMETRY_RESULTS_RA", "RA (J2000)", "%g", 0, 24, 1, 0);
+    SolverResultNP[ASTROMETRY_RESULTS_DE].fill("ASTROMETRY_RESULTS_DE", "DE (J2000)", "%g", -90, 90, 1, 0);
+    SolverResultNP[ASTROMETRY_RESULTS_PARITY].fill("ASTROMETRY_RESULTS_PARITY", "Parity", "%g", -1, 1, 1, 0);
+    SolverResultNP.fill(getDeviceName(), "ASTROMETRY_RESULTS", "Results",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Solver Data Blob
-    IUFillBLOB(&SolverDataB[0], "ASTROMETRY_DATA_BLOB", "Image", "");
-    IUFillBLOBVector(&SolverDataBP, SolverDataB, 1, getDeviceName(), "ASTROMETRY_DATA", "Upload", MAIN_CONTROL_TAB,
+    SolverDataBP[0].fill("ASTROMETRY_DATA_BLOB", "Image", "");
+    SolverDataBP.fill(getDeviceName(), "ASTROMETRY_DATA", "Upload", MAIN_CONTROL_TAB,
                      IP_WO, 60, IPS_IDLE);
 
     /**********************************************/
@@ -113,17 +113,17 @@ bool AstrometryDriver::initProperties()
     /**********************************************/
 
     // Snooped Devices
-    IUFillText(&ActiveDeviceT[0], "ACTIVE_CCD", "CCD", "CCD Simulator");
-    IUFillTextVector(&ActiveDeviceTP, ActiveDeviceT, 1, getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
+    ActiveDeviceTP[0].fill("ACTIVE_CCD", "CCD", "CCD Simulator");
+    ActiveDeviceTP.fill(getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
                      IP_RW, 60, IPS_IDLE);
 
     // Primary CCD Chip Data Blob
-    IUFillBLOB(&CCDDataB[0], "CCD1", "Image", "");
-    IUFillBLOBVector(&CCDDataBP, CCDDataB, 1, ActiveDeviceT[0].text, "CCD1", "Image Data", "Image Info", IP_RO, 60,
+    CCDDataBP[0].fill("CCD1", "Image", "");
+    CCDDataBP.fill(ActiveDeviceTP[0].getText(), "CCD1", "Image Data", "Image Info", IP_RO, 60,
                      IPS_IDLE);
 
-    IDSnoopDevice(ActiveDeviceT[0].text, "CCD1");
-    IDSnoopBLOBs(ActiveDeviceT[0].text, "CCD1", B_ONLY);
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "CCD1");
+    IDSnoopBLOBs(ActiveDeviceTP[0].getText(), "CCD1", B_ONLY);
 
     addDebugControl();
 
@@ -136,7 +136,7 @@ void AstrometryDriver::ISGetProperties(const char *dev)
 {
     DefaultDevice::ISGetProperties(dev);
 
-    defineProperty(&ActiveDeviceTP);
+    defineProperty(ActiveDeviceTP);
     loadConfig(true, "ACTIVE_DEVICES");
 }
 
@@ -146,19 +146,19 @@ bool AstrometryDriver::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&SolverSP);
-        defineProperty(&SolverSettingsTP);
-        defineProperty(&SolverDataBP);
+        defineProperty(SolverSP);
+        defineProperty(SolverSettingsTP);
+        defineProperty(SolverDataBP);
     }
     else
     {
-        if (SolverS[0].s == ISS_ON)
+        if (SolverSP[0].getState() == ISS_ON)
         {
-            deleteProperty(SolverResultNP.name);
+            deleteProperty(SolverResultNP.getName());
         }
-        deleteProperty(SolverSP.name);
-        deleteProperty(SolverSettingsTP.name);
-        deleteProperty(SolverDataBP.name);
+        deleteProperty(SolverSP.getName());
+        deleteProperty(SolverSettingsTP.getName());
+        deleteProperty(SolverDataBP.getName());
     }
 
     return true;
@@ -189,19 +189,19 @@ bool AstrometryDriver::ISNewBLOB(const char *dev, const char *name, int sizes[],
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, SolverDataBP.name) == 0)
+        if (SolverDataBP.isNameMatch(name))
         {
-            SolverDataBP.s = IPS_OK;
-            IDSetBLOB(&SolverDataBP, nullptr);
+            SolverDataBP.setState(IPS_OK);
+            SolverDataBP.apply();
 
             // If the client explicitly uploaded the data then we solve it.
-            if (SolverS[SOLVER_ENABLE].s == ISS_OFF)
+            if (SolverSP[SOLVER_ENABLE].getState() == ISS_OFF)
             {
-                SolverS[SOLVER_ENABLE].s = ISS_ON;
-                SolverS[SOLVER_DISABLE].s = ISS_OFF;
-                SolverSP.s   = IPS_BUSY;
+                SolverSP[SOLVER_ENABLE].setState(ISS_ON);
+                SolverSP[SOLVER_DISABLE].setState(ISS_OFF);
+                SolverSP.setState(IPS_BUSY);
                 LOG_INFO("Astrometry solver is enabled.");
-                defineProperty(&SolverResultNP);
+                defineProperty(SolverResultNP);
             }
 
             processBLOB(reinterpret_cast<uint8_t *>(blobs[0]), static_cast<uint32_t>(sizes[0]),
@@ -220,26 +220,26 @@ bool AstrometryDriver::ISNewText(const char *dev, const char *name, char *texts[
     {
         //  This is for our device
         //  Now lets see if it's something we process here
-        if (strcmp(name, ActiveDeviceTP.name) == 0)
+        if (ActiveDeviceTP.isNameMatch(name))
         {
-            ActiveDeviceTP.s = IPS_OK;
-            IUUpdateText(&ActiveDeviceTP, texts, names, n);
-            IDSetText(&ActiveDeviceTP, nullptr);
+            ActiveDeviceTP.setState(IPS_OK);
+            ActiveDeviceTP.update(texts, names, n);
+            ActiveDeviceTP.apply();
 
             // Update the property name!
-            strncpy(CCDDataBP.device, ActiveDeviceT[0].text, MAXINDIDEVICE);
-            IDSnoopDevice(ActiveDeviceT[0].text, "CCD1");
-            IDSnoopBLOBs(ActiveDeviceT[0].text, "CCD1", B_ONLY);
+            CCDDataBP.setDeviceName(ActiveDeviceTP[0].getText());
+            IDSnoopDevice(ActiveDeviceTP[0].getText(), "CCD1");
+            IDSnoopBLOBs(ActiveDeviceTP[0].getText(), "CCD1", B_ONLY);
 
             //  We processed this one, so, tell the world we did it
             return true;
         }
 
-        if (strcmp(name, SolverSettingsTP.name) == 0)
+        if (SolverSettingsTP.isNameMatch(name))
         {
-            IUUpdateText(&SolverSettingsTP, texts, names, n);
-            SolverSettingsTP.s = IPS_OK;
-            IDSetText(&SolverSettingsTP, nullptr);
+            SolverSettingsTP.update(texts, names, n);
+            SolverSettingsTP.setState(IPS_OK);
+            SolverSettingsTP.apply();
             return true;
         }
     }
@@ -252,25 +252,25 @@ bool AstrometryDriver::ISNewSwitch(const char *dev, const char *name, ISState *s
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Astrometry Enable/Disable
-        if (strcmp(name, SolverSP.name) == 0)
+        if (SolverSP.isNameMatch(name))
         {
             pthread_mutex_lock(&lock);
 
-            IUUpdateSwitch(&SolverSP, states, names, n);
-            SolverSP.s = IPS_OK;
+            SolverSP.update(states, names, n);
+            SolverSP.setState(IPS_OK);
 
-            if (SolverS[SOLVER_ENABLE].s == ISS_ON)
+            if (SolverSP[SOLVER_ENABLE].getState() == ISS_ON)
             {
                 LOG_INFO("Astrometry solver is enabled.");
-                defineProperty(&SolverResultNP);
+                defineProperty(SolverResultNP);
             }
             else
             {
                 LOG_INFO("Astrometry solver is disabled.");
-                deleteProperty(SolverResultNP.name);
+                deleteProperty(SolverResultNP.getName());
             }
 
-            IDSetSwitch(&SolverSP, nullptr);
+            SolverSP.apply();
 
             pthread_mutex_unlock(&lock);
             return true;
@@ -282,10 +282,10 @@ bool AstrometryDriver::ISNewSwitch(const char *dev, const char *name, ISState *s
 
 bool AstrometryDriver::ISSnoopDevice(XMLEle *root)
 {
-    if (SolverS[SOLVER_ENABLE].s == ISS_ON && IUSnoopBLOB(root, &CCDDataBP) == 0)
+    if (SolverSP[SOLVER_ENABLE].getState() == ISS_ON && IUSnoopBLOB(root, CCDDataBP.getBLOB()) == 0) // #PS: refactor needed
     {
-        processBLOB(reinterpret_cast<uint8_t *>(CCDDataB[0].blob), static_cast<uint32_t>(CCDDataB[0].size),
-                    static_cast<uint32_t>(CCDDataB[0].bloblen));
+        processBLOB(reinterpret_cast<uint8_t *>(CCDDataBP[0].blob), static_cast<uint32_t>(CCDDataBP[0].size),
+                    static_cast<uint32_t>(CCDDataBP[0].bloblen));
         return true;
     }
 
@@ -294,8 +294,8 @@ bool AstrometryDriver::ISSnoopDevice(XMLEle *root)
 
 bool AstrometryDriver::saveConfigItems(FILE *fp)
 {
-    IUSaveConfigText(fp, &ActiveDeviceTP);
-    IUSaveConfigText(fp, &SolverSettingsTP);
+    ActiveDeviceTP.save(fp);
+    SolverSettingsTP.save(fp);
     return true;
 }
 
@@ -358,18 +358,18 @@ bool AstrometryDriver::processBLOB(uint8_t *data, uint32_t size, uint32_t len)
         delete[] processedData;
 
     pthread_mutex_lock(&lock);
-    SolverSP.s = IPS_BUSY;
+    SolverSP.setState(IPS_BUSY);
     LOG_INFO("Solving image...");
-    IDSetSwitch(&SolverSP, nullptr);
+    SolverSP.apply();
     pthread_mutex_unlock(&lock);
 
     int result = pthread_create(&solverThread, nullptr, &AstrometryDriver::runSolverHelper, this);
 
     if (result != 0)
     {
-        SolverSP.s = IPS_ALERT;
+        SolverSP.setState(IPS_ALERT);
         LOGF_INFO("Failed to create solver thread: %s", strerror(errno));
-        IDSetSwitch(&SolverSP, nullptr);
+        SolverSP.apply();
     }
 
     return true;
@@ -386,7 +386,7 @@ void AstrometryDriver::runSolver()
     char cmd[MAXRBUF]={0}, line[256]={0}, parity_str[8]={0};
     float ra = -1000, dec = -1000, angle = -1000, pixscale = -1000, parity = 0;
     snprintf(cmd, MAXRBUF, "%s %s -W /tmp/solution.wcs /tmp/ccdsolver.fits",
-             SolverSettingsT[ASTROMETRY_SETTINGS_BINARY].text, SolverSettingsT[ASTROMETRY_SETTINGS_OPTIONS].text);
+             SolverSettingsTP[ASTROMETRY_SETTINGS_BINARY].getText(), SolverSettingsTP[ASTROMETRY_SETTINGS_OPTIONS].getText());
 
     LOGF_DEBUG("%s", cmd);
     FILE *handle = popen(cmd, "r");
@@ -394,8 +394,8 @@ void AstrometryDriver::runSolver()
     {
         LOGF_DEBUG("Failed to run solver: %s", strerror(errno));
         pthread_mutex_lock(&lock);
-        SolverSP.s = IPS_ALERT;
-        IDSetSwitch(&SolverSP, nullptr);
+        SolverSP.setState(IPS_ALERT);
+        SolverSP.apply();
         pthread_mutex_unlock(&lock);
         return;
     }
@@ -417,22 +417,22 @@ void AstrometryDriver::runSolver()
         if (ra != -1000 && dec != -1000 && angle != -1000 && pixscale != -1000)
         {
             // Pixscale is arcsec/pixel. Astrometry result is in arcmin
-            SolverResultN[ASTROMETRY_RESULTS_PIXSCALE].value = pixscale;
+            SolverResultNP[ASTROMETRY_RESULTS_PIXSCALE].setValue(pixscale);
             // Astrometry.net angle, E of N
-            SolverResultN[ASTROMETRY_RESULTS_ORIENTATION].value = angle;
+            SolverResultNP[ASTROMETRY_RESULTS_ORIENTATION].setValue(angle);
             // Astrometry.net J2000 RA in degrees
-            SolverResultN[ASTROMETRY_RESULTS_RA].value = ra;
+            SolverResultNP[ASTROMETRY_RESULTS_RA].setValue(ra);
             // Astrometry.net J2000 DEC in degrees
-            SolverResultN[ASTROMETRY_RESULTS_DE].value = dec;
+            SolverResultNP[ASTROMETRY_RESULTS_DE].setValue(dec);
             // Astrometry.net parity
-            SolverResultN[ASTROMETRY_RESULTS_PARITY].value = parity;
+            SolverResultNP[ASTROMETRY_RESULTS_PARITY].setValue(parity);
 
-            SolverResultNP.s = IPS_OK;
-            IDSetNumber(&SolverResultNP, nullptr);
+            SolverResultNP.setState(IPS_OK);
+            SolverResultNP.apply();
 
             pthread_mutex_lock(&lock);
-            SolverSP.s = IPS_OK;
-            IDSetSwitch(&SolverSP, nullptr);
+            SolverSP.setState(IPS_OK);
+            SolverSP.apply();
             pthread_mutex_unlock(&lock);
 
             fclose(handle);
@@ -441,10 +441,10 @@ void AstrometryDriver::runSolver()
         }
 
         pthread_mutex_lock(&lock);
-        if (SolverS[SOLVER_DISABLE].s == ISS_ON)
+        if (SolverSP[SOLVER_DISABLE].getState() == ISS_ON)
         {
-            SolverSP.s = IPS_IDLE;
-            IDSetSwitch(&SolverSP, nullptr);
+            SolverSP.setState(IPS_IDLE);
+            SolverSP.apply();
             pthread_mutex_unlock(&lock);
             fclose(handle);
             LOG_INFO("Solver canceled.");
@@ -456,8 +456,8 @@ void AstrometryDriver::runSolver()
     fclose(handle);
 
     pthread_mutex_lock(&lock);
-    SolverSP.s = IPS_ALERT;
-    IDSetSwitch(&SolverSP, nullptr);
+    SolverSP.setState(IPS_ALERT);
+    SolverSP.apply();
     LOG_INFO("Solver failed.");
     pthread_mutex_unlock(&lock);
 

--- a/drivers/auxiliary/astrometrydriver.h
+++ b/drivers/auxiliary/astrometrydriver.h
@@ -28,6 +28,12 @@
 
 #include <pthread.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertyblob.h"
+
 /**
  * @brief The AstrometryDriver class is an INDI driver frontend for astrometry.net
  *
@@ -93,26 +99,18 @@ class AstrometryDriver : public INDI::DefaultDevice
     // Astrometry
 
     // Enable/Disable solver
-    ISwitch SolverS[2];
-    ISwitchVectorProperty SolverSP;
+    INDI::PropertySwitch SolverSP {2};
     enum { SOLVER_ENABLE, SOLVER_DISABLE};
 
     // Solver Settings
-    IText SolverSettingsT[2] {};
-    ITextVectorProperty SolverSettingsTP;
+    INDI::PropertyText SolverSettingsTP {2};
 
     // Solver Results
-    INumber SolverResultN[5];
-    INumberVectorProperty SolverResultNP;
+    INDI::PropertyNumber SolverResultNP {5};
+    INDI::PropertyText ActiveDeviceTP {1};
+    INDI::PropertyBlob SolverDataBP {1};
 
-    ITextVectorProperty ActiveDeviceTP;
-    IText ActiveDeviceT[1] {};
-
-    IBLOBVectorProperty SolverDataBP;
-    IBLOB SolverDataB[1];
-
-    IBLOB CCDDataB[1];
-    IBLOBVectorProperty CCDDataBP;
+    INDI::PropertyBlob CCDDataBP {1};
 
   private:
     // Run solver thread

--- a/drivers/auxiliary/flip_flat.cpp
+++ b/drivers/auxiliary/flip_flat.cpp
@@ -90,21 +90,21 @@ bool FlipFlat::initProperties()
     INDI::DefaultDevice::initProperties();
 
     // Status
-    IUFillText(&StatusT[0], "Cover", "Cover", nullptr);
-    IUFillText(&StatusT[1], "Light", "Light", nullptr);
-    IUFillText(&StatusT[2], "Motor", "Motor", nullptr);
-    IUFillTextVector(&StatusTP, StatusT, 3, getDeviceName(), "Status", "Status", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
+    StatusTP[0].fill("Cover", "Cover", nullptr);
+    StatusTP[1].fill("Light", "Light", nullptr);
+    StatusTP[2].fill("Motor", "Motor", nullptr);
+    StatusTP.fill(getDeviceName(), "Status", "Status", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     // Firmware version
-    IUFillText(&FirmwareT[0], "Version", "Version", nullptr);
-    IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "Firmware", "Firmware", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
+    FirmwareTP[0].fill("Version", "Version", nullptr);
+    FirmwareTP.fill(getDeviceName(), "Firmware", "Firmware", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     initDustCapProperties(getDeviceName(), MAIN_CONTROL_TAB);
     initLightBoxProperties(getDeviceName(), MAIN_CONTROL_TAB);
 
-    LightIntensityN[0].min  = 0;
-    LightIntensityN[0].max  = 255;
-    LightIntensityN[0].step = 10;
+    LightIntensityNP[0].setMin(0);
+    LightIntensityNP[0].setMax(255);
+    LightIntensityNP[0].setStep(10);
 
     // Set DUSTCAP_INTEFACE later on connect after we verify whether it's flip-flat (dust cover + light) or just flip-man (light only)
     setDriverInterface(AUX_INTERFACE | LIGHTBOX_INTERFACE);
@@ -137,10 +137,10 @@ bool FlipFlat::updateProperties()
     {
         if (m_Type == FLIP_FLAT || m_Type == ALNITAK_DUST_COVER)
             defineProperty(&ParkCapSP);
-        defineProperty(&LightSP);
-        defineProperty(&LightIntensityNP);
-        defineProperty(&StatusTP);
-        defineProperty(&FirmwareTP);
+        defineProperty(LightSP);
+        defineProperty(LightIntensityNP);
+        defineProperty(StatusTP);
+        defineProperty(FirmwareTP);
 
         updateLightBoxProperties();
 
@@ -150,10 +150,10 @@ bool FlipFlat::updateProperties()
     {
         if (m_Type == FLIP_FLAT || m_Type == ALNITAK_DUST_COVER)
             deleteProperty(ParkCapSP.name);
-        deleteProperty(LightSP.name);
-        deleteProperty(LightIntensityNP.name);
-        deleteProperty(StatusTP.name);
-        deleteProperty(FirmwareTP.name);
+        deleteProperty(LightSP.getName());
+        deleteProperty(LightIntensityNP.getName());
+        deleteProperty(StatusTP.getName());
+        deleteProperty(FirmwareTP.getName());
 
         updateLightBoxProperties();
     }
@@ -420,7 +420,7 @@ bool FlipFlat::getStatus()
                 response[6] = '2';
         }
 
-        response[5] = (LightS[FLAT_LIGHT_ON].s == ISS_ON) ? '1' : '0';
+        response[5] = (LightSP[FLAT_LIGHT_ON].getState() == ISS_ON) ? '1' : '0';
     }
     else
     {
@@ -443,11 +443,11 @@ bool FlipFlat::getStatus()
         switch (coverStatus)
         {
             case 0:
-                IUSaveText(&StatusT[0], "Not Open/Closed");
+                StatusTP[0].setText("Not Open/Closed");
                 break;
 
             case 1:
-                IUSaveText(&StatusT[0], "Closed");
+                StatusTP[0].setText("Closed");
                 if (ParkCapSP.s == IPS_BUSY || ParkCapSP.s == IPS_IDLE)
                 {
                     IUResetSwitch(&ParkCapSP);
@@ -459,7 +459,7 @@ bool FlipFlat::getStatus()
                 break;
 
             case 2:
-                IUSaveText(&StatusT[0], "Open");
+                StatusTP[0].setText("Open");
                 if (ParkCapSP.s == IPS_BUSY || ParkCapSP.s == IPS_IDLE)
                 {
                     IUResetSwitch(&ParkCapSP);
@@ -471,7 +471,7 @@ bool FlipFlat::getStatus()
                 break;
 
             case 3:
-                IUSaveText(&StatusT[0], "Timed out");
+                StatusTP[0].setText("Timed out");
                 break;
         }
     }
@@ -485,22 +485,22 @@ bool FlipFlat::getStatus()
         switch (lightStatus)
         {
             case 0:
-                IUSaveText(&StatusT[1], "Off");
-                if (LightS[0].s == ISS_ON)
+                StatusTP[1].setText("Off");
+                if (LightSP[0].getState() == ISS_ON)
                 {
-                    LightS[0].s = ISS_OFF;
-                    LightS[1].s = ISS_ON;
-                    IDSetSwitch(&LightSP, nullptr);
+                    LightSP[0].setState(ISS_OFF);
+                    LightSP[1].setState(ISS_ON);
+                    LightSP.apply();
                 }
                 break;
 
             case 1:
-                IUSaveText(&StatusT[1], "On");
-                if (LightS[1].s == ISS_ON)
+                StatusTP[1].setText("On");
+                if (LightSP[1].getState() == ISS_ON)
                 {
-                    LightS[0].s = ISS_ON;
-                    LightS[1].s = ISS_OFF;
-                    IDSetSwitch(&LightSP, nullptr);
+                    LightSP[0].setState(ISS_ON);
+                    LightSP[1].setState(ISS_OFF);
+                    LightSP.apply();
                 }
                 break;
         }
@@ -515,17 +515,17 @@ bool FlipFlat::getStatus()
         switch (motorStatus)
         {
             case 0:
-                IUSaveText(&StatusT[2], "Stopped");
+                StatusTP[2].setText("Stopped");
                 break;
 
             case 1:
-                IUSaveText(&StatusT[2], "Running");
+                StatusTP[2].setText("Running");
                 break;
         }
     }
 
     if (statusUpdated)
-        IDSetText(&StatusTP, nullptr);
+        StatusTP.apply();
 
     return true;
 }
@@ -534,8 +534,8 @@ bool FlipFlat::getFirmwareVersion()
 {
     if (isSimulation())
     {
-        IUSaveText(&FirmwareT[0], "Simulation");
-        IDSetText(&FirmwareTP, nullptr);
+        FirmwareTP[0].setText("Simulation");
+        FirmwareTP.apply();
         return true;
     }
 
@@ -545,8 +545,8 @@ bool FlipFlat::getFirmwareVersion()
 
     char versionString[4] = { 0 };
     snprintf(versionString, 4, "%s", response + 4);
-    IUSaveText(&FirmwareT[0], versionString);
-    IDSetText(&FirmwareTP, nullptr);
+    FirmwareTP[0].setText(versionString);
+    FirmwareTP.apply();
 
     return true;
 }
@@ -559,7 +559,7 @@ void FlipFlat::TimerHit()
     getStatus();
 
     // parking or unparking timed out, try again
-    if (ParkCapSP.s == IPS_BUSY && !strcmp(StatusT[0].text, "Timed out"))
+    if (ParkCapSP.s == IPS_BUSY && !strcmp(StatusTP[0].getText(), "Timed out"))
     {
         if (ParkCapS[0].s == ISS_ON)
             ParkCap();
@@ -596,8 +596,8 @@ bool FlipFlat::getBrightness()
     if (brightnessValue != prevBrightness)
     {
         prevBrightness           = brightnessValue;
-        LightIntensityN[0].value = brightnessValue;
-        IDSetNumber(&LightIntensityNP, nullptr);
+        LightIntensityNP[0].setValue(brightnessValue);
+        LightIntensityNP.apply();
     }
 
     return true;
@@ -607,8 +607,8 @@ bool FlipFlat::SetLightBoxBrightness(uint16_t value)
 {
     if (isSimulation())
     {
-        LightIntensityN[0].value = value;
-        IDSetNumber(&LightIntensityNP, nullptr);
+        LightIntensityNP[0].setValue(value);
+        LightIntensityNP.apply();
         return true;
     }
 
@@ -635,8 +635,8 @@ bool FlipFlat::SetLightBoxBrightness(uint16_t value)
     if (brightnessValue != prevBrightness)
     {
         prevBrightness           = brightnessValue;
-        LightIntensityN[0].value = brightnessValue;
-        IDSetNumber(&LightIntensityNP, nullptr);
+        LightIntensityNP[0].setValue(brightnessValue);
+        LightIntensityNP.apply();
     }
 
     return true;

--- a/drivers/auxiliary/flip_flat.h
+++ b/drivers/auxiliary/flip_flat.h
@@ -30,6 +30,9 @@
 
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+
 namespace Connection
 {
 class Serial;
@@ -90,12 +93,10 @@ class FlipFlat : public INDI::DefaultDevice, public INDI::LightBoxInterface, pub
         bool Handshake();
 
         // Status
-        ITextVectorProperty StatusTP;
-        IText StatusT[3] {};
+        INDI::PropertyText StatusTP {3};
 
         // Firmware version
-        ITextVectorProperty FirmwareTP;
-        IText FirmwareT[1] {};
+        INDI::PropertyText FirmwareTP {1};
 
         int PortFD{ -1 };
         uint16_t productID{ 0 };

--- a/drivers/auxiliary/gps_simulator.cpp
+++ b/drivers/auxiliary/gps_simulator.cpp
@@ -98,19 +98,19 @@ IPState GPSSimulator::updateGPS()
 
     utc = gmtime(&raw_time);
     strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", utc);
-    IUSaveText(&TimeT[0], ts);
+    TimeTP[0].setText(ts);
 
     local = localtime(&raw_time);
     snprintf(ts, sizeof(ts), "%4.2f", (local->tm_gmtoff / 3600.0));
-    IUSaveText(&TimeT[1], ts);
+    TimeTP[1].setText(ts);
 
-    TimeTP.s = IPS_OK;
+    TimeTP.setState(IPS_OK);
 
-    LocationN[LOCATION_LATITUDE].value  = 51.0;
-    LocationN[LOCATION_LONGITUDE].value = 357.7;
-    LocationN[LOCATION_ELEVATION].value = 72;
+    LocationNP[LOCATION_LATITUDE].setValue(51.0);
+    LocationNP[LOCATION_LONGITUDE].setValue(357.7);
+    LocationNP[LOCATION_ELEVATION].setValue(72);
 
-    LocationNP.s = IPS_OK;
+    LocationNP.setState(IPS_OK);
 
     return IPS_OK;
 }

--- a/drivers/auxiliary/joystick.cpp
+++ b/drivers/auxiliary/joystick.cpp
@@ -163,12 +163,12 @@ bool JoyStick::initProperties()
     IUFillText(&PortT[0], "PORT", "Port", "/dev/input/js0");
     IUFillTextVector(&PortTP, PortT, 1, getDeviceName(), INDI::SP::DEVICE_PORT, "Ports", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillText(&JoystickInfoT[0], "JOYSTICK_NAME", "Name", "");
-    IUFillText(&JoystickInfoT[1], "JOYSTICK_VERSION", "Version", "");
-    IUFillText(&JoystickInfoT[2], "JOYSTICK_NJOYSTICKS", "# Joysticks", "");
-    IUFillText(&JoystickInfoT[3], "JOYSTICK_NAXES", "# Axes", "");
-    IUFillText(&JoystickInfoT[4], "JOYSTICK_NBUTTONS", "# Buttons", "");
-    IUFillTextVector(&JoystickInfoTP, JoystickInfoT, 5, getDeviceName(), "JOYSTICK_INFO", "Joystick Info",
+    JoystickInfoTP[0].fill("JOYSTICK_NAME", "Name", "");
+    JoystickInfoTP[1].fill("JOYSTICK_VERSION", "Version", "");
+    JoystickInfoTP[2].fill("JOYSTICK_NJOYSTICKS", "# Joysticks", "");
+    JoystickInfoTP[3].fill("JOYSTICK_NAXES", "# Axes", "");
+    JoystickInfoTP[4].fill("JOYSTICK_NBUTTONS", "# Buttons", "");
+    JoystickInfoTP.fill(getDeviceName(), "JOYSTICK_INFO", "Joystick Info",
                      MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     addDebugControl();
@@ -184,21 +184,21 @@ bool JoyStick::updateProperties()
     {
         char buf[8];
         // Name
-        IUSaveText(&JoystickInfoT[0], driver->getName());
+        JoystickInfoTP[0].setText(driver->getName());
         // Version
         snprintf(buf, 8, "%d", driver->getVersion());
-        IUSaveText(&JoystickInfoT[1], buf);
+        JoystickInfoTP[1].setText(buf);
         // # of Joysticks
         snprintf(buf, 8, "%d", driver->getNumOfJoysticks());
-        IUSaveText(&JoystickInfoT[2], buf);
+        JoystickInfoTP[2].setText(buf);
         // # of Axes
         snprintf(buf, 8, "%d", driver->getNumOfAxes());
-        IUSaveText(&JoystickInfoT[3], buf);
+        JoystickInfoTP[3].setText(buf);
         // # of buttons
         snprintf(buf, 8, "%d", driver->getNumrOfButtons());
-        IUSaveText(&JoystickInfoT[4], buf);
+        JoystickInfoTP[4].setText(buf);
 
-        defineProperty(&JoystickInfoTP);
+        defineProperty(JoystickInfoTP);
 
         for (int i = 0; i < driver->getNumOfJoysticks(); i++)
             defineProperty(&JoyStickNP[i]);
@@ -218,7 +218,7 @@ bool JoyStick::updateProperties()
     }
     else
     {
-        deleteProperty(JoystickInfoTP.name);
+        deleteProperty(JoystickInfoTP.getName());
 
         for (int i = 0; i < driver->getNumOfJoysticks(); i++)
             deleteProperty(JoyStickNP[i].name);

--- a/drivers/auxiliary/joystick.h
+++ b/drivers/auxiliary/joystick.h
@@ -25,6 +25,9 @@
 #include "defaultdevice.h"
 #include <memory>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+
 class JoyStickDriver;
 
 /**
@@ -76,9 +79,7 @@ class JoyStick : public INDI::DefaultDevice
 
         ITextVectorProperty PortTP; //  A text vector that stores out physical port name
         IText PortT[1] {};
-
-        ITextVectorProperty JoystickInfoTP;
-        IText JoystickInfoT[5] {};
+        INDI::PropertyText JoystickInfoTP {5};
 
         std::unique_ptr<JoyStickDriver> driver;
 };

--- a/drivers/auxiliary/lpm.cpp
+++ b/drivers/auxiliary/lpm.cpp
@@ -93,36 +93,36 @@ bool LPM::initProperties()
     INDI::DefaultDevice::initProperties();
 
     // Readings from device
-    IUFillNumber(&AverageReadingN[0], "SKY_BRIGHTNESS", "Quality (mag/arcsec^2)", "%6.2f", -20, 30, 0, 0);
-    IUFillNumber(&AverageReadingN[1], "AVG_SKY_BRIGHTNESS", "Avg. Quality (mag/argsec^2)", "%6.2f", -20, 30, 0, 0);
-    IUFillNumber(&AverageReadingN[2], "MIN_SKY_BRIGHTNESS", "Min. Quality (mag/argsec^2)", "%6.2f", -20, 30, 0, 0);
-    IUFillNumber(&AverageReadingN[3], "MAX_SKY_BRIGHTNESS", "Max. Quality (mag/argsec^2)", "%6.2f", -20, 30, 0, 0);
-    IUFillNumber(&AverageReadingN[4], "NAKED_EYES_LIMIT", "NELM (V mags)", "%6.2f", -20, 30, 0, 0);
+    AverageReadingNP[0].fill("SKY_BRIGHTNESS", "Quality (mag/arcsec^2)", "%6.2f", -20, 30, 0, 0);
+    AverageReadingNP[1].fill("AVG_SKY_BRIGHTNESS", "Avg. Quality (mag/argsec^2)", "%6.2f", -20, 30, 0, 0);
+    AverageReadingNP[2].fill("MIN_SKY_BRIGHTNESS", "Min. Quality (mag/argsec^2)", "%6.2f", -20, 30, 0, 0);
+    AverageReadingNP[3].fill("MAX_SKY_BRIGHTNESS", "Max. Quality (mag/argsec^2)", "%6.2f", -20, 30, 0, 0);
+    AverageReadingNP[4].fill("NAKED_EYES_LIMIT", "NELM (V mags)", "%6.2f", -20, 30, 0, 0);
 
-    IUFillNumberVector(&AverageReadingNP, AverageReadingN, 5, getDeviceName(), "SKY_QUALITY", "Readings",
+    AverageReadingNP.fill(getDeviceName(), "SKY_QUALITY", "Readings",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // add reset button for SQ-Measurements
-    IUFillSwitch(&ResetB[0], "RESET_BUTTON", "Reset", ISS_OFF);
-    IUFillSwitchVector(&ResetBP, ResetB, 1, getDeviceName(), "RESET_READINGS", "",
+    ResetBP[0].fill("RESET_BUTTON", "Reset", ISS_OFF);
+    ResetBP.fill(getDeviceName(), "RESET_READINGS", "",
                        MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillSwitch(&SaveB[SAVE_READINGS], "SAVE_BUTTON", "Save Readings", ISS_OFF);
-    IUFillSwitch(&SaveB[DISCARD_READINGS], "DISCARD_BUTTON", "Discard Readings", ISS_OFF);
-    IUFillSwitchVector(&SaveBP, SaveB, 2, getDeviceName(), "SAVE_READINGS", "",
+    SaveBP[SAVE_READINGS].fill("SAVE_BUTTON", "Save Readings", ISS_OFF);
+    SaveBP[DISCARD_READINGS].fill("DISCARD_BUTTON", "Discard Readings", ISS_OFF);
+    SaveBP.fill(getDeviceName(), "SAVE_READINGS", "",
                        MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // LPM-Readings-Log
     std::string defaultDirectory = std::string(getenv("HOME")) + std::string("/lpm");
-    IUFillText(&RecordFileT[0], "RECORD_FILE_DIR", "Dir.", defaultDirectory.data());
-    IUFillText(&RecordFileT[1], "RECORD_FILE_NAME", "Name", "lpmlog.txt");
-    IUFillTextVector(&RecordFileTP, RecordFileT, NARRAY(RecordFileT), getDeviceName(), "RECORD_FILE", "Record File",
+    RecordFileTP[0].fill("RECORD_FILE_DIR", "Dir.", defaultDirectory.data());
+    RecordFileTP[1].fill("RECORD_FILE_NAME", "Name", "lpmlog.txt");
+    RecordFileTP.fill(getDeviceName(), "RECORD_FILE", "Record File",
                      MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
-    snprintf(filename, 2048, "%s/%s", RecordFileT[0].text, RecordFileT[1].text);
+    snprintf(filename, 2048, "%s/%s", RecordFileTP[0].getText(), RecordFileTP[1].getText());
 
     // Unit Info
-    IUFillNumber(&UnitInfoN[0], "Calibdata", "", "%6.2f", -20, 30, 0, 0);
-    IUFillNumberVector(&UnitInfoNP, UnitInfoN, 1, getDeviceName(), "Unit Info", "",
+    UnitInfoNP[0].fill("Calibdata", "", "%6.2f", -20, 30, 0, 0);
+    UnitInfoNP.fill(getDeviceName(), "Unit Info", "",
                        UNIT_TAB, IP_RO, 0, IPS_IDLE);
 
     if (lpmConnection & CONNECTION_SERIAL)
@@ -145,19 +145,19 @@ bool LPM::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&AverageReadingNP);
-        defineProperty(&UnitInfoNP);
-        defineProperty(&ResetBP);
-        defineProperty(&RecordFileTP);
-        defineProperty(&SaveBP);
+        defineProperty(AverageReadingNP);
+        defineProperty(UnitInfoNP);
+        defineProperty(ResetBP);
+        defineProperty(RecordFileTP);
+        defineProperty(SaveBP);
     }
     else
     {
-        deleteProperty(AverageReadingNP.name);
-        deleteProperty(UnitInfoNP.name);
-        deleteProperty(RecordFileTP.name);
-        deleteProperty(ResetBP.name);
-        deleteProperty(SaveBP.name);
+        deleteProperty(AverageReadingNP.getName());
+        deleteProperty(UnitInfoNP.getName());
+        deleteProperty(RecordFileTP.getName());
+        deleteProperty(ResetBP.getName());
+        deleteProperty(SaveBP.getName());
     }
 
     return true;
@@ -167,12 +167,12 @@ bool LPM::ISNewText(const char *dev, const char *name, char *texts[], char *name
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, RecordFileTP.name) == 0)
+        if (RecordFileTP.isNameMatch(name))
         {
-            IUUpdateText(&RecordFileTP, texts, names, n);
-            RecordFileTP.s = IPS_OK;
-            IDSetText(&RecordFileTP, nullptr);
-            snprintf(filename, 2048, "%s/%s", RecordFileT[0].text, RecordFileT[1].text);
+            RecordFileTP.update(texts, names, n);
+            RecordFileTP.setState(IPS_OK);
+            RecordFileTP.apply();
+            snprintf(filename, 2048, "%s/%s", RecordFileTP[0].getText(), RecordFileTP[1].getText());
             LOGF_INFO("filename changed to %s", filename);
             if (fp != nullptr)
             {
@@ -191,32 +191,32 @@ bool LPM::ISNewSwitch(const char *dev, const char *name, ISState *states, char *
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Reset
-        if (!strcmp(name, ResetBP.name))
+        if (ResetBP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ResetBP, states, names, n);
-            ResetB[0].s = ISS_OFF;
-            ResetBP.s   = IPS_OK;
-            IDSetSwitch(&ResetBP, nullptr);
+            ResetBP.update(states, names, n);
+            ResetBP[0].setState(ISS_OFF);
+            ResetBP.setState(IPS_OK);
+            ResetBP.apply();
 
-            AverageReadingN[0].value = 0;
-            AverageReadingN[1].value = 0;
-            AverageReadingN[2].value = 0;
-            AverageReadingN[3].value = 0;
+            AverageReadingNP[0].setValue(0);
+            AverageReadingNP[1].setValue(0);
+            AverageReadingNP[2].setValue(0);
+            AverageReadingNP[3].setValue(0);
 
             sumSQ = 0;
             count = 0;
             return true;
-        } else if (!strcmp(name, SaveBP.name))
+        } else if (SaveBP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SaveBP, states, names, n);
+            SaveBP.update(states, names, n);
 
-            if (SaveB[SAVE_READINGS].s == ISS_ON)
+            if (SaveBP[SAVE_READINGS].getState() == ISS_ON)
             {
                 LOGF_INFO("Save readings to %s", filename);
                 if (fp == nullptr) {
                     openFilePtr();
                 }
-                SaveBP.s = IPS_OK;
+                SaveBP.setState(IPS_OK);
             } else {
                 LOG_INFO("Discard readings");
                 if (fp != nullptr) {
@@ -226,10 +226,10 @@ bool LPM::ISNewSwitch(const char *dev, const char *name, ISState *states, char *
                 } else {
                     LOG_WARN("no file open!");
                 }
-                SaveBP.s = IPS_IDLE;
+                SaveBP.setState(IPS_IDLE);
             }
 
-            IDSetSwitch(&SaveBP, nullptr);
+            SaveBP.apply();
             return true;
         }
 
@@ -241,7 +241,7 @@ bool LPM::ISNewSwitch(const char *dev, const char *name, ISState *states, char *
 void LPM::openFilePtr()
 {
     LOG_DEBUG("open file pointer");
-    mkdir(RecordFileT[0].text,S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    mkdir(RecordFileTP[0].getText(),S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     fp = fopen(filename, "a");
 }
 
@@ -273,24 +273,24 @@ bool LPM::getReadings()
             count++;
         }
 
-        AverageReadingN[0].value = mpsas;
+        AverageReadingNP[0].setValue(mpsas);
         sumSQ += mpsas;
 
         if (count > 1)
         {
-            AverageReadingN[1].value = sumSQ / count;
-            if (mpsas < AverageReadingN[2].value) {
-                AverageReadingN[2].value = mpsas;
+            AverageReadingNP[1].setValue(sumSQ / count);
+            if (mpsas < AverageReadingNP[2].getValue()) {
+                AverageReadingNP[2].setValue(mpsas);
             }
-            if (mpsas > AverageReadingN[3].value) {
-                AverageReadingN[3].value = mpsas;
+            if (mpsas > AverageReadingNP[3].getValue()) {
+                AverageReadingNP[3].setValue(mpsas);
             }
         } else {
-            AverageReadingN[2].value = mpsas;
-            AverageReadingN[3].value = mpsas;
+            AverageReadingNP[2].setValue(mpsas);
+            AverageReadingNP[3].setValue(mpsas);
         }
         //NELM (see http://unihedron.com/projects/darksky/NELM2BCalc.html)
-        AverageReadingN[4].value = 7.93-5*log(pow(10,(4.316-(mpsas/5)))+1)/log(10);
+        AverageReadingNP[4].setValue(7.93-5*log(pow(10,(4.316-(mpsas/5)))+1)/log(10));
     }
     return true;
 }
@@ -350,7 +350,7 @@ bool LPM::getDeviceInfo()
         return false;
     }
 
-    UnitInfoN[0].value = calib;
+    UnitInfoNP[0].setValue(calib);
 
     return true;
 }
@@ -362,8 +362,8 @@ void LPM::TimerHit()
 
     bool rc = getReadings();
 
-    AverageReadingNP.s = rc ? IPS_OK : IPS_ALERT;
-    IDSetNumber(&AverageReadingNP, nullptr);
+    AverageReadingNP.setState(rc ? IPS_OK : IPS_ALERT);
+    AverageReadingNP.apply();
 
     SetTimer(getCurrentPollingPeriod());
 }

--- a/drivers/auxiliary/lpm.h
+++ b/drivers/auxiliary/lpm.h
@@ -26,6 +26,11 @@
 
 #include "defaultdevice.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LPM : public INDI::DefaultDevice
 {
   public:
@@ -63,22 +68,17 @@ class LPM : public INDI::DefaultDevice
     void openFilePtr();
 
     // Readings
-    INumberVectorProperty AverageReadingNP;
-    INumber AverageReadingN[5] {};
+    INDI::PropertyNumber AverageReadingNP {5};
 
     // Record File Info
-    IText RecordFileT[2] {};
-    ITextVectorProperty RecordFileTP;
+    INDI::PropertyText RecordFileTP {2};
 
-    ISwitch ResetB[1];
-    ISwitchVectorProperty ResetBP;
+    INDI::PropertySwitch ResetBP {1};
 
-    ISwitch SaveB[2] {};
-    ISwitchVectorProperty SaveBP;
+    INDI::PropertySwitch SaveBP {2};
 
     // Device Information
-    INumberVectorProperty UnitInfoNP;
-    INumber UnitInfoN[1];
+    INDI::PropertyNumber UnitInfoNP {1};
 
     Connection::Serial *serialConnection { nullptr };
 

--- a/drivers/auxiliary/pegasus_ppb.cpp
+++ b/drivers/auxiliary/pegasus_ppb.cpp
@@ -93,26 +93,26 @@ bool PegasusPPB::initProperties()
     /// Main Control Panel
     ////////////////////////////////////////////////////////////////////////////
     // Cycle all power on/off
-    IUFillSwitch(&PowerCycleAllS[POWER_CYCLE_OFF], "POWER_CYCLE_OFF", "All Off", ISS_OFF);
-    IUFillSwitch(&PowerCycleAllS[POWER_CYCLE_ON], "POWER_CYCLE_ON", "All On", ISS_OFF);
-    IUFillSwitchVector(&PowerCycleAllSP, PowerCycleAllS, 2, getDeviceName(), "POWER_CYCLE", "Cycle Power", MAIN_CONTROL_TAB,
+    PowerCycleAllSP[POWER_CYCLE_OFF].fill("POWER_CYCLE_OFF", "All Off", ISS_OFF);
+    PowerCycleAllSP[POWER_CYCLE_ON].fill("POWER_CYCLE_ON", "All On", ISS_OFF);
+    PowerCycleAllSP.fill(getDeviceName(), "POWER_CYCLE", "Cycle Power", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // DSLR on/off
-    IUFillSwitch(&DSLRPowerS[DSLR_OFF], "DSLR_OFF", "Off", ISS_OFF);
-    IUFillSwitch(&DSLRPowerS[DSLR_ON], "DSLR_ON", "On", ISS_OFF);
-    IUFillSwitchVector(&DSLRPowerSP, DSLRPowerS, 2, getDeviceName(), "DSLR_POWER", "DSLR Power", MAIN_CONTROL_TAB, IP_RW,
+    DSLRPowerSP[DSLR_OFF].fill("DSLR_OFF", "Off", ISS_OFF);
+    DSLRPowerSP[DSLR_ON].fill("DSLR_ON", "On", ISS_OFF);
+    DSLRPowerSP.fill(getDeviceName(), "DSLR_POWER", "DSLR Power", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 60, IPS_IDLE);
 
     // Reboot
-    IUFillSwitch(&RebootS[0], "REBOOT", "Reboot Device", ISS_OFF);
-    IUFillSwitchVector(&RebootSP, RebootS, 1, getDeviceName(), "REBOOT_DEVICE", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1,
+    RebootSP[0].fill("REBOOT", "Reboot Device", ISS_OFF);
+    RebootSP.fill(getDeviceName(), "REBOOT_DEVICE", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1,
                        60, IPS_IDLE);
 
     // Power Sensors
-    IUFillNumber(&PowerSensorsN[SENSOR_VOLTAGE], "SENSOR_VOLTAGE", "Voltage (V)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_CURRENT], "SENSOR_CURRENT", "Current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumberVector(&PowerSensorsNP, PowerSensorsN, 2, getDeviceName(), "POWER_SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO,
+    PowerSensorsNP[SENSOR_VOLTAGE].fill("SENSOR_VOLTAGE", "Voltage (V)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_CURRENT].fill("SENSOR_CURRENT", "Current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP.fill(getDeviceName(), "POWER_SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO,
                        60, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
@@ -120,11 +120,11 @@ bool PegasusPPB::initProperties()
     ////////////////////////////////////////////////////////////////////////////
 
     // Power on Boot
-    IUFillSwitch(&PowerOnBootS[0], "POWER_PORT_1", "Port 1", ISS_ON);
-    IUFillSwitch(&PowerOnBootS[1], "POWER_PORT_2", "Port 2", ISS_ON);
-    IUFillSwitch(&PowerOnBootS[2], "POWER_PORT_3", "Port 3", ISS_ON);
-    IUFillSwitch(&PowerOnBootS[3], "POWER_PORT_4", "Port 4", ISS_ON);
-    IUFillSwitchVector(&PowerOnBootSP, PowerOnBootS, 4, getDeviceName(), "POWER_ON_BOOT", "Power On Boot", MAIN_CONTROL_TAB,
+    PowerOnBootSP[0].fill("POWER_PORT_1", "Port 1", ISS_ON);
+    PowerOnBootSP[1].fill("POWER_PORT_2", "Port 2", ISS_ON);
+    PowerOnBootSP[2].fill("POWER_PORT_3", "Port 3", ISS_ON);
+    PowerOnBootSP[3].fill("POWER_PORT_4", "Port 4", ISS_ON);
+    PowerOnBootSP.fill(getDeviceName(), "POWER_ON_BOOT", "Power On Boot", MAIN_CONTROL_TAB,
                        IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
@@ -132,15 +132,15 @@ bool PegasusPPB::initProperties()
     ////////////////////////////////////////////////////////////////////////////
 
     // Automatic Dew
-    IUFillSwitch(&AutoDewS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&AutoDewS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&AutoDewSP, AutoDewS, 2, getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_1OFMANY, 60,
+    AutoDewSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    AutoDewSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    AutoDewSP.fill(getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_1OFMANY, 60,
                        IPS_IDLE);
 
     // Dew PWM
-    IUFillNumber(&DewPWMN[DEW_PWM_A], "DEW_A", "Dew A (%)", "%.2f", 0, 100, 10, 0);
-    IUFillNumber(&DewPWMN[DEW_PWM_B], "DEW_B", "Dew B (%)", "%.2f", 0, 100, 10, 0);
-    IUFillNumberVector(&DewPWMNP, DewPWMN, 2, getDeviceName(), "DEW_PWM", "Dew PWM", DEW_TAB, IP_RW, 60, IPS_IDLE);
+    DewPWMNP[DEW_PWM_A].fill("DEW_A", "Dew A (%)", "%.2f", 0, 100, 10, 0);
+    DewPWMNP[DEW_PWM_B].fill("DEW_B", "Dew B (%)", "%.2f", 0, 100, 10, 0);
+    DewPWMNP.fill(getDeviceName(), "DEW_PWM", "Dew PWM", DEW_TAB, IP_RW, 60, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
     /// Environment Group
@@ -170,15 +170,15 @@ bool PegasusPPB::updateProperties()
     if (isConnected())
     {
         // Main Control
-        defineProperty(&PowerCycleAllSP);
-        defineProperty(&DSLRPowerSP);
-        defineProperty(&PowerSensorsNP);
-        defineProperty(&PowerOnBootSP);
-        defineProperty(&RebootSP);
+        defineProperty(PowerCycleAllSP);
+        defineProperty(DSLRPowerSP);
+        defineProperty(PowerSensorsNP);
+        defineProperty(PowerOnBootSP);
+        defineProperty(RebootSP);
 
         // Dew
-        defineProperty(&AutoDewSP);
-        defineProperty(&DewPWMNP);
+        defineProperty(AutoDewSP);
+        defineProperty(DewPWMNP);
 
         WI::updateProperties();
 
@@ -187,15 +187,15 @@ bool PegasusPPB::updateProperties()
     else
     {
         // Main Control
-        deleteProperty(PowerCycleAllSP.name);
-        deleteProperty(DSLRPowerSP.name);
-        deleteProperty(PowerSensorsNP.name);
-        deleteProperty(PowerOnBootSP.name);
-        deleteProperty(RebootSP.name);
+        deleteProperty(PowerCycleAllSP.getName());
+        deleteProperty(DSLRPowerSP.getName());
+        deleteProperty(PowerSensorsNP.getName());
+        deleteProperty(PowerOnBootSP.getName());
+        deleteProperty(RebootSP.getName());
 
         // Dew
-        deleteProperty(AutoDewSP.name);
-        deleteProperty(DewPWMNP.name);
+        deleteProperty(AutoDewSP.getName());
+        deleteProperty(DewPWMNP.getName());
 
         WI::updateProperties();
 
@@ -264,77 +264,77 @@ bool PegasusPPB::ISNewSwitch(const char * dev, const char * name, ISState * stat
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Cycle all power on or off
-        if (!strcmp(name, PowerCycleAllSP.name))
+        if (PowerCycleAllSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PowerCycleAllSP, states, names, n);
+            PowerCycleAllSP.update(states, names, n);
 
-            PowerCycleAllSP.s = IPS_ALERT;
+            PowerCycleAllSP.setState(IPS_ALERT);
             char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-            snprintf(cmd, PEGASUS_LEN, "P1:%d", IUFindOnSwitchIndex(&PowerCycleAllSP));
+            snprintf(cmd, PEGASUS_LEN, "P1:%d", PowerCycleAllSP.findOnSwitchIndex());
             if (sendCommand(cmd, res))
             {
-                PowerCycleAllSP.s = !strcmp(cmd, res) ? IPS_OK : IPS_ALERT;
+                PowerCycleAllSP.setState(!strcmp(cmd, res) ? IPS_OK : IPS_ALERT);
             }
 
-            IUResetSwitch(&PowerCycleAllSP);
-            IDSetSwitch(&PowerCycleAllSP, nullptr);
+            PowerCycleAllSP.reset();
+            PowerCycleAllSP.apply();
             return true;
         }
 
         // DSLR
-        if (!strcmp(name, DSLRPowerSP.name))
+        if (DSLRPowerSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&DSLRPowerSP, states, names, n);
+            DSLRPowerSP.update(states, names, n);
 
-            DSLRPowerSP.s = IPS_ALERT;
+            DSLRPowerSP.setState(IPS_ALERT);
             char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-            snprintf(cmd, PEGASUS_LEN, "P2:%d", IUFindOnSwitchIndex(&DSLRPowerSP));
+            snprintf(cmd, PEGASUS_LEN, "P2:%d", DSLRPowerSP.findOnSwitchIndex());
             if (sendCommand(cmd, res))
             {
-                DSLRPowerSP.s = !strcmp(cmd, res) ? IPS_OK : IPS_ALERT;
+                DSLRPowerSP.setState(!strcmp(cmd, res) ? IPS_OK : IPS_ALERT);
             }
 
-            IUResetSwitch(&DSLRPowerSP);
-            IDSetSwitch(&DSLRPowerSP, nullptr);
+            DSLRPowerSP.reset();
+            DSLRPowerSP.apply();
             return true;
         }
 
         // Reboot
-        if (!strcmp(name, RebootSP.name))
+        if (RebootSP.isNameMatch(name))
         {
-            RebootSP.s = reboot() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&RebootSP, nullptr);
+            RebootSP.setState(reboot() ? IPS_OK : IPS_ALERT);
+            RebootSP.apply();
             LOG_INFO("Rebooting device...");
             return true;
         }
 
         // Power on boot
-        if (!strcmp(name, PowerOnBootSP.name))
+        if (PowerOnBootSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PowerOnBootSP, states, names, n);
-            PowerOnBootSP.s = setPowerOnBoot() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&PowerOnBootSP, nullptr);
-            saveConfig(true, PowerOnBootSP.name);
+            PowerOnBootSP.update(states, names, n);
+            PowerOnBootSP.setState(setPowerOnBoot() ? IPS_OK : IPS_ALERT);
+            PowerOnBootSP.apply();
+            saveConfig(true, PowerOnBootSP.getName());
             return true;
         }
 
         // Auto Dew
-        if (!strcmp(name, AutoDewSP.name))
+        if (AutoDewSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&AutoDewSP);
-            IUUpdateSwitch(&AutoDewSP, states, names, n);
-            if (setAutoDewEnabled(AutoDewS[INDI_ENABLED].s == ISS_ON))
+            int prevIndex = AutoDewSP.findOnSwitchIndex();
+            AutoDewSP.update(states, names, n);
+            if (setAutoDewEnabled(AutoDewSP[INDI_ENABLED].getState() == ISS_ON))
             {
-                AutoDewSP.s = IPS_OK;
+                AutoDewSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&AutoDewSP);
-                AutoDewS[prevIndex].s = ISS_ON;
-                AutoDewSP.s = IPS_ALERT;
+                AutoDewSP.reset();
+                AutoDewSP[prevIndex].setState(ISS_ON);
+                AutoDewSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&AutoDewSP, nullptr);
+            AutoDewSP.apply();
             return true;
         }
     }
@@ -347,21 +347,21 @@ bool PegasusPPB::ISNewNumber(const char * dev, const char * name, double values[
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Dew PWM
-        if (!strcmp(name, DewPWMNP.name))
+        if (DewPWMNP.isNameMatch(name))
         {
             bool rc1 = false, rc2 = false;
             for (int i = 0; i < n; i++)
             {
-                if (!strcmp(names[i], DewPWMN[DEW_PWM_A].name))
+                if (!strcmp(names[i], DewPWMNP[DEW_PWM_A].getName()))
                     rc1 = setDewPWM(3, static_cast<uint8_t>(values[i] / 100.0 * 255.0));
-                else if (!strcmp(names[i], DewPWMN[DEW_PWM_B].name))
+                else if (!strcmp(names[i], DewPWMNP[DEW_PWM_B].getName()))
                     rc2 = setDewPWM(4, static_cast<uint8_t>(values[i] / 100.0 * 255.0));
             }
 
-            DewPWMNP.s = (rc1 && rc2) ? IPS_OK : IPS_ALERT;
-            if (DewPWMNP.s == IPS_OK)
-                IUUpdateNumber(&DewPWMNP, values, names, n);
-            IDSetNumber(&DewPWMNP, nullptr);
+            DewPWMNP.setState((rc1 && rc2) ? IPS_OK : IPS_ALERT);
+            if (DewPWMNP.getState() == IPS_OK)
+                DewPWMNP.update(values, names, n);
+            DewPWMNP.apply();
             return true;
         }
 
@@ -425,10 +425,10 @@ bool PegasusPPB::setAutoDewEnabled(bool enabled)
 bool PegasusPPB::setPowerOnBoot()
 {
     char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-    snprintf(cmd, PEGASUS_LEN, "PE:%d%d%d%d", PowerOnBootS[0].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[1].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[2].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[3].s == ISS_ON ? 1 : 0);
+    snprintf(cmd, PEGASUS_LEN, "PE:%d%d%d%d", PowerOnBootSP[0].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[1].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[2].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[3].getState() == ISS_ON ? 1 : 0);
     if (sendCommand(cmd, res))
     {
         return (!strcmp(res, "PE:1"));
@@ -454,7 +454,7 @@ bool PegasusPPB::saveConfigItems(FILE * fp)
 {
     INDI::DefaultDevice::saveConfigItems(fp);
     WI::saveConfigItems(fp);
-    IUSaveConfigSwitch(fp, &AutoDewSP);
+    AutoDewSP.save(fp);
 
     return true;
 }
@@ -499,11 +499,11 @@ bool PegasusPPB::getSensorData()
             return true;
 
         // Power Sensors
-        PowerSensorsN[SENSOR_VOLTAGE].value = std::stod(result[PA_VOLTAGE]);
-        PowerSensorsN[SENSOR_CURRENT].value = std::stod(result[PA_CURRENT]) / 65.0;
-        PowerSensorsNP.s = IPS_OK;
+        PowerSensorsNP[SENSOR_VOLTAGE].setValue(std::stod(result[PA_VOLTAGE]));
+        PowerSensorsNP[SENSOR_CURRENT].setValue(std::stod(result[PA_CURRENT]) / 65.0);
+        PowerSensorsNP.setState(IPS_OK);
         if (lastSensorData[PA_VOLTAGE] != result[PA_VOLTAGE] || lastSensorData[PA_CURRENT] != result[PA_CURRENT])
-            IDSetNumber(&PowerSensorsNP, nullptr);
+            PowerSensorsNP.apply();
 
         // Environment Sensors
         setParameterValue("WEATHER_TEMPERATURE", std::stod(result[PA_TEMPERATURE]));
@@ -520,30 +520,30 @@ bool PegasusPPB::getSensorData()
         }
 
         // Power Status
-        PowerCycleAllS[POWER_CYCLE_ON].s = (std::stoi(result[PA_PORT_STATUS]) == 1) ? ISS_ON : ISS_OFF;
-        PowerCycleAllS[POWER_CYCLE_ON].s = (std::stoi(result[PA_PORT_STATUS]) == 0) ? ISS_ON : ISS_OFF;
-        PowerCycleAllSP.s = (std::stoi(result[6]) == 1) ? IPS_OK : IPS_IDLE;
+        PowerCycleAllSP[POWER_CYCLE_ON].setState((std::stoi(result[PA_PORT_STATUS]) == 1) ? ISS_ON : ISS_OFF);
+        PowerCycleAllSP[POWER_CYCLE_ON].setState((std::stoi(result[PA_PORT_STATUS]) == 0) ? ISS_ON : ISS_OFF);
+        PowerCycleAllSP.setState((std::stoi(result[6]) == 1) ? IPS_OK : IPS_IDLE);
         if (lastSensorData[PA_PORT_STATUS] != result[PA_PORT_STATUS])
-            IDSetSwitch(&PowerCycleAllSP, nullptr);
+            PowerCycleAllSP.apply();
 
         // DSLR Power Status
-        DSLRPowerS[POWER_CYCLE_ON].s = (std::stoi(result[PA_DSLR_STATUS]) == 1) ? ISS_ON : ISS_OFF;
-        DSLRPowerS[POWER_CYCLE_ON].s = (std::stoi(result[PA_DSLR_STATUS]) == 0) ? ISS_ON : ISS_OFF;
-        DSLRPowerSP.s = (std::stoi(result[PA_DSLR_STATUS]) == 1) ? IPS_OK : IPS_IDLE;
+        DSLRPowerSP[POWER_CYCLE_ON].setState((std::stoi(result[PA_DSLR_STATUS]) == 1) ? ISS_ON : ISS_OFF);
+        DSLRPowerSP[POWER_CYCLE_ON].setState((std::stoi(result[PA_DSLR_STATUS]) == 0) ? ISS_ON : ISS_OFF);
+        DSLRPowerSP.setState((std::stoi(result[PA_DSLR_STATUS]) == 1) ? IPS_OK : IPS_IDLE);
         if (lastSensorData[PA_DSLR_STATUS] != result[PA_DSLR_STATUS])
-            IDSetSwitch(&DSLRPowerSP, nullptr);
+            DSLRPowerSP.apply();
 
         // Dew PWM
-        DewPWMN[0].value = std::stod(result[PA_DEW_1]) / 255.0 * 100.0;
-        DewPWMN[1].value = std::stod(result[PA_DEW_2]) / 255.0 * 100.0;
+        DewPWMNP[0].setValue(std::stod(result[PA_DEW_1]) / 255.0 * 100.0);
+        DewPWMNP[1].setValue(std::stod(result[PA_DEW_2]) / 255.0 * 100.0);
         if (lastSensorData[PA_DEW_1] != result[PA_DEW_1] || lastSensorData[PA_DEW_2] != result[PA_DEW_2])
-            IDSetNumber(&DewPWMNP, nullptr);
+            DewPWMNP.apply();
 
         // Auto Dew
-        AutoDewS[INDI_ENABLED].s  = (std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_ON : ISS_OFF;
-        AutoDewS[INDI_DISABLED].s = (std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_OFF : ISS_ON;
+        AutoDewSP[INDI_ENABLED].setState((std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_ON : ISS_OFF);
+        AutoDewSP[INDI_DISABLED].setState((std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_OFF : ISS_ON);
         if (lastSensorData[PA_AUTO_DEW] != result[PA_AUTO_DEW])
-            IDSetSwitch(&AutoDewSP, nullptr);
+            AutoDewSP.apply();
 
         lastSensorData = result;
 

--- a/drivers/auxiliary/pegasus_ppb.h
+++ b/drivers/auxiliary/pegasus_ppb.h
@@ -30,6 +30,10 @@
 #include <vector>
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 namespace Connection
 {
 class Serial;
@@ -111,12 +115,10 @@ class PegasusPPB : public INDI::DefaultDevice, public INDI::WeatherInterface
         /// Main Control
         ////////////////////////////////////////////////////////////////////////////////////
         /// Reboot Device
-        ISwitch RebootS[1];
-        ISwitchVectorProperty RebootSP;
+        INDI::PropertySwitch RebootSP {1};
 
         // Power Sensors
-        INumber PowerSensorsN[2];
-        INumberVectorProperty PowerSensorsNP;
+        INDI::PropertyNumber PowerSensorsNP {2};
         enum
         {
             SENSOR_VOLTAGE,
@@ -128,16 +130,14 @@ class PegasusPPB : public INDI::DefaultDevice, public INDI::WeatherInterface
         ////////////////////////////////////////////////////////////////////////////////////
 
         // Cycle all power on/off
-        ISwitch PowerCycleAllS[2];
-        ISwitchVectorProperty PowerCycleAllSP;
+        INDI::PropertySwitch PowerCycleAllSP {2};
         enum
         {
             POWER_CYCLE_OFF,
             POWER_CYCLE_ON,
         };
 
-        ISwitch DSLRPowerS[2];
-        ISwitchVectorProperty DSLRPowerSP;
+        INDI::PropertySwitch DSLRPowerSP {2};
         enum
         {
             DSLR_OFF,
@@ -145,20 +145,17 @@ class PegasusPPB : public INDI::DefaultDevice, public INDI::WeatherInterface
         };
 
         // Select which power is ON on bootup
-        ISwitch PowerOnBootS[4];
-        ISwitchVectorProperty PowerOnBootSP;
+        INDI::PropertySwitch PowerOnBootSP {4};
 
         ////////////////////////////////////////////////////////////////////////////////////
         /// Dew Group
         ////////////////////////////////////////////////////////////////////////////////////
 
         // Auto Dew
-        ISwitch AutoDewS[2];
-        ISwitchVectorProperty AutoDewSP;
+        INDI::PropertySwitch AutoDewSP {2};
 
         // Dew PWM
-        INumber DewPWMN[2];
-        INumberVectorProperty DewPWMNP;
+        INDI::PropertyNumber DewPWMNP {2};
         enum
         {
             DEW_PWM_A,

--- a/drivers/auxiliary/pegasus_ppba.cpp
+++ b/drivers/auxiliary/pegasus_ppba.cpp
@@ -94,52 +94,52 @@ bool PegasusPPBA::initProperties()
     /// Main Control Panel
     ////////////////////////////////////////////////////////////////////////////
     // Quad 12v Power
-    IUFillSwitch(&QuadOutS[INDI_ENABLED], "QUADOUT_ON", "Enable", ISS_OFF);
-    IUFillSwitch(&QuadOutS[INDI_DISABLED], "QUADOUT_OFF", "Disable", ISS_OFF);
-    IUFillSwitchVector(&QuadOutSP, QuadOutS, 2, getDeviceName(), "QUADOUT_POWER", "Quad Output", MAIN_CONTROL_TAB,
+    QuadOutSP[INDI_ENABLED].fill("QUADOUT_ON", "Enable", ISS_OFF);
+    QuadOutSP[INDI_DISABLED].fill("QUADOUT_OFF", "Disable", ISS_OFF);
+    QuadOutSP.fill(getDeviceName(), "QUADOUT_POWER", "Quad Output", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Adjustable Power
-    //    IUFillSwitch(&AdjOutS[INDI_ENABLED], "ADJOUT_ON", "Enable", ISS_OFF);
-    //    IUFillSwitch(&AdjOutS[INDI_DISABLED], "ADJOUT_OFF", "Disable", ISS_OFF);
-    //    IUFillSwitchVector(&AdjOutSP, AdjOutS, 2, getDeviceName(), "ADJOUT_POWER", "Adj Output", MAIN_CONTROL_TAB, IP_RW,
+    //    AdjOutSP[INDI_ENABLED].fill("ADJOUT_ON", "Enable", ISS_OFF);
+    //    AdjOutSP[INDI_DISABLED].fill("ADJOUT_OFF", "Disable", ISS_OFF);
+    //    AdjOutSP.fill(getDeviceName(), "ADJOUT_POWER", "Adj Output", MAIN_CONTROL_TAB, IP_RW,
     //                       ISR_1OFMANY, 60, IPS_IDLE);
 
     // Adjustable Voltage
-    IUFillSwitch(&AdjOutVoltS[ADJOUT_OFF], "ADJOUT_OFF", "Off", ISS_ON);
-    IUFillSwitch(&AdjOutVoltS[ADJOUT_3V], "ADJOUT_3V", "3V", ISS_OFF);
-    IUFillSwitch(&AdjOutVoltS[ADJOUT_5V], "ADJOUT_5V", "5V", ISS_OFF);
-    IUFillSwitch(&AdjOutVoltS[ADJOUT_8V], "ADJOUT_8V", "8V", ISS_OFF);
-    IUFillSwitch(&AdjOutVoltS[ADJOUT_9V], "ADJOUT_9V", "9V", ISS_OFF);
-    IUFillSwitch(&AdjOutVoltS[ADJOUT_12V], "ADJOUT_12V", "12V", ISS_OFF);
-    IUFillSwitchVector(&AdjOutVoltSP, AdjOutVoltS, 6, getDeviceName(), "ADJOUT_VOLTAGE", "Adj voltage", MAIN_CONTROL_TAB, IP_RW,
+    AdjOutVoltSP[ADJOUT_OFF].fill("ADJOUT_OFF", "Off", ISS_ON);
+    AdjOutVoltSP[ADJOUT_3V].fill("ADJOUT_3V", "3V", ISS_OFF);
+    AdjOutVoltSP[ADJOUT_5V].fill("ADJOUT_5V", "5V", ISS_OFF);
+    AdjOutVoltSP[ADJOUT_8V].fill("ADJOUT_8V", "8V", ISS_OFF);
+    AdjOutVoltSP[ADJOUT_9V].fill("ADJOUT_9V", "9V", ISS_OFF);
+    AdjOutVoltSP[ADJOUT_12V].fill("ADJOUT_12V", "12V", ISS_OFF);
+    AdjOutVoltSP.fill(getDeviceName(), "ADJOUT_VOLTAGE", "Adj voltage", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
     // Reboot
-    IUFillSwitch(&RebootS[0], "REBOOT", "Reboot Device", ISS_OFF);
-    IUFillSwitchVector(&RebootSP, RebootS, 1, getDeviceName(), "REBOOT_DEVICE", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1,
+    RebootSP[0].fill("REBOOT", "Reboot Device", ISS_OFF);
+    RebootSP.fill(getDeviceName(), "REBOOT_DEVICE", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1,
                        60, IPS_IDLE);
 
     // Power Sensors
-    IUFillNumber(&PowerSensorsN[SENSOR_VOLTAGE], "SENSOR_VOLTAGE", "Voltage (V)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_CURRENT], "SENSOR_CURRENT", "Current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_AVG_AMPS], "SENSOR_AVG_AMPS", "Average Current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_AMP_HOURS], "SENSOR_AMP_HOURS", "Amp hours (Ah)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_WATT_HOURS], "SENSOR_WATT_HOURS", "Watt hours (Wh)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_TOTAL_CURRENT], "SENSOR_TOTAL_CURRENT", "Total current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_12V_CURRENT], "SENSOR_12V_CURRENT", "12V current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_DEWA_CURRENT], "SENSOR_DEWA_CURRENT", "DewA current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_DEWB_CURRENT], "SENSOR_DEWB_CURRENT", "DewB current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumberVector(&PowerSensorsNP, PowerSensorsN, 9, getDeviceName(), "POWER_SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO,
+    PowerSensorsNP[SENSOR_VOLTAGE].fill("SENSOR_VOLTAGE", "Voltage (V)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_CURRENT].fill("SENSOR_CURRENT", "Current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_AVG_AMPS].fill("SENSOR_AVG_AMPS", "Average Current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_AMP_HOURS].fill("SENSOR_AMP_HOURS", "Amp hours (Ah)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_WATT_HOURS].fill("SENSOR_WATT_HOURS", "Watt hours (Wh)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_TOTAL_CURRENT].fill("SENSOR_TOTAL_CURRENT", "Total current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_12V_CURRENT].fill("SENSOR_12V_CURRENT", "12V current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_DEWA_CURRENT].fill("SENSOR_DEWA_CURRENT", "DewA current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_DEWB_CURRENT].fill("SENSOR_DEWB_CURRENT", "DewB current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP.fill(getDeviceName(), "POWER_SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO,
                        60, IPS_IDLE);
 
-    IUFillLight(&PowerWarnL[0], "POWER_WARN_ON", "Current Overload", IPS_IDLE);
-    IUFillLightVector(&PowerWarnLP, PowerWarnL, 1, getDeviceName(), "POWER_WARM", "Power Warn", MAIN_CONTROL_TAB, IPS_IDLE);
+    PowerWarnLP[0].fill("POWER_WARN_ON", "Current Overload", IPS_IDLE);
+    PowerWarnLP.fill(getDeviceName(), "POWER_WARM", "Power Warn", MAIN_CONTROL_TAB, IPS_IDLE);
 
     // LED Indicator
-    IUFillSwitch(&LedIndicatorS[INDI_ENABLED], "LED_ON", "Enable", ISS_ON);
-    IUFillSwitch(&LedIndicatorS[INDI_DISABLED], "LED_OFF", "Disable", ISS_OFF);
-    IUFillSwitchVector(&LedIndicatorSP, LedIndicatorS, 2, getDeviceName(), "LED_INDICATOR", "LED Indicator", MAIN_CONTROL_TAB,
+    LedIndicatorSP[INDI_ENABLED].fill("LED_ON", "Enable", ISS_ON);
+    LedIndicatorSP[INDI_DISABLED].fill("LED_OFF", "Disable", ISS_OFF);
+    LedIndicatorSP.fill(getDeviceName(), "LED_INDICATOR", "LED Indicator", MAIN_CONTROL_TAB,
                        IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
@@ -148,11 +148,11 @@ bool PegasusPPBA::initProperties()
     ////////////////////////////////////////////////////////////////////////////
 
     // Power on Boot
-    IUFillSwitch(&PowerOnBootS[0], "POWER_PORT_1", "Quad Out", ISS_ON);
-    IUFillSwitch(&PowerOnBootS[1], "POWER_PORT_2", "Adj Out", ISS_ON);
-    IUFillSwitch(&PowerOnBootS[2], "POWER_PORT_3", "Dew A", ISS_ON);
-    IUFillSwitch(&PowerOnBootS[3], "POWER_PORT_4", "Dew B", ISS_ON);
-    IUFillSwitchVector(&PowerOnBootSP, PowerOnBootS, 4, getDeviceName(), "POWER_ON_BOOT", "Power On Boot", MAIN_CONTROL_TAB,
+    PowerOnBootSP[0].fill("POWER_PORT_1", "Quad Out", ISS_ON);
+    PowerOnBootSP[1].fill("POWER_PORT_2", "Adj Out", ISS_ON);
+    PowerOnBootSP[2].fill("POWER_PORT_3", "Dew A", ISS_ON);
+    PowerOnBootSP[3].fill("POWER_PORT_4", "Dew B", ISS_ON);
+    PowerOnBootSP.fill(getDeviceName(), "POWER_ON_BOOT", "Power On Boot", MAIN_CONTROL_TAB,
                        IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
@@ -160,22 +160,22 @@ bool PegasusPPBA::initProperties()
     ////////////////////////////////////////////////////////////////////////////
 
     // Automatic Dew
-    IUFillSwitch(&AutoDewS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&AutoDewS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_OFF);
-    IUFillSwitchVector(&AutoDewSP, AutoDewS, 2, getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_1OFMANY, 60,
+    AutoDewSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    AutoDewSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_OFF);
+    AutoDewSP.fill(getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_1OFMANY, 60,
                        IPS_IDLE);
 
     // Dew PWM
-    IUFillNumber(&DewPWMN[DEW_PWM_A], "DEW_A", "Dew A (%)", "%.2f", 0, 100, 10, 0);
-    IUFillNumber(&DewPWMN[DEW_PWM_B], "DEW_B", "Dew B (%)", "%.2f", 0, 100, 10, 0);
-    IUFillNumberVector(&DewPWMNP, DewPWMN, 2, getDeviceName(), "DEW_PWM", "Dew PWM", DEW_TAB, IP_RW, 60, IPS_IDLE);
+    DewPWMNP[DEW_PWM_A].fill("DEW_A", "Dew A (%)", "%.2f", 0, 100, 10, 0);
+    DewPWMNP[DEW_PWM_B].fill("DEW_B", "Dew B (%)", "%.2f", 0, 100, 10, 0);
+    DewPWMNP.fill(getDeviceName(), "DEW_PWM", "Dew PWM", DEW_TAB, IP_RW, 60, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
     /// Firmware Group
     ////////////////////////////////////////////////////////////////////////////
-    IUFillText(&FirmwareT[FIRMWARE_VERSION], "VERSION", "Version", "NA");
-    IUFillText(&FirmwareT[FIRMWARE_UPTIME], "UPTIME", "Uptime (h)", "NA");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 2, getDeviceName(), "FIRMWARE_INFO", "Firmware", FIRMWARE_TAB, IP_RO, 60,
+    FirmwareTP[FIRMWARE_VERSION].fill("VERSION", "Version", "NA");
+    FirmwareTP[FIRMWARE_UPTIME].fill("UPTIME", "Uptime (h)", "NA");
+    FirmwareTP.fill(getDeviceName(), "FIRMWARE_INFO", "Firmware", FIRMWARE_TAB, IP_RO, 60,
                      IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
@@ -206,45 +206,45 @@ bool PegasusPPBA::updateProperties()
     if (isConnected())
     {
         // Main Control
-        defineProperty(&QuadOutSP);
-        //defineProperty(&AdjOutSP);
-        defineProperty(&AdjOutVoltSP);
-        defineProperty(&PowerSensorsNP);
-        defineProperty(&PowerOnBootSP);
-        defineProperty(&RebootSP);
-        defineProperty(&PowerWarnLP);
-        defineProperty(&LedIndicatorSP);
+        defineProperty(QuadOutSP);
+        //defineProperty(AdjOutSP);
+        defineProperty(AdjOutVoltSP);
+        defineProperty(PowerSensorsNP);
+        defineProperty(PowerOnBootSP);
+        defineProperty(RebootSP);
+        defineProperty(PowerWarnLP);
+        defineProperty(LedIndicatorSP);
 
         // Dew
-        defineProperty(&AutoDewSP);
-        defineProperty(&DewPWMNP);
+        defineProperty(AutoDewSP);
+        defineProperty(DewPWMNP);
 
         WI::updateProperties();
 
         // Firmware
-        defineProperty(&FirmwareTP);
+        defineProperty(FirmwareTP);
 
         setupComplete = true;
     }
     else
     {
         // Main Control
-        deleteProperty(QuadOutSP.name);
-        //deleteProperty(AdjOutSP.name);
-        deleteProperty(AdjOutVoltSP.name);
-        deleteProperty(PowerSensorsNP.name);
-        deleteProperty(PowerOnBootSP.name);
-        deleteProperty(RebootSP.name);
-        deleteProperty(PowerWarnLP.name);
-        deleteProperty(LedIndicatorSP.name);
+        deleteProperty(QuadOutSP.getName());
+        //deleteProperty(AdjOutSP.getName());
+        deleteProperty(AdjOutVoltSP.getName());
+        deleteProperty(PowerSensorsNP.getName());
+        deleteProperty(PowerOnBootSP.getName());
+        deleteProperty(RebootSP.getName());
+        deleteProperty(PowerWarnLP.getName());
+        deleteProperty(LedIndicatorSP.getName());
 
         // Dew
-        deleteProperty(AutoDewSP.name);
-        deleteProperty(DewPWMNP.name);
+        deleteProperty(AutoDewSP.getName());
+        deleteProperty(DewPWMNP.getName());
 
         WI::updateProperties();
 
-        deleteProperty(FirmwareTP.name);
+        deleteProperty(FirmwareTP.getName());
 
         setupComplete = false;
     }
@@ -311,47 +311,47 @@ bool PegasusPPBA::ISNewSwitch(const char * dev, const char * name, ISState * sta
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Quad 12V Power
-        if (!strcmp(name, QuadOutSP.name))
+        if (QuadOutSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&QuadOutSP, states, names, n);
+            QuadOutSP.update(states, names, n);
 
-            QuadOutSP.s = IPS_ALERT;
+            QuadOutSP.setState(IPS_ALERT);
             char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-            snprintf(cmd, PEGASUS_LEN, "P1:%d", QuadOutS[INDI_ENABLED].s == ISS_ON);
+            snprintf(cmd, PEGASUS_LEN, "P1:%d", QuadOutSP[INDI_ENABLED].getState() == ISS_ON);
             if (sendCommand(cmd, res))
             {
-                QuadOutSP.s = !strcmp(cmd, res) ? IPS_OK : IPS_ALERT;
+                QuadOutSP.setState(!strcmp(cmd, res) ? IPS_OK : IPS_ALERT);
             }
 
-            IUResetSwitch(&QuadOutSP);
-            IDSetSwitch(&QuadOutSP, nullptr);
+            QuadOutSP.reset();
+            QuadOutSP.apply();
             return true;
         }
 
         //        // Adjustable Power
-        //        if (!strcmp(name, AdjOutSP.name))
+        //        if (AdjOutSP.isNameMatch(name))
         //        {
-        //            IUUpdateSwitch(&AdjOutSP, states, names, n);
+        //            AdjOutSP.update(states, names, n);
 
-        //            AdjOutSP.s = IPS_ALERT;
+        //            AdjOutSP.setState(IPS_ALERT);
         //            char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-        //            snprintf(cmd, PEGASUS_LEN, "P2:%d", AdjOutS[INDI_ENABLED].s == ISS_ON);
+        //            snprintf(cmd, PEGASUS_LEN, "P2:%d", AdjOutSP[INDI_ENABLED].getState() == ISS_ON);
         //            if (sendCommand(cmd, res))
         //            {
-        //                AdjOutSP.s = !strcmp(cmd, res) ? IPS_OK : IPS_ALERT;
+        //                AdjOutSP.setState(!strcmp(cmd, res) ? IPS_OK : IPS_ALERT);
         //            }
 
-        //            IUResetSwitch(&AdjOutSP);
-        //            IDSetSwitch(&AdjOutSP, nullptr);
+        //            AdjOutSP.reset();
+        //            AdjOutSP.apply();
         //            return true;
         //        }
 
         // Adjustable Voltage
-        if (!strcmp(name, AdjOutVoltSP.name))
+        if (AdjOutVoltSP.isNameMatch(name))
         {
-            int previous_index = IUFindOnSwitchIndex(&AdjOutVoltSP);
-            IUUpdateSwitch(&AdjOutVoltSP, states, names, n);
-            int target_index = IUFindOnSwitchIndex(&AdjOutVoltSP);
+            int previous_index = AdjOutVoltSP.findOnSwitchIndex();
+            AdjOutVoltSP.update(states, names, n);
+            int target_index = AdjOutVoltSP.findOnSwitchIndex();
             int adjv = 0;
             switch(target_index)
             {
@@ -375,73 +375,73 @@ bool PegasusPPBA::ISNewSwitch(const char * dev, const char * name, ISState * sta
                     break;
             }
 
-            AdjOutVoltSP.s = IPS_ALERT;
+            AdjOutVoltSP.setState(IPS_ALERT);
             char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
             snprintf(cmd, PEGASUS_LEN, "P2:%d", adjv);
             if (sendCommand(cmd, res))
-                AdjOutVoltSP.s = IPS_OK;
+                AdjOutVoltSP.setState(IPS_OK);
             else
             {
-                IUResetSwitch(&AdjOutVoltSP);
-                AdjOutVoltS[previous_index].s = ISS_ON;
-                AdjOutVoltSP.s = IPS_ALERT;
+                AdjOutVoltSP.reset();
+                AdjOutVoltSP[previous_index].setState(ISS_ON);
+                AdjOutVoltSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&AdjOutVoltSP, nullptr);
+            AdjOutVoltSP.apply();
             return true;
         }
 
         // Reboot
-        if (!strcmp(name, RebootSP.name))
+        if (RebootSP.isNameMatch(name))
         {
-            RebootSP.s = reboot() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&RebootSP, nullptr);
+            RebootSP.setState(reboot() ? IPS_OK : IPS_ALERT);
+            RebootSP.apply();
             LOG_INFO("Rebooting device...");
             return true;
         }
 
         // LED Indicator
-        if (!strcmp(name, LedIndicatorSP.name))
+        if (LedIndicatorSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&LedIndicatorSP, states, names, n);
+            LedIndicatorSP.update(states, names, n);
             char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-            snprintf(cmd, PEGASUS_LEN, "PL:%d", LedIndicatorS[INDI_ENABLED].s == ISS_ON);
+            snprintf(cmd, PEGASUS_LEN, "PL:%d", LedIndicatorSP[INDI_ENABLED].getState() == ISS_ON);
             if (sendCommand(cmd, res))
             {
-                LedIndicatorSP.s = !strcmp(cmd, res) ? IPS_OK : IPS_ALERT;
+                LedIndicatorSP.setState(!strcmp(cmd, res) ? IPS_OK : IPS_ALERT);
             }
-            IDSetSwitch(&LedIndicatorSP, nullptr);
-            saveConfig(true, LedIndicatorSP.name);
+            LedIndicatorSP.apply();
+            saveConfig(true, LedIndicatorSP.getName());
             return true;
         }
 
         // Power on boot
-        if (!strcmp(name, PowerOnBootSP.name))
+        if (PowerOnBootSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PowerOnBootSP, states, names, n);
-            PowerOnBootSP.s = setPowerOnBoot() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&PowerOnBootSP, nullptr);
-            saveConfig(true, PowerOnBootSP.name);
+            PowerOnBootSP.update(states, names, n);
+            PowerOnBootSP.setState(setPowerOnBoot() ? IPS_OK : IPS_ALERT);
+            PowerOnBootSP.apply();
+            saveConfig(true, PowerOnBootSP.getName());
             return true;
         }
 
         // Auto Dew
-        if (!strcmp(name, AutoDewSP.name))
+        if (AutoDewSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&AutoDewSP);
-            IUUpdateSwitch(&AutoDewSP, states, names, n);
-            if (setAutoDewEnabled(AutoDewS[INDI_ENABLED].s == ISS_ON))
+            int prevIndex = AutoDewSP.findOnSwitchIndex();
+            AutoDewSP.update(states, names, n);
+            if (setAutoDewEnabled(AutoDewSP[INDI_ENABLED].getState() == ISS_ON))
             {
-                AutoDewSP.s = IPS_OK;
+                AutoDewSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&AutoDewSP);
-                AutoDewS[prevIndex].s = ISS_ON;
-                AutoDewSP.s = IPS_ALERT;
+                AutoDewSP.reset();
+                AutoDewSP[prevIndex].setState(ISS_ON);
+                AutoDewSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&AutoDewSP, nullptr);
+            AutoDewSP.apply();
             return true;
         }
     }
@@ -454,21 +454,21 @@ bool PegasusPPBA::ISNewNumber(const char * dev, const char * name, double values
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Dew PWM
-        if (!strcmp(name, DewPWMNP.name))
+        if (DewPWMNP.isNameMatch(name))
         {
             bool rc1 = false, rc2 = false;
             for (int i = 0; i < n; i++)
             {
-                if (!strcmp(names[i], DewPWMN[DEW_PWM_A].name))
+                if (!strcmp(names[i], DewPWMNP[DEW_PWM_A].getName()))
                     rc1 = setDewPWM(3, static_cast<uint8_t>(values[i] / 100.0 * 255.0));
-                else if (!strcmp(names[i], DewPWMN[DEW_PWM_B].name))
+                else if (!strcmp(names[i], DewPWMNP[DEW_PWM_B].getName()))
                     rc2 = setDewPWM(4, static_cast<uint8_t>(values[i] / 100.0 * 255.0));
             }
 
-            DewPWMNP.s = (rc1 && rc2) ? IPS_OK : IPS_ALERT;
-            if (DewPWMNP.s == IPS_OK)
-                IUUpdateNumber(&DewPWMNP, values, names, n);
-            IDSetNumber(&DewPWMNP, nullptr);
+            DewPWMNP.setState((rc1 && rc2) ? IPS_OK : IPS_ALERT);
+            if (DewPWMNP.getState() == IPS_OK)
+                DewPWMNP.update(values, names, n);
+            DewPWMNP.apply();
             return true;
         }
 
@@ -532,10 +532,10 @@ bool PegasusPPBA::setAutoDewEnabled(bool enabled)
 bool PegasusPPBA::setPowerOnBoot()
 {
     char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-    snprintf(cmd, PEGASUS_LEN, "PE:%d%d%d%d", PowerOnBootS[0].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[1].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[2].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[3].s == ISS_ON ? 1 : 0);
+    snprintf(cmd, PEGASUS_LEN, "PE:%d%d%d%d", PowerOnBootSP[0].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[1].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[2].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[3].getState() == ISS_ON ? 1 : 0);
     if (sendCommand(cmd, res))
     {
         return (!strcmp(res, "PE:1"));
@@ -561,7 +561,7 @@ bool PegasusPPBA::saveConfigItems(FILE * fp)
 {
     INDI::DefaultDevice::saveConfigItems(fp);
     WI::saveConfigItems(fp);
-    IUSaveConfigSwitch(fp, &AutoDewSP);
+    AutoDewSP.save(fp);
     return true;
 }
 
@@ -585,8 +585,8 @@ bool PegasusPPBA::sendFirmware()
     if (sendCommand("PV", res))
     {
         LOGF_INFO("Detected firmware %s", res);
-        IUSaveText(&FirmwareT[FIRMWARE_VERSION], res);
-        IDSetText(&FirmwareTP, nullptr);
+        FirmwareTP[FIRMWARE_VERSION].setText(res);
+        FirmwareTP.apply();
         return true;
     }
 
@@ -609,11 +609,11 @@ bool PegasusPPBA::getSensorData()
             return true;
 
         // Power Sensors
-        PowerSensorsN[SENSOR_VOLTAGE].value = std::stod(result[PA_VOLTAGE]);
-        PowerSensorsN[SENSOR_CURRENT].value = std::stod(result[PA_CURRENT]) / 65.0;
-        PowerSensorsNP.s = IPS_OK;
+        PowerSensorsNP[SENSOR_VOLTAGE].setValue(std::stod(result[PA_VOLTAGE]));
+        PowerSensorsNP[SENSOR_CURRENT].setValue(std::stod(result[PA_CURRENT]) / 65.0);
+        PowerSensorsNP.setState(IPS_OK);
         if (lastSensorData[PA_VOLTAGE] != result[PA_VOLTAGE] || lastSensorData[PA_CURRENT] != result[PA_CURRENT])
-            IDSetNumber(&PowerSensorsNP, nullptr);
+            PowerSensorsNP.apply();
 
         // Environment Sensors
         setParameterValue("WEATHER_TEMPERATURE", std::stod(result[PA_TEMPERATURE]));
@@ -630,52 +630,52 @@ bool PegasusPPBA::getSensorData()
         }
 
         // Power Status
-        QuadOutS[INDI_ENABLED].s = (std::stoi(result[PA_PORT_STATUS]) == 1) ? ISS_ON : ISS_OFF;
-        QuadOutS[INDI_DISABLED].s = (std::stoi(result[PA_PORT_STATUS]) == 1) ? ISS_OFF : ISS_ON;
-        QuadOutSP.s = (std::stoi(result[6]) == 1) ? IPS_OK : IPS_IDLE;
+        QuadOutSP[INDI_ENABLED].setState((std::stoi(result[PA_PORT_STATUS]) == 1) ? ISS_ON : ISS_OFF);
+        QuadOutSP[INDI_DISABLED].setState((std::stoi(result[PA_PORT_STATUS]) == 1) ? ISS_OFF : ISS_ON);
+        QuadOutSP.setState((std::stoi(result[6]) == 1) ? IPS_OK : IPS_IDLE);
         if (lastSensorData[PA_PORT_STATUS] != result[PA_PORT_STATUS])
-            IDSetSwitch(&QuadOutSP, nullptr);
+            QuadOutSP.apply();
 
         // Adjustable Power Status
-        //        AdjOutS[INDI_ENABLED].s = (std::stoi(result[PA_ADJ_STATUS]) == 1) ? ISS_ON : ISS_OFF;
-        //        AdjOutS[INDI_DISABLED].s = (std::stoi(result[PA_ADJ_STATUS]) == 1) ? ISS_OFF : ISS_ON;
-        //        AdjOutSP.s = (std::stoi(result[PA_ADJ_STATUS]) == 1) ? IPS_OK : IPS_IDLE;
+        //        AdjOutSP[INDI_ENABLED].setState((std::stoi(result[PA_ADJ_STATUS]) == 1) ? ISS_ON : ISS_OFF);
+        //        AdjOutSP[INDI_DISABLED].setState((std::stoi(result[PA_ADJ_STATUS]) == 1) ? ISS_OFF : ISS_ON);
+        //        AdjOutSP.setState((std::stoi(result[PA_ADJ_STATUS]) == 1) ? IPS_OK : IPS_IDLE);
         //        if (lastSensorData[PA_ADJ_STATUS] != result[PA_ADJ_STATUS])
-        //            IDSetSwitch(&AdjOutSP, nullptr);
+        //            AdjOutSP.apply();
 
         // Adjustable Power Status
-        IUResetSwitch(&AdjOutVoltSP);
+        AdjOutVoltSP.reset();
         if (std::stoi(result[PA_ADJ_STATUS]) == 0)
-            AdjOutVoltS[ADJOUT_OFF].s = ISS_ON;
+            AdjOutVoltSP[ADJOUT_OFF].setState(ISS_ON);
         else
         {
-            AdjOutVoltS[ADJOUT_3V].s = (std::stoi(result[PA_PWRADJ]) == 3) ? ISS_ON : ISS_OFF;
-            AdjOutVoltS[ADJOUT_5V].s = (std::stoi(result[PA_PWRADJ]) == 5) ? ISS_ON : ISS_OFF;
-            AdjOutVoltS[ADJOUT_8V].s = (std::stoi(result[PA_PWRADJ]) == 8) ? ISS_ON : ISS_OFF;
-            AdjOutVoltS[ADJOUT_9V].s = (std::stoi(result[PA_PWRADJ]) == 9) ? ISS_ON : ISS_OFF;
-            AdjOutVoltS[ADJOUT_12V].s = (std::stoi(result[PA_PWRADJ]) == 12) ? ISS_ON : ISS_OFF;
+            AdjOutVoltSP[ADJOUT_3V].setState((std::stoi(result[PA_PWRADJ]) == 3) ? ISS_ON : ISS_OFF);
+            AdjOutVoltSP[ADJOUT_5V].setState((std::stoi(result[PA_PWRADJ]) == 5) ? ISS_ON : ISS_OFF);
+            AdjOutVoltSP[ADJOUT_8V].setState((std::stoi(result[PA_PWRADJ]) == 8) ? ISS_ON : ISS_OFF);
+            AdjOutVoltSP[ADJOUT_9V].setState((std::stoi(result[PA_PWRADJ]) == 9) ? ISS_ON : ISS_OFF);
+            AdjOutVoltSP[ADJOUT_12V].setState((std::stoi(result[PA_PWRADJ]) == 12) ? ISS_ON : ISS_OFF);
         }
         if (lastSensorData[PA_PWRADJ] != result[PA_PWRADJ] || lastSensorData[PA_ADJ_STATUS] != result[PA_ADJ_STATUS])
-            IDSetSwitch(&AdjOutVoltSP, nullptr);
+            AdjOutVoltSP.apply();
 
         // Power Warn
-        PowerWarnL[0].s = (std::stoi(result[PA_PWR_WARN]) == 1) ? IPS_ALERT : IPS_OK;
-        PowerWarnLP.s = (std::stoi(result[PA_PWR_WARN]) == 1) ? IPS_ALERT : IPS_OK;
+        PowerWarnLP[0].setState((std::stoi(result[PA_PWR_WARN]) == 1) ? IPS_ALERT : IPS_OK);
+        PowerWarnLP.setState((std::stoi(result[PA_PWR_WARN]) == 1) ? IPS_ALERT : IPS_OK);
         if (lastSensorData[PA_PWR_WARN] != result[PA_PWR_WARN])
-            IDSetLight(&PowerWarnLP, nullptr);
+            PowerWarnLP.apply();
 
         // Dew PWM
-        DewPWMN[0].value = std::stod(result[PA_DEW_1]) / 255.0 * 100.0;
-        DewPWMN[1].value = std::stod(result[PA_DEW_2]) / 255.0 * 100.0;
+        DewPWMNP[0].setValue(std::stod(result[PA_DEW_1]) / 255.0 * 100.0);
+        DewPWMNP[1].setValue(std::stod(result[PA_DEW_2]) / 255.0 * 100.0);
         if (lastSensorData[PA_DEW_1] != result[PA_DEW_1] || lastSensorData[PA_DEW_2] != result[PA_DEW_2])
-            IDSetNumber(&DewPWMNP, nullptr);
+            DewPWMNP.apply();
 
         // Auto Dew
-        AutoDewS[INDI_DISABLED].s = (std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_OFF : ISS_ON;
-        AutoDewS[INDI_ENABLED].s  = (std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_ON : ISS_OFF;
-        AutoDewSP.s = (std::stoi(result[PA_AUTO_DEW]) == 1) ? IPS_OK : IPS_IDLE;
+        AutoDewSP[INDI_DISABLED].setState((std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_OFF : ISS_ON);
+        AutoDewSP[INDI_ENABLED].setState((std::stoi(result[PA_AUTO_DEW]) == 1) ? ISS_ON : ISS_OFF);
+        AutoDewSP.setState((std::stoi(result[PA_AUTO_DEW]) == 1) ? IPS_OK : IPS_IDLE);
         if (lastSensorData[PA_AUTO_DEW] != result[PA_AUTO_DEW])
-            IDSetSwitch(&AutoDewSP, nullptr);
+            AutoDewSP.apply();
 
         lastSensorData = result;
 
@@ -701,13 +701,13 @@ bool PegasusPPBA::getConsumptionData()
             return true;
 
         // Power Sensors
-        PowerSensorsN[SENSOR_AVG_AMPS].value = std::stod(result[PS_AVG_AMPS]);
-        PowerSensorsN[SENSOR_AMP_HOURS].value = std::stod(result[PS_AMP_HOURS]);
-        PowerSensorsN[SENSOR_WATT_HOURS].value = std::stod(result[PS_WATT_HOURS]);
-        PowerSensorsNP.s = IPS_OK;
+        PowerSensorsNP[SENSOR_AVG_AMPS].setValue(std::stod(result[PS_AVG_AMPS]));
+        PowerSensorsNP[SENSOR_AMP_HOURS].setValue(std::stod(result[PS_AMP_HOURS]));
+        PowerSensorsNP[SENSOR_WATT_HOURS].setValue(std::stod(result[PS_WATT_HOURS]));
+        PowerSensorsNP.setState(IPS_OK);
         if (lastConsumptionData[PS_AVG_AMPS] != result[PS_AVG_AMPS] || lastConsumptionData[PS_AMP_HOURS] != result[PS_AMP_HOURS]
                 || lastConsumptionData[PS_WATT_HOURS] != result[PS_WATT_HOURS])
-            IDSetNumber(&PowerSensorsNP, nullptr);
+            PowerSensorsNP.apply();
 
         lastConsumptionData = result;
 
@@ -733,23 +733,23 @@ bool PegasusPPBA::getMetricsData()
             return true;
 
         // Power Sensors
-        PowerSensorsN[SENSOR_TOTAL_CURRENT].value = std::stod(result[PC_TOTAL_CURRENT]);
-        PowerSensorsN[SENSOR_12V_CURRENT].value = std::stod(result[PC_12V_CURRENT]);
-        PowerSensorsN[SENSOR_DEWA_CURRENT].value = std::stod(result[PC_DEWA_CURRENT]);
-        PowerSensorsN[SENSOR_DEWB_CURRENT].value = std::stod(result[PC_DEWB_CURRENT]);
-        PowerSensorsNP.s = IPS_OK;
+        PowerSensorsNP[SENSOR_TOTAL_CURRENT].setValue(std::stod(result[PC_TOTAL_CURRENT]));
+        PowerSensorsNP[SENSOR_12V_CURRENT].setValue(std::stod(result[PC_12V_CURRENT]));
+        PowerSensorsNP[SENSOR_DEWA_CURRENT].setValue(std::stod(result[PC_DEWA_CURRENT]));
+        PowerSensorsNP[SENSOR_DEWB_CURRENT].setValue(std::stod(result[PC_DEWB_CURRENT]));
+        PowerSensorsNP.setState(IPS_OK);
         if (lastMetricsData[PC_TOTAL_CURRENT] != result[PC_TOTAL_CURRENT] ||
                 lastMetricsData[PC_12V_CURRENT] != result[PC_12V_CURRENT] ||
                 lastMetricsData[PC_DEWA_CURRENT] != result[PC_DEWA_CURRENT] ||
                 lastMetricsData[PC_DEWB_CURRENT] != result[PC_DEWB_CURRENT])
-            IDSetNumber(&PowerSensorsNP, nullptr);
+            PowerSensorsNP.apply();
 
         std::chrono::milliseconds uptime(std::stol(result[PC_UPTIME]));
         using dhours = std::chrono::duration<double, std::ratio<3600>>;
         std::stringstream ss;
         ss << std::fixed << std::setprecision(3) << dhours(uptime).count();
-        IUSaveText(&FirmwareT[FIRMWARE_UPTIME], ss.str().c_str());
-        IDSetText(&FirmwareTP, nullptr);
+        FirmwareTP[FIRMWARE_UPTIME].setText(ss.str());
+        FirmwareTP.apply();
 
         lastMetricsData = result;
 

--- a/drivers/auxiliary/pegasus_ppba.h
+++ b/drivers/auxiliary/pegasus_ppba.h
@@ -30,6 +30,12 @@
 #include <vector>
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
+
 namespace Connection
 {
 class Serial;
@@ -134,12 +140,10 @@ class PegasusPPBA : public INDI::DefaultDevice, public INDI::WeatherInterface
         /// Main Control
         ////////////////////////////////////////////////////////////////////////////////////
         /// Reboot Device
-        ISwitch RebootS[1];
-        ISwitchVectorProperty RebootSP;
+        INDI::PropertySwitch RebootSP {1};
 
         // Power Sensors
-        INumber PowerSensorsN[9];
-        INumberVectorProperty PowerSensorsNP;
+        INDI::PropertyNumber PowerSensorsNP {9};
         enum
         {
             SENSOR_VOLTAGE,
@@ -157,14 +161,12 @@ class PegasusPPBA : public INDI::DefaultDevice, public INDI::WeatherInterface
         /// Power Group
         ////////////////////////////////////////////////////////////////////////////////////
 
-        ISwitch QuadOutS[2];
-        ISwitchVectorProperty QuadOutSP;
+        INDI::PropertySwitch QuadOutSP {2};
 
-        //        ISwitch AdjOutS[2];
-        //        ISwitchVectorProperty AdjOutSP;
+        //        INDI::PropertySwitch AdjOutSP {2};
+        //
 
-        ISwitch AdjOutVoltS[6];
-        ISwitchVectorProperty AdjOutVoltSP;
+        INDI::PropertySwitch AdjOutVoltSP {6};
         enum
         {
             ADJOUT_OFF,
@@ -176,27 +178,22 @@ class PegasusPPBA : public INDI::DefaultDevice, public INDI::WeatherInterface
         };
 
         // Select which power is ON on bootup
-        ISwitch PowerOnBootS[4];
-        ISwitchVectorProperty PowerOnBootSP;
+        INDI::PropertySwitch PowerOnBootSP {4};
 
         // Short circuit warn
-        ILight PowerWarnL[1];
-        ILightVectorProperty PowerWarnLP;
+        INDI::PropertyLight PowerWarnLP {1};
 
-        ISwitch LedIndicatorS[2];
-        ISwitchVectorProperty LedIndicatorSP;
+        INDI::PropertySwitch LedIndicatorSP {2};
 
         ////////////////////////////////////////////////////////////////////////////////////
         /// Dew Group
         ////////////////////////////////////////////////////////////////////////////////////
 
         // Auto Dew
-        ISwitch AutoDewS[2];
-        ISwitchVectorProperty AutoDewSP;
+        INDI::PropertySwitch AutoDewSP {2};
 
         // Dew PWM
-        INumber DewPWMN[2];
-        INumberVectorProperty DewPWMNP;
+        INDI::PropertyNumber DewPWMNP {2};
         enum
         {
             DEW_PWM_A,
@@ -206,9 +203,7 @@ class PegasusPPBA : public INDI::DefaultDevice, public INDI::WeatherInterface
         ////////////////////////////////////////////////////////////////////////////////////
         /// Firmware
         ////////////////////////////////////////////////////////////////////////////////////
-
-        ITextVectorProperty FirmwareTP;
-        IText FirmwareT[2] {};
+        INDI::PropertyText FirmwareTP {2};
         enum
         {
             FIRMWARE_VERSION,

--- a/drivers/auxiliary/pegasus_upb.cpp
+++ b/drivers/auxiliary/pegasus_upb.cpp
@@ -108,28 +108,28 @@ bool PegasusUPB::initProperties()
     /// Main Control Panel
     ////////////////////////////////////////////////////////////////////////////
     // Cycle all power on/off
-    IUFillSwitch(&PowerCycleAllS[POWER_CYCLE_ON], "POWER_CYCLE_ON", "All On", ISS_OFF);
-    IUFillSwitch(&PowerCycleAllS[POWER_CYCLE_OFF], "POWER_CYCLE_OFF", "All Off", ISS_OFF);
-    IUFillSwitchVector(&PowerCycleAllSP, PowerCycleAllS, 2, getDeviceName(), "POWER_CYCLE", "Cycle Power", MAIN_CONTROL_TAB,
+    PowerCycleAllSP[POWER_CYCLE_ON].fill("POWER_CYCLE_ON", "All On", ISS_OFF);
+    PowerCycleAllSP[POWER_CYCLE_OFF].fill("POWER_CYCLE_OFF", "All Off", ISS_OFF);
+    PowerCycleAllSP.fill(getDeviceName(), "POWER_CYCLE", "Cycle Power", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Reboot
-    IUFillSwitch(&RebootS[0], "REBOOT", "Reboot Device", ISS_OFF);
-    IUFillSwitchVector(&RebootSP, RebootS, 1, getDeviceName(), "REBOOT_DEVICE", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1,
+    RebootSP[0].fill("REBOOT", "Reboot Device", ISS_OFF);
+    RebootSP.fill(getDeviceName(), "REBOOT_DEVICE", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1,
                        60, IPS_IDLE);
 
     // Power Sensors
-    IUFillNumber(&PowerSensorsN[SENSOR_VOLTAGE], "SENSOR_VOLTAGE", "Voltage (V)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_CURRENT], "SENSOR_CURRENT", "Current (A)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerSensorsN[SENSOR_POWER], "SENSOR_POWER", "Power (W)", "%4.2f", 0, 999, 100, 0);
-    IUFillNumberVector(&PowerSensorsNP, PowerSensorsN, 3, getDeviceName(), "POWER_SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO,
+    PowerSensorsNP[SENSOR_VOLTAGE].fill("SENSOR_VOLTAGE", "Voltage (V)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_CURRENT].fill("SENSOR_CURRENT", "Current (A)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP[SENSOR_POWER].fill("SENSOR_POWER", "Power (W)", "%4.2f", 0, 999, 100, 0);
+    PowerSensorsNP.fill(getDeviceName(), "POWER_SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO,
                        60, IPS_IDLE);
 
     // Overall Power Consumption
-    IUFillNumber(&PowerConsumptionN[CONSUMPTION_AVG_AMPS], "CONSUMPTION_AVG_AMPS", "Avg. Amps", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerConsumptionN[CONSUMPTION_AMP_HOURS], "CONSUMPTION_AMP_HOURS", "Amp Hours", "%4.2f", 0, 999, 100, 0);
-    IUFillNumber(&PowerConsumptionN[CONSUMPTION_WATT_HOURS], "CONSUMPTION_WATT_HOURS", "Watt Hours", "%4.2f", 0, 999, 100, 0);
-    IUFillNumberVector(&PowerConsumptionNP, PowerConsumptionN, 3, getDeviceName(), "POWER_CONSUMPTION", "Consumption",
+    PowerConsumptionNP[CONSUMPTION_AVG_AMPS].fill("CONSUMPTION_AVG_AMPS", "Avg. Amps", "%4.2f", 0, 999, 100, 0);
+    PowerConsumptionNP[CONSUMPTION_AMP_HOURS].fill("CONSUMPTION_AMP_HOURS", "Amp Hours", "%4.2f", 0, 999, 100, 0);
+    PowerConsumptionNP[CONSUMPTION_WATT_HOURS].fill("CONSUMPTION_WATT_HOURS", "Watt Hours", "%4.2f", 0, 999, 100, 0);
+    PowerConsumptionNP.fill(getDeviceName(), "POWER_CONSUMPTION", "Consumption",
                        MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
@@ -137,121 +137,121 @@ bool PegasusUPB::initProperties()
     ////////////////////////////////////////////////////////////////////////////
 
     // Dew Labels. Need to delare them here to use in the Power usage section
-    IUFillText(&DewControlsLabelsT[0], "DEW_LABEL_1", "Dew A", "Dew A");
-    IUFillText(&DewControlsLabelsT[1], "DEW_LABEL_2", "Dew B", "Dew B");
-    IUFillText(&DewControlsLabelsT[2], "DEW_LABEL_3", "Dew C", "Dew C");
-    IUFillTextVector(&DewControlsLabelsTP, DewControlsLabelsT, 3, getDeviceName(), "DEW_CONTROL_LABEL", "Dew Labels",
+    DewControlsLabelsTP[0].fill("DEW_LABEL_1", "Dew A", "Dew A");
+    DewControlsLabelsTP[1].fill("DEW_LABEL_2", "Dew B", "Dew B");
+    DewControlsLabelsTP[2].fill("DEW_LABEL_3", "Dew C", "Dew C");
+    DewControlsLabelsTP.fill(getDeviceName(), "DEW_CONTROL_LABEL", "Dew Labels",
                      DEW_TAB, IP_WO, 60, IPS_IDLE);
 
     char dewLabel[MAXINDILABEL];
 
     // Turn on/off power and power boot up
     memset(dewLabel, 0, MAXINDILABEL);
-    int dewRC = IUGetConfigText(getDeviceName(), DewControlsLabelsTP.name, DewControlsLabelsT[0].name, dewLabel,
+    int dewRC = IUGetConfigText(getDeviceName(), DewControlsLabelsTP.getName(), DewControlsLabelsTP[0].getName(), dewLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&AutoDewV2S[DEW_PWM_A], "DEW_A", dewRC == -1 ? "Dew A" : dewLabel, ISS_OFF);
+    AutoDewV2SP[DEW_PWM_A].fill("DEW_A", dewRC == -1 ? "Dew A" : dewLabel, ISS_OFF);
     memset(dewLabel, 0, MAXINDILABEL);
-    dewRC = IUGetConfigText(getDeviceName(), DewControlsLabelsTP.name, DewControlsLabelsT[1].name, dewLabel,
+    dewRC = IUGetConfigText(getDeviceName(), DewControlsLabelsTP.getName(), DewControlsLabelsTP[1].getName(), dewLabel,
                                      MAXINDILABEL);
-    IUFillSwitch(&AutoDewV2S[DEW_PWM_B], "DEW_B", dewRC == -1 ? "Dew B" : dewLabel, ISS_OFF);
+    AutoDewV2SP[DEW_PWM_B].fill("DEW_B", dewRC == -1 ? "Dew B" : dewLabel, ISS_OFF);
     memset(dewLabel, 0, MAXINDILABEL);
-    dewRC = IUGetConfigText(getDeviceName(), DewControlsLabelsTP.name, DewControlsLabelsT[2].name, dewLabel,
+    dewRC = IUGetConfigText(getDeviceName(), DewControlsLabelsTP.getName(), DewControlsLabelsTP[2].getName(), dewLabel,
                                      MAXINDILABEL);
-    IUFillSwitch(&AutoDewV2S[DEW_PWM_C], "DEW_C", dewRC == -1 ? "Dew C" : dewLabel, ISS_OFF);
-    IUFillSwitchVector(&AutoDewV2SP, AutoDewV2S, 3, getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_NOFMANY, 60,
+    AutoDewV2SP[DEW_PWM_C].fill("DEW_C", dewRC == -1 ? "Dew C" : dewLabel, ISS_OFF);
+    AutoDewV2SP.fill(getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_NOFMANY, 60,
                        IPS_IDLE);
 
     // Dew Labels with custom labels
-    IUFillText(&DewControlsLabelsT[0], "DEW_LABEL_1", "Dew A", AutoDewV2S[0].label);
-    IUFillText(&DewControlsLabelsT[1], "DEW_LABEL_2", "Dew B", AutoDewV2S[1].label);
-    IUFillText(&DewControlsLabelsT[2], "DEW_LABEL_3", "Dew C", AutoDewV2S[2].label);
-    IUFillTextVector(&DewControlsLabelsTP, DewControlsLabelsT, 3, getDeviceName(), "DEW_CONTROL_LABEL", "DEW Labels",
+    DewControlsLabelsTP[0].fill("DEW_LABEL_1", "Dew A", AutoDewV2SP[0].label);
+    DewControlsLabelsTP[1].fill("DEW_LABEL_2", "Dew B", AutoDewV2SP[1].label);
+    DewControlsLabelsTP[2].fill("DEW_LABEL_3", "Dew C", AutoDewV2SP[2].label);
+    DewControlsLabelsTP.fill(getDeviceName(), "DEW_CONTROL_LABEL", "DEW Labels",
                      DEW_TAB, IP_WO, 60, IPS_IDLE);
     // Power Labels
-    IUFillText(&PowerControlsLabelsT[0], "POWER_LABEL_1", "Port 1", "Port 1");
-    IUFillText(&PowerControlsLabelsT[1], "POWER_LABEL_2", "Port 2", "Port 2");
-    IUFillText(&PowerControlsLabelsT[2], "POWER_LABEL_3", "Port 3", "Port 3");
-    IUFillText(&PowerControlsLabelsT[3], "POWER_LABEL_4", "Port 4", "Port 4");
-    IUFillTextVector(&PowerControlsLabelsTP, PowerControlsLabelsT, 4, getDeviceName(), "POWER_CONTROL_LABEL", "Power Labels",
+    PowerControlsLabelsTP[0].fill("POWER_LABEL_1", "Port 1", "Port 1");
+    PowerControlsLabelsTP[1].fill("POWER_LABEL_2", "Port 2", "Port 2");
+    PowerControlsLabelsTP[2].fill("POWER_LABEL_3", "Port 3", "Port 3");
+    PowerControlsLabelsTP[3].fill("POWER_LABEL_4", "Port 4", "Port 4");
+    PowerControlsLabelsTP.fill(getDeviceName(), "POWER_CONTROL_LABEL", "Power Labels",
                      POWER_TAB, IP_WO, 60, IPS_IDLE);
 
     char portLabel[MAXINDILABEL];
 
     // Turn on/off power and power boot up
     memset(portLabel, 0, MAXINDILABEL);
-    int portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.name, PowerControlsLabelsT[0].name, portLabel,
+    int portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.getName(), PowerControlsLabelsTP[0].getName(), portLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&PowerControlS[0], "POWER_CONTROL_1", portRC == -1 ? "Port 1" : portLabel, ISS_OFF);
+    PowerControlSP[0].fill("POWER_CONTROL_1", portRC == -1 ? "Port 1" : portLabel, ISS_OFF);
 
     memset(portLabel, 0, MAXINDILABEL);
-    portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.name, PowerControlsLabelsT[1].name, portLabel,
+    portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.getName(), PowerControlsLabelsTP[1].getName(), portLabel,
                              MAXINDILABEL);
-    IUFillSwitch(&PowerControlS[1], "POWER_CONTROL_2", portRC == -1 ? "Port 2" : portLabel, ISS_OFF);
+    PowerControlSP[1].fill("POWER_CONTROL_2", portRC == -1 ? "Port 2" : portLabel, ISS_OFF);
 
     memset(portLabel, 0, MAXINDILABEL);
-    portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.name, PowerControlsLabelsT[2].name, portLabel,
+    portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.getName(), PowerControlsLabelsTP[2].getName(), portLabel,
                              MAXINDILABEL);
-    IUFillSwitch(&PowerControlS[2], "POWER_CONTROL_3", portRC == -1 ? "Port 3" : portLabel, ISS_OFF);
+    PowerControlSP[2].fill("POWER_CONTROL_3", portRC == -1 ? "Port 3" : portLabel, ISS_OFF);
 
     memset(portLabel, 0, MAXINDILABEL);
-    portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.name, PowerControlsLabelsT[3].name, portLabel,
+    portRC = IUGetConfigText(getDeviceName(), PowerControlsLabelsTP.getName(), PowerControlsLabelsTP[3].getName(), portLabel,
                              MAXINDILABEL);
-    IUFillSwitch(&PowerControlS[3], "POWER_CONTROL_4", portRC == -1 ? "Port 4" : portLabel, ISS_OFF);
+    PowerControlSP[3].fill("POWER_CONTROL_4", portRC == -1 ? "Port 4" : portLabel, ISS_OFF);
 
-    IUFillSwitchVector(&PowerControlSP, PowerControlS, 4, getDeviceName(), "POWER_CONTROL", "Power Control", POWER_TAB, IP_RW,
+    PowerControlSP.fill(getDeviceName(), "POWER_CONTROL", "Power Control", POWER_TAB, IP_RW,
                        ISR_NOFMANY, 60, IPS_IDLE);
 
     // Power Labels
-    IUFillText(&PowerControlsLabelsT[0], "POWER_LABEL_1", "Port 1", PowerControlS[0].label);
-    IUFillText(&PowerControlsLabelsT[1], "POWER_LABEL_2", "Port 2", PowerControlS[1].label);
-    IUFillText(&PowerControlsLabelsT[2], "POWER_LABEL_3", "Port 3", PowerControlS[2].label);
-    IUFillText(&PowerControlsLabelsT[3], "POWER_LABEL_4", "Port 4", PowerControlS[3].label);
-    IUFillTextVector(&PowerControlsLabelsTP, PowerControlsLabelsT, 4, getDeviceName(), "POWER_CONTROL_LABEL", "Power Labels",
+    PowerControlsLabelsTP[0].fill("POWER_LABEL_1", "Port 1", PowerControlSP[0].label);
+    PowerControlsLabelsTP[1].fill("POWER_LABEL_2", "Port 2", PowerControlSP[1].label);
+    PowerControlsLabelsTP[2].fill("POWER_LABEL_3", "Port 3", PowerControlSP[2].label);
+    PowerControlsLabelsTP[3].fill("POWER_LABEL_4", "Port 4", PowerControlSP[3].label);
+    PowerControlsLabelsTP.fill(getDeviceName(), "POWER_CONTROL_LABEL", "Power Labels",
                      POWER_TAB, IP_WO, 60, IPS_IDLE);
 
     // Current Draw
-    IUFillNumber(&PowerCurrentN[0], "POWER_CURRENT_1", PowerControlS[0].label, "%4.2f A", 0, 1000, 0, 0);
-    IUFillNumber(&PowerCurrentN[1], "POWER_CURRENT_2", PowerControlS[1].label, "%4.2f A", 0, 1000, 0, 0);
-    IUFillNumber(&PowerCurrentN[2], "POWER_CURRENT_3", PowerControlS[2].label, "%4.2f A", 0, 1000, 0, 0);
-    IUFillNumber(&PowerCurrentN[3], "POWER_CURRENT_4", PowerControlS[3].label, "%4.2f A", 0, 1000, 0, 0);
-    IUFillNumberVector(&PowerCurrentNP, PowerCurrentN, 4, getDeviceName(), "POWER_CURRENT", "Current Draw", POWER_TAB, IP_RO,
+    PowerCurrentNP[0].fill("POWER_CURRENT_1", PowerControlSP[0].label, "%4.2f A", 0, 1000, 0, 0);
+    PowerCurrentNP[1].fill("POWER_CURRENT_2", PowerControlSP[1].label, "%4.2f A", 0, 1000, 0, 0);
+    PowerCurrentNP[2].fill("POWER_CURRENT_3", PowerControlSP[2].label, "%4.2f A", 0, 1000, 0, 0);
+    PowerCurrentNP[3].fill("POWER_CURRENT_4", PowerControlSP[3].label, "%4.2f A", 0, 1000, 0, 0);
+    PowerCurrentNP.fill(getDeviceName(), "POWER_CURRENT", "Current Draw", POWER_TAB, IP_RO,
                        60, IPS_IDLE);
 
     // Power on Boot
-    IUFillSwitch(&PowerOnBootS[0], "POWER_PORT_1", PowerControlS[0].label, ISS_ON);
-    IUFillSwitch(&PowerOnBootS[1], "POWER_PORT_2", PowerControlS[1].label, ISS_ON);
-    IUFillSwitch(&PowerOnBootS[2], "POWER_PORT_3", PowerControlS[2].label, ISS_ON);
-    IUFillSwitch(&PowerOnBootS[3], "POWER_PORT_4", PowerControlS[3].label, ISS_ON);
-    IUFillSwitchVector(&PowerOnBootSP, PowerOnBootS, 4, getDeviceName(), "POWER_ON_BOOT", "Power On Boot", POWER_TAB, IP_RW,
+    PowerOnBootSP[0].fill("POWER_PORT_1", PowerControlSP[0].label, ISS_ON);
+    PowerOnBootSP[1].fill("POWER_PORT_2", PowerControlSP[1].label, ISS_ON);
+    PowerOnBootSP[2].fill("POWER_PORT_3", PowerControlSP[2].label, ISS_ON);
+    PowerOnBootSP[3].fill("POWER_PORT_4", PowerControlSP[3].label, ISS_ON);
+    PowerOnBootSP.fill(getDeviceName(), "POWER_ON_BOOT", "Power On Boot", POWER_TAB, IP_RW,
                        ISR_NOFMANY, 60, IPS_IDLE);
 
     // Over Current
-    IUFillLight(&OverCurrentL[0], "POWER_PORT_1", PowerControlS[0].label, IPS_OK);
-    IUFillLight(&OverCurrentL[1], "POWER_PORT_2", PowerControlS[1].label, IPS_OK);
-    IUFillLight(&OverCurrentL[2], "POWER_PORT_3", PowerControlS[2].label, IPS_OK);
-    IUFillLight(&OverCurrentL[3], "POWER_PORT_4", PowerControlS[3].label, IPS_OK);
+    OverCurrentLP[0].fill("POWER_PORT_1", PowerControlSP[0].label, IPS_OK);
+    OverCurrentLP[1].fill("POWER_PORT_2", PowerControlSP[1].label, IPS_OK);
+    OverCurrentLP[2].fill("POWER_PORT_3", PowerControlSP[2].label, IPS_OK);
+    OverCurrentLP[3].fill("POWER_PORT_4", PowerControlSP[3].label, IPS_OK);
 
     char tempLabel[MAXINDILABEL+5];
     memset(tempLabel, 0, MAXINDILABEL+5);
-    sprintf(tempLabel,"%s %s","Dew:",AutoDewV2S[0].label);
-    IUFillLight(&OverCurrentL[4], "DEW_A", tempLabel, IPS_OK);
+    sprintf(tempLabel,"%s %s","Dew:",AutoDewV2SP[0].label);
+    OverCurrentLP[4].fill("DEW_A", tempLabel, IPS_OK);
     memset(tempLabel, 0, MAXINDILABEL);
-    sprintf(tempLabel,"%s %s","Dew:",AutoDewV2S[1].label);
-    IUFillLight(&OverCurrentL[5], "DEW_B", tempLabel, IPS_OK);
+    sprintf(tempLabel,"%s %s","Dew:",AutoDewV2SP[1].label);
+    OverCurrentLP[5].fill("DEW_B", tempLabel, IPS_OK);
     memset(tempLabel, 0, MAXINDILABEL);
-    sprintf(tempLabel,"%s %s","Dew:",AutoDewV2S[2].label);
-    IUFillLight(&OverCurrentL[6], "DEW_C", tempLabel, IPS_OK);
-    IUFillLightVector(&OverCurrentLP, OverCurrentL, 7, getDeviceName(), "POWER_OVER_CURRENT", "Over Current", POWER_TAB,
+    sprintf(tempLabel,"%s %s","Dew:",AutoDewV2SP[2].label);
+    OverCurrentLP[6].fill("DEW_C", tempLabel, IPS_OK);
+    OverCurrentLP.fill(getDeviceName(), "POWER_OVER_CURRENT", "Over Current", POWER_TAB,
                       IPS_IDLE);
 
     // Power LED
-    IUFillSwitch(&PowerLEDS[POWER_LED_ON], "POWER_LED_ON", "On", ISS_ON);
-    IUFillSwitch(&PowerLEDS[POWER_LED_OFF], "POWER_LED_OFF", "Off", ISS_OFF);
-    IUFillSwitchVector(&PowerLEDSP, PowerLEDS, 2, getDeviceName(), "POWER_LED", "LED", POWER_TAB, IP_RW, ISR_1OFMANY, 60,
+    PowerLEDSP[POWER_LED_ON].fill("POWER_LED_ON", "On", ISS_ON);
+    PowerLEDSP[POWER_LED_OFF].fill("POWER_LED_OFF", "Off", ISS_OFF);
+    PowerLEDSP.fill(getDeviceName(), "POWER_LED", "LED", POWER_TAB, IP_RW, ISR_1OFMANY, 60,
                        IPS_IDLE);
 
-    IUFillNumber(&AdjustableOutputN[0], "ADJUSTABLE_VOLTAGE_VALUE", "Voltage (V)", "%.f", 3, 12, 1, 12);
-    IUFillNumberVector(&AdjustableOutputNP, AdjustableOutputN, 1, getDeviceName(), "ADJUSTABLE_VOLTAGE", "Adj. Output",
+    AdjustableOutputNP[0].fill("ADJUSTABLE_VOLTAGE_VALUE", "Voltage (V)", "%.f", 3, 12, 1, 12);
+    AdjustableOutputNP.fill(getDeviceName(), "ADJUSTABLE_VOLTAGE", "Adj. Output",
                        POWER_TAB, IP_RW, 60, IPS_IDLE);
 
 
@@ -260,26 +260,26 @@ bool PegasusUPB::initProperties()
     ////////////////////////////////////////////////////////////////////////////
 
     // Automatic Dew v1
-    IUFillSwitch(&AutoDewS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&AutoDewS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&AutoDewSP, AutoDewS, 2, getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_1OFMANY, 60,
+    AutoDewSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    AutoDewSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    AutoDewSP.fill(getDeviceName(), "AUTO_DEW", "Auto Dew", DEW_TAB, IP_RW, ISR_1OFMANY, 60,
                        IPS_IDLE);
 
     // Automatic Dew Aggressiveness v2
-    IUFillNumber(&AutoDewAggN[AUTO_DEW_AGG], "AUTO_DEW_AGG_VALUE", "Auto Dew Agg (50-250)", "%.2f", 50, 250, 20, 0);
-    IUFillNumberVector(&AutoDewAggNP, AutoDewAggN, 1, getDeviceName(), "AUTO_DEW_AGG", "Auto Dew Agg", DEW_TAB, IP_RW, 60, IPS_IDLE);
+    AutoDewAggNP[AUTO_DEW_AGG].fill("AUTO_DEW_AGG_VALUE", "Auto Dew Agg (50-250)", "%.2f", 50, 250, 20, 0);
+    AutoDewAggNP.fill(getDeviceName(), "AUTO_DEW_AGG", "Auto Dew Agg", DEW_TAB, IP_RW, 60, IPS_IDLE);
 
     // Dew PWM
-    IUFillNumber(&DewPWMN[DEW_PWM_A], "DEW_A", AutoDewV2S[0].label, "%.2f %%", 0, 100, 10, 0);
-    IUFillNumber(&DewPWMN[DEW_PWM_B], "DEW_B", AutoDewV2S[1].label, "%.2f %%", 0, 100, 10, 0);
-    IUFillNumber(&DewPWMN[DEW_PWM_C], "DEW_C", AutoDewV2S[2].label, "%.2f %%", 0, 100, 10, 0);
-    IUFillNumberVector(&DewPWMNP, DewPWMN, 3, getDeviceName(), "DEW_PWM", "Dew PWM", DEW_TAB, IP_RW, 60, IPS_IDLE);
+    DewPWMNP[DEW_PWM_A].fill("DEW_A", AutoDewV2SP[0].label, "%.2f %%", 0, 100, 10, 0);
+    DewPWMNP[DEW_PWM_B].fill("DEW_B", AutoDewV2SP[1].label, "%.2f %%", 0, 100, 10, 0);
+    DewPWMNP[DEW_PWM_C].fill("DEW_C", AutoDewV2SP[2].label, "%.2f %%", 0, 100, 10, 0);
+    DewPWMNP.fill(getDeviceName(), "DEW_PWM", "Dew PWM", DEW_TAB, IP_RW, 60, IPS_IDLE);
 
     // Dew current draw
-    IUFillNumber(&DewCurrentDrawN[DEW_PWM_A], "DEW_CURRENT_A", AutoDewV2S[0].label, "%4.2f A", 0, 1000, 10, 0);
-    IUFillNumber(&DewCurrentDrawN[DEW_PWM_B], "DEW_CURRENT_B", AutoDewV2S[1].label, "%4.2f A", 0, 1000, 10, 0);
-    IUFillNumber(&DewCurrentDrawN[DEW_PWM_C], "DEW_CURRENT_C", AutoDewV2S[2].label, "%4.2f A", 0, 1000, 10, 0);
-    IUFillNumberVector(&DewCurrentDrawNP, DewCurrentDrawN, 3, getDeviceName(), "DEW_CURRENT", "Dew Current", DEW_TAB, IP_RO, 60,
+    DewCurrentDrawNP[DEW_PWM_A].fill("DEW_CURRENT_A", AutoDewV2SP[0].label, "%4.2f A", 0, 1000, 10, 0);
+    DewCurrentDrawNP[DEW_PWM_B].fill("DEW_CURRENT_B", AutoDewV2SP[1].label, "%4.2f A", 0, 1000, 10, 0);
+    DewCurrentDrawNP[DEW_PWM_C].fill("DEW_CURRENT_C", AutoDewV2SP[2].label, "%4.2f A", 0, 1000, 10, 0);
+    DewCurrentDrawNP.fill(getDeviceName(), "DEW_CURRENT", "Dew Current", DEW_TAB, IP_RO, 60,
                        IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
@@ -287,20 +287,20 @@ bool PegasusUPB::initProperties()
     ////////////////////////////////////////////////////////////////////////////
 
     // USB Hub control v1
-    IUFillSwitch(&USBControlS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_ON);
-    IUFillSwitch(&USBControlS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_OFF);
-    IUFillSwitchVector(&USBControlSP, USBControlS, 2, getDeviceName(), "USB_HUB_CONTROL", "Hub", USB_TAB, IP_RW, ISR_1OFMANY,
+    USBControlSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_ON);
+    USBControlSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_OFF);
+    USBControlSP.fill(getDeviceName(), "USB_HUB_CONTROL", "Hub", USB_TAB, IP_RW, ISR_1OFMANY,
                        60, IPS_IDLE);
 
     // USB Labels
-    IUFillText(&USBControlsLabelsT[0], "USB_LABEL_1", "USB3 Port1", "USB3 Port1");
-    IUFillText(&USBControlsLabelsT[1], "USB_LABEL_2", "USB3 Port2", "USB3 Port2");
-    IUFillText(&USBControlsLabelsT[2], "USB_LABEL_3", "USB3 Port3", "USB3 Port3");
-    IUFillText(&USBControlsLabelsT[3], "USB_LABEL_4", "USB3 Port4", "USB3 Port4");
-    IUFillText(&USBControlsLabelsT[4], "USB_LABEL_5", "USB2 Port5", "USB2 Port5");
-    IUFillText(&USBControlsLabelsT[5], "USB_LABEL_6", "USB2 Port6", "USB2 Port6");
+    USBControlsLabelsTP[0].fill("USB_LABEL_1", "USB3 Port1", "USB3 Port1");
+    USBControlsLabelsTP[1].fill("USB_LABEL_2", "USB3 Port2", "USB3 Port2");
+    USBControlsLabelsTP[2].fill("USB_LABEL_3", "USB3 Port3", "USB3 Port3");
+    USBControlsLabelsTP[3].fill("USB_LABEL_4", "USB3 Port4", "USB3 Port4");
+    USBControlsLabelsTP[4].fill("USB_LABEL_5", "USB2 Port5", "USB2 Port5");
+    USBControlsLabelsTP[5].fill("USB_LABEL_6", "USB2 Port6", "USB2 Port6");
 
-    IUFillTextVector(&USBControlsLabelsTP, USBControlsLabelsT, 6, getDeviceName(), "USB_CONTROL_LABEL", "USB Labels",
+    USBControlsLabelsTP.fill(getDeviceName(), "USB_CONTROL_LABEL", "USB Labels",
                      USB_TAB, IP_WO, 60, IPS_IDLE);
 
     // USB Hub control v2
@@ -309,78 +309,78 @@ bool PegasusUPB::initProperties()
 
     // Turn on/off power and power boot up
     memset(USBLabel, 0, MAXINDILABEL);
-    int USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.name, USBControlsLabelsT[0].name, USBLabel,
+    int USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.getName(), USBControlsLabelsTP[0].getName(), USBLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&USBControlV2S[0], "PORT_1", USBRC == -1 ? "USB3 Port1" : USBLabel, ISS_ON);
+    USBControlV2SP[0].fill("PORT_1", USBRC == -1 ? "USB3 Port1" : USBLabel, ISS_ON);
     memset(USBLabel, 0, MAXINDILABEL);
-    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.name, USBControlsLabelsT[1].name, USBLabel,
+    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.getName(), USBControlsLabelsTP[1].getName(), USBLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&USBControlV2S[1], "PORT_2", USBRC == -1 ? "USB3 Port2" : USBLabel, ISS_ON);
+    USBControlV2SP[1].fill("PORT_2", USBRC == -1 ? "USB3 Port2" : USBLabel, ISS_ON);
     memset(USBLabel, 0, MAXINDILABEL);
-    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.name, USBControlsLabelsT[2].name, USBLabel,
+    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.getName(), USBControlsLabelsTP[2].getName(), USBLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&USBControlV2S[2], "PORT_3", USBRC == -1 ? "USB3 Port3" : USBLabel, ISS_ON);
+    USBControlV2SP[2].fill("PORT_3", USBRC == -1 ? "USB3 Port3" : USBLabel, ISS_ON);
     memset(USBLabel, 0, MAXINDILABEL);
-    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.name, USBControlsLabelsT[3].name, USBLabel,
+    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.getName(), USBControlsLabelsTP[3].getName(), USBLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&USBControlV2S[3], "PORT_4", USBRC == -1 ? "USB3 Port4" : USBLabel, ISS_ON);
+    USBControlV2SP[3].fill("PORT_4", USBRC == -1 ? "USB3 Port4" : USBLabel, ISS_ON);
     memset(USBLabel, 0, MAXINDILABEL);
-    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.name, USBControlsLabelsT[4].name, USBLabel,
+    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.getName(), USBControlsLabelsTP[4].getName(), USBLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&USBControlV2S[4], "PORT_5", USBRC == -1 ? "USB2 Port5" : USBLabel, ISS_ON);
+    USBControlV2SP[4].fill("PORT_5", USBRC == -1 ? "USB2 Port5" : USBLabel, ISS_ON);
     memset(USBLabel, 0, MAXINDILABEL);
-    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.name, USBControlsLabelsT[5].name, USBLabel,
+    USBRC = IUGetConfigText(getDeviceName(), USBControlsLabelsTP.getName(), USBControlsLabelsTP[5].getName(), USBLabel,
                                  MAXINDILABEL);
-    IUFillSwitch(&USBControlV2S[5], "PORT_6", USBRC == -1 ? "USB2 Port6" : USBLabel, ISS_ON);
+    USBControlV2SP[5].fill("PORT_6", USBRC == -1 ? "USB2 Port6" : USBLabel, ISS_ON);
 
-    IUFillSwitchVector(&USBControlV2SP, USBControlV2S, 6, getDeviceName(), "USB_PORT_CONTROL", "Ports", USB_TAB, IP_RW,
+    USBControlV2SP.fill(getDeviceName(), "USB_PORT_CONTROL", "Ports", USB_TAB, IP_RW,
                        ISR_NOFMANY, 60, IPS_IDLE);
 
     // USB Labels update with custom values
-    IUFillText(&USBControlsLabelsT[0], "USB_LABEL_1", "USB3 Port1", USBControlV2S[0].label);
-    IUFillText(&USBControlsLabelsT[1], "USB_LABEL_2", "USB3 Port2", USBControlV2S[1].label);
-    IUFillText(&USBControlsLabelsT[2], "USB_LABEL_3", "USB3 Port3", USBControlV2S[2].label);
-    IUFillText(&USBControlsLabelsT[3], "USB_LABEL_4", "USB3 Port4", USBControlV2S[3].label);
-    IUFillText(&USBControlsLabelsT[4], "USB_LABEL_5", "USB2 Port5", USBControlV2S[4].label);
-    IUFillText(&USBControlsLabelsT[5], "USB_LABEL_6", "USB2 Port6", USBControlV2S[5].label);
+    USBControlsLabelsTP[0].fill("USB_LABEL_1", "USB3 Port1", USBControlV2SP[0].label);
+    USBControlsLabelsTP[1].fill("USB_LABEL_2", "USB3 Port2", USBControlV2SP[1].label);
+    USBControlsLabelsTP[2].fill("USB_LABEL_3", "USB3 Port3", USBControlV2SP[2].label);
+    USBControlsLabelsTP[3].fill("USB_LABEL_4", "USB3 Port4", USBControlV2SP[3].label);
+    USBControlsLabelsTP[4].fill("USB_LABEL_5", "USB2 Port5", USBControlV2SP[4].label);
+    USBControlsLabelsTP[5].fill("USB_LABEL_6", "USB2 Port6", USBControlV2SP[5].label);
 
-    IUFillTextVector(&USBControlsLabelsTP, USBControlsLabelsT, 6, getDeviceName(), "USB_CONTROL_LABEL", "USB Labels",
+    USBControlsLabelsTP.fill(getDeviceName(), "USB_CONTROL_LABEL", "USB Labels",
                      USB_TAB, IP_WO, 60, IPS_IDLE);
     // USB Hub Status
-    IUFillLight(&USBStatusL[0], "PORT_1", USBControlV2S[0].label, IPS_OK);
-    IUFillLight(&USBStatusL[1], "PORT_2", USBControlV2S[1].label, IPS_OK);
-    IUFillLight(&USBStatusL[2], "PORT_3", USBControlV2S[2].label, IPS_OK);
-    IUFillLight(&USBStatusL[3], "PORT_4", USBControlV2S[3].label, IPS_OK);
-    IUFillLight(&USBStatusL[4], "PORT_5", USBControlV2S[4].label, IPS_OK);
-    IUFillLight(&USBStatusL[5], "PORT_6", USBControlV2S[5].label, IPS_OK);
-    IUFillLightVector(&USBStatusLP, USBStatusL, 6, getDeviceName(), "USB_PORT_STATUS", "Status", USB_TAB, IPS_IDLE);
+    USBStatusLP[0].fill("PORT_1", USBControlV2SP[0].label, IPS_OK);
+    USBStatusLP[1].fill("PORT_2", USBControlV2SP[1].label, IPS_OK);
+    USBStatusLP[2].fill("PORT_3", USBControlV2SP[2].label, IPS_OK);
+    USBStatusLP[3].fill("PORT_4", USBControlV2SP[3].label, IPS_OK);
+    USBStatusLP[4].fill("PORT_5", USBControlV2SP[4].label, IPS_OK);
+    USBStatusLP[5].fill("PORT_6", USBControlV2SP[5].label, IPS_OK);
+    USBStatusLP.fill(getDeviceName(), "USB_PORT_STATUS", "Status", USB_TAB, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
     /// Focuser Group
     ////////////////////////////////////////////////////////////////////////////
 
     // Settings
-    //    IUFillNumber(&FocusBacklashN[0], "SETTING_BACKLASH", "Backlash (steps)", "%.f", 0, 999, 100, 0);
-    IUFillNumber(&FocuserSettingsN[SETTING_MAX_SPEED], "SETTING_MAX_SPEED", "Max Speed (%)", "%.f", 0, 900, 100, 400);
-    IUFillNumberVector(&FocuserSettingsNP, FocuserSettingsN, 1, getDeviceName(), "FOCUSER_SETTINGS", "Settings", FOCUS_TAB,
+    //    FocusBacklashNP[0].fill("SETTING_BACKLASH", "Backlash (steps)", "%.f", 0, 999, 100, 0);
+    FocuserSettingsNP[SETTING_MAX_SPEED].fill("SETTING_MAX_SPEED", "Max Speed (%)", "%.f", 0, 900, 100, 400);
+    FocuserSettingsNP.fill(getDeviceName(), "FOCUSER_SETTINGS", "Settings", FOCUS_TAB,
                        IP_RW, 60, IPS_IDLE);
 
     // Backlash
-    //    IUFillSwitch(&FocusBacklashS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    //    IUFillSwitch(&FocusBacklashS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    //    IUFillSwitchVector(&FocusBacklashSP, FocusBacklashS, 2, getDeviceName(), "FOCUSER_BACKLASH", "Backlash", FOCUS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    //    FocusBacklashSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    //    FocusBacklashSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    //    FocusBacklashSP.fill(getDeviceName(), "FOCUSER_BACKLASH", "Backlash", FOCUS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Temperature
-    IUFillNumber(&FocuserTemperatureN[0], "FOCUSER_TEMPERATURE_VALUE", "Value (C)", "%4.2f", -50, 85, 1, 0);
-    IUFillNumberVector(&FocuserTemperatureNP, FocuserTemperatureN, 1, getDeviceName(), "FOCUSER_TEMPERATURE", "Temperature",
+    FocuserTemperatureNP[0].fill("FOCUSER_TEMPERATURE_VALUE", "Value (C)", "%4.2f", -50, 85, 1, 0);
+    FocuserTemperatureNP.fill(getDeviceName(), "FOCUSER_TEMPERATURE", "Temperature",
                        FOCUS_TAB, IP_RO, 60, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////
     /// Firmware Group
     ////////////////////////////////////////////////////////////////////////////
-    IUFillText(&FirmwareT[FIRMWARE_VERSION], "VERSION", "Version", "NA");
-    IUFillText(&FirmwareT[FIRMWARE_UPTIME], "UPTIME", "Uptime (h)", "NA");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 2, getDeviceName(), "FIRMWARE_INFO", "Firmware", FIRMWARE_TAB, IP_RO, 60,
+    FirmwareTP[FIRMWARE_VERSION].fill("VERSION", "Version", "NA");
+    FirmwareTP[FIRMWARE_UPTIME].fill("UPTIME", "Uptime (h)", "NA");
+    FirmwareTP.fill(getDeviceName(), "FIRMWARE_INFO", "Firmware", FIRMWARE_TAB, IP_RO, 60,
                      IPS_IDLE);
     ////////////////////////////////////////////////////////////////////////////
     /// Environment Group
@@ -413,110 +413,110 @@ bool PegasusUPB::updateProperties()
         setupParams();
 
         // Main Control
-        defineProperty(&PowerCycleAllSP);
-        defineProperty(&PowerSensorsNP);
-        defineProperty(&PowerConsumptionNP);
-        defineProperty(&RebootSP);
+        defineProperty(PowerCycleAllSP);
+        defineProperty(PowerSensorsNP);
+        defineProperty(PowerConsumptionNP);
+        defineProperty(RebootSP);
 
         // Power
-        defineProperty(&PowerControlSP);
-        defineProperty(&PowerControlsLabelsTP);
-        defineProperty(&PowerCurrentNP);
-        defineProperty(&PowerOnBootSP);
-        OverCurrentLP.nlp = (version == UPB_V1) ? 4 : 7;
-        defineProperty(&OverCurrentLP);
+        defineProperty(PowerControlSP);
+        defineProperty(PowerControlsLabelsTP);
+        defineProperty(PowerCurrentNP);
+        defineProperty(PowerOnBootSP);
+        OverCurrentLP.resize((version == UPB_V1) ? 4 : 7);
+        defineProperty(OverCurrentLP);
         if (version == UPB_V1)
-            defineProperty(&PowerLEDSP);
+            defineProperty(PowerLEDSP);
         if (version == UPB_V2)
-            defineProperty(&AdjustableOutputNP);
+            defineProperty(AdjustableOutputNP);
 
         // Dew
         if (version == UPB_V1)
-            defineProperty(&AutoDewSP);
+            defineProperty(AutoDewSP);
         else
-            defineProperty(&AutoDewV2SP);
+            defineProperty(AutoDewV2SP);
 
-        DewControlsLabelsTP.ntp = (version == UPB_V1) ? 2 : 3;
-        defineProperty(&DewControlsLabelsTP);
+        DewControlsLabelsTP.resize((version == UPB_V1) ? 2 : 3);
+        defineProperty(DewControlsLabelsTP);
 
         if (version == UPB_V2)
-            defineProperty(&AutoDewAggNP);
+            defineProperty(AutoDewAggNP);
 
-        DewPWMNP.nnp = (version == UPB_V1) ? 2 : 3;
-        defineProperty(&DewPWMNP);
+        DewPWMNP.resize((version == UPB_V1) ? 2 : 3);
+        defineProperty(DewPWMNP);
 
-        DewCurrentDrawNP.nnp = (version == UPB_V1) ? 2 : 3;
-        defineProperty(&DewCurrentDrawNP);
+        DewCurrentDrawNP.resize((version == UPB_V1) ? 2 : 3);
+        defineProperty(DewCurrentDrawNP);
 
         // USB
-        defineProperty(&USBControlSP);
+        defineProperty(USBControlSP);
         if (version == UPB_V2)
-            defineProperty(&USBControlV2SP);
+            defineProperty(USBControlV2SP);
         if (version == UPB_V1)
-            defineProperty(&USBStatusLP);
-        defineProperty(&USBControlsLabelsTP);
+            defineProperty(USBStatusLP);
+        defineProperty(USBControlsLabelsTP);
 
         // Focuser
         FI::updateProperties();
-        defineProperty(&FocuserSettingsNP);
-        //defineProperty(&FocusBacklashSP);
-        defineProperty(&FocuserTemperatureNP);
+        defineProperty(FocuserSettingsNP);
+        //defineProperty(FocusBacklashSP);
+        defineProperty(FocuserTemperatureNP);
 
         WI::updateProperties();
 
         // Firmware
-        defineProperty(&FirmwareTP);
+        defineProperty(FirmwareTP);
 
         setupComplete = true;
     }
     else
     {
         // Main Control
-        deleteProperty(PowerCycleAllSP.name);
-        deleteProperty(PowerSensorsNP.name);
-        deleteProperty(PowerConsumptionNP.name);
-        deleteProperty(RebootSP.name);
+        deleteProperty(PowerCycleAllSP.getName());
+        deleteProperty(PowerSensorsNP.getName());
+        deleteProperty(PowerConsumptionNP.getName());
+        deleteProperty(RebootSP.getName());
 
         // Power
-        deleteProperty(PowerControlSP.name);
-        deleteProperty(PowerControlsLabelsTP.name);
-        deleteProperty(PowerCurrentNP.name);
-        deleteProperty(PowerOnBootSP.name);
-        deleteProperty(OverCurrentLP.name);
+        deleteProperty(PowerControlSP.getName());
+        deleteProperty(PowerControlsLabelsTP.getName());
+        deleteProperty(PowerCurrentNP.getName());
+        deleteProperty(PowerOnBootSP.getName());
+        deleteProperty(OverCurrentLP.getName());
         if (version == UPB_V1)
-            deleteProperty(PowerLEDSP.name);
+            deleteProperty(PowerLEDSP.getName());
         if (version == UPB_V2)
-            deleteProperty(AdjustableOutputNP.name);
+            deleteProperty(AdjustableOutputNP.getName());
 
         // Dew
         if (version == UPB_V1)
-            deleteProperty(AutoDewSP.name);
+            deleteProperty(AutoDewSP.getName());
         else
         {
-            deleteProperty(AutoDewV2SP.name);
-            deleteProperty(DewControlsLabelsTP.name);
-            deleteProperty(AutoDewAggNP.name);
+            deleteProperty(AutoDewV2SP.getName());
+            deleteProperty(DewControlsLabelsTP.getName());
+            deleteProperty(AutoDewAggNP.getName());
         }
 
-        deleteProperty(DewPWMNP.name);
-        deleteProperty(DewCurrentDrawNP.name);
+        deleteProperty(DewPWMNP.getName());
+        deleteProperty(DewCurrentDrawNP.getName());
 
         // USB
-        deleteProperty(USBControlSP.name);
+        deleteProperty(USBControlSP.getName());
         if (version == UPB_V2)
-            deleteProperty(USBControlV2SP.name);
+            deleteProperty(USBControlV2SP.getName());
         if (version == UPB_V1)
-            deleteProperty(USBStatusLP.name);
-        deleteProperty(USBControlsLabelsTP.name);
+            deleteProperty(USBStatusLP.getName());
+        deleteProperty(USBControlsLabelsTP.getName());
 
         // Focuser
         FI::updateProperties();
-        deleteProperty(FocuserSettingsNP.name);
-        deleteProperty(FocuserTemperatureNP.name);
+        deleteProperty(FocuserSettingsNP.getName());
+        deleteProperty(FocuserTemperatureNP.getName());
 
         WI::updateProperties();
 
-        deleteProperty(FirmwareTP.name);
+        deleteProperty(FirmwareTP.getName());
 
         setupComplete = false;
     }
@@ -602,39 +602,39 @@ bool PegasusUPB::ISNewSwitch(const char * dev, const char * name, ISState * stat
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Cycle all power on or off
-        if (!strcmp(name, PowerCycleAllSP.name))
+        if (PowerCycleAllSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PowerCycleAllSP, states, names, n);
+            PowerCycleAllSP.update(states, names, n);
 
-            PowerCycleAllSP.s = IPS_ALERT;
+            PowerCycleAllSP.setState(IPS_ALERT);
             char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-            snprintf(cmd, PEGASUS_LEN, "PZ:%d", IUFindOnSwitchIndex(&PowerCycleAllSP));
+            snprintf(cmd, PEGASUS_LEN, "PZ:%d", PowerCycleAllSP.findOnSwitchIndex());
             if (sendCommand(cmd, res))
             {
-                PowerCycleAllSP.s = !strcmp(cmd, res) ? IPS_OK : IPS_ALERT;
+                PowerCycleAllSP.setState(!strcmp(cmd, res) ? IPS_OK : IPS_ALERT);
             }
 
-            IUResetSwitch(&PowerCycleAllSP);
-            IDSetSwitch(&PowerCycleAllSP, nullptr);
+            PowerCycleAllSP.reset();
+            PowerCycleAllSP.apply();
             return true;
         }
 
         // Reboot
-        if (!strcmp(name, RebootSP.name))
+        if (RebootSP.isNameMatch(name))
         {
-            RebootSP.s = reboot() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&RebootSP, nullptr);
+            RebootSP.setState(reboot() ? IPS_OK : IPS_ALERT);
+            RebootSP.apply();
             LOG_INFO("Rebooting device...");
             return true;
         }
 
         // Control Power per port
-        if (!strcmp(name, PowerControlSP.name))
+        if (PowerControlSP.isNameMatch(name))
         {
             bool failed = false;
             for (int i = 0; i < n; i++)
             {
-                if (!strcmp(names[i], PowerControlS[i].name) && states[i] != PowerControlS[i].s)
+                if (!strcmp(names[i], PowerControlSP[i].getName()) && states[i] != PowerControlSP[i].getState())
                 {
                     if (setPowerEnabled(i + 1, states[i] == ISS_ON) == false)
                     {
@@ -645,167 +645,167 @@ bool PegasusUPB::ISNewSwitch(const char * dev, const char * name, ISState * stat
             }
 
             if (failed)
-                PowerControlSP.s = IPS_ALERT;
+                PowerControlSP.setState(IPS_ALERT);
             else
             {
-                PowerControlSP.s = IPS_OK;
-                IUUpdateSwitch(&PowerControlSP, states, names, n);
+                PowerControlSP.setState(IPS_OK);
+                PowerControlSP.update(states, names, n);
             }
 
-            IDSetSwitch(&PowerControlSP, nullptr);
+            PowerControlSP.apply();
             return true;
         }
 
         // Power on boot
-        if (!strcmp(name, PowerOnBootSP.name))
+        if (PowerOnBootSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PowerOnBootSP, states, names, n);
-            PowerOnBootSP.s = setPowerOnBoot() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&PowerOnBootSP, nullptr);
-            saveConfig(true, PowerOnBootSP.name);
+            PowerOnBootSP.update(states, names, n);
+            PowerOnBootSP.setState(setPowerOnBoot() ? IPS_OK : IPS_ALERT);
+            PowerOnBootSP.apply();
+            saveConfig(true, PowerOnBootSP.getName());
             return true;
         }
 
         // Auto Dew v1.
-        if ((!strcmp(name, AutoDewSP.name)) && (version == UPB_V1))
+        if ((!strcmp(name, AutoDewSP.getName())) && (version == UPB_V1))
         {
-            int prevIndex = IUFindOnSwitchIndex(&AutoDewSP);
-            IUUpdateSwitch(&AutoDewSP, states, names, n);
-            if (setAutoDewEnabled(AutoDewS[INDI_ENABLED].s == ISS_ON))
+            int prevIndex = AutoDewSP.findOnSwitchIndex();
+            AutoDewSP.update(states, names, n);
+            if (setAutoDewEnabled(AutoDewSP[INDI_ENABLED].getState() == ISS_ON))
             {
-                AutoDewSP.s = IPS_OK;
+                AutoDewSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&AutoDewSP);
-                AutoDewS[prevIndex].s = ISS_ON;
-                AutoDewSP.s = IPS_ALERT;
+                AutoDewSP.reset();
+                AutoDewSP[prevIndex].setState(ISS_ON);
+                AutoDewSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&AutoDewSP, nullptr);
+            AutoDewSP.apply();
             return true;
         }
 
         // Auto Dew v2.
-        if ((!strcmp(name, AutoDewV2SP.name)) && (version == UPB_V2))
+        if ((!strcmp(name, AutoDewV2SP.getName())) && (version == UPB_V2))
         {
-            ISState Dew1 = AutoDewV2S[DEW_PWM_A].s;
-            ISState Dew2 = AutoDewV2S[DEW_PWM_B].s;
-            ISState Dew3 = AutoDewV2S[DEW_PWM_C].s;
-            IUUpdateSwitch(&AutoDewV2SP, states, names, n);
+            ISState Dew1 = AutoDewV2SP[DEW_PWM_A].getState();
+            ISState Dew2 = AutoDewV2SP[DEW_PWM_B].getState();
+            ISState Dew3 = AutoDewV2SP[DEW_PWM_C].getState();
+            AutoDewV2SP.update(states, names, n);
             if (toggleAutoDewV2())
             {
-                Dew1 = AutoDewV2S[DEW_PWM_A].s;
-                Dew2 = AutoDewV2S[DEW_PWM_B].s;
-                Dew3 = AutoDewV2S[DEW_PWM_C].s;
+                Dew1 = AutoDewV2SP[DEW_PWM_A].getState();
+                Dew2 = AutoDewV2SP[DEW_PWM_B].getState();
+                Dew3 = AutoDewV2SP[DEW_PWM_C].getState();
                 if (Dew1 == ISS_OFF && Dew2 == ISS_OFF && Dew3 == ISS_OFF)
-                    AutoDewV2SP.s = IPS_IDLE;
+                    AutoDewV2SP.setState(IPS_IDLE);
                 else
-                    AutoDewV2SP.s = IPS_OK;
+                    AutoDewV2SP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&AutoDewV2SP);
-                AutoDewV2S[DEW_PWM_A].s = Dew1;
-                AutoDewV2S[DEW_PWM_B].s = Dew2;
-                AutoDewV2S[DEW_PWM_C].s = Dew3;
-                AutoDewV2SP.s = IPS_ALERT;
+                AutoDewV2SP.reset();
+                AutoDewV2SP[DEW_PWM_A].setState(Dew1);
+                AutoDewV2SP[DEW_PWM_B].setState(Dew2);
+                AutoDewV2SP[DEW_PWM_C].setState(Dew3);
+                AutoDewV2SP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&AutoDewV2SP, nullptr);
+            AutoDewV2SP.apply();
             return true;
         }
 
         // USB Hub Control v1
-        if (!strcmp(name, USBControlSP.name))
+        if (USBControlSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&USBControlSP);
-            IUUpdateSwitch(&USBControlSP, states, names, n);
-            if (setUSBHubEnabled(USBControlS[0].s == ISS_ON))
+            int prevIndex = USBControlSP.findOnSwitchIndex();
+            USBControlSP.update(states, names, n);
+            if (setUSBHubEnabled(USBControlSP[0].getState() == ISS_ON))
             {
-                USBControlSP.s = IPS_OK;
+                USBControlSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&USBControlSP);
-                USBControlS[prevIndex].s = ISS_ON;
-                USBControlSP.s = IPS_ALERT;
+                USBControlSP.reset();
+                USBControlSP[prevIndex].setState(ISS_ON);
+                USBControlSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&USBControlSP, nullptr);
+            USBControlSP.apply();
             return true;
         }
 
         // USB Hub Control v2
-        if (!strcmp(name, USBControlV2SP.name))
+        if (USBControlV2SP.isNameMatch(name))
         {
             bool rc[6] = {true};
             ISState ports[6] = {ISS_ON};
 
-            for (int i = 0; i < USBControlV2SP.nsp; i++)
-                ports[i] = USBControlV2S[i].s;
+            for (size_t i = 0; i < USBControlV2SP.size(); i++)
+                ports[i] = USBControlV2SP[i].getState();
 
-            IUUpdateSwitch(&USBControlV2SP, states, names, n);
-            for (int i = 0; i < USBControlV2SP.nsp; i++)
+            USBControlV2SP.update(states, names, n);
+            for (size_t i = 0; i < USBControlV2SP.size(); i++)
             {
-                if (ports[i] != USBControlV2S[i].s)
-                    rc[i] = setUSBPortEnabled(i, USBControlV2S[i].s == ISS_ON);
+                if (ports[i] != USBControlV2SP[i].getState())
+                    rc[i] = setUSBPortEnabled(i, USBControlV2SP[i].getState() == ISS_ON);
             }
 
             // All is OK
             if (rc[0] && rc[1] && rc[2] && rc[3] && rc[4] && rc[5])
             {
-                USBControlSP.s = IPS_OK;
+                USBControlSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&USBControlV2SP);
-                for (int i = 0; i < USBControlV2SP.nsp; i++)
-                    USBControlV2S[i].s = ports[i];
-                USBControlV2SP.s = IPS_ALERT;
+                USBControlV2SP.reset();
+                for (size_t i = 0; i < USBControlV2SP.size(); i++)
+                    USBControlV2SP[i].setState(ports[i]);
+                USBControlV2SP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&USBControlSP, nullptr);
+            USBControlSP.apply();
             return true;
         }
 
         // Focuser backlash
-        //        if (!strcmp(name, FocusBacklashSP.name))
+        //        if (FocusBacklashSP.isNameMatch(name))
         //        {
-        //            int prevIndex = IUFindOnSwitchIndex(&FocusBacklashSP);
-        //            IUUpdateSwitch(&FocusBacklashSP, states, names, n);
-        //            if (setFocuserBacklashEnabled(FocusBacklashS[0].s == ISS_ON))
+        //            int prevIndex = FocusBacklashSP.findOnSwitchIndex();
+        //            FocusBacklashSP.update(states, names, n);
+        //            if (setFocuserBacklashEnabled(FocusBacklashSP[0].getState() == ISS_ON))
         //            {
-        //                FocusBacklashSP.s = IPS_OK;
+        //                FocusBacklashSP.setState(IPS_OK);
         //            }
         //            else
         //            {
-        //                IUResetSwitch(&FocusBacklashSP);
-        //                FocusBacklashS[prevIndex].s = ISS_ON;
-        //                FocusBacklashSP.s = IPS_ALERT;
+        //                FocusBacklashSP.reset();
+        //                FocusBacklashSP[prevIndex].setState(ISS_ON);
+        //                FocusBacklashSP.setState(IPS_ALERT);
         //            }
 
-        //            IDSetSwitch(&FocusBacklashSP, nullptr);
+        //            FocusBacklashSP.apply();
         //            return true;
         //        }
 
         // Power LED
-        if (!strcmp(name, PowerLEDSP.name) && (version == UPB_V1))
+        if (!strcmp(name, PowerLEDSP.getName()) && (version == UPB_V1))
         {
-            int prevIndex = IUFindOnSwitchIndex(&PowerLEDSP);
-            IUUpdateSwitch(&PowerLEDSP, states, names, n);
-            if (setPowerLEDEnabled(PowerLEDS[0].s == ISS_ON))
+            int prevIndex = PowerLEDSP.findOnSwitchIndex();
+            PowerLEDSP.update(states, names, n);
+            if (setPowerLEDEnabled(PowerLEDSP[0].getState() == ISS_ON))
             {
-                PowerLEDSP.s = IPS_OK;
+                PowerLEDSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&PowerLEDSP);
-                PowerLEDS[prevIndex].s = ISS_ON;
-                PowerLEDSP.s = IPS_ALERT;
+                PowerLEDSP.reset();
+                PowerLEDSP[prevIndex].setState(ISS_ON);
+                PowerLEDSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&PowerLEDSP, nullptr);
+            PowerLEDSP.apply();
             return true;
         }
 
@@ -824,72 +824,72 @@ bool PegasusUPB::ISNewNumber(const char * dev, const char * name, double values[
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Adjustable output
-        if (!strcmp(name, AdjustableOutputNP.name))
+        if (AdjustableOutputNP.isNameMatch(name))
         {
             if (setAdjustableOutput(static_cast<uint8_t>(values[0])))
             {
-                IUUpdateNumber(&AdjustableOutputNP, values, names, n);
-                AdjustableOutputNP.s = IPS_OK;
+                AdjustableOutputNP.update(values, names, n);
+                AdjustableOutputNP.setState(IPS_OK);
             }
             else
-                AdjustableOutputNP.s = IPS_ALERT;
+                AdjustableOutputNP.setState(IPS_ALERT);
 
-            IDSetNumber(&AdjustableOutputNP, nullptr);
+            AdjustableOutputNP.apply();
             return true;
         }
 
         // Dew PWM
-        if (!strcmp(name, DewPWMNP.name))
+        if (DewPWMNP.isNameMatch(name))
         {
             bool rc1 = false, rc2 = false, rc3 = false;
             for (int i = 0; i < n; i++)
             {
-                if (!strcmp(names[i], DewPWMN[DEW_PWM_A].name))
+                if (!strcmp(names[i], DewPWMNP[DEW_PWM_A].getName()))
                     rc1 = setDewPWM(5, static_cast<uint8_t>(values[i] / 100.0 * 255.0));
-                else if (!strcmp(names[i], DewPWMN[DEW_PWM_B].name))
+                else if (!strcmp(names[i], DewPWMNP[DEW_PWM_B].getName()))
                     rc2 = setDewPWM(6, static_cast<uint8_t>(values[i] / 100.0 * 255.0));
-                else if (!strcmp(names[i], DewPWMN[DEW_PWM_C].name))
+                else if (!strcmp(names[i], DewPWMNP[DEW_PWM_C].getName()))
                     rc3 = setDewPWM(7, static_cast<uint8_t>(values[i] / 100.0 * 255.0));
             }
 
-            DewPWMNP.s = (rc1 && rc2 && rc3) ? IPS_OK : IPS_ALERT;
-            if (DewPWMNP.s == IPS_OK)
-                IUUpdateNumber(&DewPWMNP, values, names, n);
-            IDSetNumber(&DewPWMNP, nullptr);
+            DewPWMNP.setState((rc1 && rc2 && rc3) ? IPS_OK : IPS_ALERT);
+            if (DewPWMNP.getState() == IPS_OK)
+                DewPWMNP.update(values, names, n);
+            DewPWMNP.apply();
             return true;
         }
 
         // Auto Dew Aggressiveness
-        if (!strcmp(name,AutoDewAggNP.name))
+        if (AutoDewAggNP.isNameMatch(name))
         {
             if (setAutoDewAgg(values[0]))
             {
-                AutoDewAggN[0].value = values[0];
-                AutoDewAggNP.s = IPS_OK;
+                AutoDewAggNP[0].setValue(values[0]);
+                AutoDewAggNP.setState(IPS_OK);
             }
             else
             {
-                AutoDewAggNP.s = IPS_ALERT;
+                AutoDewAggNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&AutoDewAggNP, nullptr);
+            AutoDewAggNP.apply();
             return true;
         }
 
         // Focuser Settings
-        if (!strcmp(name, FocuserSettingsNP.name))
+        if (FocuserSettingsNP.isNameMatch(name))
         {
             if (setFocuserMaxSpeed(values[0]))
             {
-                FocuserSettingsN[0].value = values[0];
-                FocuserSettingsNP.s = IPS_OK;
+                FocuserSettingsNP[0].setValue(values[0]);
+                FocuserSettingsNP.setState(IPS_OK);
             }
             else
             {
-                FocuserSettingsNP.s = IPS_ALERT;
+                FocuserSettingsNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&FocuserSettingsNP, nullptr);
+            FocuserSettingsNP.apply();
             return true;
         }
 
@@ -910,33 +910,33 @@ bool PegasusUPB::ISNewText(const char * dev, const char * name, char * texts[], 
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Power Labels
-        if (!strcmp(name, PowerControlsLabelsTP.name))
+        if (PowerControlsLabelsTP.isNameMatch(name))
         {
-            IUUpdateText(&PowerControlsLabelsTP, texts, names, n);
-            PowerControlsLabelsTP.s = IPS_OK;
+            PowerControlsLabelsTP.update(texts, names, n);
+            PowerControlsLabelsTP.setState(IPS_OK);
             LOG_INFO("Power port labels saved. Driver must be restarted for the labels to take effect.");
             saveConfig();
-            IDSetText(&PowerControlsLabelsTP, nullptr);
+            PowerControlsLabelsTP.apply();
             return true;
         }
         // Dew Labels
-        if (!strcmp(name, DewControlsLabelsTP.name))
+        if (DewControlsLabelsTP.isNameMatch(name))
         {
-            IUUpdateText(&DewControlsLabelsTP, texts, names, n);
-            DewControlsLabelsTP.s = IPS_OK;
+            DewControlsLabelsTP.update(texts, names, n);
+            DewControlsLabelsTP.setState(IPS_OK);
             LOG_INFO("Dew labels saved. Driver must be restarted for the labels to take effect.");
             saveConfig();
-            IDSetText(&DewControlsLabelsTP, nullptr);
+            DewControlsLabelsTP.apply();
             return true;
         }
         // USB Labels
-        if (!strcmp(name, USBControlsLabelsTP.name))
+        if (USBControlsLabelsTP.isNameMatch(name))
         {
-            IUUpdateText(&USBControlsLabelsTP, texts, names, n);
-            USBControlsLabelsTP.s = IPS_OK;
+            USBControlsLabelsTP.update(texts, names, n);
+            USBControlsLabelsTP.setState(IPS_OK);
             LOG_INFO("USB labels saved. Driver must be restarted for the labels to take effect.");
             saveConfig();
-            IDSetText(&USBControlsLabelsTP, nullptr);
+            USBControlsLabelsTP.apply();
             return true;
         }
     }
@@ -1045,7 +1045,7 @@ IPState PegasusUPB::MoveAbsFocuser(uint32_t targetTicks)
 //////////////////////////////////////////////////////////////////////
 IPState PegasusUPB::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
-    return MoveAbsFocuser(dir == FOCUS_INWARD ? FocusAbsPosN[0].value - ticks : FocusAbsPosN[0].value + ticks);
+    return MoveAbsFocuser(dir == FOCUS_INWARD ? FocusAbsPosNP[0].getValue() - ticks : FocusAbsPosNP[0].getValue() + ticks);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -1198,10 +1198,10 @@ bool PegasusUPB::setAdjustableOutput(uint8_t voltage)
 bool PegasusUPB::setPowerOnBoot()
 {
     char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-    snprintf(cmd, PEGASUS_LEN, "PE:%d%d%d%d", PowerOnBootS[0].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[1].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[2].s == ISS_ON ? 1 : 0,
-             PowerOnBootS[3].s == ISS_ON ? 1 : 0);
+    snprintf(cmd, PEGASUS_LEN, "PE:%d%d%d%d", PowerOnBootSP[0].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[1].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[2].getState() == ISS_ON ? 1 : 0,
+             PowerOnBootSP[3].getState() == ISS_ON ? 1 : 0);
     if (sendCommand(cmd, res))
     {
         return (!strcmp(res, "PE:1"));
@@ -1226,13 +1226,13 @@ bool PegasusUPB::getPowerOnBoot()
         }
 
         const char *status = result[1].c_str();
-        PowerOnBootS[0].s = (status[0] == '1') ? ISS_ON : ISS_OFF;
-        PowerOnBootS[1].s = (status[1] == '1') ? ISS_ON : ISS_OFF;
-        PowerOnBootS[2].s = (status[2] == '1') ? ISS_ON : ISS_OFF;
-        PowerOnBootS[3].s = (status[3] == '1') ? ISS_ON : ISS_OFF;
+        PowerOnBootSP[0].setState((status[0] == '1') ? ISS_ON : ISS_OFF);
+        PowerOnBootSP[1].setState((status[1] == '1') ? ISS_ON : ISS_OFF);
+        PowerOnBootSP[2].setState((status[2] == '1') ? ISS_ON : ISS_OFF);
+        PowerOnBootSP[3].setState((status[3] == '1') ? ISS_ON : ISS_OFF);
 
-        AdjustableOutputN[0].value = std::stod(result[2]);
-        AdjustableOutputNP.s = IPS_OK;
+        AdjustableOutputNP[0].setValue(std::stod(result[2]));
+        AdjustableOutputNP.setState(IPS_OK);
 
         return true;
     }
@@ -1297,21 +1297,21 @@ bool PegasusUPB::toggleAutoDewV2()
 
     uint8_t value = 0;
 
-    if (IUFindOnSwitchIndex(&AutoDewV2SP) == -1)
+    if (AutoDewV2SP.findOnSwitchIndex() == -1)
         value = 0;
-    else if (AutoDewV2S[DEW_PWM_A].s == ISS_ON && AutoDewV2S[DEW_PWM_B].s == ISS_ON && AutoDewV2S[DEW_PWM_C].s == ISS_ON)
+    else if (AutoDewV2SP[DEW_PWM_A].getState() == ISS_ON && AutoDewV2SP[DEW_PWM_B].s == ISS_ON && AutoDewV2SP[DEW_PWM_C].s == ISS_ON)
         value = 1;
-    else if (AutoDewV2S[DEW_PWM_A].s == ISS_ON && AutoDewV2S[DEW_PWM_B].s == ISS_ON)
+    else if (AutoDewV2SP[DEW_PWM_A].getState() == ISS_ON && AutoDewV2SP[DEW_PWM_B].s == ISS_ON)
         value = 5;
-    else if (AutoDewV2S[DEW_PWM_A].s == ISS_ON && AutoDewV2S[DEW_PWM_C].s == ISS_ON)
+    else if (AutoDewV2SP[DEW_PWM_A].getState() == ISS_ON && AutoDewV2SP[DEW_PWM_C].s == ISS_ON)
         value = 6;
-    else if (AutoDewV2S[DEW_PWM_B].s == ISS_ON && AutoDewV2S[DEW_PWM_C].s == ISS_ON)
+    else if (AutoDewV2SP[DEW_PWM_B].getState() == ISS_ON && AutoDewV2SP[DEW_PWM_C].s == ISS_ON)
         value = 7;
-    else if (AutoDewV2S[DEW_PWM_A].s == ISS_ON)
+    else if (AutoDewV2SP[DEW_PWM_A].getState() == ISS_ON)
         value = 2;
-    else if (AutoDewV2S[DEW_PWM_B].s == ISS_ON)
+    else if (AutoDewV2SP[DEW_PWM_B].getState() == ISS_ON)
         value = 3;
-    else if (AutoDewV2S[DEW_PWM_C].s == ISS_ON)
+    else if (AutoDewV2SP[DEW_PWM_C].getState() == ISS_ON)
         value = 4;
 
     snprintf(cmd, PEGASUS_LEN, "PD:%d", value);
@@ -1334,13 +1334,13 @@ bool PegasusUPB::saveConfigItems(FILE * fp)
     FI::saveConfigItems(fp);
     WI::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &PowerLEDSP);
-    IUSaveConfigSwitch(fp, &AutoDewSP);
-    IUSaveConfigNumber(fp, &AutoDewAggNP);
-    IUSaveConfigNumber(fp, &FocuserSettingsNP);
-    IUSaveConfigText(fp, &PowerControlsLabelsTP);
-    IUSaveConfigText(fp, &DewControlsLabelsTP);
-    IUSaveConfigText(fp, &USBControlsLabelsTP);
+    PowerLEDSP.save(fp);
+    AutoDewSP.save(fp);
+    AutoDewAggNP.save(fp);
+    FocuserSettingsNP.save(fp);
+    PowerControlsLabelsTP.save(fp);
+    DewControlsLabelsTP.save(fp);
+    USBControlsLabelsTP.save(fp);
     return true;
 }
 
@@ -1374,8 +1374,8 @@ bool PegasusUPB::sendFirmware()
     if (sendCommand("PV", res))
     {
         LOGF_INFO("Detected firmware %s", res);
-        IUSaveText(&FirmwareT[FIRMWARE_VERSION], res);
-        IDSetText(&FirmwareTP, nullptr);
+        FirmwareTP[FIRMWARE_VERSION].setText(res);
+        FirmwareTP.apply();
         return true;
     }
 
@@ -1414,13 +1414,13 @@ bool PegasusUPB::getSensorData()
             return true;
 
         // Power Sensors
-        PowerSensorsN[SENSOR_VOLTAGE].value = std::stod(result[1]);
-        PowerSensorsN[SENSOR_CURRENT].value = std::stod(result[2]);
-        PowerSensorsN[SENSOR_POWER].value = std::stod(result[3]);
-        PowerSensorsNP.s = IPS_OK;
+        PowerSensorsNP[SENSOR_VOLTAGE].setValue(std::stod(result[1]));
+        PowerSensorsNP[SENSOR_CURRENT].setValue(std::stod(result[2]));
+        PowerSensorsNP[SENSOR_POWER].setValue(std::stod(result[3]));
+        PowerSensorsNP.setState(IPS_OK);
         //if (lastSensorData[0] != result[0] || lastSensorData[1] != result[1] || lastSensorData[2] != result[2])
         if (sensorUpdated(result, 0, 2))
-            IDSetNumber(&PowerSensorsNP, nullptr);
+            PowerSensorsNP.apply();
 
         // Environment Sensors
         setParameterValue("WEATHER_TEMPERATURE", std::stod(result[4]));
@@ -1437,89 +1437,89 @@ bool PegasusUPB::getSensorData()
 
         // Port Status
         const char * portStatus = result[7].c_str();
-        PowerControlS[0].s = (portStatus[0] == '1') ? ISS_ON : ISS_OFF;
-        PowerControlS[1].s = (portStatus[1] == '1') ? ISS_ON : ISS_OFF;
-        PowerControlS[2].s = (portStatus[2] == '1') ? ISS_ON : ISS_OFF;
-        PowerControlS[3].s = (portStatus[3] == '1') ? ISS_ON : ISS_OFF;
+        PowerControlSP[0].setState((portStatus[0] == '1') ? ISS_ON : ISS_OFF);
+        PowerControlSP[1].setState((portStatus[1] == '1') ? ISS_ON : ISS_OFF);
+        PowerControlSP[2].setState((portStatus[2] == '1') ? ISS_ON : ISS_OFF);
+        PowerControlSP[3].setState((portStatus[3] == '1') ? ISS_ON : ISS_OFF);
         //if (lastSensorData[7] != result[7])
         if (sensorUpdated(result, 7, 7))
-            IDSetSwitch(&PowerControlSP, nullptr);
+            PowerControlSP.apply();
 
         // Hub Status
         const char * usb_status = result[8].c_str();
         if (version == UPB_V1)
         {
-            USBControlS[0].s = (usb_status[0] == '0') ? ISS_ON : ISS_OFF;
-            USBControlS[1].s = (usb_status[0] == '0') ? ISS_OFF : ISS_ON;
-            USBStatusL[0].s = (USBControlS[0].s == ISS_ON) ? IPS_OK : IPS_IDLE;
-            USBStatusL[1].s = (USBControlS[0].s == ISS_ON) ? IPS_OK : IPS_IDLE;
-            USBStatusL[2].s = (USBControlS[0].s == ISS_ON) ? IPS_OK : IPS_IDLE;
-            USBStatusL[3].s = (USBControlS[0].s == ISS_ON) ? IPS_OK : IPS_IDLE;
-            USBStatusL[4].s = (USBControlS[0].s == ISS_ON) ? IPS_OK : IPS_IDLE;
+            USBControlSP[0].setState((usb_status[0] == '0') ? ISS_ON : ISS_OFF);
+            USBControlSP[1].setState((usb_status[0] == '0') ? ISS_OFF : ISS_ON);
+            USBStatusLP[0].setState((USBControlSP[0].getState() == ISS_ON) ? IPS_OK : IPS_IDLE);
+            USBStatusLP[1].setState((USBControlSP[0].getState() == ISS_ON) ? IPS_OK : IPS_IDLE);
+            USBStatusLP[2].setState((USBControlSP[0].getState() == ISS_ON) ? IPS_OK : IPS_IDLE);
+            USBStatusLP[3].setState((USBControlSP[0].getState() == ISS_ON) ? IPS_OK : IPS_IDLE);
+            USBStatusLP[4].setState((USBControlSP[0].getState() == ISS_ON) ? IPS_OK : IPS_IDLE);
             //if (lastSensorData[8] != result[8])
             if (sensorUpdated(result, 8, 8))
             {
-                USBControlSP.s = (IUFindOnSwitchIndex(&USBControlSP) == 0) ? IPS_OK : IPS_IDLE;
-                IDSetSwitch(&USBControlSP, nullptr);
-                IDSetLight(&USBStatusLP, nullptr);
+                USBControlSP.setState((USBControlSP.findOnSwitchIndex() == 0) ? IPS_OK : IPS_IDLE);
+                USBControlSP.apply();
+                USBStatusLP.apply();
             }
         }
         else
         {
-            USBControlV2S[0].s = (usb_status[0] == '1') ? ISS_ON : ISS_OFF;
-            USBControlV2S[1].s = (usb_status[1] == '1') ? ISS_ON : ISS_OFF;
-            USBControlV2S[2].s = (usb_status[2] == '1') ? ISS_ON : ISS_OFF;
-            USBControlV2S[3].s = (usb_status[3] == '1') ? ISS_ON : ISS_OFF;
-            USBControlV2S[4].s = (usb_status[4] == '1') ? ISS_ON : ISS_OFF;
-            USBControlV2S[5].s = (usb_status[5] == '1') ? ISS_ON : ISS_OFF;
-            USBControlV2SP.s = IPS_OK;
+            USBControlV2SP[0].setState((usb_status[0] == '1') ? ISS_ON : ISS_OFF);
+            USBControlV2SP[1].setState((usb_status[1] == '1') ? ISS_ON : ISS_OFF);
+            USBControlV2SP[2].setState((usb_status[2] == '1') ? ISS_ON : ISS_OFF);
+            USBControlV2SP[3].setState((usb_status[3] == '1') ? ISS_ON : ISS_OFF);
+            USBControlV2SP[4].setState((usb_status[4] == '1') ? ISS_ON : ISS_OFF);
+            USBControlV2SP[5].setState((usb_status[5] == '1') ? ISS_ON : ISS_OFF);
+            USBControlV2SP.setState(IPS_OK);
             //if (lastSensorData[8] != result[8])
             if (sensorUpdated(result, 8, 8))
             {
-                IDSetSwitch(&USBControlV2SP, nullptr);
+                USBControlV2SP.apply();
             }
         }
 
         // From here, we get differences between v1 and v2 readings
         int index = 9;
         // Dew PWM
-        DewPWMN[DEW_PWM_A].value = std::stod(result[index]) / 255.0 * 100.0;
-        DewPWMN[DEW_PWM_B].value = std::stod(result[index + 1]) / 255.0 * 100.0;
+        DewPWMNP[DEW_PWM_A].setValue(std::stod(result[index]) / 255.0 * 100.0);
+        DewPWMNP[DEW_PWM_B].setValue(std::stod(result[index + 1]) / 255.0 * 100.0);
         if (version == UPB_V2)
-            DewPWMN[DEW_PWM_C].value = std::stod(result[index + 2]) / 255.0 * 100.0;
+            DewPWMNP[DEW_PWM_C].setValue(std::stod(result[index + 2]) / 255.0 * 100.0);
         //        if (lastSensorData[index] != result[index] ||
         //                lastSensorData[index + 1] != result[index + 1] ||
         //                (version == UPB_V2 && lastSensorData[index +2] != result[index + 2]))
         if (sensorUpdated(result, index, version == UPB_V1 ? index + 1 : index + 2))
-            IDSetNumber(&DewPWMNP, nullptr);
+            DewPWMNP.apply();
 
         index = (version == UPB_V1) ? 11 : 12;
 
         const double ampDivision = (version == UPB_V1) ? 400.0 : 300.0;
 
         // Current draw
-        PowerCurrentN[0].value = std::stod(result[index]) / ampDivision;
-        PowerCurrentN[1].value = std::stod(result[index + 1]) / ampDivision;
-        PowerCurrentN[2].value = std::stod(result[index + 2]) / ampDivision;
-        PowerCurrentN[3].value = std::stod(result[index + 3]) / ampDivision;
+        PowerCurrentNP[0].setValue(std::stod(result[index]) / ampDivision);
+        PowerCurrentNP[1].setValue(std::stod(result[index + 1]) / ampDivision);
+        PowerCurrentNP[2].setValue(std::stod(result[index + 2]) / ampDivision);
+        PowerCurrentNP[3].setValue(std::stod(result[index + 3]) / ampDivision);
         //        if (lastSensorData[index] != result[index] ||
         //                lastSensorData[index + 1] != result[index + 1] ||
         //                lastSensorData[index + 2] != result[index + 2] ||
         //                lastSensorData[index + 3] != result[index + 3])
         if (sensorUpdated(result, index, index + 3))
-            IDSetNumber(&PowerCurrentNP, nullptr);
+            PowerCurrentNP.apply();
 
         index = (version == UPB_V1) ? 15 : 16;
 
-        DewCurrentDrawN[DEW_PWM_A].value = std::stod(result[index]) / ampDivision;
-        DewCurrentDrawN[DEW_PWM_B].value = std::stod(result[index + 1]) / ampDivision;
+        DewCurrentDrawNP[DEW_PWM_A].setValue(std::stod(result[index]) / ampDivision);
+        DewCurrentDrawNP[DEW_PWM_B].setValue(std::stod(result[index + 1]) / ampDivision);
         if (version == UPB_V2)
-            DewCurrentDrawN[DEW_PWM_C].value = std::stod(result[index + 2]) / (ampDivision * 2);
+            DewCurrentDrawNP[DEW_PWM_C].setValue(std::stod(result[index + 2]) / (ampDivision * 2));
         //        if (lastSensorData[index] != result[index] ||
         //                lastSensorData[index + 1] != result[index + 1] ||
         //                (version == UPB_V2 && lastSensorData[index + 2] != result[index + 2]))
         if (sensorUpdated(result, index, version == UPB_V1 ? index + 1 : index + 2))
-            IDSetNumber(&DewCurrentDrawNP, nullptr);
+            DewCurrentDrawNP.apply();
 
         index = (version == UPB_V1) ? 17 : 19;
 
@@ -1528,18 +1528,18 @@ bool PegasusUPB::getSensorData()
         if (sensorUpdated(result, index, index))
         {
             const char * over_curent = result[index].c_str();
-            OverCurrentL[0].s = (over_curent[0] == '0') ? IPS_OK : IPS_ALERT;
-            OverCurrentL[1].s = (over_curent[1] == '0') ? IPS_OK : IPS_ALERT;
-            OverCurrentL[2].s = (over_curent[2] == '0') ? IPS_OK : IPS_ALERT;
-            OverCurrentL[3].s = (over_curent[3] == '0') ? IPS_OK : IPS_ALERT;
+            OverCurrentLP[0].setState((over_curent[0] == '0') ? IPS_OK : IPS_ALERT);
+            OverCurrentLP[1].setState((over_curent[1] == '0') ? IPS_OK : IPS_ALERT);
+            OverCurrentLP[2].setState((over_curent[2] == '0') ? IPS_OK : IPS_ALERT);
+            OverCurrentLP[3].setState((over_curent[3] == '0') ? IPS_OK : IPS_ALERT);
             if (version == UPB_V2)
             {
-                OverCurrentL[4].s = (over_curent[4] == '0') ? IPS_OK : IPS_ALERT;
-                OverCurrentL[5].s = (over_curent[5] == '0') ? IPS_OK : IPS_ALERT;
-                OverCurrentL[6].s = (over_curent[6] == '0') ? IPS_OK : IPS_ALERT;
+                OverCurrentLP[4].setState((over_curent[4] == '0') ? IPS_OK : IPS_ALERT);
+                OverCurrentLP[5].setState((over_curent[5] == '0') ? IPS_OK : IPS_ALERT);
+                OverCurrentLP[6].setState((over_curent[6] == '0') ? IPS_OK : IPS_ALERT);
             }
 
-            IDSetLight(&OverCurrentLP, nullptr);
+            OverCurrentLP.apply();
         }
 
         index = (version == UPB_V1) ? 18 : 20;
@@ -1550,9 +1550,9 @@ bool PegasusUPB::getSensorData()
             //if (lastSensorData[index] != result[index])
             if (sensorUpdated(result, index, index))
             {
-                AutoDewS[INDI_ENABLED].s  = (std::stoi(result[index]) == 1) ? ISS_ON : ISS_OFF;
-                AutoDewS[INDI_DISABLED].s = (std::stoi(result[index]) == 1) ? ISS_OFF : ISS_ON;
-                IDSetSwitch(&AutoDewSP, nullptr);
+                AutoDewSP[INDI_ENABLED].setState((std::stoi(result[index]) == 1) ? ISS_ON : ISS_OFF);
+                AutoDewSP[INDI_DISABLED].setState((std::stoi(result[index]) == 1) ? ISS_OFF : ISS_ON);
+                AutoDewSP.apply();
             }
         }
         else
@@ -1561,43 +1561,43 @@ bool PegasusUPB::getSensorData()
             if (sensorUpdated(result, index, index))
             {
                 int value = std::stoi(result[index]);
-                IUResetSwitch(&AutoDewV2SP);
+                AutoDewV2SP.reset();
                 switch (value)
                 {
                     case 1:
-                        AutoDewV2S[DEW_PWM_A].s = AutoDewV2S[DEW_PWM_B].s = AutoDewV2S[DEW_PWM_C].s = ISS_ON;
+                        AutoDewV2SP[DEW_PWM_A].setState(AutoDewV2SP[DEW_PWM_B].s = AutoDewV2SP[DEW_PWM_C].s = ISS_ON);
                         break;
 
                     case 2:
-                        AutoDewV2S[DEW_PWM_A].s = ISS_ON;
+                        AutoDewV2SP[DEW_PWM_A].setState(ISS_ON);
                         break;
 
                     case 3:
-                        AutoDewV2S[DEW_PWM_B].s = ISS_ON;
+                        AutoDewV2SP[DEW_PWM_B].setState(ISS_ON);
                         break;
 
                     case 4:
-                        AutoDewV2S[DEW_PWM_C].s = ISS_ON;
+                        AutoDewV2SP[DEW_PWM_C].setState(ISS_ON);
                         break;
 
                     case 5:
-                        AutoDewV2S[DEW_PWM_A].s = ISS_ON;
-                        AutoDewV2S[DEW_PWM_B].s = ISS_ON;
+                        AutoDewV2SP[DEW_PWM_A].setState(ISS_ON);
+                        AutoDewV2SP[DEW_PWM_B].setState(ISS_ON);
                         break;
 
                     case 6:
-                        AutoDewV2S[DEW_PWM_A].s = ISS_ON;
-                        AutoDewV2S[DEW_PWM_C].s = ISS_ON;
+                        AutoDewV2SP[DEW_PWM_A].setState(ISS_ON);
+                        AutoDewV2SP[DEW_PWM_C].setState(ISS_ON);
                         break;
 
                     case 7:
-                        AutoDewV2S[DEW_PWM_B].s = ISS_ON;
-                        AutoDewV2S[DEW_PWM_C].s = ISS_ON;
+                        AutoDewV2SP[DEW_PWM_B].setState(ISS_ON);
+                        AutoDewV2SP[DEW_PWM_C].setState(ISS_ON);
                         break;
                     default:
                         break;
                 }
-                IDSetSwitch(&AutoDewV2SP, nullptr);
+                AutoDewV2SP.apply();
             }
         }
 
@@ -1627,11 +1627,11 @@ bool PegasusUPB::getPowerData()
         if (result == lastPowerData)
             return true;
 
-        PowerConsumptionN[CONSUMPTION_AVG_AMPS].value = std::stod(result[0]);
-        PowerConsumptionN[CONSUMPTION_AMP_HOURS].value = std::stod(result[1]);
-        PowerConsumptionN[CONSUMPTION_WATT_HOURS].value = std::stod(result[2]);
-        PowerConsumptionNP.s = IPS_OK;
-        IDSetNumber(&PowerConsumptionNP, nullptr);
+        PowerConsumptionNP[CONSUMPTION_AVG_AMPS].setValue(std::stod(result[0]));
+        PowerConsumptionNP[CONSUMPTION_AMP_HOURS].setValue(std::stod(result[1]));
+        PowerConsumptionNP[CONSUMPTION_WATT_HOURS].setValue(std::stod(result[2]));
+        PowerConsumptionNP.setState(IPS_OK);
+        PowerConsumptionNP.apply();
 
         if (version == UPB_V2)
         {
@@ -1639,8 +1639,8 @@ bool PegasusUPB::getPowerData()
             using dhours = std::chrono::duration<double, std::ratio<3600>>;
             std::stringstream ss;
             ss << std::fixed << std::setprecision(3) << dhours(uptime).count();
-            IUSaveText(&FirmwareT[FIRMWARE_UPTIME], ss.str().c_str());
-            IDSetText(&FirmwareTP, nullptr);
+            FirmwareTP[FIRMWARE_UPTIME].setText(ss.str());
+            FirmwareTP.apply();
         }
 
         lastPowerData = result;
@@ -1668,46 +1668,46 @@ bool PegasusUPB::getStepperData()
         if (result == lastStepperData)
             return true;
 
-        FocusAbsPosN[0].value = std::stoi(result[0]);
+        FocusAbsPosNP[0].setValue(std::stoi(result[0]));
         focusMotorRunning = (std::stoi(result[1]) == 1);
 
-        if (FocusAbsPosNP.s == IPS_BUSY && focusMotorRunning == false)
+        if (FocusAbsPosNP.getState() == IPS_BUSY && focusMotorRunning == false)
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
         }
         else if (result[0] != lastStepperData[0])
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP.apply();
 
-        FocusReverseS[INDI_ENABLED].s = (std::stoi(result[2]) == 1) ? ISS_ON : ISS_OFF;
-        FocusReverseS[INDI_DISABLED].s = (std::stoi(result[2]) == 1) ? ISS_OFF : ISS_ON;
+        FocusReverseSP[INDI_ENABLED].setState((std::stoi(result[2]) == 1) ? ISS_ON : ISS_OFF);
+        FocusReverseSP[INDI_DISABLED].setState((std::stoi(result[2]) == 1) ? ISS_OFF : ISS_ON);
 
         if (result[2] != lastStepperData[2])
-            IDSetSwitch(&FocusReverseSP, nullptr);
+            FocusReverseSP.apply();
 
         uint16_t backlash = std::stoi(result[3]);
         if (backlash == 0)
         {
-            FocusBacklashN[0].value = backlash;
-            FocusBacklashS[INDI_ENABLED].s = ISS_OFF;
-            FocusBacklashS[INDI_DISABLED].s = ISS_ON;
+            FocusBacklashNP[0].setValue(backlash);
+            FocusBacklashSP[INDI_ENABLED].setState(ISS_OFF);
+            FocusBacklashSP[INDI_DISABLED].setState(ISS_ON);
             if (result[3] != lastStepperData[3])
             {
-                IDSetSwitch(&FocusBacklashSP, nullptr);
-                IDSetNumber(&FocuserSettingsNP, nullptr);
+                FocusBacklashSP.apply();
+                FocuserSettingsNP.apply();
             }
         }
         else
         {
-            FocusBacklashS[INDI_ENABLED].s = ISS_ON;
-            FocusBacklashS[INDI_DISABLED].s = ISS_OFF;
-            FocusBacklashN[0].value = backlash;
+            FocusBacklashSP[INDI_ENABLED].setState(ISS_ON);
+            FocusBacklashSP[INDI_DISABLED].setState(ISS_OFF);
+            FocusBacklashNP[0].setValue(backlash);
             if (result[3] != lastStepperData[3])
             {
-                IDSetSwitch(&FocusBacklashSP, nullptr);
-                IDSetNumber(&FocuserSettingsNP, nullptr);
+                FocusBacklashSP.apply();
+                FocuserSettingsNP.apply();
             }
         }
 
@@ -1732,9 +1732,9 @@ bool PegasusUPB::getDewAggData()
         if (result == lastDewAggData)
             return true;
 
-        AutoDewAggN[0].value = std::stod(result[1]);
-        AutoDewAggNP.s = IPS_OK;
-        IDSetNumber(&AutoDewAggNP, nullptr);
+        AutoDewAggNP[0].setValue(std::stod(result[1]));
+        AutoDewAggNP.setState(IPS_OK);
+        AutoDewAggNP.apply();
 
         lastDewAggData = result;
         return true;
@@ -1781,12 +1781,12 @@ bool PegasusUPB::setupParams()
         {
             LOGF_WARN("Invalid maximum speed detected: %u. Please set maximum speed appropiate for your motor focus type (0-900)",
                       value);
-            FocuserSettingsNP.s = IPS_ALERT;
+            FocuserSettingsNP.setState(IPS_ALERT);
         }
         else
         {
-            FocuserSettingsN[SETTING_MAX_SPEED].value = value;
-            FocuserSettingsNP.s = IPS_OK;
+            FocuserSettingsNP[SETTING_MAX_SPEED].setValue(value);
+            FocuserSettingsNP.setState(IPS_OK);
         }
     }
 

--- a/drivers/auxiliary/pegasus_upb.h
+++ b/drivers/auxiliary/pegasus_upb.h
@@ -29,6 +29,12 @@
 #include "indiweatherinterface.h"
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
+
 namespace Connection
 {
 class Serial;
@@ -141,12 +147,10 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
         /// Main Control
         ////////////////////////////////////////////////////////////////////////////////////
         /// Reboot Device
-        ISwitch RebootS[1];
-        ISwitchVectorProperty RebootSP;
+        INDI::PropertySwitch RebootSP {1};
 
         // Power Sensors
-        INumber PowerSensorsN[3];
-        INumberVectorProperty PowerSensorsNP;
+        INDI::PropertyNumber PowerSensorsNP {3};
         enum
         {
             SENSOR_VOLTAGE,
@@ -155,8 +159,7 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
         };
 
         // Power Consumption
-        INumber PowerConsumptionN[3];
-        INumberVectorProperty PowerConsumptionNP;
+        INDI::PropertyNumber PowerConsumptionNP {3};
         enum
         {
             CONSUMPTION_AVG_AMPS,
@@ -169,8 +172,7 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
         ////////////////////////////////////////////////////////////////////////////////////
 
         // Cycle all power on/off
-        ISwitch PowerCycleAllS[2];
-        ISwitchVectorProperty PowerCycleAllSP;
+        INDI::PropertySwitch PowerCycleAllSP {2};
         enum
         {
             POWER_CYCLE_OFF,
@@ -178,28 +180,22 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
         };
 
         // Turn on/off power
-        ISwitch PowerControlS[4];
-        ISwitchVectorProperty PowerControlSP;
+        INDI::PropertySwitch PowerControlSP {4};
 
         // Rename the power controls above
-        IText PowerControlsLabelsT[4] = {};
-        ITextVectorProperty PowerControlsLabelsTP;
+        INDI::PropertyText PowerControlsLabelsTP {4};
 
         // Current Draw
-        INumber PowerCurrentN[4];
-        INumberVectorProperty PowerCurrentNP;
+        INDI::PropertyNumber PowerCurrentNP {4};
 
         // Select which power is ON on bootup
-        ISwitch PowerOnBootS[4];
-        ISwitchVectorProperty PowerOnBootSP;
+        INDI::PropertySwitch PowerOnBootSP {4};
 
         // Overcurrent status
-        ILight OverCurrentL[7];
-        ILightVectorProperty OverCurrentLP;
+        INDI::PropertyLight OverCurrentLP {7};
 
         // Power LED
-        ISwitch PowerLEDS[2];
-        ISwitchVectorProperty PowerLEDSP;
+        INDI::PropertySwitch PowerLEDSP {2};
         enum
         {
             POWER_LED_ON,
@@ -207,16 +203,14 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
         };
 
         // Adjustable Output
-        INumber AdjustableOutputN[1];
-        INumberVectorProperty AdjustableOutputNP;
+        INDI::PropertyNumber AdjustableOutputNP {1};
 
         ////////////////////////////////////////////////////////////////////////////////////
         /// Dew Group
         ////////////////////////////////////////////////////////////////////////////////////
 
         // Auto Dew v1
-        ISwitch AutoDewS[2];
-        ISwitchVectorProperty AutoDewSP;
+        INDI::PropertySwitch AutoDewSP {2};
 
         enum
         {
@@ -226,12 +220,10 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
         };
 
         // Auto Dew v2
-        ISwitch AutoDewV2S[3];
-        ISwitchVectorProperty AutoDewV2SP;
+        INDI::PropertySwitch AutoDewV2SP {3};
 
         // Rename the power controls above
-        IText DewControlsLabelsT[3] = {};
-        ITextVectorProperty DewControlsLabelsTP;
+        INDI::PropertyText DewControlsLabelsTP {3};
 
         // Auto Dew v2 Aggressiveness
 
@@ -240,44 +232,36 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
             AUTO_DEW_AGG,
         };
 
-        INumber AutoDewAggN[1];
-        INumberVectorProperty AutoDewAggNP;
+        INDI::PropertyNumber AutoDewAggNP {1};
 
         // Dew PWM
-        INumber DewPWMN[3];
-        INumberVectorProperty DewPWMNP;
+        INDI::PropertyNumber DewPWMNP {3};
 
         // Current Draw
-        INumber DewCurrentDrawN[3];
-        INumberVectorProperty DewCurrentDrawNP;
+        INDI::PropertyNumber DewCurrentDrawNP {3};
 
         ////////////////////////////////////////////////////////////////////////////////////
         /// USB
         ////////////////////////////////////////////////////////////////////////////////////
 
         // Turn on/off usb ports 1-5 (v1)
-        ISwitch USBControlS[2];
-        ISwitchVectorProperty USBControlSP;
+        INDI::PropertySwitch USBControlSP {2};
 
         // Turn on/off usb ports 1-6 (v2)
-        ISwitch USBControlV2S[6];
-        ISwitchVectorProperty USBControlV2SP;
+        INDI::PropertySwitch USBControlV2SP {6};
 
         // USB Port Status (1-6)
-        ILight USBStatusL[6];
-        ILightVectorProperty USBStatusLP;
+        INDI::PropertyLight USBStatusLP {6};
 
         // Rename the USB controls above
-        IText USBControlsLabelsT[6] = {};
-        ITextVectorProperty USBControlsLabelsTP;
+        INDI::PropertyText USBControlsLabelsTP {6};
 
         ////////////////////////////////////////////////////////////////////////////////////
         /// Focuser
         ////////////////////////////////////////////////////////////////////////////////////
 
         // Focuser speed
-        INumber FocuserSettingsN[1];
-        INumberVectorProperty FocuserSettingsNP;
+        INDI::PropertyNumber FocuserSettingsNP {1};
         enum
         {
             //SETTING_BACKLASH,
@@ -287,8 +271,7 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
         ////////////////////////////////////////////////////////////////////////////////////
         /// USB
         ////////////////////////////////////////////////////////////////////////////////////
-        ITextVectorProperty FirmwareTP;
-        IText FirmwareT[2] {};
+        INDI::PropertyText FirmwareTP {2};
         enum
         {
             FIRMWARE_VERSION,
@@ -297,8 +280,7 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
 
 
         // Temperature
-        INumber FocuserTemperatureN[1];
-        INumberVectorProperty FocuserTemperatureNP;
+        INDI::PropertyNumber FocuserTemperatureNP {1};
 
         std::vector<std::string> lastSensorData, lastPowerData, lastStepperData, lastDewAggData;
         bool focusMotorRunning { false };

--- a/drivers/auxiliary/planewave_delta.h
+++ b/drivers/auxiliary/planewave_delta.h
@@ -28,6 +28,11 @@
 #include <memory>
 #include <map>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class DeltaT : public INDI::DefaultDevice
 {
     public:
@@ -117,8 +122,7 @@ class DeltaT : public INDI::DefaultDevice
         ///////////////////////////////////////////////////////////////////////////////////
 
         // Delta-T Informatin
-        ITextVectorProperty InfoTP;
-        IText InfoT[1] {};
+        INDI::PropertyText InfoTP {1};
         enum
         {
             INFO_VERSION
@@ -126,8 +130,7 @@ class DeltaT : public INDI::DefaultDevice
 
 
         // Force Control
-        ISwitchVectorProperty ForceSP;
-        ISwitch ForceS[2];
+        INDI::PropertySwitch ForceSP {2};
         enum
         {
             FORCE_RESET,
@@ -166,8 +169,7 @@ class DeltaT : public INDI::DefaultDevice
         };
 
         // Read Only Temperature Reporting
-        INumberVectorProperty TemperatureNP;
-        INumber TemperatureN[3];
+        INDI::PropertyNumber TemperatureNP {3};
         enum
         {
             // Primary is 0 , not used in this driver.

--- a/drivers/auxiliary/skysafari.h
+++ b/drivers/auxiliary/skysafari.h
@@ -31,6 +31,10 @@
 
 #include <memory>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+
 class SkySafariClient;
 
 class SkySafari : public INDI::DefaultDevice
@@ -70,8 +74,7 @@ class SkySafari : public INDI::DefaultDevice
         std::vector<std::string> split(const std::string &s, char delim);
 
         // Settings
-        ITextVectorProperty SettingsTP;
-        IText SettingsT[3] {};
+        INDI::PropertyText SettingsTP {3};
         enum
         {
             INDISERVER_HOST,
@@ -80,16 +83,14 @@ class SkySafari : public INDI::DefaultDevice
         };
 
         // Active Devices
-        ITextVectorProperty ActiveDeviceTP;
-        IText ActiveDeviceT[1] {};
+        INDI::PropertyText ActiveDeviceTP {1};
         enum
         {
             ACTIVE_TELESCOPE
         };
 
         // Server Control
-        ISwitchVectorProperty ServerControlSP;
-        ISwitch ServerControlS[2];
+        INDI::PropertySwitch ServerControlSP {2};
         enum
         {
             SERVER_ENABLE,

--- a/drivers/auxiliary/snapcap.h
+++ b/drivers/auxiliary/snapcap.h
@@ -34,6 +34,10 @@
 
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+
 namespace Connection
 {
 class Serial;
@@ -82,20 +86,16 @@ class SnapCap : public INDI::DefaultDevice, public INDI::LightBoxInterface, publ
     IPState Abort();
 
     // Status
-    ITextVectorProperty StatusTP;
-    IText StatusT[3]{};
+    INDI::PropertyText StatusTP {3};
 
     // Firmware version
-    ITextVectorProperty FirmwareTP;
-    IText FirmwareT[1]{};
+    INDI::PropertyText FirmwareTP {1};
 
     // Abort
-    ISwitch AbortS[1];
-    ISwitchVectorProperty AbortSP;
+    INDI::PropertySwitch AbortSP {1};
 
     // Force open & close
-    ISwitch ForceS[2];
-    ISwitchVectorProperty ForceSP;
+    INDI::PropertySwitch ForceSP {2};
 
     int PortFD{ -1 };
     bool hasLight{ true };

--- a/drivers/auxiliary/sqm.cpp
+++ b/drivers/auxiliary/sqm.cpp
@@ -87,20 +87,20 @@ bool SQM::initProperties()
     INDI::DefaultDevice::initProperties();
 
     // Average Readings
-    IUFillNumber(&AverageReadingN[SKY_BRIGHTNESS], "SKY_BRIGHTNESS", "Quality (mag/arcsec^2)", "%6.2f", -20, 30, 0, 0);
-    IUFillNumber(&AverageReadingN[SENSOR_FREQUENCY], "SENSOR_FREQUENCY", "Freq (Hz)", "%6.2f", 0, 1000000, 0, 0);
-    IUFillNumber(&AverageReadingN[SENSOR_COUNTS], "SENSOR_COUNTS", "Period (counts)", "%6.2f", 0, 1000000, 0, 0);
-    IUFillNumber(&AverageReadingN[SENSOR_PERIOD], "SENSOR_PERIOD", "Period (s)", "%6.2f", 0, 1000000, 0, 0);
-    IUFillNumber(&AverageReadingN[SKY_TEMPERATURE], "SKY_TEMPERATURE", "Temperature (C)", "%6.2f", -50, 80, 0, 0);
-    IUFillNumberVector(&AverageReadingNP, AverageReadingN, 5, getDeviceName(), "SKY_QUALITY", "Readings",
+    AverageReadingNP[SKY_BRIGHTNESS].fill("SKY_BRIGHTNESS", "Quality (mag/arcsec^2)", "%6.2f", -20, 30, 0, 0);
+    AverageReadingNP[SENSOR_FREQUENCY].fill("SENSOR_FREQUENCY", "Freq (Hz)", "%6.2f", 0, 1000000, 0, 0);
+    AverageReadingNP[SENSOR_COUNTS].fill("SENSOR_COUNTS", "Period (counts)", "%6.2f", 0, 1000000, 0, 0);
+    AverageReadingNP[SENSOR_PERIOD].fill("SENSOR_PERIOD", "Period (s)", "%6.2f", 0, 1000000, 0, 0);
+    AverageReadingNP[SKY_TEMPERATURE].fill("SKY_TEMPERATURE", "Temperature (C)", "%6.2f", -50, 80, 0, 0);
+    AverageReadingNP.fill(getDeviceName(), "SKY_QUALITY", "Readings",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Unit Info
-    IUFillNumber(&UnitInfoN[UNIT_PROTOCOL], "UNIT_PROTOCOL", "Protocol", "%.f", 0, 1000000, 0, 0);
-    IUFillNumber(&UnitInfoN[UNIT_MODEL], "UNIT_MODEL", "Model", "%.f", 0, 1000000, 0, 0);
-    IUFillNumber(&UnitInfoN[UNIT_FEATURE], "UNIT_FEATURE", "Feature", "%.f", 0, 1000000, 0, 0);
-    IUFillNumber(&UnitInfoN[UNIT_SERIAL], "UNIT_SERIAL", "Serial", "%.f", 0, 1000000, 0, 0);
-    IUFillNumberVector(&UnitInfoNP, UnitInfoN, 4, getDeviceName(), "Unit Info", "", UNIT_TAB, IP_RW, 0, IPS_IDLE);
+    UnitInfoNP[UNIT_PROTOCOL].fill("UNIT_PROTOCOL", "Protocol", "%.f", 0, 1000000, 0, 0);
+    UnitInfoNP[UNIT_MODEL].fill("UNIT_MODEL", "Model", "%.f", 0, 1000000, 0, 0);
+    UnitInfoNP[UNIT_FEATURE].fill("UNIT_FEATURE", "Feature", "%.f", 0, 1000000, 0, 0);
+    UnitInfoNP[UNIT_SERIAL].fill("UNIT_SERIAL", "Serial", "%.f", 0, 1000000, 0, 0);
+    UnitInfoNP.fill(getDeviceName(), "Unit Info", "", UNIT_TAB, IP_RW, 0, IPS_IDLE);
 
     if (sqmConnection & CONNECTION_SERIAL)
     {
@@ -138,16 +138,16 @@ bool SQM::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&AverageReadingNP);
-        defineProperty(&UnitInfoNP);
+        defineProperty(AverageReadingNP);
+        defineProperty(UnitInfoNP);
 
         getReadings();
 
     }
     else
     {
-        deleteProperty(AverageReadingNP.name);
-        deleteProperty(UnitInfoNP.name);
+        deleteProperty(AverageReadingNP.getName());
+        deleteProperty(UnitInfoNP.getName());
     }
 
     return true;
@@ -191,11 +191,11 @@ bool SQM::getReadings()
         }
     }
 
-    AverageReadingN[0].value = mpsas;
-    AverageReadingN[1].value = frequency;
-    AverageReadingN[2].value = period_counts;
-    AverageReadingN[3].value = period_seconds;
-    AverageReadingN[4].value = temperature;
+    AverageReadingNP[0].setValue(mpsas);
+    AverageReadingNP[1].setValue(frequency);
+    AverageReadingNP[2].setValue(period_counts);
+    AverageReadingNP[3].setValue(period_seconds);
+    AverageReadingNP[4].setValue(temperature);
 
     return true;
 }
@@ -242,10 +242,10 @@ bool SQM::getDeviceInfo()
         return false;
     }
 
-    UnitInfoN[0].value = protocol;
-    UnitInfoN[1].value = model;
-    UnitInfoN[2].value = feature;
-    UnitInfoN[3].value = serial;
+    UnitInfoNP[0].setValue(protocol);
+    UnitInfoNP[1].setValue(model);
+    UnitInfoNP[2].setValue(feature);
+    UnitInfoNP[3].setValue(serial);
 
     return true;
 }
@@ -257,8 +257,8 @@ void SQM::TimerHit()
 
     bool rc = getReadings();
 
-    AverageReadingNP.s = rc ? IPS_OK : IPS_ALERT;
-    IDSetNumber(&AverageReadingNP, nullptr);
+    AverageReadingNP.setState(rc ? IPS_OK : IPS_ALERT);
+    AverageReadingNP.apply();
 
     SetTimer(getCurrentPollingPeriod());
 }

--- a/drivers/auxiliary/sqm.h
+++ b/drivers/auxiliary/sqm.h
@@ -26,6 +26,9 @@
 
 #include "defaultdevice.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class SQM : public INDI::DefaultDevice
 {
     public:
@@ -56,8 +59,7 @@ class SQM : public INDI::DefaultDevice
         bool getDeviceInfo();
 
         // Readings
-        INumberVectorProperty AverageReadingNP;
-        INumber AverageReadingN[5];
+        INDI::PropertyNumber AverageReadingNP {5};
         enum
         {
             SKY_BRIGHTNESS,
@@ -68,8 +70,7 @@ class SQM : public INDI::DefaultDevice
         };
 
         // Device Information
-        INumberVectorProperty UnitInfoNP;
-        INumber UnitInfoN[4];
+        INDI::PropertyNumber UnitInfoNP {4};
         enum
         {
             UNIT_PROTOCOL,

--- a/drivers/auxiliary/usb_dewpoint.cpp
+++ b/drivers/auxiliary/usb_dewpoint.cpp
@@ -82,65 +82,65 @@ bool USBDewpoint::initProperties()
     DefaultDevice::initProperties();
 
     /* Channel duty cycles */
-    IUFillNumber(&OutputsN[0], "CHANNEL1", "Channel 1", "%3.0f", 0., 100., 10., 0.);
-    IUFillNumber(&OutputsN[1], "CHANNEL2", "Channel 2", "%3.0f", 0., 100., 10., 0.);
-    IUFillNumber(&OutputsN[2], "CHANNEL3", "Channel 3", "%3.0f", 0., 100., 10., 0.);
-    IUFillNumberVector(&OutputsNP, OutputsN, 3, getDeviceName(), "OUTPUT", "Outputs", MAIN_CONTROL_TAB, IP_RW, 0,
+    OutputsNP[0].fill("CHANNEL1", "Channel 1", "%3.0f", 0., 100., 10., 0.);
+    OutputsNP[1].fill("CHANNEL2", "Channel 2", "%3.0f", 0., 100., 10., 0.);
+    OutputsNP[2].fill("CHANNEL3", "Channel 3", "%3.0f", 0., 100., 10., 0.);
+    OutputsNP.fill(getDeviceName(), "OUTPUT", "Outputs", MAIN_CONTROL_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     /* Temperatures */
-    IUFillNumber(&TemperaturesN[0], "CHANNEL1", "Channel 1", "%3.2f", -50., 70., 0., 0.);
-    IUFillNumber(&TemperaturesN[1], "CHANNEL2", "Channel 2", "%3.2f", -50., 70., 0., 0.);
-    IUFillNumber(&TemperaturesN[2], "AMBIENT", "Ambient", "%3.2f", -50., 70., 0., 0.);
-    IUFillNumberVector(&TemperaturesNP, TemperaturesN, 3, getDeviceName(), "TEMPERATURES", "Temperatures",
+    TemperaturesNP[0].fill("CHANNEL1", "Channel 1", "%3.2f", -50., 70., 0., 0.);
+    TemperaturesNP[1].fill("CHANNEL2", "Channel 2", "%3.2f", -50., 70., 0., 0.);
+    TemperaturesNP[2].fill("AMBIENT", "Ambient", "%3.2f", -50., 70., 0., 0.);
+    TemperaturesNP.fill(getDeviceName(), "TEMPERATURES", "Temperatures",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     /* Humidity */
-    IUFillNumber(&HumidityN[0], "HUMIDITY", "Humidity", "%3.2f", 0., 100., 0., 0.);
-    IUFillNumberVector(&HumidityNP, HumidityN, 1, getDeviceName(), "HUMIDITY", "Humidity", MAIN_CONTROL_TAB, IP_RO, 0,
+    HumidityNP[0].fill("HUMIDITY", "Humidity", "%3.2f", 0., 100., 0., 0.);
+    HumidityNP.fill(getDeviceName(), "HUMIDITY", "Humidity", MAIN_CONTROL_TAB, IP_RO, 0,
                        IPS_IDLE);
 
     /* Dew point */
-    IUFillNumber(&DewpointN[0], "DEWPOINT", "Dew point", "%3.2f", -50., 70., 0., 0.);
-    IUFillNumberVector(&DewpointNP, DewpointN, 1, getDeviceName(), "DEWPOINT", "Dew point", MAIN_CONTROL_TAB, IP_RO, 0,
+    DewpointNP[0].fill("DEWPOINT", "Dew point", "%3.2f", -50., 70., 0., 0.);
+    DewpointNP.fill(getDeviceName(), "DEWPOINT", "Dew point", MAIN_CONTROL_TAB, IP_RO, 0,
                        IPS_IDLE);
 
     /* Temperature calibration values */
-    IUFillNumber(&CalibrationsN[0], "CHANNEL1", "Channel 1", "%1.0f", 0., 9., 1., 0.);
-    IUFillNumber(&CalibrationsN[1], "CHANNEL2", "Channel 2", "%1.0f", 0., 9., 1., 0.);
-    IUFillNumber(&CalibrationsN[2], "AMBIENT", "Ambient", "%1.0f", 0., 9., 1., 0.);
-    IUFillNumberVector(&CalibrationsNP, CalibrationsN, 3, getDeviceName(), "CALIBRATIONS", "Calibrations", OPTIONS_TAB,
+    CalibrationsNP[0].fill("CHANNEL1", "Channel 1", "%1.0f", 0., 9., 1., 0.);
+    CalibrationsNP[1].fill("CHANNEL2", "Channel 2", "%1.0f", 0., 9., 1., 0.);
+    CalibrationsNP[2].fill("AMBIENT", "Ambient", "%1.0f", 0., 9., 1., 0.);
+    CalibrationsNP.fill(getDeviceName(), "CALIBRATIONS", "Calibrations", OPTIONS_TAB,
                        IP_RW, 0, IPS_IDLE);
 
     /* Temperature threshold values */
-    IUFillNumber(&ThresholdsN[0], "CHANNEL1", "Channel 1", "%1.0f", 0., 9., 1., 0.);
-    IUFillNumber(&ThresholdsN[1], "CHANNEL2", "Channel 2", "%1.0f", 0., 9., 1., 0.);
-    IUFillNumberVector(&ThresholdsNP, ThresholdsN, 2, getDeviceName(), "THRESHOLDS", "Thresholds", OPTIONS_TAB, IP_RW,
+    ThresholdsNP[0].fill("CHANNEL1", "Channel 1", "%1.0f", 0., 9., 1., 0.);
+    ThresholdsNP[1].fill("CHANNEL2", "Channel 2", "%1.0f", 0., 9., 1., 0.);
+    ThresholdsNP.fill(getDeviceName(), "THRESHOLDS", "Thresholds", OPTIONS_TAB, IP_RW,
                        0, IPS_IDLE);
 
     /* Heating aggressivity */
-    IUFillNumber(&AggressivityN[0], "AGGRESSIVITY", "Aggressivity", "%1.0f", 1., 4., 1., 1.);
-    IUFillNumberVector(&AggressivityNP, AggressivityN, 1, getDeviceName(), "AGGRESSIVITY", "Aggressivity", OPTIONS_TAB,
+    AggressivityNP[0].fill("AGGRESSIVITY", "Aggressivity", "%1.0f", 1., 4., 1., 1.);
+    AggressivityNP.fill(getDeviceName(), "AGGRESSIVITY", "Aggressivity", OPTIONS_TAB,
                        IP_RW, 0, IPS_IDLE);
 
     /*  Automatic mode enable */
-    IUFillSwitch(&AutoModeS[0], "MANUAL", "Manual", ISS_OFF);
-    IUFillSwitch(&AutoModeS[1], "AUTO", "Automatic", ISS_ON);
-    IUFillSwitchVector(&AutoModeSP, AutoModeS, 2, getDeviceName(), "MODE", "Operating mode", MAIN_CONTROL_TAB, IP_RW,
+    AutoModeSP[0].fill("MANUAL", "Manual", ISS_OFF);
+    AutoModeSP[1].fill("AUTO", "Automatic", ISS_ON);
+    AutoModeSP.fill(getDeviceName(), "MODE", "Operating mode", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Link channel 2 & 3 */
-    IUFillSwitch(&LinkOut23S[0], "INDEPENDENT", "Independent", ISS_ON);
-    IUFillSwitch(&LinkOut23S[1], "LINK", "Link", ISS_OFF);
-    IUFillSwitchVector(&LinkOut23SP, LinkOut23S, 2, getDeviceName(), "LINK23", "Link ch 2&3", OPTIONS_TAB, IP_RW,
+    LinkOut23SP[0].fill("INDEPENDENT", "Independent", ISS_ON);
+    LinkOut23SP[1].fill("LINK", "Link", ISS_OFF);
+    LinkOut23SP.fill(getDeviceName(), "LINK23", "Link ch 2&3", OPTIONS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
     /* Reset settings */
-    IUFillSwitch(&ResetS[0], "Reset", "", ISS_OFF);
-    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "Reset", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    ResetSP[0].fill("Reset", "", ISS_OFF);
+    ResetSP.fill(getDeviceName(), "Reset", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Firmware version */
-    IUFillNumber(&FWversionN[0], "FIRMWARE", "Firmware Version", "%4.0f", 0., 65535., 1., 0.);
-    IUFillNumberVector(&FWversionNP, FWversionN, 1, getDeviceName(), "FW_VERSION", "Firmware", OPTIONS_TAB, IP_RO, 0,
+    FWversionNP[0].fill("FIRMWARE", "Firmware Version", "%4.0f", 0., 65535., 1., 0.);
+    FWversionNP.fill(getDeviceName(), "FW_VERSION", "Firmware", OPTIONS_TAB, IP_RO, 0,
                        IPS_IDLE);
 
     setDriverInterface(AUX_INTERFACE);
@@ -165,17 +165,17 @@ bool USBDewpoint::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&OutputsNP);
-        defineProperty(&TemperaturesNP);
-        defineProperty(&HumidityNP);
-        defineProperty(&DewpointNP);
-        defineProperty(&CalibrationsNP);
-        defineProperty(&ThresholdsNP);
-        defineProperty(&AggressivityNP);
-        defineProperty(&AutoModeSP);
-        defineProperty(&LinkOut23SP);
-        defineProperty(&ResetSP);
-        defineProperty(&FWversionNP);
+        defineProperty(OutputsNP);
+        defineProperty(TemperaturesNP);
+        defineProperty(HumidityNP);
+        defineProperty(DewpointNP);
+        defineProperty(CalibrationsNP);
+        defineProperty(ThresholdsNP);
+        defineProperty(AggressivityNP);
+        defineProperty(AutoModeSP);
+        defineProperty(LinkOut23SP);
+        defineProperty(ResetSP);
+        defineProperty(FWversionNP);
 
         loadConfig(true);
         readSettings();
@@ -184,17 +184,17 @@ bool USBDewpoint::updateProperties()
     }
     else
     {
-        deleteProperty(OutputsNP.name);
-        deleteProperty(TemperaturesNP.name);
-        deleteProperty(HumidityNP.name);
-        deleteProperty(DewpointNP.name);
-        deleteProperty(CalibrationsNP.name);
-        deleteProperty(ThresholdsNP.name);
-        deleteProperty(AggressivityNP.name);
-        deleteProperty(AutoModeSP.name);
-        deleteProperty(LinkOut23SP.name);
-        deleteProperty(ResetSP.name);
-        deleteProperty(FWversionNP.name);
+        deleteProperty(OutputsNP.getName());
+        deleteProperty(TemperaturesNP.getName());
+        deleteProperty(HumidityNP.getName());
+        deleteProperty(DewpointNP.getName());
+        deleteProperty(CalibrationsNP.getName());
+        deleteProperty(ThresholdsNP.getName());
+        deleteProperty(AggressivityNP.getName());
+        deleteProperty(AutoModeSP.getName());
+        deleteProperty(LinkOut23SP.getName());
+        deleteProperty(ResetSP.getName());
+        deleteProperty(FWversionNP.getName());
     }
 
     return true;
@@ -312,8 +312,8 @@ bool USBDewpoint::Ack()
         return false;
     }
 
-    FWversionN[0].value = firmware;
-    FWversionNP.s       = IPS_OK;
+    FWversionNP[0].setValue(firmware);
+    FWversionNP.setState(IPS_OK);
     return true;
 }
 
@@ -381,39 +381,39 @@ bool USBDewpoint::ISNewSwitch(const char *dev, const char *name, ISState *states
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(AutoModeSP.name, name) == 0)
+        if (AutoModeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&AutoModeSP, states, names, n);
-            int target_mode = IUFindOnSwitchIndex(&AutoModeSP);
-            AutoModeSP.s    = IPS_BUSY;
-            IDSetSwitch(&AutoModeSP, nullptr);
+            AutoModeSP.update(states, names, n);
+            int target_mode = AutoModeSP.findOnSwitchIndex();
+            AutoModeSP.setState(IPS_BUSY);
+            AutoModeSP.apply();
             setAutoMode(target_mode == 1);
             readSettings();
             return true;
         }
-        if (strcmp(LinkOut23SP.name, name) == 0)
+        if (LinkOut23SP.isNameMatch(name))
         {
-            IUUpdateSwitch(&LinkOut23SP, states, names, n);
-            int target_mode = IUFindOnSwitchIndex(&LinkOut23SP);
-            LinkOut23SP.s   = IPS_BUSY;
-            IDSetSwitch(&LinkOut23SP, nullptr);
+            LinkOut23SP.update(states, names, n);
+            int target_mode = LinkOut23SP.findOnSwitchIndex();
+            LinkOut23SP.setState(IPS_BUSY);
+            LinkOut23SP.apply();
             setLinkMode(target_mode == 1);
             readSettings();
             return true;
         }
-        if (strcmp(ResetSP.name, name) == 0)
+        if (ResetSP.isNameMatch(name))
         {
-            IUResetSwitch(&ResetSP);
+            ResetSP.reset();
 
             if (reset())
             {
-                ResetSP.s = IPS_OK;
+                ResetSP.setState(IPS_OK);
                 readSettings();
             }
             else
-                ResetSP.s = IPS_ALERT;
+                ResetSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&ResetSP, nullptr);
+            ResetSP.apply();
             return true;
         }
     }
@@ -425,56 +425,56 @@ bool USBDewpoint::ISNewNumber(const char *dev, const char *name, double values[]
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, OutputsNP.name) == 0)
+        if (OutputsNP.isNameMatch(name))
         {
             // Warn if we are in auto mode
-            int target_mode = IUFindOnSwitchIndex(&AutoModeSP);
+            int target_mode = AutoModeSP.findOnSwitchIndex();
             if (target_mode == 1)
             {
                 LOG_WARN("Setting output power is ignored in auto mode!");
                 return true;
             }
-            IUUpdateNumber(&OutputsNP, values, names, n);
-            OutputsNP.s = IPS_BUSY;
-            IDSetNumber(&OutputsNP, nullptr);
-            setOutput(1, OutputsN[0].value);
-            setOutput(2, OutputsN[1].value);
-            setOutput(3, OutputsN[2].value);
+            OutputsNP.update(values, names, n);
+            OutputsNP.setState(IPS_BUSY);
+            OutputsNP.apply();
+            setOutput(1, OutputsNP[0].getValue());
+            setOutput(2, OutputsNP[1].getValue());
+            setOutput(3, OutputsNP[2].getValue());
             readSettings();
             return true;
         }
-        if (strcmp(name, CalibrationsNP.name) == 0)
+        if (CalibrationsNP.isNameMatch(name))
         {
-            IUUpdateNumber(&CalibrationsNP, values, names, n);
-            CalibrationsNP.s = IPS_BUSY;
-            IDSetNumber(&CalibrationsNP, nullptr);
-            setCalibrations(CalibrationsN[0].value, CalibrationsN[1].value, CalibrationsN[2].value);
+            CalibrationsNP.update(values, names, n);
+            CalibrationsNP.setState(IPS_BUSY);
+            CalibrationsNP.apply();
+            setCalibrations(CalibrationsNP[0].value, CalibrationsNP[1].getValue(), CalibrationsNP[2].getValue());
             readSettings();
             return true;
         }
-        if (strcmp(name, ThresholdsNP.name) == 0)
+        if (ThresholdsNP.isNameMatch(name))
         {
-            IUUpdateNumber(&ThresholdsNP, values, names, n);
-            ThresholdsNP.s = IPS_BUSY;
-            IDSetNumber(&ThresholdsNP, nullptr);
-            setThresholds(ThresholdsN[0].value, ThresholdsN[1].value);
+            ThresholdsNP.update(values, names, n);
+            ThresholdsNP.setState(IPS_BUSY);
+            ThresholdsNP.apply();
+            setThresholds(ThresholdsNP[0].value, ThresholdsNP[1].getValue());
             readSettings();
             return true;
         }
-        if (strcmp(name, AggressivityNP.name) == 0)
+        if (AggressivityNP.isNameMatch(name))
         {
-            IUUpdateNumber(&AggressivityNP, values, names, n);
-            AggressivityNP.s = IPS_BUSY;
-            IDSetNumber(&AggressivityNP, nullptr);
-            setAggressivity(AggressivityN[0].value);
+            AggressivityNP.update(values, names, n);
+            AggressivityNP.setState(IPS_BUSY);
+            AggressivityNP.apply();
+            setAggressivity(AggressivityNP[0].value);
             readSettings();
             return true;
         }
-        if (strcmp(name, FWversionNP.name) == 0)
+        if (FWversionNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FWversionNP, values, names, n);
-            FWversionNP.s = IPS_OK;
-            IDSetNumber(&FWversionNP, nullptr);
+            FWversionNP.update(values, names, n);
+            FWversionNP.setState(IPS_OK);
+            FWversionNP.apply();
             return true;
         }
     }
@@ -504,50 +504,50 @@ bool USBDewpoint::readSettings()
 
     if (ok == 16)
     {
-        TemperaturesN[0].value = temp1;
-        TemperaturesN[1].value = temp2;
-        TemperaturesN[2].value = temp_ambient;
-        TemperaturesNP.s       = IPS_OK;
-        IDSetNumber(&TemperaturesNP, nullptr);
+        TemperaturesNP[0].setValue(temp1);
+        TemperaturesNP[1].setValue(temp2);
+        TemperaturesNP[2].setValue(temp_ambient);
+        TemperaturesNP.setState(IPS_OK);
+        TemperaturesNP.apply();
 
-        HumidityN[0].value = humidity;
-        HumidityNP.s       = IPS_OK;
-        IDSetNumber(&HumidityNP, nullptr);
+        HumidityNP[0].setValue(humidity);
+        HumidityNP.setState(IPS_OK);
+        HumidityNP.apply();
 
-        DewpointN[0].value = dewpoint;
-        DewpointNP.s       = IPS_OK;
-        IDSetNumber(&DewpointNP, nullptr);
+        DewpointNP[0].setValue(dewpoint);
+        DewpointNP.setState(IPS_OK);
+        DewpointNP.apply();
 
-        OutputsN[0].value = output1;
-        OutputsN[1].value = output2;
-        OutputsN[2].value = output3;
-        OutputsNP.s       = IPS_OK;
-        IDSetNumber(&OutputsNP, nullptr);
+        OutputsNP[0].setValue(output1);
+        OutputsNP[1].setValue(output2);
+        OutputsNP[2].setValue(output3);
+        OutputsNP.setState(IPS_OK);
+        OutputsNP.apply();
 
-        CalibrationsN[0].value = calibration1;
-        CalibrationsN[1].value = calibration2;
-        CalibrationsN[2].value = calibration_ambient;
-        CalibrationsNP.s       = IPS_OK;
-        IDSetNumber(&CalibrationsNP, nullptr);
+        CalibrationsNP[0].setValue(calibration1);
+        CalibrationsNP[1].setValue(calibration2);
+        CalibrationsNP[2].setValue(calibration_ambient);
+        CalibrationsNP.setState(IPS_OK);
+        CalibrationsNP.apply();
 
-        ThresholdsN[0].value = threshold1;
-        ThresholdsN[1].value = threshold2;
-        ThresholdsNP.s       = IPS_OK;
-        IDSetNumber(&ThresholdsNP, nullptr);
+        ThresholdsNP[0].setValue(threshold1);
+        ThresholdsNP[1].setValue(threshold2);
+        ThresholdsNP.setState(IPS_OK);
+        ThresholdsNP.apply();
 
-        IUResetSwitch(&AutoModeSP);
-        AutoModeS[automode].s = ISS_ON;
-        AutoModeSP.s          = IPS_OK;
-        IDSetSwitch(&AutoModeSP, nullptr);
+        AutoModeSP.reset();
+        AutoModeSP[automode].setState(ISS_ON);
+        AutoModeSP.setState(IPS_OK);
+        AutoModeSP.apply();
 
-        IUResetSwitch(&LinkOut23SP);
-        LinkOut23S[linkout23].s = ISS_ON;
-        LinkOut23SP.s           = IPS_OK;
-        IDSetSwitch(&LinkOut23SP, nullptr);
+        LinkOut23SP.reset();
+        LinkOut23SP[linkout23].setState(ISS_ON);
+        LinkOut23SP.setState(IPS_OK);
+        LinkOut23SP.apply();
 
-        AggressivityN[0].value = aggressivity;
-        AggressivityNP.s       = IPS_OK;
-        IDSetNumber(&AggressivityNP, nullptr);
+        AggressivityNP[0].setValue(aggressivity);
+        AggressivityNP.setState(IPS_OK);
+        AggressivityNP.apply();
     }
     return true;
 }

--- a/drivers/auxiliary/usb_dewpoint.h
+++ b/drivers/auxiliary/usb_dewpoint.h
@@ -22,6 +22,10 @@
 
 #include <defaultdevice.h>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /***************************** USB_Dewpoint Commands **************************/
 
 // All commands are exactly 6 bytes, no start/end markers
@@ -110,36 +114,25 @@ class USBDewpoint : public INDI::DefaultDevice
     Connection::Serial *serialConnection{ nullptr };
     int PortFD{ -1 };
 
-    INumber OutputsN[3];
-    INumberVectorProperty OutputsNP;
+    INDI::PropertyNumber OutputsNP {3};
 
-    INumber TemperaturesN[3];
-    INumberVectorProperty TemperaturesNP;
+    INDI::PropertyNumber TemperaturesNP {3};
 
-    INumber CalibrationsN[3];
-    INumberVectorProperty CalibrationsNP;
+    INDI::PropertyNumber CalibrationsNP {3};
 
-    INumber ThresholdsN[2];
-    INumberVectorProperty ThresholdsNP;
+    INDI::PropertyNumber ThresholdsNP {2};
 
-    INumber HumidityN[1];
-    INumberVectorProperty HumidityNP;
+    INDI::PropertyNumber HumidityNP {1};
 
-    INumber DewpointN[1];
-    INumberVectorProperty DewpointNP;
+    INDI::PropertyNumber DewpointNP {1};
 
-    INumber AggressivityN[1];
-    INumberVectorProperty AggressivityNP;
+    INDI::PropertyNumber AggressivityNP {1};
 
-    ISwitch AutoModeS[2];
-    ISwitchVectorProperty AutoModeSP;
+    INDI::PropertySwitch AutoModeSP {2};
 
-    ISwitch LinkOut23S[2];
-    ISwitchVectorProperty LinkOut23SP;
+    INDI::PropertySwitch LinkOut23SP {2};
 
-    ISwitch ResetS[1];
-    ISwitchVectorProperty ResetSP;
+    INDI::PropertySwitch ResetSP {1};
 
-    INumber FWversionN[1];
-    INumberVectorProperty FWversionNP;
+    INDI::PropertyNumber FWversionNP {1};
 };

--- a/drivers/auxiliary/watchdog.cpp
+++ b/drivers/auxiliary/watchdog.cpp
@@ -108,28 +108,28 @@ const char *WatchDog::getDefaultName()
 ////////////////////////////////////////////////////////////////////////////////////
 bool WatchDog::Connect()
 {
-    if (ShutdownTriggerS[TRIGGER_CLIENT].s == ISS_ON && HeartBeatN[0].value > 0)
+    if (ShutdownTriggerSP[TRIGGER_CLIENT].getState() == ISS_ON && HeartBeatNP[0].getValue() > 0)
     {
         LOGF_INFO("Client Watchdog is enabled. Shutdown is triggered after %.f seconds of communication loss with the client.",
-                  HeartBeatN[0].value);
+                  HeartBeatNP[0].getValue());
         if (m_WatchDogTimer > 0)
             RemoveTimer(m_WatchDogTimer);
-        m_WatchDogTimer = SetTimer(HeartBeatN[0].value * 1000);
+        m_WatchDogTimer = SetTimer(HeartBeatNP[0].value * 1000);
     }
 
-    if (ShutdownTriggerS[TRIGGER_WEATHER].s == ISS_ON)
+    if (ShutdownTriggerSP[TRIGGER_WEATHER].getState() == ISS_ON)
     {
-        if (WeatherThresholdN[0].value > 0)
+        if (WeatherThresholdNP[0].value > 0)
             LOGF_INFO("Weather Watchdog is enabled. Shutdown is triggered %.f seconds after Weather status enters DANGER zone.",
-                      WeatherThresholdN[0].value);
+                      WeatherThresholdNP[0].getValue());
         else
             LOG_INFO("Weather Watchdog is enabled. Shutdown is triggered when Weather status in DANGER zone.");
         // Trigger Snoop
-        IDSnoopDevice(ActiveDeviceT[ACTIVE_WEATHER].text, "WEATHER_STATUS");
+        IDSnoopDevice(ActiveDeviceTP[ACTIVE_WEATHER].getText(), "WEATHER_STATUS");
     }
 
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "TELESCOPE_PARK");
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_DOME].text, "DOME_PARK");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "TELESCOPE_PARK");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_DOME].getText(), "DOME_PARK");
 
     return true;
 }
@@ -164,46 +164,46 @@ bool WatchDog::initProperties()
     INDI::DefaultDevice::initProperties();
 
     // Heart Beat to client
-    IUFillNumber(&HeartBeatN[0], "WATCHDOG_HEARTBEAT_VALUE", "Threshold (s)", "%.f", 0, 3600, 60, 0);
-    IUFillNumberVector(&HeartBeatNP, HeartBeatN, 1, getDeviceName(), "WATCHDOG_HEARTBEAT", "Heart beat",
+    HeartBeatNP[0].fill("WATCHDOG_HEARTBEAT_VALUE", "Threshold (s)", "%.f", 0, 3600, 60, 0);
+    HeartBeatNP.fill(getDeviceName(), "WATCHDOG_HEARTBEAT", "Heart beat",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     // Weather Threshold
-    IUFillNumber(&WeatherThresholdN[0], "WATCHDOG_WEATHER_VALUE", "Threshold (s)", "%.f", 0, 3600, 60, 0);
-    IUFillNumberVector(&WeatherThresholdNP, WeatherThresholdN, 1, getDeviceName(), "WATCHDOG_WEATHER", "Weather",
+    WeatherThresholdNP[0].fill("WATCHDOG_WEATHER_VALUE", "Threshold (s)", "%.f", 0, 3600, 60, 0);
+    WeatherThresholdNP.fill(getDeviceName(), "WATCHDOG_WEATHER", "Weather",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     // INDI Server Settings
-    IUFillText(&SettingsT[INDISERVER_HOST], "INDISERVER_HOST", "indiserver host", "localhost");
-    IUFillText(&SettingsT[INDISERVER_PORT], "INDISERVER_PORT", "indiserver port", "7624");
-    IUFillText(&SettingsT[SHUTDOWN_SCRIPT], "SHUTDOWN_SCRIPT", "shutdown script", nullptr);
-    IUFillTextVector(&SettingsTP, SettingsT, 3, getDeviceName(), "WATCHDOG_SETTINGS", "Settings", MAIN_CONTROL_TAB,
+    SettingsTP[INDISERVER_HOST].fill("INDISERVER_HOST", "indiserver host", "localhost");
+    SettingsTP[INDISERVER_PORT].fill("INDISERVER_PORT", "indiserver port", "7624");
+    SettingsTP[SHUTDOWN_SCRIPT].fill("SHUTDOWN_SCRIPT", "shutdown script", nullptr);
+    SettingsTP.fill(getDeviceName(), "WATCHDOG_SETTINGS", "Settings", MAIN_CONTROL_TAB,
                      IP_RW, 60, IPS_IDLE);
 
     // Shutdown procedure
-    IUFillSwitch(&ShutdownProcedureS[PARK_MOUNT], "PARK_MOUNT", "Park Mount", ISS_OFF);
-    IUFillSwitch(&ShutdownProcedureS[PARK_DOME], "PARK_DOME", "Park Dome", ISS_OFF);
-    IUFillSwitch(&ShutdownProcedureS[EXECUTE_SCRIPT], "EXECUTE_SCRIPT", "Execute Script", ISS_OFF);
-    IUFillSwitchVector(&ShutdownProcedureSP, ShutdownProcedureS, 3, getDeviceName(), "WATCHDOG_SHUTDOWN", "Shutdown",
+    ShutdownProcedureSP[PARK_MOUNT].fill("PARK_MOUNT", "Park Mount", ISS_OFF);
+    ShutdownProcedureSP[PARK_DOME].fill("PARK_DOME", "Park Dome", ISS_OFF);
+    ShutdownProcedureSP[EXECUTE_SCRIPT].fill("EXECUTE_SCRIPT", "Execute Script", ISS_OFF);
+    ShutdownProcedureSP.fill(getDeviceName(), "WATCHDOG_SHUTDOWN", "Shutdown",
                        MAIN_CONTROL_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
     // Shutdown Trigger
-    IUFillSwitch(&ShutdownTriggerS[TRIGGER_CLIENT], "TRIGGER_CLIENT", "Client", ISS_OFF);
-    IUFillSwitch(&ShutdownTriggerS[TRIGGER_WEATHER], "TRIGGER_WEATHER", "Weather", ISS_OFF);
-    IUFillSwitchVector(&ShutdownTriggerSP, ShutdownTriggerS, 2, getDeviceName(), "WATCHDOG_Trigger", "Trigger",
+    ShutdownTriggerSP[TRIGGER_CLIENT].fill("TRIGGER_CLIENT", "Client", ISS_OFF);
+    ShutdownTriggerSP[TRIGGER_WEATHER].fill("TRIGGER_WEATHER", "Weather", ISS_OFF);
+    ShutdownTriggerSP.fill(getDeviceName(), "WATCHDOG_Trigger", "Trigger",
                        MAIN_CONTROL_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
     // Mount Policy
-    IUFillSwitch(&MountPolicyS[MOUNT_IGNORED], "MOUNT_IGNORED", "Mount ignored", ISS_ON);
-    IUFillSwitch(&MountPolicyS[MOUNT_LOCKS], "MOUNT_LOCKS", "Mount locks", ISS_OFF);
-    IUFillSwitchVector(&MountPolicySP, MountPolicyS, 2, getDeviceName(), "WATCHDOG_MOUNT_POLICY", "Mount Policy",
+    MountPolicySP[MOUNT_IGNORED].fill("MOUNT_IGNORED", "Mount ignored", ISS_ON);
+    MountPolicySP[MOUNT_LOCKS].fill("MOUNT_LOCKS", "Mount locks", ISS_OFF);
+    MountPolicySP.fill(getDeviceName(), "WATCHDOG_MOUNT_POLICY", "Mount Policy",
                        OPTIONS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Active Devices
-    IUFillText(&ActiveDeviceT[ACTIVE_TELESCOPE], "ACTIVE_TELESCOPE", "Telescope", "Telescope Simulator");
-    IUFillText(&ActiveDeviceT[ACTIVE_DOME], "ACTIVE_DOME", "Dome", "Dome Simulator");
-    IUFillText(&ActiveDeviceT[ACTIVE_WEATHER], "ACTIVE_WEATHER", "Weather", "Weather Simulator");
-    IUFillTextVector(&ActiveDeviceTP, ActiveDeviceT, 3, getDeviceName(), "ACTIVE_DEVICES", "Active devices",
+    ActiveDeviceTP[ACTIVE_TELESCOPE].fill("ACTIVE_TELESCOPE", "Telescope", "Telescope Simulator");
+    ActiveDeviceTP[ACTIVE_DOME].fill("ACTIVE_DOME", "Dome", "Dome Simulator");
+    ActiveDeviceTP[ACTIVE_WEATHER].fill("ACTIVE_WEATHER", "Weather", "Weather Simulator");
+    ActiveDeviceTP.fill(getDeviceName(), "ACTIVE_DEVICES", "Active devices",
                      OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
 
     addDebugControl();
@@ -218,13 +218,13 @@ void WatchDog::ISGetProperties(const char *dev)
 {
     DefaultDevice::ISGetProperties(dev);
 
-    defineProperty(&HeartBeatNP);
-    defineProperty(&WeatherThresholdNP);
-    defineProperty(&SettingsTP);
-    defineProperty(&ShutdownTriggerSP);
-    defineProperty(&ShutdownProcedureSP);
-    defineProperty(&MountPolicySP);
-    defineProperty(&ActiveDeviceTP);
+    defineProperty(HeartBeatNP);
+    defineProperty(WeatherThresholdNP);
+    defineProperty(SettingsTP);
+    defineProperty(ShutdownTriggerSP);
+    defineProperty(ShutdownProcedureSP);
+    defineProperty(MountPolicySP);
+    defineProperty(ActiveDeviceTP);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////
@@ -235,44 +235,44 @@ bool WatchDog::ISNewText(const char *dev, const char *name, char *texts[], char 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Update Settings
-        if (!strcmp(SettingsTP.name, name))
+        if (SettingsTP.isNameMatch(name))
         {
-            IUUpdateText(&SettingsTP, texts, names, n);
-            SettingsTP.s = IPS_OK;
-            IDSetText(&SettingsTP, nullptr);
+            SettingsTP.update(texts, names, n);
+            SettingsTP.setState(IPS_OK);
+            SettingsTP.apply();
 
             try
             {
-                m_INDIServerPort = std::stoi(SettingsT[INDISERVER_PORT].text);
+                m_INDIServerPort = std::stoi(SettingsTP[INDISERVER_PORT].getText());
             }
             catch(...)
             {
-                SettingsTP.s = IPS_ALERT;
+                SettingsTP.setState(IPS_ALERT);
                 LOG_ERROR("Failed to parse numbers.");
             }
 
-            IDSetText(&SettingsTP, nullptr);
+            SettingsTP.apply();
             return true;
         }
 
         // Snoop Active Devices.
-        if (!strcmp(ActiveDeviceTP.name, name))
+        if (ActiveDeviceTP.isNameMatch(name))
         {
             if (watchdogClient->isBusy())
             {
-                ActiveDeviceTP.s = IPS_ALERT;
-                IDSetText(&ActiveDeviceTP, nullptr);
+                ActiveDeviceTP.setState(IPS_ALERT);
+                ActiveDeviceTP.apply();
                 LOG_ERROR("Cannot change devices names while shutdown is in progress...");
                 return true;
             }
 
-            IDSnoopDevice(ActiveDeviceT[ACTIVE_WEATHER].text, "WEATHER_STATUS");
-            IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "TELESCOPE_PARK");
-            IDSnoopDevice(ActiveDeviceT[ACTIVE_DOME].text, "DOME_PARK");
+            IDSnoopDevice(ActiveDeviceTP[ACTIVE_WEATHER].getText(), "WEATHER_STATUS");
+            IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "TELESCOPE_PARK");
+            IDSnoopDevice(ActiveDeviceTP[ACTIVE_DOME].getText(), "DOME_PARK");
 
-            IUUpdateText(&ActiveDeviceTP, texts, names, n);
-            ActiveDeviceTP.s = IPS_OK;
-            IDSetText(&ActiveDeviceTP, nullptr);
+            ActiveDeviceTP.update(texts, names, n);
+            ActiveDeviceTP.setState(IPS_OK);
+            ActiveDeviceTP.apply();
             return true;
         }
     }
@@ -288,51 +288,51 @@ bool WatchDog::ISNewNumber(const char *dev, const char *name, double values[], c
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Weather threshold
-        if (!strcmp(WeatherThresholdNP.name, name))
+        if (WeatherThresholdNP.isNameMatch(name))
         {
-            IUUpdateNumber(&WeatherThresholdNP, values, names, n);
-            WeatherThresholdNP.s = IPS_OK;
-            IDSetNumber(&WeatherThresholdNP, nullptr);
+            WeatherThresholdNP.update(values, names, n);
+            WeatherThresholdNP.setState(IPS_OK);
+            WeatherThresholdNP.apply();
             return true;
         }
         // Heart Beat
         // Client must set this property to indicate it is alive.
         // If heat beat not received from client then shutdown procedure begins if
         // the client trigger is selected.
-        else if (!strcmp(HeartBeatNP.name, name))
+        else if (HeartBeatNP.isNameMatch(name))
         {
-            double prevHeartBeat = HeartBeatN[0].value;
+            double prevHeartBeat = HeartBeatNP[0].getValue();
 
             if (watchdogClient->isBusy())
             {
-                HeartBeatNP.s = IPS_ALERT;
-                IDSetNumber(&HeartBeatNP, nullptr);
+                HeartBeatNP.setState(IPS_ALERT);
+                HeartBeatNP.apply();
                 LOG_ERROR("Cannot change heart beat while shutdown is in progress...");
                 return true;
             }
 
-            IUUpdateNumber(&HeartBeatNP, values, names, n);
-            HeartBeatNP.s = IPS_OK;
+            HeartBeatNP.update(values, names, n);
+            HeartBeatNP.setState(IPS_OK);
 
             // If trigger is not set, don't do anything else
-            if (ShutdownTriggerS[TRIGGER_CLIENT].s == ISS_OFF)
+            if (ShutdownTriggerSP[TRIGGER_CLIENT].getState() == ISS_OFF)
             {
                 if (m_WatchDogTimer > 0)
                 {
                     RemoveTimer(m_WatchDogTimer);
                     m_WatchDogTimer = -1;
                 }
-                IDSetNumber(&HeartBeatNP, nullptr);
+                HeartBeatNP.apply();
                 return true;
             }
 
-            if (HeartBeatN[0].value == 0)
+            if (HeartBeatNP[0].value == 0)
                 LOG_INFO("Client Watchdog is disabled.");
             else
             {
-                if (prevHeartBeat != HeartBeatN[0].value)
+                if (prevHeartBeat != HeartBeatNP[0].getValue())
                     LOGF_INFO("Client Watchdog is enabled. Shutdown is triggered after %.f seconds of communication loss with the client.",
-                              HeartBeatN[0].value);
+                              HeartBeatNP[0].getValue());
 
                 LOG_DEBUG("Received heart beat from client.");
 
@@ -342,9 +342,9 @@ bool WatchDog::ISNewNumber(const char *dev, const char *name, double values[], c
                     m_WatchDogTimer = -1;
                 }
 
-                m_WatchDogTimer = SetTimer(HeartBeatN[0].value * 1000);
+                m_WatchDogTimer = SetTimer(HeartBeatNP[0].value * 1000);
             }
-            IDSetNumber(&HeartBeatNP, nullptr);
+            HeartBeatNP.apply();
 
             return true;
         }
@@ -361,45 +361,45 @@ bool WatchDog::ISNewSwitch(const char *dev, const char *name, ISState *states, c
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Shutdown procedure setting
-        if (!strcmp(ShutdownProcedureSP.name, name))
+        if (ShutdownProcedureSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ShutdownProcedureSP, states, names, n);
+            ShutdownProcedureSP.update(states, names, n);
 
-            if (ShutdownProcedureS[EXECUTE_SCRIPT].s == ISS_ON &&
-                    (SettingsT[EXECUTE_SCRIPT].text == nullptr || SettingsT[EXECUTE_SCRIPT].text[0] == '\0'))
+            if (ShutdownProcedureSP[EXECUTE_SCRIPT].getState() == ISS_ON &&
+                    (SettingsTP[EXECUTE_SCRIPT].text == nullptr || SettingsTP[EXECUTE_SCRIPT].text[0] == '\0'))
             {
                 LOG_ERROR("Error: shutdown script file is not set.");
-                ShutdownProcedureSP.s                = IPS_ALERT;
-                ShutdownProcedureS[EXECUTE_SCRIPT].s = ISS_OFF;
+                ShutdownProcedureSP.setState(IPS_ALERT);
+                ShutdownProcedureSP[EXECUTE_SCRIPT].setState(ISS_OFF);
             }
             else
-                ShutdownProcedureSP.s = IPS_OK;
-            IDSetSwitch(&ShutdownProcedureSP, nullptr);
+                ShutdownProcedureSP.setState(IPS_OK);
+            ShutdownProcedureSP.apply();
             return true;
         }
         // Mount Lock Policy
-        else if (!strcmp(MountPolicySP.name, name))
+        else if (MountPolicySP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MountPolicySP, states, names, n);
-            MountPolicySP.s = IPS_OK;
+            MountPolicySP.update(states, names, n);
+            MountPolicySP.setState(IPS_OK);
 
-            if (MountPolicyS[MOUNT_IGNORED].s == ISS_ON)
+            if (MountPolicySP[MOUNT_IGNORED].getState() == ISS_ON)
                 LOG_INFO("Mount is ignored. Dome can start parking without waiting for mount to complete parking.");
             else
                 LOG_INFO("Mount locks. Dome must wait for mount to park before it can start the parking procedure.");
-            IDSetSwitch(&MountPolicySP, nullptr);
+            MountPolicySP.apply();
             return true;
         }
         // Shutdown Trigger handling
-        else if (!strcmp(ShutdownTriggerSP.name, name))
+        else if (ShutdownTriggerSP.isNameMatch(name))
         {
-            std::vector<ISState> oldStates(ShutdownTriggerSP.nsp, ISS_OFF);
-            std::vector<ISState> newStates(ShutdownTriggerSP.nsp, ISS_OFF);
-            for (int i = 0; i < ShutdownTriggerSP.nsp; i++)
-                oldStates[i] = ShutdownTriggerS[i].s;
-            IUUpdateSwitch(&ShutdownTriggerSP, states, names, n);
-            for (int i = 0; i < ShutdownTriggerSP.nsp; i++)
-                newStates[i] = ShutdownTriggerS[i].s;
+            std::vector<ISState> oldStates(ShutdownTriggerSP.size(), ISS_OFF);
+            std::vector<ISState> newStates(ShutdownTriggerSP.size(), ISS_OFF);
+            for (size_t i = 0; i < ShutdownTriggerSP.size(); i++)
+                oldStates[i] = ShutdownTriggerSP[i].getState();
+            ShutdownTriggerSP.update(states, names, n);
+            for (size_t i = 0; i < ShutdownTriggerSP.size(); i++)
+                newStates[i] = ShutdownTriggerSP[i].getState();
 
 
             // Check for client changes
@@ -419,21 +419,21 @@ bool WatchDog::ISNewSwitch(const char *dev, const char *name, ISState *states, c
                 else
                 {
                     // Check first that we have a valid heart beat
-                    if (HeartBeatN[0].value == 0)
+                    if (HeartBeatNP[0].value == 0)
                     {
                         LOG_ERROR("Heart beat timeout should be set first.");
-                        ShutdownTriggerSP.s = IPS_ALERT;
-                        for (int i = 0; i < ShutdownTriggerSP.nsp; i++)
-                            ShutdownTriggerS[i].s = oldStates[i];
-                        IDSetSwitch(&ShutdownTriggerSP, nullptr);
+                        ShutdownTriggerSP.setState(IPS_ALERT);
+                        for (size_t i = 0; i < ShutdownTriggerSP.size(); i++)
+                            ShutdownTriggerSP[i].setState(oldStates[i]);
+                        ShutdownTriggerSP.apply();
                         return true;
                     }
 
                     LOGF_INFO("Client Watchdog is enabled. Shutdown is triggered after %.f seconds of communication loss with the client.",
-                              HeartBeatN[0].value);
+                              HeartBeatNP[0].getValue());
                     if (m_WatchDogTimer > 0)
                         RemoveTimer(m_WatchDogTimer);
-                    m_WatchDogTimer = SetTimer(HeartBeatN[0].value * 1000);
+                    m_WatchDogTimer = SetTimer(HeartBeatNP[0].value * 1000);
                 }
             }
 
@@ -457,8 +457,8 @@ bool WatchDog::ISNewSwitch(const char *dev, const char *name, ISState *states, c
 
             }
 
-            ShutdownTriggerSP.s = IPS_OK;
-            IDSetSwitch(&ShutdownTriggerSP, nullptr);
+            ShutdownTriggerSP.setState(IPS_OK);
+            ShutdownTriggerSP.apply();
             return true;
         }
     }
@@ -500,11 +500,11 @@ bool WatchDog::ISSnoopDevice(XMLEle * root)
         if (m_WeatherState != IPS_ALERT && newWeatherState == IPS_ALERT)
         {
             LOG_WARN("Weather is in DANGER zone.");
-            if (ShutdownTriggerS[TRIGGER_WEATHER].s == ISS_ON && m_WeatherAlertTimer == -1)
+            if (ShutdownTriggerSP[TRIGGER_WEATHER].getState() == ISS_ON && m_WeatherAlertTimer == -1)
             {
-                if (WeatherThresholdN[0].value > 0)
-                    LOGF_INFO("Shutdown procedure shall commence in %.f seconds unless weather status improves.", WeatherThresholdN[0].value);
-                m_WeatherAlertTimer = SetTimer(WeatherThresholdN[0].value * 1000);
+                if (WeatherThresholdNP[0].value > 0)
+                    LOGF_INFO("Shutdown procedure shall commence in %.f seconds unless weather status improves.", WeatherThresholdNP[0].getValue());
+                m_WeatherAlertTimer = SetTimer(WeatherThresholdNP[0].value * 1000);
             }
         }
 
@@ -534,9 +534,9 @@ bool WatchDog::ISSnoopDevice(XMLEle * root)
                 // And weather shutdown trigger was active and mount parking was selected
                 // then we force the mount to park again.
                 if (parked == false &&
-                        ShutdownTriggerS[TRIGGER_WEATHER].s == ISS_ON &&
+                        ShutdownTriggerSP[TRIGGER_WEATHER].getState() == ISS_ON &&
                         m_WeatherState == IPS_ALERT &&
-                        ShutdownProcedureS[PARK_MOUNT].s == ISS_ON)
+                        ShutdownProcedureSP[PARK_MOUNT].getState() == ISS_ON)
                 {
                     LOG_WARN("Mount unparked while weather alert is active! Parking mount...");
                     watchdogClient->parkMount();
@@ -569,9 +569,9 @@ bool WatchDog::ISSnoopDevice(XMLEle * root)
                 // And weather shutdown trigger was active and mount parking was selected
                 // then we force the mount to park again.
                 if (parked == false &&
-                        ShutdownTriggerS[TRIGGER_WEATHER].s == ISS_ON &&
+                        ShutdownTriggerSP[TRIGGER_WEATHER].getState() == ISS_ON &&
                         m_WeatherState == IPS_ALERT &&
-                        ShutdownProcedureS[PARK_DOME].s == ISS_ON)
+                        ShutdownProcedureSP[PARK_DOME].getState() == ISS_ON)
                 {
                     LOG_WARN("Dome unparked while weather alert is active! Parking dome...");
                     watchdogClient->parkDome();
@@ -591,13 +591,13 @@ bool WatchDog::saveConfigItems(FILE * fp)
 {
     INDI::DefaultDevice::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &HeartBeatNP);
-    IUSaveConfigNumber(fp, &WeatherThresholdNP);
-    IUSaveConfigText(fp, &SettingsTP);
-    IUSaveConfigText(fp, &ActiveDeviceTP);
-    IUSaveConfigSwitch(fp, &MountPolicySP);
-    IUSaveConfigSwitch(fp, &ShutdownTriggerSP);
-    IUSaveConfigSwitch(fp, &ShutdownProcedureSP);
+    HeartBeatNP.save(fp);
+    WeatherThresholdNP.save(fp);
+    SettingsTP.save(fp);
+    ActiveDeviceTP.save(fp);
+    MountPolicySP.save(fp);
+    ShutdownTriggerSP.save(fp);
+    ShutdownProcedureSP.save(fp);
 
     return true;
 }
@@ -610,8 +610,8 @@ void WatchDog::TimerHit()
     // Timer is up, we need to start shutdown procedure
 
     // If nothing to do, then return
-    if (ShutdownProcedureS[PARK_DOME].s == ISS_OFF && ShutdownProcedureS[PARK_MOUNT].s == ISS_OFF &&
-            ShutdownProcedureS[EXECUTE_SCRIPT].s == ISS_OFF)
+    if (ShutdownProcedureSP[PARK_DOME].getState() == ISS_OFF && ShutdownProcedureSP[PARK_MOUNT].s == ISS_OFF &&
+            ShutdownProcedureSP[EXECUTE_SCRIPT].getState() == ISS_OFF)
         return;
 
     switch (m_ShutdownStage)
@@ -619,8 +619,8 @@ void WatchDog::TimerHit()
         // Connect to server
         case WATCHDOG_IDLE:
 
-            ShutdownProcedureSP.s = IPS_BUSY;
-            IDSetSwitch(&ShutdownProcedureSP, nullptr);
+            ShutdownProcedureSP.setState(IPS_BUSY);
+            ShutdownProcedureSP.apply();
 
             if (m_WeatherState == IPS_ALERT)
                 LOG_WARN("Warning! Weather status in DANGER zone, executing shutdown procedure...");
@@ -628,22 +628,22 @@ void WatchDog::TimerHit()
                 LOG_WARN("Warning! Heartbeat threshold timed out, executing shutdown procedure...");
 
             // No need to start client if only we need to execute the script
-            if (ShutdownProcedureS[PARK_MOUNT].s == ISS_OFF && ShutdownProcedureS[PARK_DOME].s == ISS_OFF &&
-                    ShutdownProcedureS[EXECUTE_SCRIPT].s == ISS_ON)
+            if (ShutdownProcedureSP[PARK_MOUNT].getState() == ISS_OFF && ShutdownProcedureSP[PARK_DOME].s == ISS_OFF &&
+                    ShutdownProcedureSP[EXECUTE_SCRIPT].getState() == ISS_ON)
             {
                 executeScript();
                 break;
             }
 
             // Watch mount if requied
-            if (ShutdownProcedureS[PARK_MOUNT].s == ISS_ON)
-                watchdogClient->setMount(ActiveDeviceT[ACTIVE_TELESCOPE].text);
+            if (ShutdownProcedureSP[PARK_MOUNT].getState() == ISS_ON)
+                watchdogClient->setMount(ActiveDeviceTP[ACTIVE_TELESCOPE].getText());
             // Watch dome
-            if (ShutdownProcedureS[PARK_DOME].s == ISS_ON)
-                watchdogClient->setDome(ActiveDeviceT[ACTIVE_DOME].text);
+            if (ShutdownProcedureSP[PARK_DOME].getState() == ISS_ON)
+                watchdogClient->setDome(ActiveDeviceTP[ACTIVE_DOME].getText());
 
             // Set indiserver host and port
-            watchdogClient->setServer(SettingsT[INDISERVER_HOST].text, m_INDIServerPort);
+            watchdogClient->setServer(SettingsTP[INDISERVER_HOST].getText(), m_INDIServerPort);
 
             LOG_DEBUG("Connecting to INDI server...");
 
@@ -657,14 +657,14 @@ void WatchDog::TimerHit()
             // Check if client is ready
             if (watchdogClient->isConnected())
             {
-                LOGF_DEBUG("Connected to INDI server %s @ %s", SettingsT[0].text,
-                           SettingsT[1].text);
+                LOGF_DEBUG("Connected to INDI server %s @ %s", SettingsTP[0].getText(),
+                           SettingsTP[1].getText());
 
-                if (ShutdownProcedureS[PARK_MOUNT].s == ISS_ON)
+                if (ShutdownProcedureSP[PARK_MOUNT].getState() == ISS_ON)
                     parkMount();
-                else if (ShutdownProcedureS[PARK_DOME].s == ISS_ON)
+                else if (ShutdownProcedureSP[PARK_DOME].getState() == ISS_ON)
                     parkDome();
-                else if (ShutdownProcedureS[EXECUTE_SCRIPT].s == ISS_ON)
+                else if (ShutdownProcedureSP[EXECUTE_SCRIPT].getState() == ISS_ON)
                     executeScript();
             }
             else
@@ -680,9 +680,9 @@ void WatchDog::TimerHit()
             {
                 LOG_INFO("Mount parked.");
 
-                if (ShutdownProcedureS[PARK_DOME].s == ISS_ON)
+                if (ShutdownProcedureSP[PARK_DOME].getState() == ISS_ON)
                     parkDome();
-                else if (ShutdownProcedureS[EXECUTE_SCRIPT].s == ISS_ON)
+                else if (ShutdownProcedureSP[EXECUTE_SCRIPT].getState() == ISS_ON)
                     executeScript();
                 else
                     m_ShutdownStage = WATCHDOG_COMPLETE;
@@ -699,7 +699,7 @@ void WatchDog::TimerHit()
             {
                 LOG_INFO("Dome parked.");
 
-                if (ShutdownProcedureS[EXECUTE_SCRIPT].s == ISS_ON)
+                if (ShutdownProcedureSP[EXECUTE_SCRIPT].getState() == ISS_ON)
                     executeScript();
                 else
                     m_ShutdownStage = WATCHDOG_COMPLETE;
@@ -709,8 +709,8 @@ void WatchDog::TimerHit()
 
         case WATCHDOG_COMPLETE:
             LOG_INFO("Shutdown procedure complete.");
-            ShutdownProcedureSP.s = IPS_OK;
-            IDSetSwitch(&ShutdownProcedureSP, nullptr);
+            ShutdownProcedureSP.setState(IPS_OK);
+            ShutdownProcedureSP.apply();
             // If watch dog client still connected, keep it as such
             if (watchdogClient->isConnected())
                 m_ShutdownStage = WATCHDOG_CLIENT_STARTED;
@@ -720,8 +720,8 @@ void WatchDog::TimerHit()
             return;
 
         case WATCHDOG_ERROR:
-            ShutdownProcedureSP.s = IPS_ALERT;
-            IDSetSwitch(&ShutdownProcedureSP, nullptr);
+            ShutdownProcedureSP.setState(IPS_ALERT);
+            ShutdownProcedureSP.apply();
             return;
     }
 
@@ -754,7 +754,7 @@ void WatchDog::parkMount()
 
     // If mount is set to ignored, and we have active dome shutdown then we start
     // parking the dome immediately.
-    if (MountPolicyS[MOUNT_IGNORED].s == ISS_ON && ShutdownProcedureS[PARK_DOME].s == ISS_ON)
+    if (MountPolicySP[MOUNT_IGNORED].getState() == ISS_ON && ShutdownProcedureSP[PARK_DOME].s == ISS_ON)
         parkDome();
     else
         m_ShutdownStage = WATCHDOG_MOUNT_PARKED;
@@ -765,7 +765,7 @@ void WatchDog::executeScript()
     // child
     if (fork() == 0)
     {
-        int rc = execlp(SettingsT[EXECUTE_SCRIPT].text, SettingsT[EXECUTE_SCRIPT].text, nullptr);
+        int rc = execlp(SettingsTP[EXECUTE_SCRIPT].getText(), SettingsTP[EXECUTE_SCRIPT].getText(), nullptr);
 
         if (rc)
             exit(rc);
@@ -774,7 +774,7 @@ void WatchDog::executeScript()
     else
     {
         int statval;
-        LOGF_INFO("Executing script %s...", SettingsT[EXECUTE_SCRIPT].text);
+        LOGF_INFO("Executing script %s...", SettingsTP[EXECUTE_SCRIPT].getText());
         LOGF_INFO("Waiting for script with PID %d to complete...", getpid());
         wait(&statval);
         if (WIFEXITED(statval))
@@ -787,7 +787,7 @@ void WatchDog::executeScript()
             else
             {
                 LOGF_ERROR("Error: script %s failed. Shutdown procedure terminated.",
-                           SettingsT[EXECUTE_SCRIPT].text);
+                           SettingsTP[EXECUTE_SCRIPT].getText());
                 m_ShutdownStage = WATCHDOG_ERROR;
                 return;
             }
@@ -796,7 +796,7 @@ void WatchDog::executeScript()
         {
             LOGF_ERROR(
                 "Error: script %s did not terminate with exit. Shutdown procedure terminated.",
-                SettingsT[EXECUTE_SCRIPT].text);
+                SettingsTP[EXECUTE_SCRIPT].getText());
             m_ShutdownStage = WATCHDOG_ERROR;
             return;
         }

--- a/drivers/auxiliary/watchdog.h
+++ b/drivers/auxiliary/watchdog.h
@@ -29,6 +29,11 @@
 
 #include "defaultdevice.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class WatchDogClient;
 
 class WatchDog : public INDI::DefaultDevice
@@ -72,34 +77,27 @@ class WatchDog : public INDI::DefaultDevice
         void executeScript();
 
         // Heart Beat to check if client is alive
-        INumberVectorProperty HeartBeatNP;
-        INumber HeartBeatN[1];
+        INDI::PropertyNumber HeartBeatNP {1};
 
         // Weather threshold
-        INumberVectorProperty WeatherThresholdNP;
-        INumber WeatherThresholdN[1];
+        INDI::PropertyNumber WeatherThresholdNP {1};
 
         // Settings
-        ITextVectorProperty SettingsTP;
-        IText SettingsT[4] {};
+        INDI::PropertyText SettingsTP {4};
         enum {INDISERVER_HOST, INDISERVER_PORT, SHUTDOWN_SCRIPT};
 
         // Shutdown steps
-        ISwitchVectorProperty ShutdownProcedureSP;
-        ISwitch ShutdownProcedureS[3];
+        INDI::PropertySwitch ShutdownProcedureSP {3};
 
         // Mount Policy
-        ISwitchVectorProperty MountPolicySP;
-        ISwitch MountPolicyS[2];
+        INDI::PropertySwitch MountPolicySP {2};
 
         // Which source should trigger the shutdown?
-        ISwitchVectorProperty ShutdownTriggerSP;
-        ISwitch ShutdownTriggerS[2];
+        INDI::PropertySwitch ShutdownTriggerSP {2};
         enum { TRIGGER_CLIENT, TRIGGER_WEATHER };
 
         // Active Devices to Snoop on
-        ITextVectorProperty ActiveDeviceTP;
-        IText ActiveDeviceT[3] {};
+        INDI::PropertyText ActiveDeviceTP {3};
         enum { ACTIVE_TELESCOPE, ACTIVE_DOME, ACTIVE_WEATHER };
 
         // Pointer to client to issue commands to the respective mount and/or dome drivers.

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -82,32 +82,32 @@ CCDSim::CCDSim() : INDI::FilterInterface(this)
     time(&RunStart);
 
     // Filter stuff
-    FilterSlotN[0].min = 1;
-    FilterSlotN[0].max = 8;
+    FilterSlotNP[0].setMin(1);
+    FilterSlotNP[0].setMax(8);
 }
 
 bool CCDSim::setupParameters()
 {
-    SetCCDParams(SimulatorSettingsN[SIM_XRES].value,
-                 SimulatorSettingsN[SIM_YRES].value,
+    SetCCDParams(SimulatorSettingsNP[SIM_XRES].value,
+                 SimulatorSettingsNP[SIM_YRES].getValue(),
                  16,
-                 SimulatorSettingsN[SIM_XSIZE].value,
-                 SimulatorSettingsN[SIM_YSIZE].value);
+                 SimulatorSettingsNP[SIM_XSIZE].getValue(),
+                 SimulatorSettingsNP[SIM_YSIZE].getValue());
 
-    m_MaxNoise      = SimulatorSettingsN[SIM_NOISE].value;
-    m_SkyGlow       = SimulatorSettingsN[SIM_SKYGLOW].value;
-    m_MaxVal        = SimulatorSettingsN[SIM_MAXVAL].value;
+    m_MaxNoise      = SimulatorSettingsNP[SIM_NOISE].getValue();
+    m_SkyGlow       = SimulatorSettingsNP[SIM_SKYGLOW].getValue();
+    m_MaxVal        = SimulatorSettingsNP[SIM_MAXVAL].getValue();
     m_Bias          = OffsetN[0].value;
-    m_LimitingMag   = SimulatorSettingsN[SIM_LIMITINGMAG].value;
-    m_SaturationMag = SimulatorSettingsN[SIM_SATURATION].value;
+    m_LimitingMag   = SimulatorSettingsNP[SIM_LIMITINGMAG].getValue();
+    m_SaturationMag = SimulatorSettingsNP[SIM_SATURATION].getValue();
     //  An oag is offset this much from center of scope position (arcminutes);
-    m_OAGOffset = SimulatorSettingsN[SIM_OAGOFFSET].value;
-    m_PolarError = SimulatorSettingsN[SIM_POLAR].value;
-    m_PolarDrift = SimulatorSettingsN[SIM_POLARDRIFT].value;
-    m_PEPeriod = SimulatorSettingsN[SIM_PE_PERIOD].value;
-    m_PEMax = SimulatorSettingsN[SIM_PE_MAX].value;
-    m_TimeFactor = SimulatorSettingsN[SIM_TIME_FACTOR].value;
-    RotatorAngle = SimulatorSettingsN[SIM_ROTATION].value;
+    m_OAGOffset = SimulatorSettingsNP[SIM_OAGOFFSET].getValue();
+    m_PolarError = SimulatorSettingsNP[SIM_POLAR].getValue();
+    m_PolarDrift = SimulatorSettingsNP[SIM_POLARDRIFT].getValue();
+    m_PEPeriod = SimulatorSettingsNP[SIM_PE_PERIOD].getValue();
+    m_PEMax = SimulatorSettingsNP[SIM_PE_MAX].getValue();
+    m_TimeFactor = SimulatorSettingsNP[SIM_TIME_FACTOR].getValue();
+    RotatorAngle = SimulatorSettingsNP[SIM_ROTATION].getValue();
 
     uint32_t nbuf = PrimaryCCD.getXRes() * PrimaryCCD.getYRes() * PrimaryCCD.getBPP() / 8;
     PrimaryCCD.setFrameBufferSize(nbuf);
@@ -147,63 +147,63 @@ bool CCDSim::initProperties()
 {
     INDI::CCD::initProperties();
 
-    IUFillNumber(&SimulatorSettingsN[SIM_XRES], "SIM_XRES", "CCD X resolution", "%4.0f", 512, 8192, 512, 1280);
-    IUFillNumber(&SimulatorSettingsN[SIM_YRES], "SIM_YRES", "CCD Y resolution", "%4.0f", 512, 8192, 512, 1024);
-    IUFillNumber(&SimulatorSettingsN[SIM_XSIZE], "SIM_XSIZE", "CCD X Pixel Size", "%4.2f", 1, 30, 5, 5.2);
-    IUFillNumber(&SimulatorSettingsN[SIM_YSIZE], "SIM_YSIZE", "CCD Y Pixel Size", "%4.2f", 1, 30, 5, 5.2);
-    IUFillNumber(&SimulatorSettingsN[SIM_MAXVAL], "SIM_MAXVAL", "CCD Maximum ADU", "%4.0f", 255, 65000, 1000, 65000);
-    IUFillNumber(&SimulatorSettingsN[SIM_SATURATION], "SIM_SATURATION", "Saturation Mag", "%4.1f", 0, 20, 1, 1.0);
-    IUFillNumber(&SimulatorSettingsN[SIM_LIMITINGMAG], "SIM_LIMITINGMAG", "Limiting Mag", "%4.1f", 0, 20, 1, 17.0);
-    IUFillNumber(&SimulatorSettingsN[SIM_NOISE], "SIM_NOISE", "CCD Noise", "%4.0f", 0, 6000, 500, 10);
-    IUFillNumber(&SimulatorSettingsN[SIM_SKYGLOW], "SIM_SKYGLOW", "Sky Glow (magnitudes)", "%4.1f", 0, 6000, 500, 19.5);
-    IUFillNumber(&SimulatorSettingsN[SIM_OAGOFFSET], "SIM_OAGOFFSET", "Oag Offset (arcminutes)", "%4.1f", 0, 6000, 500, 0);
-    IUFillNumber(&SimulatorSettingsN[SIM_POLAR], "SIM_POLAR", "PAE (arcminutes)", "%4.1f", -600, 600, 100, 0);
-    IUFillNumber(&SimulatorSettingsN[SIM_POLARDRIFT], "SIM_POLARDRIFT", "PAE Drift (minutes)", "%4.1f", 0, 60, 5, 0);
-    IUFillNumber(&SimulatorSettingsN[SIM_PE_PERIOD], "SIM_PEPERIOD", "PE Period (minutes)", "%4.1f", 0, 60, 5, 0);
-    IUFillNumber(&SimulatorSettingsN[SIM_PE_MAX], "SIM_PEMAX", "PE Max (arcsec)", "%4.1f", 0, 6000, 500, 0);
-    IUFillNumber(&SimulatorSettingsN[SIM_TIME_FACTOR], "SIM_TIME_FACTOR", "Time Factor (x)", "%.2f", 0.01, 100, 10, 1);
-    IUFillNumber(&SimulatorSettingsN[SIM_ROTATION], "SIM_ROTATION", "CCD Rotation", "%.2f", 0, 360, 10, 0);
+    SimulatorSettingsNP[SIM_XRES].fill("SIM_XRES", "CCD X resolution", "%4.0f", 512, 8192, 512, 1280);
+    SimulatorSettingsNP[SIM_YRES].fill("SIM_YRES", "CCD Y resolution", "%4.0f", 512, 8192, 512, 1024);
+    SimulatorSettingsNP[SIM_XSIZE].fill("SIM_XSIZE", "CCD X Pixel Size", "%4.2f", 1, 30, 5, 5.2);
+    SimulatorSettingsNP[SIM_YSIZE].fill("SIM_YSIZE", "CCD Y Pixel Size", "%4.2f", 1, 30, 5, 5.2);
+    SimulatorSettingsNP[SIM_MAXVAL].fill("SIM_MAXVAL", "CCD Maximum ADU", "%4.0f", 255, 65000, 1000, 65000);
+    SimulatorSettingsNP[SIM_SATURATION].fill("SIM_SATURATION", "Saturation Mag", "%4.1f", 0, 20, 1, 1.0);
+    SimulatorSettingsNP[SIM_LIMITINGMAG].fill("SIM_LIMITINGMAG", "Limiting Mag", "%4.1f", 0, 20, 1, 17.0);
+    SimulatorSettingsNP[SIM_NOISE].fill("SIM_NOISE", "CCD Noise", "%4.0f", 0, 6000, 500, 10);
+    SimulatorSettingsNP[SIM_SKYGLOW].fill("SIM_SKYGLOW", "Sky Glow (magnitudes)", "%4.1f", 0, 6000, 500, 19.5);
+    SimulatorSettingsNP[SIM_OAGOFFSET].fill("SIM_OAGOFFSET", "Oag Offset (arcminutes)", "%4.1f", 0, 6000, 500, 0);
+    SimulatorSettingsNP[SIM_POLAR].fill("SIM_POLAR", "PAE (arcminutes)", "%4.1f", -600, 600, 100, 0);
+    SimulatorSettingsNP[SIM_POLARDRIFT].fill("SIM_POLARDRIFT", "PAE Drift (minutes)", "%4.1f", 0, 60, 5, 0);
+    SimulatorSettingsNP[SIM_PE_PERIOD].fill("SIM_PEPERIOD", "PE Period (minutes)", "%4.1f", 0, 60, 5, 0);
+    SimulatorSettingsNP[SIM_PE_MAX].fill("SIM_PEMAX", "PE Max (arcsec)", "%4.1f", 0, 6000, 500, 0);
+    SimulatorSettingsNP[SIM_TIME_FACTOR].fill("SIM_TIME_FACTOR", "Time Factor (x)", "%.2f", 0.01, 100, 10, 1);
+    SimulatorSettingsNP[SIM_ROTATION].fill("SIM_ROTATION", "CCD Rotation", "%.2f", 0, 360, 10, 0);
 
-    IUFillNumberVector(&SimulatorSettingsNP, SimulatorSettingsN, SIM_N, getDeviceName(), "SIMULATOR_SETTINGS",
+    SimulatorSettingsNP.fill(getDeviceName(), "SIMULATOR_SETTINGS",
                        "Settings", SIMULATOR_TAB, IP_RW, 60, IPS_IDLE);
 
     // RGB Simulation
-    IUFillSwitch(&SimulateBayerS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&SimulateBayerS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&SimulateBayerSP, SimulateBayerS, 2, getDeviceName(), "SIMULATE_BAYER", "Bayer", SIMULATOR_TAB, IP_RW,
+    SimulateBayerSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    SimulateBayerSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    SimulateBayerSP.fill(getDeviceName(), "SIMULATE_BAYER", "Bayer", SIMULATOR_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
     // Simulate focusing
-    IUFillNumber(&FocusSimulationN[0], "SIM_FOCUS_POSITION", "Focus", "%.f", 0.0, 100000.0, 1.0, 36700.0);
-    IUFillNumber(&FocusSimulationN[1], "SIM_FOCUS_MAX", "Max. Position", "%.f", 0.0, 100000.0, 1.0, 100000.0);
-    IUFillNumber(&FocusSimulationN[2], "SIM_SEEING", "Seeing (arcsec)", "%4.2f", 0, 60, 0, 3.5);
-    IUFillNumberVector(&FocusSimulationNP, FocusSimulationN, 3, getDeviceName(), "SIM_FOCUSING", "Focus Simulation",
+    FocusSimulationNP[0].fill("SIM_FOCUS_POSITION", "Focus", "%.f", 0.0, 100000.0, 1.0, 36700.0);
+    FocusSimulationNP[1].fill("SIM_FOCUS_MAX", "Max. Position", "%.f", 0.0, 100000.0, 1.0, 100000.0);
+    FocusSimulationNP[2].fill("SIM_SEEING", "Seeing (arcsec)", "%4.2f", 0, 60, 0, 3.5);
+    FocusSimulationNP.fill(getDeviceName(), "SIM_FOCUSING", "Focus Simulation",
                        SIMULATOR_TAB, IP_RW, 60, IPS_IDLE);
 
     // Simulate Crash
-    IUFillSwitch(&CrashS[0], "CRASH", "Crash driver", ISS_OFF);
-    IUFillSwitchVector(&CrashSP, CrashS, 1, getDeviceName(), "CCD_SIMULATE_CRASH", "Crash", SIMULATOR_TAB, IP_WO,
+    CrashSP[0].fill("CRASH", "Crash driver", ISS_OFF);
+    CrashSP.fill(getDeviceName(), "CCD_SIMULATE_CRASH", "Crash", SIMULATOR_TAB, IP_WO,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
     // Periodic Error
-    IUFillNumber(&EqPEN[AXIS_RA], "RA_PE", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-    IUFillNumber(&EqPEN[AXIS_DE], "DEC_PE", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-    IUFillNumberVector(&EqPENP, EqPEN, 2, getDeviceName(), "EQUATORIAL_PE", "EQ PE", SIMULATOR_TAB, IP_RW, 60,
+    EqPENP[AXIS_RA].fill("RA_PE", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+    EqPENP[AXIS_DE].fill("DEC_PE", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+    EqPENP.fill(getDeviceName(), "EQUATORIAL_PE", "EQ PE", SIMULATOR_TAB, IP_RW, 60,
                        IPS_IDLE);
 
     // FWHM
-    IUFillNumber(&FWHMN[0], "SIM_FWHM", "FWHM (arcseconds)", "%4.2f", 0, 60, 0, 7.5);
-    IUFillNumberVector(&FWHMNP, FWHMN, 1, ActiveDeviceT[ACTIVE_FOCUSER].text, "FWHM", "FWHM", OPTIONS_TAB, IP_RO, 60, IPS_IDLE);
+    FWHMNP[0].fill("SIM_FWHM", "FWHM (arcseconds)", "%4.2f", 0, 60, 0, 7.5);
+    FWHMNP.fill(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FWHM", "FWHM", OPTIONS_TAB, IP_RO, 60, IPS_IDLE);
 
     // Cooler
-    IUFillSwitch(&CoolerS[INDI_ENABLED], "COOLER_ON", "ON", ISS_OFF);
-    IUFillSwitch(&CoolerS[INDI_DISABLED], "COOLER_OFF", "OFF", ISS_ON);
-    IUFillSwitchVector(&CoolerSP, CoolerS, 2, getDeviceName(), "CCD_COOLER", "Cooler", MAIN_CONTROL_TAB, IP_WO,
+    CoolerSP[INDI_ENABLED].fill("COOLER_ON", "ON", ISS_OFF);
+    CoolerSP[INDI_DISABLED].fill("COOLER_OFF", "OFF", ISS_ON);
+    CoolerSP.fill(getDeviceName(), "CCD_COOLER", "Cooler", MAIN_CONTROL_TAB, IP_WO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Gain
-    IUFillNumber(&GainN[0], "GAIN", "value", "%.f", 0, 100, 10, 50);
-    IUFillNumberVector(&GainNP, GainN, 1, getDeviceName(), "CCD_GAIN", "Gain", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    GainNP[0].fill("GAIN", "value", "%.f", 0, 100, 10, 50);
+    GainNP.fill(getDeviceName(), "CCD_GAIN", "Gain", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     // Offset
     IUFillNumber(&OffsetN[0], "OFFSET", "value", "%.f", 0, 6000, 500, 0);
@@ -211,24 +211,24 @@ bool CCDSim::initProperties()
 
     // Directory to read images from. This is useful to test real images captured by camera
     // For each capture, one file is read (sorted by name) and is sent to client.
-    IUFillText(&DirectoryT[0], "LOCATION", "Location", getenv("HOME"));
-    IUFillTextVector(&DirectoryTP, DirectoryT, 1, getDeviceName(), "CCD_DIRECTORY_LOCATION", "Directory", SIMULATOR_TAB, IP_RW,
+    DirectoryTP[0].fill("LOCATION", "Location", getenv("HOME"));
+    DirectoryTP.fill(getDeviceName(), "CCD_DIRECTORY_LOCATION", "Directory", SIMULATOR_TAB, IP_RW,
                      60, IPS_IDLE);
 
     // Toggle Directory Reading. If enabled. The simulator will just read images from the directory and not generate them.
-    IUFillSwitch(&DirectoryS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&DirectoryS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&DirectorySP, DirectoryS, 2, getDeviceName(), "CCD_DIRECTORY_TOGGLE", "Use Dir.", SIMULATOR_TAB, IP_RW,
+    DirectorySP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    DirectorySP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    DirectorySP.fill(getDeviceName(), "CCD_DIRECTORY_TOGGLE", "Use Dir.", SIMULATOR_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
 #ifdef USE_EQUATORIAL_PE
-    IDSnoopDevice(ActiveDeviceT[0].text, "EQUATORIAL_PE");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "EQUATORIAL_PE");
 #else
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
 #endif
 
 
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FWHM");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FWHM");
 
     uint32_t cap = 0;
 
@@ -254,16 +254,16 @@ bool CCDSim::initProperties()
 
     INDI::FilterInterface::initProperties(FILTER_TAB);
 
-    FilterSlotN[0].min = 1;
-    FilterSlotN[0].max = 8;
+    FilterSlotNP[0].setMin(1);
+    FilterSlotNP[0].setMax(8);
 
     addDebugControl();
 
     setDriverInterface(getDriverInterface() | FILTER_INTERFACE);
 
     // Make Guide Scope ON by default
-    TelescopeTypeS[TELESCOPE_PRIMARY].s = ISS_OFF;
-    TelescopeTypeS[TELESCOPE_GUIDE].s = ISS_ON;
+    TelescopeTypeSP[TELESCOPE_PRIMARY].setState(ISS_OFF);
+    TelescopeTypeSP[TELESCOPE_GUIDE].setState(ISS_ON);
 
     return true;
 }
@@ -273,9 +273,9 @@ void CCDSim::setBayerEnabled(bool onOff)
     if (onOff)
     {
         SetCCDCapability(GetCCDCapability() | CCD_HAS_BAYER);
-        IUSaveText(&BayerT[0], "0");
-        IUSaveText(&BayerT[1], "0");
-        IUSaveText(&BayerT[2], "RGGB");
+        BayerTP[0].setText("0");
+        BayerTP[1].setText("0");
+        BayerTP[2].setText("RGGB");
     }
     else
     {
@@ -287,11 +287,11 @@ void CCDSim::ISGetProperties(const char * dev)
 {
     INDI::CCD::ISGetProperties(dev);
 
-    defineProperty(&SimulatorSettingsNP);
-    defineProperty(&EqPENP);
-    defineProperty(&FocusSimulationNP);
-    defineProperty(&SimulateBayerSP);
-    defineProperty(&CrashSP);
+    defineProperty(SimulatorSettingsNP);
+    defineProperty(EqPENP);
+    defineProperty(FocusSimulationNP);
+    defineProperty(SimulateBayerSP);
+    defineProperty(CrashSP);
 }
 
 bool CCDSim::updateProperties()
@@ -301,13 +301,13 @@ bool CCDSim::updateProperties()
     if (isConnected())
     {
         if (HasCooler())
-            defineProperty(&CoolerSP);
+            defineProperty(CoolerSP);
 
-        defineProperty(&GainNP);
+        defineProperty(GainNP);
         defineProperty(&OffsetNP);
 
-        defineProperty(&DirectoryTP);
-        defineProperty(&DirectorySP);
+        defineProperty(DirectoryTP);
+        defineProperty(DirectorySP);
 
         setupParameters();
 
@@ -323,12 +323,12 @@ bool CCDSim::updateProperties()
     else
     {
         if (HasCooler())
-            deleteProperty(CoolerSP.name);
+            deleteProperty(CoolerSP.getName());
 
-        deleteProperty(GainNP.name);
+        deleteProperty(GainNP.getName());
         deleteProperty(OffsetNP.name);
-        deleteProperty(DirectoryTP.name);
-        deleteProperty(DirectorySP.name);
+        deleteProperty(DirectoryTP.getName());
+        deleteProperty(DirectorySP.getName());
 
         INDI::FilterInterface::updateProperties();
     }
@@ -339,16 +339,16 @@ bool CCDSim::updateProperties()
 int CCDSim::SetTemperature(double temperature)
 {
     TemperatureRequest = temperature;
-    if (fabs(temperature - TemperatureN[0].value) < 0.1)
+    if (fabs(temperature - TemperatureNP[0].getValue()) < 0.1)
     {
-        TemperatureN[0].value = temperature;
+        TemperatureNP[0].setValue(temperature);
         return 1;
     }
 
-    CoolerS[0].s = ISS_ON;
-    CoolerS[1].s = ISS_OFF;
-    CoolerSP.s   = IPS_BUSY;
-    IDSetSwitch(&CoolerSP, nullptr);
+    CoolerSP[0].setState(ISS_ON);
+    CoolerSP[1].setState(ISS_OFF);
+    CoolerSP.setState(IPS_BUSY);
+    CoolerSP.apply();
     return 0;
 }
 
@@ -369,7 +369,7 @@ bool CCDSim::StartExposure(float duration)
     PrimaryCCD.setExposureDuration(duration);
     gettimeofday(&ExpStart, nullptr);
     //  Leave the proper time showing for the draw routines
-    if (DirectoryS[INDI_ENABLED].s == ISS_ON)
+    if (DirectorySP[INDI_ENABLED].getState() == ISS_ON)
     {
         if (loadNextImage() == false)
             return false;
@@ -462,7 +462,7 @@ void CCDSim::TimerHit()
                 {
                     InExposure = false;
                     // We don't bin for raw images.
-                    if (DirectoryS[INDI_DISABLED].s == ISS_ON)
+                    if (DirectorySP[INDI_DISABLED].getState() == ISS_ON)
                         PrimaryCCD.binFrame();
                     ExposureComplete(&PrimaryCCD);
                 }
@@ -515,31 +515,31 @@ void CCDSim::TimerHit()
         }
     }
 
-    if (TemperatureNP.s == IPS_BUSY)
+    if (TemperatureNP.getState() == IPS_BUSY)
     {
-        if (fabs(TemperatureRequest - TemperatureN[0].value) <= 0.5)
+        if (fabs(TemperatureRequest - TemperatureNP[0].getValue()) <= 0.5)
         {
             LOGF_INFO("Temperature reached requested value %.2f degrees C", TemperatureRequest);
-            TemperatureN[0].value = TemperatureRequest;
-            TemperatureNP.s       = IPS_OK;
+            TemperatureNP[0].setValue(TemperatureRequest);
+            TemperatureNP.setState(IPS_OK);
         }
         else
         {
-            if (TemperatureRequest < TemperatureN[0].value)
-                TemperatureN[0].value -= 0.5;
+            if (TemperatureRequest < TemperatureNP[0].getValue())
+                TemperatureNP[0].value -= 0.5;
             else
-                TemperatureN[0].value += 0.5;
+                TemperatureNP[0].value += 0.5;
         }
 
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 
         // Above 20, cooler is off
-        if (TemperatureN[0].value >= 20)
+        if (TemperatureNP[0].value >= 20)
         {
-            CoolerS[0].s = ISS_OFF;
-            CoolerS[1].s = ISS_ON;
-            CoolerSP.s   = IPS_IDLE;
-            IDSetSwitch(&CoolerSP, nullptr);
+            CoolerSP[0].setState(ISS_OFF);
+            CoolerSP[1].setState(ISS_ON);
+            CoolerSP.setState(IPS_IDLE);
+            CoolerSP.apply();
         }
     }
 
@@ -571,12 +571,12 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
     else
         exposure_time = ExposureRequest;
 
-    if (GainN[0].value > 50)
-        exposure_time *= sqrt(GainN[0].value - 50);
-    else if (GainN[0].value < 50)
-        exposure_time /= sqrt(50 - GainN[0].value);
+    if (GainNP[0].value > 50)
+        exposure_time *= sqrt(GainNP[0].value - 50);
+    else if (GainNP[0].value < 50)
+        exposure_time /= sqrt(50 - GainNP[0].getValue());
 
-    if (TelescopeTypeS[TELESCOPE_PRIMARY].s == ISS_ON)
+    if (TelescopeTypeSP[TELESCOPE_PRIMARY].getState() == ISS_ON)
         targetFocalLength = primaryFocalLength;
     else
         targetFocalLength = guiderFocalLength;
@@ -1095,11 +1095,11 @@ bool CCDSim::ISNewText(const char * dev, const char * name, char * texts[], char
             INDI::FilterInterface::processText(dev, name, texts, names, n);
             return true;
         }
-        else if (!strcmp(DirectoryTP.name, name))
+        else if (DirectoryTP.isNameMatch(name))
         {
-            IUUpdateText(&DirectoryTP, texts, names, n);
-            DirectoryTP.s = IPS_OK;
-            IDSetText(&DirectoryTP, nullptr);
+            DirectoryTP.update(texts, names, n);
+            DirectoryTP.setState(IPS_OK);
+            DirectoryTP.apply();
             return true;
         }
 
@@ -1113,11 +1113,11 @@ bool CCDSim::ISNewNumber(const char * dev, const char * name, double values[], c
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
 
-        if (!strcmp(name, GainNP.name))
+        if (GainNP.isNameMatch(name))
         {
-            IUUpdateNumber(&GainNP, values, names, n);
-            GainNP.s = IPS_OK;
-            IDSetNumber(&GainNP, nullptr);
+            GainNP.update(values, names, n);
+            GainNP.setState(IPS_OK);
+            GainNP.apply();
             return true;
         }
         if (!strcmp(name, OffsetNP.name))
@@ -1128,29 +1128,29 @@ bool CCDSim::ISNewNumber(const char * dev, const char * name, double values[], c
             m_Bias = OffsetN[0].value;
             return true;
         }
-        else if (!strcmp(name, SimulatorSettingsNP.name))
+        else if (SimulatorSettingsNP.isNameMatch(name))
         {
-            IUUpdateNumber(&SimulatorSettingsNP, values, names, n);
-            SimulatorSettingsNP.s = IPS_OK;
+            SimulatorSettingsNP.update(values, names, n);
+            SimulatorSettingsNP.setState(IPS_OK);
 
             //  Reset our parameters now
             setupParameters();
-            IDSetNumber(&SimulatorSettingsNP, nullptr);
+            SimulatorSettingsNP.apply();
             return true;
         }
         // Record PE EQ to simulate different position in the sky than actual mount coordinate
         // This can be useful to simulate Periodic Error or cone error or any arbitrary error.
-        else if (!strcmp(name, EqPENP.name))
+        else if (EqPENP.isNameMatch(name))
         {
-            IUUpdateNumber(&EqPENP, values, names, n);
-            EqPENP.s = IPS_OK;
+            EqPENP.update(values, names, n);
+            EqPENP.setState(IPS_OK);
 
             ln_equ_posn epochPos { 0, 0 }, J2000Pos { 0, 0 };
-            epochPos.ra  = EqPEN[AXIS_RA].value * 15.0;
-            epochPos.dec = EqPEN[AXIS_DE].value;
+            epochPos.ra  = EqPENP[AXIS_RA].value * 15.0;
+            epochPos.dec = EqPENP[AXIS_DE].getValue();
 
-            RA = EqPEN[AXIS_RA].value;
-            Dec = EqPEN[AXIS_DE].value;
+            RA = EqPENP[AXIS_RA].getValue();
+            Dec = EqPENP[AXIS_DE].getValue();
 
             LibAstro::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
             //ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
@@ -1158,20 +1158,20 @@ bool CCDSim::ISNewNumber(const char * dev, const char * name, double values[], c
             currentDE = J2000Pos.dec;
             usePE = true;
 
-            IDSetNumber(&EqPENP, nullptr);
+            EqPENP.apply();
             return true;
         }
-        else if (!strcmp(name, FilterSlotNP.name))
+        else if (FilterSlotNP.isNameMatch(name))
         {
             INDI::FilterInterface::processNumber(dev, name, values, names, n);
             return true;
         }
-        else if (!strcmp(name, FocusSimulationNP.name))
+        else if (FocusSimulationNP.isNameMatch(name))
         {
             // update focus simulation parameters
-            IUUpdateNumber(&FocusSimulationNP, values, names, n);
-            FocusSimulationNP.s = IPS_OK;
-            IDSetNumber(&FocusSimulationNP, nullptr);
+            FocusSimulationNP.update(values, names, n);
+            FocusSimulationNP.setState(IPS_OK);
+            FocusSimulationNP.apply();
         }
     }
 
@@ -1183,56 +1183,56 @@ bool CCDSim::ISNewSwitch(const char * dev, const char * name, ISState * states, 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Simulate RGB
-        if (!strcmp(name, SimulateBayerSP.name))
+        if (SimulateBayerSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SimulateBayerSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&SimulateBayerSP);
+            SimulateBayerSP.update(states, names, n);
+            int index = SimulateBayerSP.findOnSwitchIndex();
             if (index == -1)
             {
-                SimulateBayerSP.s = IPS_ALERT;
+                SimulateBayerSP.setState(IPS_ALERT);
                 LOG_INFO("Cannot determine whether RGB simulation should be switched on or off.");
-                IDSetSwitch(&SimulateBayerSP, nullptr);
+                SimulateBayerSP.apply();
                 return false;
             }
 
             m_SimulateBayer = index == 0;
             setBayerEnabled(m_SimulateBayer);
 
-            SimulateBayerS[INDI_ENABLED].s = m_SimulateBayer ? ISS_ON : ISS_OFF;
-            SimulateBayerS[INDI_DISABLED].s = m_SimulateBayer ? ISS_OFF : ISS_ON;
-            SimulateBayerSP.s   = IPS_OK;
-            IDSetSwitch(&SimulateBayerSP, nullptr);
+            SimulateBayerSP[INDI_ENABLED].setState(m_SimulateBayer ? ISS_ON : ISS_OFF);
+            SimulateBayerSP[INDI_DISABLED].setState(m_SimulateBayer ? ISS_OFF : ISS_ON);
+            SimulateBayerSP.setState(IPS_OK);
+            SimulateBayerSP.apply();
 
             return true;
         }
-        else if (strcmp(name, CoolerSP.name) == 0)
+        else if (CoolerSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&CoolerSP, states, names, n);
+            CoolerSP.update(states, names, n);
 
-            if (CoolerS[0].s == ISS_ON)
-                CoolerSP.s = IPS_BUSY;
+            if (CoolerSP[0].getState() == ISS_ON)
+                CoolerSP.setState(IPS_BUSY);
             else
             {
-                CoolerSP.s         = IPS_IDLE;
+                CoolerSP.setState(IPS_IDLE);
                 TemperatureRequest = 20;
-                TemperatureNP.s    = IPS_BUSY;
+                TemperatureNP.setState(IPS_BUSY);
             }
 
-            IDSetSwitch(&CoolerSP, nullptr);
+            CoolerSP.apply();
 
             return true;
         }
-        else if (!strcmp(DirectorySP.name, name))
+        else if (DirectorySP.isNameMatch(name))
         {
-            IUUpdateSwitch(&DirectorySP, states, names, n);
+            DirectorySP.update(states, names, n);
             m_AllFiles.clear();
             m_RemainingFiles.clear();
-            if (DirectoryS[INDI_ENABLED].s == ISS_ON)
+            if (DirectorySP[INDI_ENABLED].getState() == ISS_ON)
             {
-                DIR* dirp = opendir(DirectoryT[0].text);
+                DIR* dirp = opendir(DirectoryTP[0].getText());
                 struct dirent * dp;
-                std::string d_dir = std::string(DirectoryT[0].text);
-                if (DirectoryT[0].text[strlen(DirectoryT[0].text) - 1] != '/')
+                std::string d_dir = std::string(DirectoryTP[0].getText());
+                if (DirectoryTP[0].text[strlen(DirectoryTP[0].getText()) - 1] != '/')
                     d_dir += "/";
                 while ((dp = readdir(dirp)) != NULL)
                 {
@@ -1245,31 +1245,31 @@ bool CCDSim::ISNewSwitch(const char * dev, const char * name, ISState * states, 
 
                 if (m_AllFiles.empty())
                 {
-                    IUResetSwitch(&DirectorySP);
-                    DirectoryS[INDI_DISABLED].s = ISS_ON;
-                    DirectorySP.s = IPS_ALERT;
-                    LOGF_ERROR("No FITS files found in directory %s", DirectoryT[0].text);
-                    IDSetSwitch(&DirectorySP, nullptr);
+                    DirectorySP.reset();
+                    DirectorySP[INDI_DISABLED].setState(ISS_ON);
+                    DirectorySP.setState(IPS_ALERT);
+                    LOGF_ERROR("No FITS files found in directory %s", DirectoryTP[0].getText());
+                    DirectorySP.apply();
                 }
                 else
                 {
-                    DirectorySP.s = IPS_OK;
+                    DirectorySP.setState(IPS_OK);
                     std::sort(m_AllFiles.begin(), m_AllFiles.end());
                     m_RemainingFiles = m_AllFiles;
-                    LOGF_INFO("Directory-based images are enabled. Subsequent exposures will be loaded from directory %s", DirectoryT[0].text);
+                    LOGF_INFO("Directory-based images are enabled. Subsequent exposures will be loaded from directory %s", DirectoryTP[0].getText());
                 }
             }
             else
             {
                 m_RemainingFiles.clear();
-                DirectorySP.s = IPS_OK;
-                setBayerEnabled(SimulateBayerS[INDI_ENABLED].s == ISS_ON);
+                DirectorySP.setState(IPS_OK);
+                setBayerEnabled(SimulateBayerSP[INDI_ENABLED].getState() == ISS_ON);
                 LOG_INFO("Directory-based images are disabled.");
             }
-            IDSetSwitch(&DirectorySP, nullptr);
+            DirectorySP.apply();
             return true;
         }
-        else if (strcmp(name, CrashSP.name) == 0)
+        else if (CrashSP.isNameMatch(name))
         {
             abort();
         }
@@ -1282,21 +1282,21 @@ bool CCDSim::ISNewSwitch(const char * dev, const char * name, ISState * states, 
 void CCDSim::activeDevicesUpdated()
 {
 #ifdef USE_EQUATORIAL_PE
-    IDSnoopDevice(ActiveDeviceT[0].text, "EQUATORIAL_PE");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "EQUATORIAL_PE");
 #else
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
 #endif
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FWHM");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FWHM");
 
-    strncpy(FWHMNP.device, ActiveDeviceT[ACTIVE_FOCUSER].text, MAXINDIDEVICE);
+    FWHMNP.setDeviceName(ActiveDeviceTP[ACTIVE_FOCUSER].getText());
 }
 
 bool CCDSim::ISSnoopDevice(XMLEle * root)
 {
-    if (IUSnoopNumber(root, &FWHMNP) == 0)
+    if (IUSnoopNumber(root, FWHMNP.getNumber()) == 0) // #PS: refactor needed
     {
         // we calculate the FWHM and do not snoop it from the focus simulator
-        // seeing = FWHMNP.np[0].value;
+        // seeing = FWHMNP[0].getValue();
         return true;
     }
 
@@ -1314,9 +1314,9 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
                 FocuserPos = atol(pcdataXMLEle(ep));
 
                 // calculate FWHM
-                double focus       = FocusSimulationN[0].value;
-                double max         = FocusSimulationN[1].value;
-                double optimalFWHM = FocusSimulationN[2].value;
+                double focus       = FocusSimulationNP[0].getValue();
+                double max         = FocusSimulationNP[1].getValue();
+                double optimalFWHM = FocusSimulationNP[2].getValue();
 
                 // limit to +/- 10
                 double ticks = 20 * (FocuserPos - focus) / max;
@@ -1329,7 +1329,7 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
     // We try to snoop EQPEC first, if not found, we snoop regular EQNP
 #ifdef USE_EQUATORIAL_PE
     const char * propName = findXMLAttValu(root, "name");
-    if (!strcmp(propName, EqPENP.name))
+    if (EqPENP.isNameMatch(propName))
     {
         XMLEle * ep = nullptr;
         int rc_ra = -1, rc_de = -1;
@@ -1355,9 +1355,9 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
             decPE = J2000Pos.dec;
             usePE = true;
 
-            EqPEN[AXIS_RA].value = newra;
-            EqPEN[AXIS_DE].value = newdec;
-            IDSetNumber(&EqPENP, nullptr);
+            EqPENP[AXIS_RA].setValue(newra);
+            EqPENP[AXIS_DE].setValue(newdec);
+            EqPENP.apply();
 
             LOGF_DEBUG("raPE %g  decPE %g Snooped raPE %g  decPE %g", raPE, decPE, newra, newdec);
 
@@ -1378,20 +1378,20 @@ bool CCDSim::saveConfigItems(FILE * fp)
     INDI::FilterInterface::saveConfigItems(fp);
 
     // Save CCD Simulator Config
-    IUSaveConfigNumber(fp, &SimulatorSettingsNP);
+    SimulatorSettingsNP.save(fp);
 
     // Gain
-    IUSaveConfigNumber(fp, &GainNP);
+    GainNP.save(fp);
     IUSaveConfigNumber(fp, &OffsetNP);
 
     // Directory
-    IUSaveConfigText(fp, &DirectoryTP);
+    DirectoryTP.save(fp);
 
     // Bayer
-    IUSaveConfigSwitch(fp, &SimulateBayerSP);
+    SimulateBayerSP.save(fp);
 
     // Focus simulation
-    IUSaveConfigNumber(fp, &FocusSimulationNP);
+    FocusSimulationNP.save(fp);
 
     return true;
 }
@@ -1520,7 +1520,7 @@ void CCDSim::addFITSKeywords(fitsfile *fptr, INDI::CCDChip *targetChip)
     INDI::CCD::addFITSKeywords(fptr, targetChip);
 
     int status = 0;
-    fits_update_key_dbl(fptr, "Gain", GainN[0].value, 3, "Gain", &status);
+    fits_update_key_dbl(fptr, "Gain", GainNP[0].getValue(), 3, "Gain", &status);
 }
 
 bool CCDSim::loadNextImage()
@@ -1582,9 +1582,9 @@ bool CCDSim::loadNextImage()
     if (channels == 1 && strlen(bayer_pattern)  == 4)
     {
         SetCCDCapability(GetCCDCapability() | CCD_HAS_BAYER);
-        IUSaveText(&BayerT[0], "0");
-        IUSaveText(&BayerT[1], "0");
-        IUSaveText(&BayerT[2], bayer_pattern);
+        BayerTP[0].setText("0");
+        BayerTP[1].setText("0");
+        BayerTP[2].setText(bayer_pattern);
     }
     else
     {

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -23,6 +23,11 @@
 #include "indiccd.h"
 #include "indifilterinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * @brief The CCDSim class provides an advanced simulator for a CCD that includes a dedicated on-board guide chip.
  *
@@ -199,15 +204,11 @@ class CCDSim : public INDI::CCD, public INDI::FilterInterface
         std::deque<std::string> m_AllFiles, m_RemainingFiles;
 
         //  And this lives in our simulator settings page
-        INumberVectorProperty SimulatorSettingsNP;
-        INumber SimulatorSettingsN[SIM_N];
-
-        ISwitchVectorProperty SimulateBayerSP;
-        ISwitch SimulateBayerS[2];
+        INDI::PropertyNumber SimulatorSettingsNP {SIM_N};
+        INDI::PropertySwitch SimulateBayerSP {2};
 
         //  We are going to snoop these from focuser
-        INumberVectorProperty FWHMNP;
-        INumber FWHMN[1];
+        INDI::PropertyNumber FWHMNP {1};
 
         // Focuser positions for focusing simulation
         // FocuserPosition[0] is the position where the scope is in focus
@@ -215,29 +216,20 @@ class CCDSim : public INDI::CCD, public INDI::FilterInterface
         // FocuserPosition[2] is the seeing (in arcsec)
         // We need to have these values here, since we cannot snoop it from the focuser (the focuser does not
         // publish these values)
-        INumberVectorProperty FocusSimulationNP;
-        INumber FocusSimulationN[3];
+        INDI::PropertyNumber FocusSimulationNP {3};
+        INDI::PropertyNumber EqPENP {2};
 
-        INumberVectorProperty EqPENP;
-        INumber EqPEN[2];
+        INDI::PropertySwitch CoolerSP {2};
 
-        ISwitch CoolerS[2];
-        ISwitchVectorProperty CoolerSP;
-
-        INumber GainN[1];
-        INumberVectorProperty GainNP;
+        INDI::PropertyNumber GainNP {1};
 
         INumber OffsetN[1];
         INumberVectorProperty OffsetNP;
 
-        IText DirectoryT[1] {};
-        ITextVectorProperty DirectoryTP;
+        INDI::PropertyText DirectoryTP {1};
 
-        ISwitch DirectoryS[2];
-        ISwitchVectorProperty DirectorySP;
-
-        ISwitchVectorProperty CrashSP;
-        ISwitch CrashS[1];
+        INDI::PropertySwitch DirectorySP {2};
+        INDI::PropertySwitch CrashSP {1};
 
         static const constexpr char* SIMULATOR_TAB = "Simulator Config";
 };

--- a/drivers/ccd/guide_simulator.cpp
+++ b/drivers/ccd/guide_simulator.cpp
@@ -84,30 +84,30 @@ GuideSim::GuideSim()
 bool GuideSim::SetupParms()
 {
     int nbuf;
-    SetCCDParams(SimulatorSettingsN[0].value, SimulatorSettingsN[1].value, 16, SimulatorSettingsN[2].value,
-                 SimulatorSettingsN[3].value);
+    SetCCDParams(SimulatorSettingsNP[0].value, SimulatorSettingsNP[1].getValue(), 16, SimulatorSettingsNP[2].getValue(),
+                 SimulatorSettingsNP[3].getValue());
 
     if (HasCooler())
     {
-        TemperatureN[0].value = 20;
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP[0].setValue(20);
+        TemperatureNP.apply();
     }
 
     //  Kwiq
-    maxnoise      = SimulatorSettingsN[8].value;
-    skyglow       = SimulatorSettingsN[9].value;
-    maxval        = SimulatorSettingsN[4].value;
-    bias          = SimulatorSettingsN[5].value;
-    limitingmag   = SimulatorSettingsN[7].value;
-    saturationmag = SimulatorSettingsN[6].value;
-    OAGoffset = SimulatorSettingsN[10].value; //  An oag is offset this much from center of scope position (arcminutes);
-    polarError = SimulatorSettingsN[11].value;
-    polarDrift = SimulatorSettingsN[12].value;
-    rotationCW = SimulatorSettingsN[13].value;
+    maxnoise      = SimulatorSettingsNP[8].getValue();
+    skyglow       = SimulatorSettingsNP[9].getValue();
+    maxval        = SimulatorSettingsNP[4].getValue();
+    bias          = SimulatorSettingsNP[5].getValue();
+    limitingmag   = SimulatorSettingsNP[7].getValue();
+    saturationmag = SimulatorSettingsNP[6].getValue();
+    OAGoffset = SimulatorSettingsNP[10].getValue(); //  An oag is offset this much from center of scope position (arcminutes);
+    polarError = SimulatorSettingsNP[11].getValue();
+    polarDrift = SimulatorSettingsNP[12].getValue();
+    rotationCW = SimulatorSettingsNP[13].getValue();
     //  Kwiq++
-    king_gamma = SimulatorSettingsN[14].value * 0.0174532925;
-    king_theta = SimulatorSettingsN[15].value * 0.0174532925;
-    TimeFactor = SimulatorSettingsN[16].value;
+    king_gamma = SimulatorSettingsNP[14].value * 0.0174532925;
+    king_theta = SimulatorSettingsNP[15].value * 0.0174532925;
+    TimeFactor = SimulatorSettingsNP[16].getValue();
 
     nbuf = PrimaryCCD.getXRes() * PrimaryCCD.getYRes() * PrimaryCCD.getBPP() / 8;
     //nbuf += 512;
@@ -150,59 +150,59 @@ bool GuideSim::initProperties()
     //  but the simulators are a special case
     INDI::CCD::initProperties();
 
-    IUFillNumber(&SimulatorSettingsN[0], "SIM_XRES", "CCD X resolution", "%4.0f", 0, 8192, 0, 1280);
-    IUFillNumber(&SimulatorSettingsN[1], "SIM_YRES", "CCD Y resolution", "%4.0f", 0, 8192, 0, 1024);
-    IUFillNumber(&SimulatorSettingsN[2], "SIM_XSIZE", "CCD X Pixel Size", "%4.2f", 0, 60, 0, 5.2);
-    IUFillNumber(&SimulatorSettingsN[3], "SIM_YSIZE", "CCD Y Pixel Size", "%4.2f", 0, 60, 0, 5.2);
-    IUFillNumber(&SimulatorSettingsN[4], "SIM_MAXVAL", "CCD Maximum ADU", "%4.0f", 0, 65000, 0, 65000);
-    IUFillNumber(&SimulatorSettingsN[5], "SIM_BIAS", "CCD Bias", "%4.0f", 0, 6000, 0, 10);
-    IUFillNumber(&SimulatorSettingsN[6], "SIM_SATURATION", "Saturation Mag", "%4.1f", 0, 20, 0, 1.0);
-    IUFillNumber(&SimulatorSettingsN[7], "SIM_LIMITINGMAG", "Limiting Mag", "%4.1f", 0, 20, 0, 17.0);
-    IUFillNumber(&SimulatorSettingsN[8], "SIM_NOISE", "CCD Noise", "%4.0f", 0, 6000, 0, 10);
-    IUFillNumber(&SimulatorSettingsN[9], "SIM_SKYGLOW", "Sky Glow (magnitudes)", "%4.1f", 0, 6000, 0, 19.5);
-    IUFillNumber(&SimulatorSettingsN[10], "SIM_OAGOFFSET", "Oag Offset (arcminutes)", "%4.1f", 0, 6000, 0, 0);
-    IUFillNumber(&SimulatorSettingsN[11], "SIM_POLAR", "PAE (arcminutes)", "%4.1f", -600, 600, 0,
+    SimulatorSettingsNP[0].fill("SIM_XRES", "CCD X resolution", "%4.0f", 0, 8192, 0, 1280);
+    SimulatorSettingsNP[1].fill("SIM_YRES", "CCD Y resolution", "%4.0f", 0, 8192, 0, 1024);
+    SimulatorSettingsNP[2].fill("SIM_XSIZE", "CCD X Pixel Size", "%4.2f", 0, 60, 0, 5.2);
+    SimulatorSettingsNP[3].fill("SIM_YSIZE", "CCD Y Pixel Size", "%4.2f", 0, 60, 0, 5.2);
+    SimulatorSettingsNP[4].fill("SIM_MAXVAL", "CCD Maximum ADU", "%4.0f", 0, 65000, 0, 65000);
+    SimulatorSettingsNP[5].fill("SIM_BIAS", "CCD Bias", "%4.0f", 0, 6000, 0, 10);
+    SimulatorSettingsNP[6].fill("SIM_SATURATION", "Saturation Mag", "%4.1f", 0, 20, 0, 1.0);
+    SimulatorSettingsNP[7].fill("SIM_LIMITINGMAG", "Limiting Mag", "%4.1f", 0, 20, 0, 17.0);
+    SimulatorSettingsNP[8].fill("SIM_NOISE", "CCD Noise", "%4.0f", 0, 6000, 0, 10);
+    SimulatorSettingsNP[9].fill("SIM_SKYGLOW", "Sky Glow (magnitudes)", "%4.1f", 0, 6000, 0, 19.5);
+    SimulatorSettingsNP[10].fill("SIM_OAGOFFSET", "Oag Offset (arcminutes)", "%4.1f", 0, 6000, 0, 0);
+    SimulatorSettingsNP[11].fill("SIM_POLAR", "PAE (arcminutes)", "%4.1f", -600, 600, 0,
                  0); /* PAE = Polar Alignment Error */
-    IUFillNumber(&SimulatorSettingsN[12], "SIM_POLARDRIFT", "PAE Drift (minutes)", "%4.1f", 0, 6000, 0, 0);
-    IUFillNumber(&SimulatorSettingsN[13], "SIM_ROTATION", "Rotation CW (degrees)", "%4.1f", -360, 360, 0, 0);
-    IUFillNumber(&SimulatorSettingsN[14], "SIM_KING_GAMMA", "(CP,TCP), deg", "%4.1f", 0, 10, 0, 0);
-    IUFillNumber(&SimulatorSettingsN[15], "SIM_KING_THETA", "hour hangle, deg", "%4.1f", 0, 360, 0, 0);
-    IUFillNumber(&SimulatorSettingsN[16], "SIM_TIME_FACTOR", "Time Factor (x)", "%.2f", 0.01, 100, 0, 1);
+    SimulatorSettingsNP[12].fill("SIM_POLARDRIFT", "PAE Drift (minutes)", "%4.1f", 0, 6000, 0, 0);
+    SimulatorSettingsNP[13].fill("SIM_ROTATION", "Rotation CW (degrees)", "%4.1f", -360, 360, 0, 0);
+    SimulatorSettingsNP[14].fill("SIM_KING_GAMMA", "(CP,TCP), deg", "%4.1f", 0, 10, 0, 0);
+    SimulatorSettingsNP[15].fill("SIM_KING_THETA", "hour hangle, deg", "%4.1f", 0, 360, 0, 0);
+    SimulatorSettingsNP[16].fill("SIM_TIME_FACTOR", "Time Factor (x)", "%.2f", 0.01, 100, 0, 1);
 
-    IUFillNumberVector(&SimulatorSettingsNP, SimulatorSettingsN, 17, getDeviceName(), "SIMULATOR_SETTINGS",
+    SimulatorSettingsNP.fill(getDeviceName(), "SIMULATOR_SETTINGS",
                        "Simulator Settings", "Simulator Config", IP_RW, 60, IPS_IDLE);
 
     // RGB Simulation
-    IUFillSwitch(&SimulateRgbS[0], "SIMULATE_YES", "Yes", ISS_OFF);
-    IUFillSwitch(&SimulateRgbS[1], "SIMULATE_NO", "No", ISS_ON);
-    IUFillSwitchVector(&SimulateRgbSP, SimulateRgbS, 2, getDeviceName(), "SIMULATE_RGB", "Simulate RGB",
+    SimulateRgbSP[0].fill("SIMULATE_YES", "Yes", ISS_OFF);
+    SimulateRgbSP[1].fill("SIMULATE_NO", "No", ISS_ON);
+    SimulateRgbSP.fill(getDeviceName(), "SIMULATE_RGB", "Simulate RGB",
                        "Simulator Config", IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&FWHMN[0], "SIM_FWHM", "FWHM (arcseconds)", "%4.2f", 0, 60, 0, 7.5);
-    IUFillNumberVector(&FWHMNP, FWHMN, 1, ActiveDeviceT[ACTIVE_FOCUSER].text, "FWHM", "FWHM", OPTIONS_TAB, IP_RO, 60, IPS_IDLE);
+    FWHMNP[0].fill("SIM_FWHM", "FWHM (arcseconds)", "%4.2f", 0, 60, 0, 7.5);
+    FWHMNP.fill(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FWHM", "FWHM", OPTIONS_TAB, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&CoolerS[0], "COOLER_ON", "ON", ISS_OFF);
-    IUFillSwitch(&CoolerS[1], "COOLER_OFF", "OFF", ISS_ON);
-    IUFillSwitchVector(&CoolerSP, CoolerS, 2, getDeviceName(), "CCD_COOLER", "Cooler", MAIN_CONTROL_TAB, IP_WO,
+    CoolerSP[0].fill("COOLER_ON", "ON", ISS_OFF);
+    CoolerSP[1].fill("COOLER_OFF", "OFF", ISS_ON);
+    CoolerSP.fill(getDeviceName(), "CCD_COOLER", "Cooler", MAIN_CONTROL_TAB, IP_WO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // CCD Gain
-    IUFillNumber(&GainN[0], "GAIN", "Gain", "%.f", 0, 100, 10, 50);
-    IUFillNumberVector(&GainNP, GainN, 1, getDeviceName(), "CCD_GAIN", "Gain", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    GainNP[0].fill("GAIN", "Gain", "%.f", 0, 100, 10, 50);
+    GainNP.fill(getDeviceName(), "CCD_GAIN", "Gain", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillNumber(&EqPEN[0], "RA_PE", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-    IUFillNumber(&EqPEN[1], "DEC_PE", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-    IUFillNumberVector(&EqPENP, EqPEN, 2, getDeviceName(), "EQUATORIAL_PE", "EQ PE", "Simulator Config", IP_RW, 60,
+    EqPENP[0].fill("RA_PE", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+    EqPENP[1].fill("DEC_PE", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+    EqPENP.fill(getDeviceName(), "EQUATORIAL_PE", "EQ PE", "Simulator Config", IP_RW, 60,
                        IPS_IDLE);
 
 #ifdef USE_EQUATORIAL_PE
-    IDSnoopDevice(ActiveDeviceT[0].text, "EQUATORIAL_PE");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "EQUATORIAL_PE");
 #else
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
 #endif
 
 
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FWHM");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FWHM");
 
     uint32_t cap = 0;
 
@@ -228,8 +228,8 @@ bool GuideSim::initProperties()
     setDriverInterface(getDriverInterface());
 
     // Make Guide Scope ON by default
-    TelescopeTypeS[TELESCOPE_PRIMARY].s = ISS_OFF;
-    TelescopeTypeS[TELESCOPE_GUIDE].s = ISS_ON;
+    TelescopeTypeSP[TELESCOPE_PRIMARY].setState(ISS_OFF);
+    TelescopeTypeSP[TELESCOPE_GUIDE].setState(ISS_ON);
 
     return true;
 }
@@ -239,9 +239,9 @@ void GuideSim::setRGB(bool onOff)
     if (onOff)
     {
         SetCCDCapability(GetCCDCapability() | CCD_HAS_BAYER);
-        IUSaveText(&BayerT[0], "0");
-        IUSaveText(&BayerT[1], "0");
-        IUSaveText(&BayerT[2], "RGGB");
+        BayerTP[0].setText("0");
+        BayerTP[1].setText("0");
+        BayerTP[2].setText("RGGB");
     }
     else
     {
@@ -253,9 +253,9 @@ void GuideSim::ISGetProperties(const char * dev)
 {
     INDI::CCD::ISGetProperties(dev);
 
-    defineProperty(&SimulatorSettingsNP);
-    defineProperty(&EqPENP);
-    defineProperty(&SimulateRgbSP);
+    defineProperty(SimulatorSettingsNP);
+    defineProperty(EqPENP);
+    defineProperty(SimulateRgbSP);
 }
 
 bool GuideSim::updateProperties()
@@ -265,9 +265,9 @@ bool GuideSim::updateProperties()
     if (isConnected())
     {
         if (HasCooler())
-            defineProperty(&CoolerSP);
+            defineProperty(CoolerSP);
 
-        defineProperty(&GainNP);
+        defineProperty(GainNP);
 
         SetupParms();
 
@@ -281,9 +281,9 @@ bool GuideSim::updateProperties()
     else
     {
         if (HasCooler())
-            deleteProperty(CoolerSP.name);
+            deleteProperty(CoolerSP.getName());
 
-        deleteProperty(GainNP.name);
+        deleteProperty(GainNP.getName());
     }
 
     return true;
@@ -292,16 +292,16 @@ bool GuideSim::updateProperties()
 int GuideSim::SetTemperature(double temperature)
 {
     TemperatureRequest = temperature;
-    if (fabs(temperature - TemperatureN[0].value) < 0.1)
+    if (fabs(temperature - TemperatureNP[0].getValue()) < 0.1)
     {
-        TemperatureN[0].value = temperature;
+        TemperatureNP[0].setValue(temperature);
         return 1;
     }
 
-    CoolerS[0].s = ISS_ON;
-    CoolerS[1].s = ISS_OFF;
-    CoolerSP.s   = IPS_BUSY;
-    IDSetSwitch(&CoolerSP, nullptr);
+    CoolerSP[0].setState(ISS_ON);
+    CoolerSP[1].setState(ISS_OFF);
+    CoolerSP.setState(IPS_BUSY);
+    CoolerSP.apply();
     return 0;
 }
 
@@ -430,7 +430,7 @@ void GuideSim::TimerHit()
         if (timeleft < 0)
             timeleft = 0;
 
-        //ImageExposureN[0].value = timeleft;
+        //ImageExposureNP[0].setValue(timeleft);
         //IDSetNumber(ImageExposureNP, nullptr);
         GuideCCD.setExposureLeft(timeleft);
 
@@ -466,31 +466,31 @@ void GuideSim::TimerHit()
         }
     }
 
-    if (TemperatureNP.s == IPS_BUSY)
+    if (TemperatureNP.getState() == IPS_BUSY)
     {
-        if (fabs(TemperatureRequest - TemperatureN[0].value) <= 0.5)
+        if (fabs(TemperatureRequest - TemperatureNP[0].getValue()) <= 0.5)
         {
             LOGF_INFO("Temperature reached requested value %.2f degrees C", TemperatureRequest);
-            TemperatureN[0].value = TemperatureRequest;
-            TemperatureNP.s       = IPS_OK;
+            TemperatureNP[0].setValue(TemperatureRequest);
+            TemperatureNP.setState(IPS_OK);
         }
         else
         {
-            if (TemperatureRequest < TemperatureN[0].value)
-                TemperatureN[0].value -= 0.5;
+            if (TemperatureRequest < TemperatureNP[0].getValue())
+                TemperatureNP[0].value -= 0.5;
             else
-                TemperatureN[0].value += 0.5;
+                TemperatureNP[0].value += 0.5;
         }
 
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 
         // Above 20, cooler is off
-        if (TemperatureN[0].value >= 20)
+        if (TemperatureNP[0].value >= 20)
         {
-            CoolerS[0].s = ISS_OFF;
-            CoolerS[0].s = ISS_ON;
-            CoolerSP.s   = IPS_IDLE;
-            IDSetSwitch(&CoolerSP, nullptr);
+            CoolerSP[0].setState(ISS_OFF);
+            CoolerSP[0].setState(ISS_ON);
+            CoolerSP.setState(IPS_IDLE);
+            CoolerSP.apply();
         }
     }
 
@@ -513,12 +513,12 @@ int GuideSim::DrawCcdFrame(INDI::CCDChip * targetChip)
     else
         exposure_time = ExposureRequest;
 
-    if (GainN[0].value > 50)
-        exposure_time *= sqrt(GainN[0].value - 50);
-    else if (GainN[0].value < 50)
-        exposure_time /= sqrt(50 - GainN[0].value);
+    if (GainNP[0].value > 50)
+        exposure_time *= sqrt(GainNP[0].value - 50);
+    else if (GainNP[0].value < 50)
+        exposure_time /= sqrt(50 - GainNP[0].getValue());
 
-    if (TelescopeTypeS[TELESCOPE_PRIMARY].s == ISS_ON)
+    if (TelescopeTypeSP[TELESCOPE_PRIMARY].getState() == ISS_ON)
         targetFocalLength = primaryFocalLength;
     else
         targetFocalLength = guiderFocalLength;
@@ -1136,54 +1136,54 @@ bool GuideSim::ISNewNumber(const char * dev, const char * name, double values[],
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
 
-        if (!strcmp(name, GainNP.name))
+        if (GainNP.isNameMatch(name))
         {
-            IUUpdateNumber(&GainNP, values, names, n);
-            GainNP.s = IPS_OK;
-            IDSetNumber(&GainNP, nullptr);
+            GainNP.update(values, names, n);
+            GainNP.setState(IPS_OK);
+            GainNP.apply();
             return true;
         }
 
         if (strcmp(name, "SIMULATOR_SETTINGS") == 0)
         {
-            IUUpdateNumber(&SimulatorSettingsNP, values, names, n);
-            SimulatorSettingsNP.s = IPS_OK;
+            SimulatorSettingsNP.update(values, names, n);
+            SimulatorSettingsNP.setState(IPS_OK);
 
             //  Reset our parameters now
             SetupParms();
-            IDSetNumber(&SimulatorSettingsNP, nullptr);
+            SimulatorSettingsNP.apply();
 
-            maxnoise      = SimulatorSettingsN[8].value;
-            skyglow       = SimulatorSettingsN[9].value;
-            maxval        = SimulatorSettingsN[4].value;
-            bias          = SimulatorSettingsN[5].value;
-            limitingmag   = SimulatorSettingsN[7].value;
-            saturationmag = SimulatorSettingsN[6].value;
-            OAGoffset = SimulatorSettingsN[10].value;
-            polarError = SimulatorSettingsN[11].value;
-            polarDrift = SimulatorSettingsN[12].value;
-            rotationCW = SimulatorSettingsN[13].value;
+            maxnoise      = SimulatorSettingsNP[8].getValue();
+            skyglow       = SimulatorSettingsNP[9].getValue();
+            maxval        = SimulatorSettingsNP[4].getValue();
+            bias          = SimulatorSettingsNP[5].getValue();
+            limitingmag   = SimulatorSettingsNP[7].getValue();
+            saturationmag = SimulatorSettingsNP[6].getValue();
+            OAGoffset = SimulatorSettingsNP[10].getValue();
+            polarError = SimulatorSettingsNP[11].getValue();
+            polarDrift = SimulatorSettingsNP[12].getValue();
+            rotationCW = SimulatorSettingsNP[13].getValue();
             //  Kwiq++
-            king_gamma = SimulatorSettingsN[14].value * 0.0174532925;
-            king_theta = SimulatorSettingsN[15].value * 0.0174532925;
-            TimeFactor = SimulatorSettingsN[16].value;
+            king_gamma = SimulatorSettingsNP[14].value * 0.0174532925;
+            king_theta = SimulatorSettingsNP[15].value * 0.0174532925;
+            TimeFactor = SimulatorSettingsNP[16].getValue();
 
             return true;
         }
 
         // Record PE EQ to simulate different position in the sky than actual mount coordinate
         // This can be useful to simulate Periodic Error or cone error or any arbitrary error.
-        if (!strcmp(name, EqPENP.name))
+        if (EqPENP.isNameMatch(name))
         {
-            IUUpdateNumber(&EqPENP, values, names, n);
-            EqPENP.s = IPS_OK;
+            EqPENP.update(values, names, n);
+            EqPENP.setState(IPS_OK);
 
             ln_equ_posn epochPos { 0, 0 }, J2000Pos { 0, 0 };
-            epochPos.ra  = EqPEN[AXIS_RA].value * 15.0;
-            epochPos.dec = EqPEN[AXIS_DE].value;
+            epochPos.ra  = EqPENP[AXIS_RA].value * 15.0;
+            epochPos.dec = EqPENP[AXIS_DE].getValue();
 
-            RA = EqPEN[AXIS_RA].value;
-            Dec = EqPEN[AXIS_DE].value;
+            RA = EqPENP[AXIS_RA].getValue();
+            Dec = EqPENP[AXIS_DE].getValue();
 
             LibAstro::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
             //ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
@@ -1191,7 +1191,7 @@ bool GuideSim::ISNewNumber(const char * dev, const char * name, double values[],
             currentDE = J2000Pos.dec;
             usePE = true;
 
-            IDSetNumber(&EqPENP, nullptr);
+            EqPENP.apply();
             return true;
         }
 
@@ -1205,43 +1205,43 @@ bool GuideSim::ISNewSwitch(const char * dev, const char * name, ISState * states
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
 
-        if (!strcmp(name, SimulateRgbSP.name))
+        if (SimulateRgbSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SimulateRgbSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&SimulateRgbSP);
+            SimulateRgbSP.update(states, names, n);
+            int index = SimulateRgbSP.findOnSwitchIndex();
             if (index == -1)
             {
-                SimulateRgbSP.s = IPS_ALERT;
+                SimulateRgbSP.setState(IPS_ALERT);
                 LOG_INFO("Cannot determine whether RGB simulation should be switched on or off.");
-                IDSetSwitch(&SimulateRgbSP, nullptr);
+                SimulateRgbSP.apply();
                 return false;
             }
 
             simulateRGB = index == 0;
             setRGB(simulateRGB);
 
-            SimulateRgbS[0].s = simulateRGB ? ISS_ON : ISS_OFF;
-            SimulateRgbS[1].s = simulateRGB ? ISS_OFF : ISS_ON;
-            SimulateRgbSP.s   = IPS_OK;
-            IDSetSwitch(&SimulateRgbSP, nullptr);
+            SimulateRgbSP[0].setState(simulateRGB ? ISS_ON : ISS_OFF);
+            SimulateRgbSP[1].setState(simulateRGB ? ISS_OFF : ISS_ON);
+            SimulateRgbSP.setState(IPS_OK);
+            SimulateRgbSP.apply();
 
             return true;
         }
 
-        if (strcmp(name, CoolerSP.name) == 0)
+        if (CoolerSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&CoolerSP, states, names, n);
+            CoolerSP.update(states, names, n);
 
-            if (CoolerS[0].s == ISS_ON)
-                CoolerSP.s = IPS_BUSY;
+            if (CoolerSP[0].getState() == ISS_ON)
+                CoolerSP.setState(IPS_BUSY);
             else
             {
-                CoolerSP.s         = IPS_IDLE;
+                CoolerSP.setState(IPS_IDLE);
                 TemperatureRequest = 20;
-                TemperatureNP.s    = IPS_BUSY;
+                TemperatureNP.setState(IPS_BUSY);
             }
 
-            IDSetSwitch(&CoolerSP, nullptr);
+            CoolerSP.apply();
 
             return true;
         }
@@ -1254,27 +1254,27 @@ bool GuideSim::ISNewSwitch(const char * dev, const char * name, ISState * states
 void GuideSim::activeDevicesUpdated()
 {
 #ifdef USE_EQUATORIAL_PE
-    IDSnoopDevice(ActiveDeviceT[0].text, "EQUATORIAL_PE");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "EQUATORIAL_PE");
 #else
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
 #endif
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FWHM");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FWHM");
 
-    strncpy(FWHMNP.device, ActiveDeviceT[ACTIVE_FOCUSER].text, MAXINDIDEVICE);
+    FWHMNP.setDeviceName(ActiveDeviceTP[ACTIVE_FOCUSER].getText());
 }
 
 bool GuideSim::ISSnoopDevice(XMLEle * root)
 {
-    if (IUSnoopNumber(root, &FWHMNP) == 0)
+    if (IUSnoopNumber(root, FWHMNP.getNumber()) == 0) // #PS: refactor needed
     {
-        seeing = FWHMNP.np[0].value;
+        seeing = FWHMNP[0].getValue();
         return true;
     }
 
     // We try to snoop EQPEC first, if not found, we snoop regular EQNP
 #ifdef USE_EQUATORIAL_PE
     const char * propName = findXMLAttValu(root, "name");
-    if (!strcmp(propName, EqPENP.name))
+    if (EqPENP.isNameMatch(propName))
     {
         XMLEle * ep = nullptr;
         int rc_ra = -1, rc_de = -1;
@@ -1300,9 +1300,9 @@ bool GuideSim::ISSnoopDevice(XMLEle * root)
             decPE = J2000Pos.dec;
             usePE = true;
 
-            EqPEN[AXIS_RA].value = newra;
-            EqPEN[AXIS_DE].value = newdec;
-            IDSetNumber(&EqPENP, nullptr);
+            EqPENP[AXIS_RA].setValue(newra);
+            EqPENP[AXIS_DE].setValue(newdec);
+            EqPENP.apply();
 
             LOGF_DEBUG("raPE %g  decPE %g Snooped raPE %g  decPE %g", raPE, decPE, newra, newdec);
 
@@ -1321,13 +1321,13 @@ bool GuideSim::saveConfigItems(FILE * fp)
 
 
     // Save CCD Simulator Config
-    IUSaveConfigNumber(fp, &SimulatorSettingsNP);
+    SimulatorSettingsNP.save(fp);
 
     // Gain
-    IUSaveConfigNumber(fp, &GainNP);
+    GainNP.save(fp);
 
     // RGB
-    IUSaveConfigSwitch(fp, &SimulateRgbSP);
+    SimulateRgbSP.save(fp);
 
     return true;
 }
@@ -1438,5 +1438,5 @@ void GuideSim::addFITSKeywords(fitsfile *fptr, INDI::CCDChip *targetChip)
     INDI::CCD::addFITSKeywords(fptr, targetChip);
 
     int status = 0;
-    fits_update_key_dbl(fptr, "Gain", GainN[0].value, 3, "Gain", &status);
+    fits_update_key_dbl(fptr, "Gain", GainNP[0].getValue(), 3, "Gain", &status);
 }

--- a/drivers/ccd/guide_simulator.h
+++ b/drivers/ccd/guide_simulator.h
@@ -21,6 +21,10 @@
 #include "indiccd.h"
 #include "indifilterinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * @brief The GuideSim class provides an advanced simulator for a CCD that includes a dedicated on-board guide chip.
  *
@@ -165,23 +169,14 @@ class GuideSim : public INDI::CCD
         bool terminateThread;
 
         //  And this lives in our simulator settings page
-
-        INumberVectorProperty SimulatorSettingsNP;
-        INumber SimulatorSettingsN[17];
-
-        ISwitchVectorProperty SimulateRgbSP;
-        ISwitch SimulateRgbS[2];
+        INDI::PropertyNumber SimulatorSettingsNP {17};
+        INDI::PropertySwitch SimulateRgbSP {2};
 
         //  We are going to snoop these from focuser
-        INumberVectorProperty FWHMNP;
-        INumber FWHMN[1];
+        INDI::PropertyNumber FWHMNP {1};
+        INDI::PropertyNumber EqPENP {2};
 
-        INumberVectorProperty EqPENP;
-        INumber EqPEN[2];
+        INDI::PropertySwitch CoolerSP {2};
 
-        ISwitch CoolerS[2];
-        ISwitchVectorProperty CoolerSP;
-
-        INumber GainN[1];
-        INumberVectorProperty GainNP;
+        INDI::PropertyNumber GainNP {1};
 };

--- a/drivers/dome/baader_dome.h
+++ b/drivers/dome/baader_dome.h
@@ -22,6 +22,9 @@
 
 #include "indibase/indidome.h"
 
+/* Smart Widget-Property */
+#include "indipropertyswitch.h"
+
 class BaaderDome : public INDI::Dome
 {
   public:
@@ -76,11 +79,9 @@ class BaaderDome : public INDI::Dome
     double DomeAzToMountAz(unsigned short domeAz);
     bool SetupParms();
 
-    ISwitch CalibrateS[1];
-    ISwitchVectorProperty CalibrateSP;
+    INDI::PropertySwitch CalibrateSP {1};
 
-    ISwitch DomeFlapS[2];
-    ISwitchVectorProperty DomeFlapSP;
+    INDI::PropertySwitch DomeFlapSP {2};
 
     DomeStatus status { DOME_UNKNOWN };
     FlapStatus flapStatus { FLAP_OPENED };

--- a/drivers/dome/ddw_dome.h
+++ b/drivers/dome/ddw_dome.h
@@ -35,6 +35,9 @@
 #include "indidome.h"
 #include <memory>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class DDW : public INDI::Dome
 {
     public:
@@ -66,8 +69,7 @@ class DDW : public INDI::Dome
     protected:
         bool SetupParms();
 
-        INumber FirmwareVersionN[1];
-        INumberVectorProperty FirmwareVersionNP;
+        INDI::PropertyNumber FirmwareVersionNP {1};
 
     private:
         int writeCmd(const char *cmd);

--- a/drivers/dome/dome_script.h
+++ b/drivers/dome/dome_script.h
@@ -20,6 +20,9 @@
 
 #include "indidome.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+
 class DomeScript : public INDI::Dome
 {
   public:
@@ -48,9 +51,7 @@ class DomeScript : public INDI::Dome
   private:
     bool ReadDomeStatus();
     bool RunScript(int script, ...);
-
-    ITextVectorProperty ScriptsTP;
-    IText ScriptsT[15] {};
+    INDI::PropertyText ScriptsTP {15};
     double TargetAz { 0 };
     int TimeSinceUpdate { 0 };
 };

--- a/drivers/dome/domepro2.h
+++ b/drivers/dome/domepro2.h
@@ -23,6 +23,11 @@
 #include "indibase/indidome.h"
 #include <map>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class DomePro2 : public INDI::Dome
 {
     public:
@@ -137,25 +142,19 @@ class DomePro2 : public INDI::Dome
             VERSION_FIRMWARE,
             VERSION_HARDWARE
         };
-
-        ISwitchVectorProperty HomeSP;
-        ISwitch HomeS[2] {};
+        INDI::PropertySwitch HomeSP {2};
         enum
         {
             HOME_DISCOVER,
             HOME_GOTO
         };
-
-        ITextVectorProperty StatusTP;
-        IText StatusT[2] {};
+        INDI::PropertyText StatusTP {2};
         enum
         {
             STATUS_DOME,
             STATUS_SHUTTER
         };
-
-        INumberVectorProperty SettingsNP;
-        INumber SettingsN[5];
+        INDI::PropertyNumber SettingsNP {5};
         enum
         {
             SETTINGS_AZ_CPR,

--- a/drivers/dome/rigel_dome.cpp
+++ b/drivers/dome/rigel_dome.cpp
@@ -97,16 +97,16 @@ bool RigelDome::initProperties()
 {
     INDI::Dome::initProperties();
 
-    IUFillSwitch(&OperationS[OPERATION_FIND_HOME], "OPERATION_FIND_HOME", "Find Home", ISS_OFF);
-    IUFillSwitch(&OperationS[OPERATION_CALIBRATE], "OPERATION_CALIBRATE", "Calibrate", ISS_OFF);
-    IUFillSwitchVector(&OperationSP, OperationS, 2, getDeviceName(), "OPERATION", "Operation", MAIN_CONTROL_TAB, IP_RW,
+    OperationSP[OPERATION_FIND_HOME].fill("OPERATION_FIND_HOME", "Find Home", ISS_OFF);
+    OperationSP[OPERATION_CALIBRATE].fill("OPERATION_CALIBRATE", "Calibrate", ISS_OFF);
+    OperationSP.fill(getDeviceName(), "OPERATION", "Operation", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillText(&InfoT[INFO_FIRMWARE], "FIRMWARE", "Version", "NA");
-    IUFillText(&InfoT[INFO_MODEL], "MODEL", "Model", "NA");
-    IUFillText(&InfoT[INFO_TICKS], "TICKS_PER_REV", "Ticks/Rev", "NA");
-    IUFillText(&InfoT[INFO_BATTERY], "BATTERY", "Battery", "NA");
-    IUFillTextVector(&InfoTP, InfoT, 4, getDeviceName(), "FIRMWARE_INFO", "Info", INFO_TAB, IP_RO, 60, IPS_IDLE);
+    InfoTP[INFO_FIRMWARE].fill("FIRMWARE", "Version", "NA");
+    InfoTP[INFO_MODEL].fill("MODEL", "Model", "NA");
+    InfoTP[INFO_TICKS].fill("TICKS_PER_REV", "Ticks/Rev", "NA");
+    InfoTP[INFO_BATTERY].fill("BATTERY", "Battery", "NA");
+    InfoTP.fill(getDeviceName(), "FIRMWARE_INFO", "Info", INFO_TAB, IP_RO, 60, IPS_IDLE);
 
     serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
 
@@ -124,16 +124,16 @@ bool RigelDome::getStartupValues()
 {
     targetAz = 0;
 
-    InfoTP.s = (readFirmware() && readModel() && readStepsPerRevolution()) ? IPS_OK : IPS_ALERT;
+    InfoTP.setState((readFirmware() && readModel() && readStepsPerRevolution()) ? IPS_OK : IPS_ALERT);
     if (HasShutter())
         readBatteryLevels();
-    IDSetText(&InfoTP, nullptr);
+    InfoTP.apply();
 
     if (readPosition())
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
 
     if (readShutterStatus())
-        IDSetSwitch(&DomeShutterSP, nullptr);
+        DomeShutterSP.apply();
 
     if (InitPark())
     {
@@ -182,15 +182,15 @@ bool RigelDome::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&OperationSP);
-        defineProperty(&InfoTP);
+        defineProperty(OperationSP);
+        defineProperty(InfoTP);
 
         getStartupValues();
     }
     else
     {
-        deleteProperty(OperationSP.name);
-        deleteProperty(InfoTP.name);
+        deleteProperty(OperationSP.getName());
+        deleteProperty(InfoTP.getName());
     }
 
     return true;
@@ -203,41 +203,41 @@ bool RigelDome::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(OperationSP.name, name))
+        if (OperationSP.isNameMatch(name))
         {
             const char *requestedOperation = IUFindOnSwitchName(states, names, n);
-            if (!strcmp(requestedOperation, OperationS[OPERATION_FIND_HOME].name))
+            if (!strcmp(requestedOperation, OperationSP[OPERATION_FIND_HOME].getName()))
             {
                 if (home())
                 {
-                    IUResetSwitch(&OperationSP);
-                    OperationS[OPERATION_FIND_HOME].s = ISS_ON;
-                    OperationSP.s = IPS_BUSY;
+                    OperationSP.reset();
+                    OperationSP[OPERATION_FIND_HOME].setState(ISS_ON);
+                    OperationSP.setState(IPS_BUSY);
                     LOG_INFO("Dome is moving to home position...");
                     setDomeState(DOME_MOVING);
                 }
                 else
                 {
-                    OperationSP.s = IPS_ALERT;
+                    OperationSP.setState(IPS_ALERT);
                 }
             }
-            else if (!strcmp(requestedOperation, OperationS[OPERATION_CALIBRATE].name))
+            else if (!strcmp(requestedOperation, OperationSP[OPERATION_CALIBRATE].getName()))
             {
                 if (calibrate())
                 {
-                    IUResetSwitch(&OperationSP);
-                    OperationS[OPERATION_CALIBRATE].s = ISS_ON;
-                    OperationSP.s = IPS_BUSY;
+                    OperationSP.reset();
+                    OperationSP[OPERATION_CALIBRATE].setState(ISS_ON);
+                    OperationSP.setState(IPS_BUSY);
                     LOG_INFO("Dome is calibrating...");
                     setDomeState(DOME_MOVING);
                 }
                 else
                 {
-                    OperationSP.s = IPS_ALERT;
+                    OperationSP.setState(IPS_ALERT);
                 }
             }
 
-            IDSetSwitch(&OperationSP, nullptr);
+            OperationSP.apply();
             return true;
         }
     }
@@ -257,25 +257,25 @@ void RigelDome::TimerHit()
 
     bool isMoving = (m_rawMotorState != M_Idle && m_rawMotorState != M_MovingAtSideral);
 
-    if (DomeAbsPosNP.s == IPS_BUSY && isMoving == false)
+    if (DomeAbsPosNP.getState() == IPS_BUSY && isMoving == false)
     {
-        bool isHoming = (OperationSP.s == IPS_BUSY && OperationS[OPERATION_FIND_HOME].s == ISS_ON);
-        bool isCalibrating = (OperationSP.s == IPS_BUSY && OperationS[OPERATION_CALIBRATE].s == ISS_ON);
+        bool isHoming = (OperationSP.getState() == IPS_BUSY && OperationSP[OPERATION_FIND_HOME].s == ISS_ON);
+        bool isCalibrating = (OperationSP.getState() == IPS_BUSY && OperationSP[OPERATION_CALIBRATE].s == ISS_ON);
 
         if (isHoming)
         {
             LOG_INFO("Dome completed homing...");
-            IUResetSwitch(&OperationSP);
-            OperationSP.s = IPS_OK;
-            IDSetSwitch(&OperationSP, nullptr);
+            OperationSP.reset();
+            OperationSP.setState(IPS_OK);
+            OperationSP.apply();
             setDomeState(DOME_SYNCED);
         }
         else if (isCalibrating)
         {
             LOG_INFO("Dome completed calibration...");
-            IUResetSwitch(&OperationSP);
-            OperationSP.s = IPS_OK;
-            IDSetSwitch(&OperationSP, nullptr);
+            OperationSP.reset();
+            OperationSP.setState(IPS_OK);
+            OperationSP.apply();
             setDomeState(DOME_SYNCED);
         }
         else if (getDomeState() == DOME_PARKING)
@@ -285,16 +285,16 @@ void RigelDome::TimerHit()
         }
         else
         {
-            LOGF_INFO("Dome reached requested azimuth: %.3f Degrees", DomeAbsPosN[0].value);
+            LOGF_INFO("Dome reached requested azimuth: %.3f Degrees", DomeAbsPosNP[0].getValue());
             setDomeState(DOME_SYNCED);
         }
     }
     else
     {
-        if (DomeAbsPosNP.s != IPS_BUSY && isMoving)
-            DomeAbsPosNP.s = IPS_BUSY;
+        if (DomeAbsPosNP.getState() != IPS_BUSY && isMoving)
+            DomeAbsPosNP.setState(IPS_BUSY);
 
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
     }
 
     if (HasShutter())
@@ -306,7 +306,7 @@ void RigelDome::TimerHit()
         }
 
         if (readBatteryLevels())
-            IDSetText(&InfoTP, nullptr);
+            InfoTP.apply();
     }
 
     SetTimer(getCurrentPollingPeriod());
@@ -331,12 +331,12 @@ IPState RigelDome::MoveAbs(double az)
 /////////////////////////////////////////////////////////////////////////////
 IPState RigelDome::MoveRel(double azDiff)
 {
-    targetAz = DomeAbsPosN[0].value + azDiff;
+    targetAz = DomeAbsPosNP[0].getValue() + azDiff;
 
-    if (targetAz < DomeAbsPosN[0].min)
-        targetAz += DomeAbsPosN[0].max;
-    if (targetAz > DomeAbsPosN[0].max)
-        targetAz -= DomeAbsPosN[0].max;
+    if (targetAz < DomeAbsPosNP[0].min)
+        targetAz += DomeAbsPosNP[0].getMax();
+    if (targetAz > DomeAbsPosNP[0].max)
+        targetAz -= DomeAbsPosNP[0].getMax();
 
     // It will take a few cycles to reach final position
     return MoveAbs(targetAz);
@@ -433,17 +433,17 @@ bool RigelDome::Abort()
 {
     if (sendCommand("STOP"))
     {
-        if (OperationSP.s == IPS_BUSY)
+        if (OperationSP.getState() == IPS_BUSY)
         {
-            LOGF_INFO("%s is aborted.", OperationS[OPERATION_CALIBRATE].s == ISS_ON ? "Calibration" : "Finding home");
-            IUResetSwitch(&OperationSP);
-            OperationSP.s = IPS_ALERT;
-            IDSetSwitch(&OperationSP, nullptr);
+            LOGF_INFO("%s is aborted.", OperationSP[OPERATION_CALIBRATE].getState() == ISS_ON ? "Calibration" : "Finding home");
+            OperationSP.reset();
+            OperationSP.setState(IPS_ALERT);
+            OperationSP.apply();
         }
         else if (getShutterState() == SHUTTER_MOVING)
         {
-            DomeShutterSP.s = IPS_ALERT;
-            IDSetSwitch(&DomeShutterSP, nullptr);
+            DomeShutterSP.setState(IPS_ALERT);
+            DomeShutterSP.apply();
             LOG_WARN("Shutter motion aborted!");
         }
         else
@@ -462,7 +462,7 @@ bool RigelDome::Abort()
 /////////////////////////////////////////////////////////////////////////////
 bool RigelDome::SetCurrentPark()
 {
-    SetAxis1Park(DomeAbsPosN[0].value);
+    SetAxis1Park(DomeAbsPosNP[0].value);
     return true;
 }
 
@@ -508,7 +508,7 @@ bool RigelDome::readStepsPerRevolution()
     if (sendCommand("ENCREV", res) == false)
         return false;
 
-    IUSaveText(&InfoT[INFO_TICKS], res);
+    InfoTP[INFO_TICKS].setText(res);
     return true;
 }
 
@@ -529,7 +529,7 @@ bool RigelDome::readBatteryLevels()
 
     char levels[DRIVER_LEN] = {0};
     snprintf(levels, DRIVER_LEN, "%.2fv (%d%%)", volts / 1000.0, percent);
-    IUSaveText(&InfoT[INFO_BATTERY], levels);
+    InfoTP[INFO_BATTERY].setText(levels);
     return true;
 }
 
@@ -542,7 +542,7 @@ bool RigelDome::readPosition()
     if (sendCommand("ANGLE", res) == false)
         return false;
 
-    DomeAbsPosN[0].value = std::stod(res);
+    DomeAbsPosNP[0].setValue(std::stod(res));
     return true;
 }
 
@@ -573,7 +573,7 @@ bool RigelDome::readState()
     if (fields.size() < 13)
         return false;
 
-    DomeAbsPosN[0].value = std::stod(fields[0]);
+    DomeAbsPosNP[0].setValue(std::stod(fields[0]));
     m_rawMotorState = static_cast<RigelMotorState>(std::stoi(fields[1]));
     m_rawShutterState = static_cast<RigelShutterState>(std::stoi(fields[5]));
     return true;
@@ -628,7 +628,7 @@ bool RigelDome::readFirmware()
     if (sendCommand("VER", res) == false)
         return false;
 
-    IUSaveText(&InfoT[INFO_FIRMWARE], res);
+    InfoTP[INFO_FIRMWARE].setText(res);
 
     return true;
 }
@@ -643,7 +643,7 @@ bool RigelDome::readModel()
     if (sendCommand("PULSAR", res) == false)
         return false;
 
-    IUSaveText(&InfoT[INFO_MODEL], res);
+    InfoTP[INFO_MODEL].setText(res);
 
     return true;
 }
@@ -749,7 +749,7 @@ IPState RigelDome::Move(DomeDirection dir, DomeMotionCommand operation)
 
     if (operation == MOTION_START)
     {
-        target = DomeAbsPosN[0].value;
+        target = DomeAbsPosNP[0].getValue();
         if(dir == DOME_CW)
         {
             target += 5;
@@ -766,7 +766,7 @@ IPState RigelDome::Move(DomeDirection dir, DomeMotionCommand operation)
     }
     else
     {
-        target = DomeAbsPosN[0].value;
+        target = DomeAbsPosNP[0].getValue();
     }
 
     MoveAbs(target);

--- a/drivers/dome/rigel_dome.h
+++ b/drivers/dome/rigel_dome.h
@@ -23,6 +23,10 @@
 
 #include "indibase/indidome.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+
 class RigelDome : public INDI::Dome
 {
     public:
@@ -100,8 +104,7 @@ class RigelDome : public INDI::Dome
         ///////////////////////////////////////////////////////////////////////////////////
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////////
-        ISwitchVectorProperty OperationSP;
-        ISwitch OperationS[2];
+        INDI::PropertySwitch OperationSP {2};
         enum
         {
             OPERATION_FIND_HOME,
@@ -109,8 +112,7 @@ class RigelDome : public INDI::Dome
         };
 
         // Info
-        ITextVectorProperty InfoTP;
-        IText InfoT[4] {};
+        INDI::PropertyText InfoTP {4};
         enum
         {
             INFO_FIRMWARE,

--- a/drivers/dome/roll_off.cpp
+++ b/drivers/dome/roll_off.cpp
@@ -159,7 +159,7 @@ void RollOff::TimerHit()
     if (!isConnected())
         return; //  No need to reset timer if we are not connected anymore
 
-    if (DomeMotionSP.s == IPS_BUSY)
+    if (DomeMotionSP.getState() == IPS_BUSY)
     {
         // Abort called
         if (MotionRequest < 0)
@@ -171,7 +171,7 @@ void RollOff::TimerHit()
         }
 
         // Roll off is opening
-        if (DomeMotionS[DOME_CW].s == ISS_ON)
+        if (DomeMotionSP[DOME_CW].getState() == ISS_ON)
         {
             if (getFullOpenedLimitSwitch())
             {
@@ -181,7 +181,7 @@ void RollOff::TimerHit()
             }
         }
         // Roll Off is closing
-        else if (DomeMotionS[DOME_CCW].s == ISS_ON)
+        else if (DomeMotionSP[DOME_CCW].getState() == ISS_ON)
         {
             if (getFullClosedLimitSwitch())
             {
@@ -271,9 +271,9 @@ bool RollOff::Abort()
     // If both limit switches are off, then we're neither parked nor unparked.
     if (fullOpenLimitSwitch == ISS_OFF && fullClosedLimitSwitch == ISS_OFF)
     {
-        IUResetSwitch(&ParkSP);
-        ParkSP.s = IPS_IDLE;
-        IDSetSwitch(&ParkSP, nullptr);
+        ParkSP.reset();
+        ParkSP.setState(IPS_IDLE);
+        ParkSP.apply();
     }
 
     return true;

--- a/drivers/dome/scopedome_dome.cpp
+++ b/drivers/dome/scopedome_dome.cpp
@@ -140,95 +140,95 @@ bool ScopeDome::initProperties()
 {
     INDI::Dome::initProperties();
 
-    IUFillNumber(&DomeHomePositionN[0], "DH_POSITION", "AZ (deg)", "%6.2f", 0.0, 360.0, 1.0, 0.0);
-    IUFillNumberVector(&DomeHomePositionNP, DomeHomePositionN, 1, getDeviceName(), "DOME_HOME_POSITION",
+    DomeHomePositionNP[0].fill("DH_POSITION", "AZ (deg)", "%6.2f", 0.0, 360.0, 1.0, 0.0);
+    DomeHomePositionNP.fill(getDeviceName(), "DOME_HOME_POSITION",
                        "Home sensor position", SITE_TAB, IP_RW, 60, IPS_OK);
 
-    IUFillSwitch(&ParkShutterS[0], "ON", "On", ISS_ON);
-    IUFillSwitch(&ParkShutterS[1], "OFF", "Off", ISS_OFF);
-    IUFillSwitchVector(&ParkShutterSP, ParkShutterS, 2, getDeviceName(), "PARK_SHUTTER", "Park controls shutter",
+    ParkShutterSP[0].fill("ON", "On", ISS_ON);
+    ParkShutterSP[1].fill("OFF", "Off", ISS_OFF);
+    ParkShutterSP.fill(getDeviceName(), "PARK_SHUTTER", "Park controls shutter",
                        OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_OK);
 
-    IUFillSwitch(&FindHomeS[0], "START", "Start", ISS_OFF);
-    IUFillSwitchVector(&FindHomeSP, FindHomeS, 1, getDeviceName(), "FIND_HOME", "Find home", MAIN_CONTROL_TAB, IP_RW,
+    FindHomeSP[0].fill("START", "Start", ISS_OFF);
+    FindHomeSP.fill(getDeviceName(), "FIND_HOME", "Find home", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_OK);
 
-    IUFillSwitch(&DerotateS[0], "START", "Start", ISS_OFF);
-    IUFillSwitchVector(&DerotateSP, DerotateS, 1, getDeviceName(), "DEROTATE", "Derotate", MAIN_CONTROL_TAB, IP_RW,
+    DerotateSP[0].fill("START", "Start", ISS_OFF);
+    DerotateSP.fill(getDeviceName(), "DEROTATE", "Derotate", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_OK);
 
-    IUFillSwitch(&PowerRelaysS[0], "CCD", "CCD", ISS_OFF);
-    IUFillSwitch(&PowerRelaysS[1], "SCOPE", "Telescope", ISS_OFF);
-    IUFillSwitch(&PowerRelaysS[2], "LIGHT", "Light", ISS_OFF);
-    IUFillSwitch(&PowerRelaysS[3], "FAN", "Fan", ISS_OFF);
-    IUFillSwitchVector(&PowerRelaysSP, PowerRelaysS, 4, getDeviceName(), "POWER_RELAYS", "Power relays",
+    PowerRelaysSP[0].fill("CCD", "CCD", ISS_OFF);
+    PowerRelaysSP[1].fill("SCOPE", "Telescope", ISS_OFF);
+    PowerRelaysSP[2].fill("LIGHT", "Light", ISS_OFF);
+    PowerRelaysSP[3].fill("FAN", "Fan", ISS_OFF);
+    PowerRelaysSP.fill(getDeviceName(), "POWER_RELAYS", "Power relays",
                        MAIN_CONTROL_TAB, IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&RelaysS[0], "RELAY_1", "Relay 1 (reset)", ISS_OFF);
-    IUFillSwitch(&RelaysS[1], "RELAY_2", "Relay 2 (heater)", ISS_OFF);
-    IUFillSwitch(&RelaysS[2], "RELAY_3", "Relay 3", ISS_OFF);
-    IUFillSwitch(&RelaysS[3], "RELAY_4", "Relay 4", ISS_OFF);
-    IUFillSwitchVector(&RelaysSP, RelaysS, 4, getDeviceName(), "RELAYS", "Relays", MAIN_CONTROL_TAB, IP_RW, ISR_NOFMANY,
+    RelaysSP[0].fill("RELAY_1", "Relay 1 (reset)", ISS_OFF);
+    RelaysSP[1].fill("RELAY_2", "Relay 2 (heater)", ISS_OFF);
+    RelaysSP[2].fill("RELAY_3", "Relay 3", ISS_OFF);
+    RelaysSP[3].fill("RELAY_4", "Relay 4", ISS_OFF);
+    RelaysSP.fill(getDeviceName(), "RELAYS", "Relays", MAIN_CONTROL_TAB, IP_RW, ISR_NOFMANY,
                        0, IPS_IDLE);
 
-    IUFillSwitch(&AutoCloseS[0], "CLOUD", "Cloud sensor", ISS_OFF);
-    IUFillSwitch(&AutoCloseS[1], "RAIN", "Rain sensor", ISS_OFF);
-    IUFillSwitch(&AutoCloseS[2], "FREE", "Free input", ISS_OFF);
-    IUFillSwitch(&AutoCloseS[3], "NO_POWER", "No power", ISS_OFF);
-    IUFillSwitch(&AutoCloseS[4], "DOME_LOW", "Low dome battery", ISS_OFF);
-    IUFillSwitch(&AutoCloseS[5], "SHUTTER_LOW", "Low shutter battery", ISS_OFF);
-    IUFillSwitch(&AutoCloseS[6], "WEATHER", "Bad weather", ISS_OFF);
-    IUFillSwitch(&AutoCloseS[7], "LOST_CONNECTION", "Lost connection", ISS_OFF);
-    IUFillSwitchVector(&AutoCloseSP, AutoCloseS, 8, getDeviceName(), "AUTO_CLOSE", "Close shutter automatically",
+    AutoCloseSP[0].fill("CLOUD", "Cloud sensor", ISS_OFF);
+    AutoCloseSP[1].fill("RAIN", "Rain sensor", ISS_OFF);
+    AutoCloseSP[2].fill("FREE", "Free input", ISS_OFF);
+    AutoCloseSP[3].fill("NO_POWER", "No power", ISS_OFF);
+    AutoCloseSP[4].fill("DOME_LOW", "Low dome battery", ISS_OFF);
+    AutoCloseSP[5].fill("SHUTTER_LOW", "Low shutter battery", ISS_OFF);
+    AutoCloseSP[6].fill("WEATHER", "Bad weather", ISS_OFF);
+    AutoCloseSP[7].fill("LOST_CONNECTION", "Lost connection", ISS_OFF);
+    AutoCloseSP.fill(getDeviceName(), "AUTO_CLOSE", "Close shutter automatically",
                        SITE_TAB, IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&EnvironmentSensorsN[0], "LINK_STRENGTH", "Shutter link strength", "%3.0f", 0.0, 100.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[1], "SHUTTER_POWER", "Shutter internal power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[2], "SHUTTER_BATTERY", "Shutter battery power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[3], "CARD_POWER", "Card internal power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[4], "CARD_BATTERY", "Card battery power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[5], "TEMP_DOME_IN", "Temperature in dome", "%2.2f", -100.0, 100.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[6], "TEMP_DOME_OUT", "Temperature outside dome", "%2.2f", -100.0, 100.0, 1.0,
+    EnvironmentSensorsNP[0].fill("LINK_STRENGTH", "Shutter link strength", "%3.0f", 0.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP[1].fill("SHUTTER_POWER", "Shutter internal power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP[2].fill("SHUTTER_BATTERY", "Shutter battery power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP[3].fill("CARD_POWER", "Card internal power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP[4].fill("CARD_BATTERY", "Card battery power", "%2.2f", 0.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP[5].fill("TEMP_DOME_IN", "Temperature in dome", "%2.2f", -100.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP[6].fill("TEMP_DOME_OUT", "Temperature outside dome", "%2.2f", -100.0, 100.0, 1.0,
                  0.0);
-    IUFillNumber(&EnvironmentSensorsN[7], "TEMP_DOME_HUMIDITY", "Temperature humidity sensor", "%2.2f", -100.0, 100.0,
+    EnvironmentSensorsNP[7].fill("TEMP_DOME_HUMIDITY", "Temperature humidity sensor", "%2.2f", -100.0, 100.0,
                  1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[8], "HUMIDITY", "Humidity", "%3.2f", 0.0, 100.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[9], "PRESSURE", "Pressure", "%4.1f", 0.0, 2000.0, 1.0, 0.0);
-    IUFillNumber(&EnvironmentSensorsN[10], "DEW_POINT", "Dew point", "%2.2f", -100.0, 100.0, 1.0, 0.0);
-    IUFillNumberVector(&EnvironmentSensorsNP, EnvironmentSensorsN, 11, getDeviceName(), "SCOPEDOME_SENSORS",
+    EnvironmentSensorsNP[8].fill("HUMIDITY", "Humidity", "%3.2f", 0.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP[9].fill("PRESSURE", "Pressure", "%4.1f", 0.0, 2000.0, 1.0, 0.0);
+    EnvironmentSensorsNP[10].fill("DEW_POINT", "Dew point", "%2.2f", -100.0, 100.0, 1.0, 0.0);
+    EnvironmentSensorsNP.fill(getDeviceName(), "SCOPEDOME_SENSORS",
                        "Environment sensors", INFO_TAB, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&SensorsS[0], "AZ_COUNTER", "Az counter", ISS_OFF);
-    IUFillSwitch(&SensorsS[1], "ROTATE_CCW", "Rotate CCW", ISS_OFF);
-    IUFillSwitch(&SensorsS[2], "HOME", "Dome at home", ISS_OFF);
-    IUFillSwitch(&SensorsS[3], "OPEN_1", "Shutter 1 open", ISS_OFF);
-    IUFillSwitch(&SensorsS[4], "CLOSE_1", "Shutter 1 closed", ISS_OFF);
-    IUFillSwitch(&SensorsS[5], "OPEN_2", "Shutter 2 open", ISS_OFF);
-    IUFillSwitch(&SensorsS[6], "CLOSE_2", "Shutter 2 closed", ISS_OFF);
-    IUFillSwitch(&SensorsS[7], "SCOPE_HOME", "Scope at home", ISS_OFF);
-    IUFillSwitch(&SensorsS[8], "RAIN", "Rain sensor", ISS_OFF);
-    IUFillSwitch(&SensorsS[9], "CLOUD", "Cloud sensor", ISS_OFF);
-    IUFillSwitch(&SensorsS[10], "SAFE", "Observatory safe", ISS_OFF);
-    IUFillSwitch(&SensorsS[11], "LINK", "Rotary link", ISS_OFF);
-    IUFillSwitch(&SensorsS[12], "FREE", "Free input", ISS_OFF);
-    IUFillSwitchVector(&SensorsSP, SensorsS, 13, getDeviceName(), "INPUTS", "Input sensors", INFO_TAB, IP_RO,
+    SensorsSP[0].fill("AZ_COUNTER", "Az counter", ISS_OFF);
+    SensorsSP[1].fill("ROTATE_CCW", "Rotate CCW", ISS_OFF);
+    SensorsSP[2].fill("HOME", "Dome at home", ISS_OFF);
+    SensorsSP[3].fill("OPEN_1", "Shutter 1 open", ISS_OFF);
+    SensorsSP[4].fill("CLOSE_1", "Shutter 1 closed", ISS_OFF);
+    SensorsSP[5].fill("OPEN_2", "Shutter 2 open", ISS_OFF);
+    SensorsSP[6].fill("CLOSE_2", "Shutter 2 closed", ISS_OFF);
+    SensorsSP[7].fill("SCOPE_HOME", "Scope at home", ISS_OFF);
+    SensorsSP[8].fill("RAIN", "Rain sensor", ISS_OFF);
+    SensorsSP[9].fill("CLOUD", "Cloud sensor", ISS_OFF);
+    SensorsSP[10].fill("SAFE", "Observatory safe", ISS_OFF);
+    SensorsSP[11].fill("LINK", "Rotary link", ISS_OFF);
+    SensorsSP[12].fill("FREE", "Free input", ISS_OFF);
+    SensorsSP.fill(getDeviceName(), "INPUTS", "Input sensors", INFO_TAB, IP_RO,
                        ISR_NOFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&FirmwareVersionsN[0], "MAIN", "Main part", "%2.2f", 0.0, 99.0, 1.0, 0.0);
-    IUFillNumber(&FirmwareVersionsN[1], "ROTARY", "Rotary part", "%2.1f", 0.0, 99.0, 1.0, 0.0);
-    IUFillNumberVector(&FirmwareVersionsNP, FirmwareVersionsN, 2, getDeviceName(), "FIRMWARE_VERSION",
+    FirmwareVersionsNP[0].fill("MAIN", "Main part", "%2.2f", 0.0, 99.0, 1.0, 0.0);
+    FirmwareVersionsNP[1].fill("ROTARY", "Rotary part", "%2.1f", 0.0, 99.0, 1.0, 0.0);
+    FirmwareVersionsNP.fill(getDeviceName(), "FIRMWARE_VERSION",
                        "Firmware versions", INFO_TAB, IP_RO, 60, IPS_IDLE);
 
-    IUFillNumber(&StepsPerRevolutionN[0], "STEPS", "Steps per revolution", "%5.0f", 0.0, 99999.0, 1.0, 0.0);
-    IUFillNumberVector(&StepsPerRevolutionNP, StepsPerRevolutionN, 1, getDeviceName(), "CALIBRATION_VALUES",
+    StepsPerRevolutionNP[0].fill("STEPS", "Steps per revolution", "%5.0f", 0.0, 99999.0, 1.0, 0.0);
+    StepsPerRevolutionNP.fill(getDeviceName(), "CALIBRATION_VALUES",
                        "Calibration values", SITE_TAB, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&CalibrationNeededS[0], "CALIBRATION_NEEDED", "Calibration needed", ISS_OFF);
-    IUFillSwitchVector(&CalibrationNeededSP, CalibrationNeededS, 1, getDeviceName(), "CALIBRATION_STATUS",
+    CalibrationNeededSP[0].fill("CALIBRATION_NEEDED", "Calibration needed", ISS_OFF);
+    CalibrationNeededSP.fill(getDeviceName(), "CALIBRATION_STATUS",
                        "Calibration status", SITE_TAB, IP_RO, ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&StartCalibrationS[0], "START", "Start", ISS_OFF);
-    IUFillSwitchVector(&StartCalibrationSP, StartCalibrationS, 1, getDeviceName(), "RUN_CALIBRATION", "Run calibration",
+    StartCalibrationSP[0].fill("START", "Start", ISS_OFF);
+    StartCalibrationSP.fill(getDeviceName(), "RUN_CALIBRATION", "Run calibration",
                        SITE_TAB, IP_RW, ISR_ATMOST1, 0, IPS_OK);
 
     SetParkDataType(PARK_AZ);
@@ -252,18 +252,18 @@ bool ScopeDome::SetupParms()
 
     readU32(GetImpPerTurn, stepsPerTurn);
     LOGF_INFO("Steps per turn read as %d", stepsPerTurn);
-    StepsPerRevolutionN[0].value = stepsPerTurn;
-    StepsPerRevolutionNP.s       = IPS_OK;
-    IDSetNumber(&StepsPerRevolutionNP, nullptr);
+    StepsPerRevolutionNP[0].setValue(stepsPerTurn);
+    StepsPerRevolutionNP.setState(IPS_OK);
+    StepsPerRevolutionNP.apply();
 
     readS32(GetHomeSensorPosition, homePosition);
     LOGF_INFO("Home position read as %d", homePosition);
 
     if (UpdatePosition())
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
 
     if (UpdateShutterStatus())
-        IDSetSwitch(&DomeShutterSP, nullptr);
+        DomeShutterSP.apply();
 
     UpdateSensorStatus();
     UpdateRelayStatus();
@@ -284,19 +284,19 @@ bool ScopeDome::SetupParms()
 
     uint8_t calibrationNeeded = false;
     readU8(IsFullSystemCalReq, calibrationNeeded);
-    CalibrationNeededS[0].s = calibrationNeeded ? ISS_ON : ISS_OFF;
-    CalibrationNeededSP.s   = IPS_OK;
-    IDSetSwitch(&CalibrationNeededSP, nullptr);
+    CalibrationNeededSP[0].setState(calibrationNeeded ? ISS_ON : ISS_OFF);
+    CalibrationNeededSP.setState(IPS_OK);
+    CalibrationNeededSP.apply();
 
     uint16_t fwVersion;
     readU16(GetVersionFirmware, fwVersion);
-    FirmwareVersionsN[0].value = fwVersion / 100.0;
+    FirmwareVersionsNP[0].setValue(fwVersion / 100.0);
 
     uint8_t fwVersionRotary;
     readU8(GetVersionFirmwareRotary, fwVersionRotary);
-    FirmwareVersionsN[1].value = (fwVersionRotary + 9) / 10.0;
-    FirmwareVersionsNP.s       = IPS_OK;
-    IDSetNumber(&FirmwareVersionsNP, nullptr);
+    FirmwareVersionsNP[1].setValue((fwVersionRotary + 9) / 10.0);
+    FirmwareVersionsNP.setState(IPS_OK);
+    FirmwareVersionsNP.apply();
     return true;
 }
 
@@ -325,36 +325,36 @@ bool ScopeDome::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&FindHomeSP);
-        defineProperty(&DerotateSP);
-        defineProperty(&AutoCloseSP);
-        defineProperty(&PowerRelaysSP);
-        defineProperty(&RelaysSP);
-        defineProperty(&DomeHomePositionNP);
-        defineProperty(&EnvironmentSensorsNP);
-        defineProperty(&SensorsSP);
-        defineProperty(&ParkShutterSP);
-        defineProperty(&StepsPerRevolutionNP);
-        defineProperty(&CalibrationNeededSP);
-        defineProperty(&StartCalibrationSP);
-        defineProperty(&FirmwareVersionsNP);
+        defineProperty(FindHomeSP);
+        defineProperty(DerotateSP);
+        defineProperty(AutoCloseSP);
+        defineProperty(PowerRelaysSP);
+        defineProperty(RelaysSP);
+        defineProperty(DomeHomePositionNP);
+        defineProperty(EnvironmentSensorsNP);
+        defineProperty(SensorsSP);
+        defineProperty(ParkShutterSP);
+        defineProperty(StepsPerRevolutionNP);
+        defineProperty(CalibrationNeededSP);
+        defineProperty(StartCalibrationSP);
+        defineProperty(FirmwareVersionsNP);
         SetupParms();
     }
     else
     {
-        deleteProperty(FindHomeSP.name);
-        deleteProperty(DerotateSP.name);
-        deleteProperty(PowerRelaysSP.name);
-        deleteProperty(RelaysSP.name);
-        deleteProperty(SensorsSP.name);
-        deleteProperty(AutoCloseSP.name);
-        deleteProperty(DomeHomePositionNP.name);
-        deleteProperty(EnvironmentSensorsNP.name);
-        deleteProperty(ParkShutterSP.name);
-        deleteProperty(StepsPerRevolutionNP.name);
-        deleteProperty(CalibrationNeededSP.name);
-        deleteProperty(StartCalibrationSP.name);
-        deleteProperty(FirmwareVersionsNP.name);
+        deleteProperty(FindHomeSP.getName());
+        deleteProperty(DerotateSP.getName());
+        deleteProperty(PowerRelaysSP.getName());
+        deleteProperty(RelaysSP.getName());
+        deleteProperty(SensorsSP.getName());
+        deleteProperty(AutoCloseSP.getName());
+        deleteProperty(DomeHomePositionNP.getName());
+        deleteProperty(EnvironmentSensorsNP.getName());
+        deleteProperty(ParkShutterSP.getName());
+        deleteProperty(StepsPerRevolutionNP.getName());
+        deleteProperty(CalibrationNeededSP.getName());
+        deleteProperty(StartCalibrationSP.getName());
+        deleteProperty(FirmwareVersionsNP.getName());
     }
 
     return true;
@@ -367,77 +367,77 @@ bool ScopeDome::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, FindHomeSP.name) == 0)
+        if (FindHomeSP.isNameMatch(name))
         {
             if (status != DOME_HOMING)
             {
                 LOG_INFO("Finding home sensor");
                 status = DOME_HOMING;
-                IUResetSwitch(&FindHomeSP);
-                DomeAbsPosNP.s = IPS_BUSY;
-                FindHomeSP.s   = IPS_BUSY;
-                IDSetSwitch(&FindHomeSP, nullptr);
+                FindHomeSP.reset();
+                DomeAbsPosNP.setState(IPS_BUSY);
+                FindHomeSP.setState(IPS_BUSY);
+                FindHomeSP.apply();
                 writeCmd(FindHome);
             }
             return true;
         }
 
-        if (strcmp(name, DerotateSP.name) == 0)
+        if (DerotateSP.isNameMatch(name))
         {
             if (status != DOME_DEROTATING)
             {
                 LOG_INFO("De-rotating started");
                 status = DOME_DEROTATING;
-                IUResetSwitch(&DerotateSP);
-                DomeAbsPosNP.s = IPS_BUSY;
-                DerotateSP.s   = IPS_BUSY;
-                IDSetSwitch(&DerotateSP, nullptr);
+                DerotateSP.reset();
+                DomeAbsPosNP.setState(IPS_BUSY);
+                DerotateSP.setState(IPS_BUSY);
+                DerotateSP.apply();
             }
             return true;
         }
 
-        if (strcmp(name, StartCalibrationSP.name) == 0)
+        if (StartCalibrationSP.isNameMatch(name))
         {
             if (status != DOME_CALIBRATING)
             {
                 LOG_INFO("Calibration started");
                 status = DOME_CALIBRATING;
-                IUResetSwitch(&StartCalibrationSP);
-                DomeAbsPosNP.s       = IPS_BUSY;
-                StartCalibrationSP.s = IPS_BUSY;
-                IDSetSwitch(&StartCalibrationSP, nullptr);
+                StartCalibrationSP.reset();
+                DomeAbsPosNP.setState(IPS_BUSY);
+                StartCalibrationSP.setState(IPS_BUSY);
+                StartCalibrationSP.apply();
                 writeCmd(FullSystemCal);
             }
             return true;
         }
 
-        if (strcmp(name, PowerRelaysSP.name) == 0)
+        if (PowerRelaysSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PowerRelaysSP, states, names, n);
-            setOutputState(OUT_CCD, PowerRelaysS[0].s);
-            setOutputState(OUT_SCOPE, PowerRelaysS[1].s);
-            setOutputState(OUT_LIGHT, PowerRelaysS[2].s);
-            setOutputState(OUT_FAN, PowerRelaysS[3].s);
-            IDSetSwitch(&PowerRelaysSP, nullptr);
+            PowerRelaysSP.update(states, names, n);
+            setOutputState(OUT_CCD, PowerRelaysSP[0].getState());
+            setOutputState(OUT_SCOPE, PowerRelaysSP[1].getState());
+            setOutputState(OUT_LIGHT, PowerRelaysSP[2].getState());
+            setOutputState(OUT_FAN, PowerRelaysSP[3].getState());
+            PowerRelaysSP.apply();
             return true;
         }
 
-        if (strcmp(name, RelaysSP.name) == 0)
+        if (RelaysSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&RelaysSP, states, names, n);
-            setOutputState(OUT_RELAY1, RelaysS[0].s);
-            setOutputState(OUT_RELAY2, RelaysS[1].s);
-            setOutputState(OUT_RELAY3, RelaysS[2].s);
-            setOutputState(OUT_RELAY4, RelaysS[3].s);
-            IDSetSwitch(&RelaysSP, nullptr);
+            RelaysSP.update(states, names, n);
+            setOutputState(OUT_RELAY1, RelaysSP[0].getState());
+            setOutputState(OUT_RELAY2, RelaysSP[1].getState());
+            setOutputState(OUT_RELAY3, RelaysSP[2].getState());
+            setOutputState(OUT_RELAY4, RelaysSP[3].getState());
+            RelaysSP.apply();
             return true;
         }
 
-        if (strcmp(name, ParkShutterSP.name) == 0)
+        if (ParkShutterSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ParkShutterSP, states, names, n);
-            ParkShutterSP.s = IPS_OK;
-            IDSetSwitch(&ParkShutterSP, nullptr);
+            ParkShutterSP.update(states, names, n);
+            ParkShutterSP.setState(IPS_OK);
+            ParkShutterSP.apply();
             return true;
         }
     }
@@ -449,11 +449,11 @@ bool ScopeDome::ISNewNumber(const char *dev, const char *name, double values[], 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, DomeHomePositionNP.name) == 0)
+        if (DomeHomePositionNP.isNameMatch(name))
         {
-            IUUpdateNumber(&DomeHomePositionNP, values, names, n);
-            DomeHomePositionNP.s = IPS_OK;
-            IDSetNumber(&DomeHomePositionNP, nullptr);
+            DomeHomePositionNP.update(values, names, n);
+            DomeHomePositionNP.setState(IPS_OK);
+            DomeHomePositionNP.apply();
             return true;
         }
     }
@@ -494,24 +494,24 @@ bool ScopeDome::UpdateShutterStatus()
     // LOGF_INFO("digitalext %x %x %x %x %x", digitalSensorState[0],
     // digitalSensorState[1], digitalSensorState[2], digitalSensorState[3],
     // digitalSensorState[4]);
-    SensorsS[0].s  = getInputState(IN_ENCODER);
-    SensorsS[1].s  = ISS_OFF; // ?
-    SensorsS[2].s  = getInputState(IN_HOME);
-    SensorsS[3].s  = getInputState(IN_OPEN1);
-    SensorsS[4].s  = getInputState(IN_CLOSED1);
-    SensorsS[5].s  = getInputState(IN_OPEN2);
-    SensorsS[6].s  = getInputState(IN_CLOSED2);
-    SensorsS[7].s  = getInputState(IN_S_HOME);
-    SensorsS[8].s  = getInputState(IN_CLOUDS);
-    SensorsS[9].s  = getInputState(IN_CLOUD);
-    SensorsS[10].s = getInputState(IN_SAFE);
-    SensorsS[11].s = getInputState(IN_ROT_LINK);
-    SensorsS[12].s = getInputState(IN_FREE);
-    SensorsSP.s    = IPS_OK;
-    IDSetSwitch(&SensorsSP, nullptr);
+    SensorsSP[0].setState(getInputState(IN_ENCODER));
+    SensorsSP[1].setState(ISS_OFF); // ?
+    SensorsSP[2].setState(getInputState(IN_HOME));
+    SensorsSP[3].setState(getInputState(IN_OPEN1));
+    SensorsSP[4].setState(getInputState(IN_CLOSED1));
+    SensorsSP[5].setState(getInputState(IN_OPEN2));
+    SensorsSP[6].setState(getInputState(IN_CLOSED2));
+    SensorsSP[7].setState(getInputState(IN_S_HOME));
+    SensorsSP[8].setState(getInputState(IN_CLOUDS));
+    SensorsSP[9].setState(getInputState(IN_CLOUD));
+    SensorsSP[10].setState(getInputState(IN_SAFE));
+    SensorsSP[11].setState(getInputState(IN_ROT_LINK));
+    SensorsSP[12].setState(getInputState(IN_FREE));
+    SensorsSP.setState(IPS_OK);
+    SensorsSP.apply();
 
-    DomeShutterSP.s = IPS_OK;
-    IUResetSwitch(&DomeShutterSP);
+    DomeShutterSP.setState(IPS_OK);
+    DomeShutterSP.reset();
 
     if (getInputState(IN_OPEN1) == ISS_ON) // shutter open switch triggered
     {
@@ -523,7 +523,7 @@ bool ScopeDome::UpdateShutterStatus()
             if (getDomeState() == DOME_UNPARKING)
                 SetParked(false);
         }
-        DomeShutterS[SHUTTER_OPEN].s = ISS_ON;
+        DomeShutterSP[SHUTTER_OPEN].setState(ISS_ON);
     }
     else if (getInputState(IN_CLOSED1) == ISS_ON) // shutter closed switch triggered
     {
@@ -533,17 +533,17 @@ bool ScopeDome::UpdateShutterStatus()
             setOutputState(OUT_CLOSE1, ISS_OFF);
             m_ShutterState = SHUTTER_CLOSED;
 
-            if (getDomeState() == DOME_PARKING && DomeAbsPosNP.s != IPS_BUSY)
+            if (getDomeState() == DOME_PARKING && DomeAbsPosNP.getState() != IPS_BUSY)
             {
                 SetParked(true);
             }
         }
-        DomeShutterS[SHUTTER_CLOSE].s = ISS_ON;
+        DomeShutterSP[SHUTTER_CLOSE].setState(ISS_ON);
     }
     else
     {
         m_ShutterState    = SHUTTER_MOVING;
-        DomeShutterSP.s = IPS_BUSY;
+        DomeShutterSP.setState(IPS_BUSY);
     }
     return true;
 }
@@ -559,13 +559,13 @@ bool ScopeDome::UpdatePosition()
     //    LOGF_INFO("Counters are %d - %d", counter, counter2);
 
     // We assume counter value 0 is at home sensor position
-    double az = ((double)rotationCounter * -360.0 / stepsPerTurn) + DomeHomePositionN[0].value;
+    double az = ((double)rotationCounter * -360.0 / stepsPerTurn) + DomeHomePositionNP[0].getValue();
     az        = fmod(az, 360.0);
     if (az < 0.0)
     {
         az += 360.0;
     }
-    DomeAbsPosN[0].value = az;
+    DomeAbsPosNP[0].setValue(az);
     return true;
 }
 
@@ -585,15 +585,15 @@ bool ScopeDome::UpdateSensorStatus()
     readFloat(GetHum, sensors[7]);
     readFloat(GetPressure, sensors[8]);
 
-    EnvironmentSensorsN[0].value = linkStrength;
+    EnvironmentSensorsNP[0].setValue(linkStrength);
     for (int i = 0; i < 9; ++i)
     {
-        EnvironmentSensorsN[i + 1].value = sensors[i];
+        EnvironmentSensorsNP[i + 1].setValue(sensors[i]);
     }
-    EnvironmentSensorsN[10].value = getDewPoint(EnvironmentSensorsN[8].value, EnvironmentSensorsN[7].value);
-    EnvironmentSensorsNP.s        = IPS_OK;
+    EnvironmentSensorsNP[10].setValue(getDewPoint(EnvironmentSensorsNP[8].value, EnvironmentSensorsNP[7].getValue()));
+    EnvironmentSensorsNP.setState(IPS_OK);
 
-    IDSetNumber(&EnvironmentSensorsNP, nullptr);
+    EnvironmentSensorsNP.apply();
 
     // My shutter unit occasionally disconnects so implement a simple watchdog
     // to check for link strength and reset the controller if link is lost for
@@ -621,19 +621,19 @@ bool ScopeDome::UpdateSensorStatus()
 * ***********************************************************************************/
 bool ScopeDome::UpdateRelayStatus()
 {
-    PowerRelaysS[0].s = getInputState(OUT_CCD);
-    PowerRelaysS[1].s = getInputState(OUT_SCOPE);
-    PowerRelaysS[2].s = getInputState(OUT_LIGHT);
-    PowerRelaysS[3].s = getInputState(OUT_FAN);
-    PowerRelaysSP.s   = IPS_OK;
-    IDSetSwitch(&PowerRelaysSP, nullptr);
+    PowerRelaysSP[0].setState(getInputState(OUT_CCD));
+    PowerRelaysSP[1].setState(getInputState(OUT_SCOPE));
+    PowerRelaysSP[2].setState(getInputState(OUT_LIGHT));
+    PowerRelaysSP[3].setState(getInputState(OUT_FAN));
+    PowerRelaysSP.setState(IPS_OK);
+    PowerRelaysSP.apply();
 
-    RelaysS[0].s = getInputState(OUT_RELAY1);
-    RelaysS[1].s = getInputState(OUT_RELAY2);
-    RelaysS[2].s = getInputState(OUT_RELAY3);
-    RelaysS[3].s = getInputState(OUT_RELAY4);
-    RelaysSP.s   = IPS_OK;
-    IDSetSwitch(&RelaysSP, nullptr);
+    RelaysSP[0].setState(getInputState(OUT_RELAY1));
+    RelaysSP[1].setState(getInputState(OUT_RELAY2));
+    RelaysSP[2].setState(getInputState(OUT_RELAY3));
+    RelaysSP[3].setState(getInputState(OUT_RELAY4));
+    RelaysSP.setState(IPS_OK);
+    RelaysSP.apply();
     return true;
 }
 
@@ -650,7 +650,7 @@ void ScopeDome::TimerHit()
     UpdatePosition();
 
     UpdateShutterStatus();
-    IDSetSwitch(&DomeShutterSP, nullptr);
+    DomeShutterSP.apply();
 
     UpdateRelayStatus();
 
@@ -658,7 +658,7 @@ void ScopeDome::TimerHit()
     {
         if ((currentStatus & (STATUS_HOMING | STATUS_MOVING)) == 0)
         {
-            double azDiff = DomeHomePositionN[0].value - DomeAbsPosN[0].value;
+            double azDiff = DomeHomePositionNP[0].getValue() - DomeAbsPosNP[0].getValue();
 
             if (azDiff > 180)
             {
@@ -669,28 +669,28 @@ void ScopeDome::TimerHit()
                 azDiff += 360;
             }
 
-            if (getInputState(IN_HOME) || fabs(azDiff) <= DomeParamN[0].value)
+            if (getInputState(IN_HOME) || fabs(azDiff) <= DomeParamNP[0].getValue())
             {
                 // Found home (or close enough)
                 LOG_INFO("Home sensor found");
                 status   = DOME_READY;
-                targetAz = DomeHomePositionN[0].value;
+                targetAz = DomeHomePositionNP[0].getValue();
 
                 // Reset counters
                 writeCmd(ResetCounter);
                 writeCmd(ResetCounterExt);
 
-                FindHomeSP.s   = IPS_OK;
-                DomeAbsPosNP.s = IPS_OK;
-                IDSetSwitch(&FindHomeSP, nullptr);
+                FindHomeSP.setState(IPS_OK);
+                DomeAbsPosNP.setState(IPS_OK);
+                FindHomeSP.apply();
             }
             else
             {
                 // We overshoot, go closer
-                MoveAbs(DomeHomePositionN[0].value);
+                MoveAbs(DomeHomePositionNP[0].value);
             }
         }
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
     }
     else if (status == DOME_DEROTATING)
     {
@@ -703,9 +703,9 @@ void ScopeDome::TimerHit()
                 // Close enough
                 LOG_INFO("De-rotation complete");
                 status         = DOME_READY;
-                DerotateSP.s   = IPS_OK;
-                DomeAbsPosNP.s = IPS_OK;
-                IDSetSwitch(&DerotateSP, nullptr);
+                DerotateSP.setState(IPS_OK);
+                DomeAbsPosNP.setState(IPS_OK);
+                DerotateSP.apply();
             }
             else
             {
@@ -719,7 +719,7 @@ void ScopeDome::TimerHit()
                 }
             }
         }
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
     }
     else if (status == DOME_CALIBRATING)
     {
@@ -727,21 +727,21 @@ void ScopeDome::TimerHit()
         {
             readU32(GetImpPerTurn, stepsPerTurn);
             LOGF_INFO("Calibration complete, steps per turn read as %d", stepsPerTurn);
-            StepsPerRevolutionN[0].value = stepsPerTurn;
-            StepsPerRevolutionNP.s       = IPS_OK;
-            IDSetNumber(&StepsPerRevolutionNP, nullptr);
-            StartCalibrationSP.s = IPS_OK;
-            DomeAbsPosNP.s       = IPS_OK;
-            IDSetSwitch(&StartCalibrationSP, nullptr);
+            StepsPerRevolutionNP[0].setValue(stepsPerTurn);
+            StepsPerRevolutionNP.setState(IPS_OK);
+            StepsPerRevolutionNP.apply();
+            StartCalibrationSP.setState(IPS_OK);
+            DomeAbsPosNP.setState(IPS_OK);
+            StartCalibrationSP.apply();
             status = DOME_READY;
         }
     }
-    else if (DomeAbsPosNP.s == IPS_BUSY)
+    else if (DomeAbsPosNP.getState() == IPS_BUSY)
     {
         if ((currentStatus & STATUS_MOVING) == 0)
         {
             // Rotation idle, are we close enough?
-            double azDiff = targetAz - DomeAbsPosN[0].value;
+            double azDiff = targetAz - DomeAbsPosNP[0].getValue();
 
             if (azDiff > 180)
             {
@@ -751,16 +751,16 @@ void ScopeDome::TimerHit()
             {
                 azDiff += 360;
             }
-            if (!refineMove || fabs(azDiff) <= DomeParamN[0].value)
+            if (!refineMove || fabs(azDiff) <= DomeParamNP[0].getValue())
             {
                 if (refineMove)
-                    DomeAbsPosN[0].value = targetAz;
-                DomeAbsPosNP.s = IPS_OK;
+                    DomeAbsPosNP[0].setValue(targetAz);
+                DomeAbsPosNP.setState(IPS_OK);
                 LOG_INFO("Dome reached requested azimuth angle.");
 
                 if (getDomeState() == DOME_PARKING)
                 {
-                    if (ParkShutterS[0].s == ISS_ON && getInputState(IN_CLOSED1) == ISS_OFF)
+                    if (ParkShutterSP[0].getState() == ISS_ON && getInputState(IN_CLOSED1) == ISS_OFF)
                     {
                         ControlShutter(SHUTTER_CLOSE);
                     }
@@ -781,10 +781,10 @@ void ScopeDome::TimerHit()
             }
         }
 
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
     }
     else
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
 
     // Read temperatures only every 10th time
     static int tmpCounter = 0;
@@ -804,7 +804,7 @@ IPState ScopeDome::MoveAbs(double az)
 {
     LOGF_DEBUG("MoveAbs (%f)", az);
     targetAz      = az;
-    double azDiff = az - DomeAbsPosN[0].value;
+    double azDiff = az - DomeAbsPosNP[0].getValue();
     LOGF_DEBUG("azDiff = %f", azDiff);
 
     // Make relative (-180 - 180) regardless if it passes az 0
@@ -900,7 +900,7 @@ IPState ScopeDome::Park()
     // First move to park position and then optionally close shutter
     targetAz  = GetAxis1Park();
     IPState s = MoveAbs(targetAz);
-    if (s == IPS_OK && ParkShutterS[0].s == ISS_ON)
+    if (s == IPS_OK && ParkShutterSP[0].s == ISS_ON)
     {
         // Already at home, just close if needed
         return ControlShutter(SHUTTER_CLOSE);
@@ -913,7 +913,7 @@ IPState ScopeDome::Park()
 * ***********************************************************************************/
 IPState ScopeDome::UnPark()
 {
-    if (ParkShutterS[0].s == ISS_ON)
+    if (ParkShutterSP[0].getState() == ISS_ON)
     {
         return ControlShutter(SHUTTER_OPEN);
     }
@@ -971,8 +971,8 @@ bool ScopeDome::saveConfigItems(FILE *fp)
 {
     INDI::Dome::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &DomeHomePositionNP);
-    IUSaveConfigSwitch(fp, &ParkShutterSP);
+    DomeHomePositionNP.save(fp);
+    ParkShutterSP.save(fp);
     return true;
 }
 
@@ -981,7 +981,7 @@ bool ScopeDome::saveConfigItems(FILE *fp)
 * ***********************************************************************************/
 bool ScopeDome::SetCurrentPark()
 {
-    SetAxis1Park(DomeAbsPosN[0].value);
+    SetAxis1Park(DomeAbsPosNP[0].value);
     return true;
 }
 /************************************************************************************

--- a/drivers/dome/scopedome_dome.h
+++ b/drivers/dome/scopedome_dome.h
@@ -33,6 +33,10 @@
 #include "indidome.h"
 #include <memory>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * Interface to either a real ScopeDome card or simulator
  */
@@ -455,45 +459,31 @@ class ScopeDome : public INDI::Dome
     bool sim{ false };
     double simShutterTimer{ 0 };
     ShutterState simShutterStatus{ SHUTTER_OPENED };
+    INDI::PropertyNumber DomeHomePositionNP {1};
 
-    INumberVectorProperty DomeHomePositionNP;
-    INumber DomeHomePositionN[1];
+    INDI::PropertySwitch FindHomeSP {1};
 
-    ISwitch FindHomeS[1];
-    ISwitchVectorProperty FindHomeSP;
+    INDI::PropertySwitch DerotateSP {1};
 
-    ISwitch DerotateS[1];
-    ISwitchVectorProperty DerotateSP;
+    INDI::PropertySwitch PowerRelaysSP {4};
 
-    ISwitch PowerRelaysS[4];
-    ISwitchVectorProperty PowerRelaysSP;
+    INDI::PropertySwitch RelaysSP {4};
 
-    ISwitch RelaysS[4];
-    ISwitchVectorProperty RelaysSP;
+    INDI::PropertySwitch ParkShutterSP {2};
 
-    ISwitch ParkShutterS[2];
-    ISwitchVectorProperty ParkShutterSP;
+    INDI::PropertySwitch AutoCloseSP {8};
 
-    ISwitch AutoCloseS[8];
-    ISwitchVectorProperty AutoCloseSP;
+    INDI::PropertyNumber EnvironmentSensorsNP {11};
 
-    INumber EnvironmentSensorsN[11];
-    INumberVectorProperty EnvironmentSensorsNP;
+    INDI::PropertySwitch SensorsSP {13};
 
-    ISwitch SensorsS[13];
-    ISwitchVectorProperty SensorsSP;
+    INDI::PropertyNumber StepsPerRevolutionNP {1};
 
-    INumber StepsPerRevolutionN[1];
-    INumberVectorProperty StepsPerRevolutionNP;
+    INDI::PropertySwitch CalibrationNeededSP {1};
 
-    ISwitch CalibrationNeededS[1];
-    ISwitchVectorProperty CalibrationNeededSP;
+    INDI::PropertySwitch StartCalibrationSP {1};
 
-    ISwitch StartCalibrationS[1];
-    ISwitchVectorProperty StartCalibrationSP;
-
-    INumber FirmwareVersionsN[2];
-    INumberVectorProperty FirmwareVersionsNP;
+    INDI::PropertyNumber FirmwareVersionsNP {2};
 
   private:
     uint8_t digitalSensorState[5];

--- a/drivers/filter_wheel/filter_simulator.cpp
+++ b/drivers/filter_wheel/filter_simulator.cpp
@@ -70,8 +70,8 @@ const char *FilterSim::getDefaultName()
 bool FilterSim::Connect()
 {
     CurrentFilter      = 1;
-    FilterSlotN[0].min = 1;
-    FilterSlotN[0].max = 8;
+    FilterSlotNP[0].setMin(1);
+    FilterSlotNP[0].setMax(8);
     return true;
 }
 

--- a/drivers/filter_wheel/ifwoptec.cpp
+++ b/drivers/filter_wheel/ifwoptec.cpp
@@ -141,32 +141,32 @@ bool FilterIFW::initProperties()
     INDI::FilterWheel::initProperties();
 
     // Settings
-    IUFillText(&WheelIDT[0], "ID", "ID", "-");
-    IUFillTextVector(&WheelIDTP, WheelIDT, 1, getDeviceName(), "WHEEL_ID", "Wheel", FILTER_TAB, IP_RO, 60, IPS_IDLE);
+    WheelIDTP[0].fill("ID", "ID", "-");
+    WheelIDTP.fill(getDeviceName(), "WHEEL_ID", "Wheel", FILTER_TAB, IP_RO, 60, IPS_IDLE);
 
     // Command
-    IUFillSwitch(&HomeS[0], "HOME", "Home", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 1, getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
+    HomeSP[0].fill("HOME", "Home", ISS_OFF);
+    HomeSP.fill(getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Within simulation mode, provide possibilities to select the kind of filter wheel: 5 or 8 filters
-    IUFillSwitch(&FilterNbrS[0], "VAL5", "5", ISS_ON);
-    IUFillSwitch(&FilterNbrS[1], "VAL6", "6", ISS_OFF);
-    IUFillSwitch(&FilterNbrS[2], "VAL8", "8", ISS_OFF);
-    IUFillSwitch(&FilterNbrS[3], "VAL9", "9", ISS_OFF);
-    IUFillSwitchVector(&FilterNbrSP, FilterNbrS, 4, getDeviceName(), "FILTER_NBR", "Filter nbr", FILTER_TAB, IP_RW,
+    FilterNbrSP[0].fill("VAL5", "5", ISS_ON);
+    FilterNbrSP[1].fill("VAL6", "6", ISS_OFF);
+    FilterNbrSP[2].fill("VAL8", "8", ISS_OFF);
+    FilterNbrSP[3].fill("VAL9", "9", ISS_OFF);
+    FilterNbrSP.fill(getDeviceName(), "FILTER_NBR", "Filter nbr", FILTER_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // User could choice to unrestrict chars set to set the filternames if he accepts to have crazy display name on IFW box
     // Within simulation mode, provide possibilities to select the kind of filter wheel: 5 or 8 filters
-    IUFillSwitch(&CharSetS[0], "RES", "Restricted", ISS_ON);
-    IUFillSwitch(&CharSetS[1], "UNRES", "All", ISS_OFF);
-    IUFillSwitchVector(&CharSetSP, CharSetS, 2, getDeviceName(), "CHARSET", "Chars allowed", FILTER_TAB, IP_RW,
+    CharSetSP[0].fill("RES", "Restricted", ISS_ON);
+    CharSetSP[1].fill("UNRES", "All", ISS_OFF);
+    CharSetSP.fill(getDeviceName(), "CHARSET", "Chars allowed", FILTER_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Firmware of the IFW
-    IUFillText(&FirmwareT[0], "FIRMWARE", "Firmware", "Unknown");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "FIRMWARE_ID", "IFW", FILTER_TAB, IP_RO, 60, IPS_IDLE);
+    FirmwareTP[0].fill("FIRMWARE", "Firmware", "Unknown");
+    FirmwareTP.fill(getDeviceName(), "FIRMWARE_ID", "IFW", FILTER_TAB, IP_RO, 60, IPS_IDLE);
 
 
     addAuxControls();
@@ -183,14 +183,14 @@ bool FilterIFW::updateProperties()
    INDI::FilterWheel::updateProperties();
 	 if (isConnected())
     {
-        defineProperty(&HomeSP);
-        defineProperty(&FirmwareTP);
-        defineProperty(&WheelIDTP); // ID of the wheel first in Filter tab page
+        defineProperty(HomeSP);
+        defineProperty(FirmwareTP);
+        defineProperty(WheelIDTP); // ID of the wheel first in Filter tab page
         // Then the button only for Simulation to select the number of filter of the Wheel (5 or 8)
         if (isSimulation())
-            defineProperty(&FilterNbrSP);
-        defineProperty(&CharSetSP);
-        defineProperty(&FilterSlotNP);
+            defineProperty(FilterNbrSP);
+        defineProperty(CharSetSP);
+        defineProperty(FilterSlotNP);
         controller->updateProperties();
 
         GetFirmware(); // Try to get Firmware version of the IFW. NOt all Firmware support this function
@@ -198,12 +198,12 @@ bool FilterIFW::updateProperties()
     }
     else
     {
-        deleteProperty(HomeSP.name);
-        deleteProperty(FirmwareTP.name);
-        deleteProperty(WheelIDTP.name);
-        deleteProperty(CharSetSP.name);
-        deleteProperty(FilterNbrSP.name);
-        deleteProperty(FilterSlotNP.name);
+        deleteProperty(HomeSP.getName());
+        deleteProperty(FirmwareTP.getName());
+        deleteProperty(WheelIDTP.getName());
+        deleteProperty(CharSetSP.getName());
+        deleteProperty(FilterNbrSP.getName());
+        deleteProperty(FilterSlotNP.getName());
         deleteProperty(FilterNameTP->name);
         controller->updateProperties();
     }
@@ -356,7 +356,7 @@ bool FilterIFW::ISNewText(const char *dev, const char *name, char *texts[], char
 
             bool match = true;
             //Check only if user allowed chars restriction
-            if (CharSetS[0].s == ISS_ON)
+            if (CharSetSP[0].getState() == ISS_ON)
             {
                 for (int i = 0; i < n; i++)
                 {
@@ -397,12 +397,12 @@ bool FilterIFW::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(HomeSP.name, name) == 0)
+        if (HomeSP.isNameMatch(name))
         {
             bool result = true;
             // User request the IWF reset (Home procedure will read the Wheel ID, load from EEProm the filters names and goes to filter N°1
-            IUUpdateSwitch(&HomeSP, states, names, n);
-            IUResetSwitch(&HomeSP);
+            HomeSP.update(states, names, n);
+            HomeSP.reset();
             LOG_INFO("Executing Home command...");
 
             FilterNameTP->s = IPS_BUSY;
@@ -410,7 +410,7 @@ bool FilterIFW::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
             if (!moveHome())
             {
-                HomeSP.s = IPS_ALERT;
+                HomeSP.setState(IPS_ALERT);
                 result   = false;
             }
             else
@@ -419,12 +419,12 @@ bool FilterIFW::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
                 if (!(GetFilterNames() && GetFilterPos() != 0))
                 {
-                    HomeSP.s = IPS_ALERT;
+                    HomeSP.setState(IPS_ALERT);
                     result   = false;
                 }
             }
 
-            IDSetSwitch(&HomeSP, nullptr);
+            HomeSP.apply();
             if (!result)
             {
                 LOGF_INFO("%s() failed to get information", __FUNCTION__);
@@ -435,54 +435,54 @@ bool FilterIFW::ISNewSwitch(const char *dev, const char *name, ISState *states, 
             return true;
         }
 
-        if (strcmp(FilterNbrSP.name, name) == 0)
+        if (FilterNbrSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FilterNbrSP, states, names, n);
+            FilterNbrSP.update(states, names, n);
 
             // Is simulation active, User can change from 5 positions wheel to 6, 8 or 9 ones
             // Check if selection is different from active one
 
-            if ((FilterNbrS[0].s == ISS_ON) & (FilterSlotN[0].max != 5))
+            if ((FilterNbrSP[0].getState() == ISS_ON) & (FilterSlotNP[0].max != 5))
             {
                 strncpy(filterSim, filterSim5, sizeof(filterSim));
-                FilterNbrSP.s = (GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT;
+                FilterNbrSP.setState((GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT);
             }
-            else if ((FilterNbrS[1].s == ISS_ON) & (FilterSlotN[0].max != 6))
+            else if ((FilterNbrSP[1].getState() == ISS_ON) & (FilterSlotNP[0].max != 6))
             {
                 strncpy(filterSim, filterSim6, sizeof(filterSim));
-                FilterNbrSP.s = (GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT;
+                FilterNbrSP.setState((GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT);
             }
-            else if ((FilterNbrS[2].s == ISS_ON) & (FilterSlotN[0].max != 8))
+            else if ((FilterNbrSP[2].getState() == ISS_ON) & (FilterSlotNP[0].max != 8))
             {
                 strncpy(filterSim, filterSim8, sizeof(filterSim));
-                FilterNbrSP.s = (GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT;
+                FilterNbrSP.setState((GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT);
             }
-            else if ((FilterNbrS[3].s == ISS_ON) & (FilterSlotN[0].max != 9))
+            else if ((FilterNbrSP[3].getState() == ISS_ON) & (FilterSlotNP[0].max != 9))
             {
                 strncpy(filterSim, filterSim9, sizeof(filterSim));
-                FilterNbrSP.s = (GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT;
+                FilterNbrSP.setState((GetFilterNames() && GetFilterPos() != 0) ? IPS_OK : IPS_ALERT);
             }
             else
-                FilterNbrSP.s = IPS_OK;
+                FilterNbrSP.setState(IPS_OK);
 
-            if (FilterNbrSP.s == IPS_ALERT)
+            if (FilterNbrSP.getState() == IPS_ALERT)
             {
-                IDSetSwitch(&FilterNbrSP, "%s() failed to change number of filters", __FUNCTION__);
+                FilterNbrSP.apply("%s() failed to change number of filters", __FUNCTION__);
                 return false;
             }
             else
-                IDSetSwitch(&FilterNbrSP, nullptr);
+                FilterNbrSP.apply();
 
             return true;
         }
 
         // Set switch from user selection to allowed use of all chars or restricted to display IFW
         // 0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ=.#/-%
-        if (strcmp(CharSetSP.name, name) == 0)
+        if (CharSetSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&CharSetSP, states, names, n);
-            CharSetSP.s = IPS_OK;
-            IDSetSwitch(&CharSetSP, nullptr);
+            CharSetSP.update(states, names, n);
+            CharSetSP.setState(IPS_OK);
+            CharSetSP.apply();
             return true;
         }
     }
@@ -500,11 +500,11 @@ void FilterIFW::simulationTriggered(bool enable)
     {
         if (isConnected())
         {
-            defineProperty(&FilterNbrSP);
+            defineProperty(FilterNbrSP);
         }
     }
     else
-        deleteProperty(FilterNbrSP.name);
+        deleteProperty(FilterNbrSP.getName());
 }
 
 /************************************************************************************
@@ -528,8 +528,8 @@ bool FilterIFW::SelectFilter(int f)
     memset(response, 0, sizeof(response));
     snprintf(cmd, 32, "%s%d", "WGOTO", f);
 
-    FilterSlotNP.s = IPS_BUSY;
-    IDSetNumber(&FilterSlotNP, "*** Moving to filter n° %d ***", f);
+    FilterSlotNP.setState(IPS_BUSY);
+    FilterSlotNP.apply("*** Moving to filter n° %d ***", f);
 
     if (!WriteTTY(cmd))
     {
@@ -541,7 +541,7 @@ bool FilterIFW::SelectFilter(int f)
         if (isSimulation())
         {
             // Time depend of rotation direction. Goes via shortest way
-            int maxFilter = FilterSlotN[0].max;
+            int maxFilter = FilterSlotNP[0].getMax();
             int way1, way2;
             if (f > actualSimFilter)
             {
@@ -582,16 +582,16 @@ bool FilterIFW::SelectFilter(int f)
 
     if (!result)
     {
-        FilterSlotNP.s = IPS_ALERT;
-        IDSetNumber(&FilterSlotNP, "*** UNABLE TO SELECT THE FILTER ***");
+        FilterSlotNP.setState(IPS_ALERT);
+        FilterSlotNP.apply("*** UNABLE TO SELECT THE FILTER ***");
         return false;
     }
 
     // As to be called when filter has moved to new position:
     SelectFilterDone(GetFilterPos());
 
-    FilterSlotNP.s = IPS_OK;
-    IDSetNumber(&FilterSlotNP, "Selected filter position reached");
+    FilterSlotNP.setState(IPS_OK);
+    FilterSlotNP.apply("Selected filter position reached");
     return true;
 }
 
@@ -672,11 +672,11 @@ bool FilterIFW::GetFilterNames()
 
             LOG_DEBUG("Redo filters name list");
             // Set new max value on the filter_slot property
-            FilterSlotN[0].max = maxFilter;
+            FilterSlotNP[0].setMax(maxFilter);
             if (isSimulation())
-                FilterSlotN[0].value = actualSimFilter = 1;
-            IUUpdateMinMax(&FilterSlotNP);
-            IDSetNumber(&FilterSlotNP, nullptr);
+                FilterSlotNP[0].setValue(actualSimFilter = 1);
+            FilterSlotNP.updateMinMax();
+            FilterSlotNP.apply();
 
             deleteProperty(FilterNameTP->name);
 
@@ -697,7 +697,7 @@ bool FilterIFW::GetFilterNames()
                 IUFillText(&FilterNameT[i], filterName, filterLabel, filterNameIFW[i]);
             }
 
-            IUFillTextVector(FilterNameTP, FilterNameT, maxFilter, getDeviceName(), "FILTER_NAME", "Filters", FilterSlotNP.group,
+            IUFillTextVector(FilterNameTP, FilterNameT, maxFilter, getDeviceName(), "FILTER_NAME", "Filters", FilterSlotNP.getGroupName(),
                              IP_RW, 0, IPS_OK);
             defineProperty(FilterNameTP);
 
@@ -743,15 +743,15 @@ bool FilterIFW::SetFilterNames()
     memset(response, 0, sizeof(response));
 
     FilterNameTP->s = IPS_BUSY;
-    FilterSlotNP.s = IPS_BUSY;
-    WheelIDTP.s = IPS_BUSY;
+    FilterSlotNP.setState(IPS_BUSY);
+    WheelIDTP.setState(IPS_BUSY);
     IDSetText(FilterNameTP, "*** Saving filters name to IFW... ***");
-    IDSetNumber(&FilterSlotNP, nullptr);
-    IDSetText(&WheelIDTP, nullptr);
+    FilterSlotNP.apply();
+    WheelIDTP.apply();
 
-    snprintf(cmd, 8, "WLOAD%s*", WheelIDT[0].text);
+    snprintf(cmd, 8, "WLOAD%s*", WheelIDTP[0].getText());
 
-    for (int i = 0; i < FilterSlotN[0].max; i++)
+    for (int i = 0; i < FilterSlotNP[0].getMax(); i++)
     {
         // Prepare string in tempo with blank space at right to complete to 8 chars for each filter name
         memset(tempo, ' ', sizeof(tempo));
@@ -840,8 +840,8 @@ bool FilterIFW::GetWheelID()
 
     memset(response, 0, sizeof(response));
 
-    WheelIDTP.s = IPS_BUSY;
-    IDSetText(&WheelIDTP, nullptr);
+    WheelIDTP.setState(IPS_BUSY);
+    WheelIDTP.apply();
 
     if (!WriteTTY((char *)"WIDENT"))
     {
@@ -864,14 +864,14 @@ bool FilterIFW::GetWheelID()
     }
     if (!result)
     {
-        WheelIDTP.s = IPS_ALERT;
-        IDSetText(&WheelIDTP, "*** UNABLE TO GET WHEEL ID ***");
+        WheelIDTP.setState(IPS_ALERT);
+        WheelIDTP.apply("*** UNABLE TO GET WHEEL ID ***");
         return false;
     }
 
-    WheelIDTP.s = IPS_OK;
-    IUSaveText(&WheelIDT[0], response);
-    IDSetText(&WheelIDTP, "IFW wheel active is %s", response);
+    WheelIDTP.setState(IPS_OK);
+    WheelIDTP[0].setText(response);
+    WheelIDTP.apply("IFW wheel active is %s", response);
 
     return true;
 }
@@ -888,8 +888,8 @@ int FilterIFW::GetFilterPos()
 
     memset(response, 0, sizeof(response));
 
-    FilterSlotNP.s = IPS_BUSY;
-    IDSetNumber(&FilterSlotNP, nullptr);
+    FilterSlotNP.setState(IPS_BUSY);
+    FilterSlotNP.apply();
 
     if (!WriteTTY((char *)"WFILTR"))
     {
@@ -910,15 +910,15 @@ int FilterIFW::GetFilterPos()
 
     if (result == -1)
     {
-        FilterSlotNP.s = IPS_ALERT;
-        IDSetNumber(&FilterSlotNP, "*** UNABLE TO GET ACTIVE FILTER ***");
+        FilterSlotNP.setState(IPS_ALERT);
+        FilterSlotNP.apply("*** UNABLE TO GET ACTIVE FILTER ***");
         return result;
     }
 
     result               = atoi(response);
-    FilterSlotN[0].value = result;
-    FilterSlotNP.s       = IPS_OK;
-    IDSetNumber(&FilterSlotNP, "IFW filter active is n° %s -> %s", response, FilterNameT[result - 1].text);
+    FilterSlotNP[0].setValue(result);
+    FilterSlotNP.setState(IPS_OK);
+    FilterSlotNP.apply("IFW filter active is n° %s -> %s", response, FilterNameT[result - 1].text);
     return result;
 }
 
@@ -933,12 +933,12 @@ bool FilterIFW::moveHome()
 
     memset(response, 0, sizeof(response));
 
-    HomeSP.s = IPS_BUSY;
-    WheelIDTP.s = IPS_BUSY;
-    FilterSlotNP.s = IPS_BUSY;
-    IDSetSwitch(&HomeSP, "*** Initialisation of the IFW. Please wait... ***");
-    IDSetText(&WheelIDTP, nullptr);
-    IDSetNumber(&FilterSlotNP, nullptr);
+    HomeSP.setState(IPS_BUSY);
+    WheelIDTP.setState(IPS_BUSY);
+    FilterSlotNP.setState(IPS_BUSY);
+    HomeSP.apply("*** Initialisation of the IFW. Please wait... ***");
+    WheelIDTP.apply();
+    FilterSlotNP.apply();
 
     if (!WriteTTY((char *)"WHOME"))
     {
@@ -968,15 +968,15 @@ bool FilterIFW::moveHome()
 
     if (!result || !GetWheelID() || !GetFilterNames() || (GetFilterPos() <= 0))
     {
-        HomeSP.s = IPS_ALERT;
-        WheelIDTP.s = IPS_ALERT;
-        IDSetSwitch(&HomeSP, "*** INITIALISATION FAILED ***");
+        HomeSP.setState(IPS_ALERT);
+        WheelIDTP.setState(IPS_ALERT);
+        HomeSP.apply("*** INITIALISATION FAILED ***");
         return false;
     }
 
-    HomeSP.s = IPS_OK;
-    WheelIDTP.s = IPS_OK;
-    IDSetSwitch(&HomeSP, "IFW ready");
+    HomeSP.setState(IPS_OK);
+    WheelIDTP.setState(IPS_OK);
+    HomeSP.apply("IFW ready");
     return true;
 }
 
@@ -991,8 +991,8 @@ bool FilterIFW::GetFirmware()
 
     memset(response, 0, sizeof(response));
 
-    FirmwareTP.s = IPS_BUSY;
-    IDSetText(&FirmwareTP, nullptr);
+    FirmwareTP.setState(IPS_BUSY);
+    FirmwareTP.apply();
 
     if (!WriteTTY((char *)"WVAAAA"))
     {
@@ -1015,8 +1015,8 @@ bool FilterIFW::GetFirmware()
     }
     if (!result)
     {
-        FirmwareTP.s = IPS_ALERT;
-        IDSetText(&FirmwareTP, "*** UNABLE TO GET FIRMWARE ***");
+        FirmwareTP.setState(IPS_ALERT);
+        FirmwareTP.apply("*** UNABLE TO GET FIRMWARE ***");
         return false;
     }
 
@@ -1032,9 +1032,9 @@ bool FilterIFW::GetFirmware()
         }
     }
 
-    FirmwareTP.s = IPS_OK;
-    IUSaveText(&FirmwareT[0], p);
-    IDSetText(&FirmwareTP, "IFW Firmware is %s", response);
+    FirmwareTP.setState(IPS_OK);
+    FirmwareTP[0].setText(p);
+    FirmwareTP.apply("IFW Firmware is %s", response);
 
     return true;
 }
@@ -1046,8 +1046,8 @@ bool FilterIFW::saveConfigItems(FILE *fp)
 {
     INDI::FilterWheel::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &CharSetSP);
-    IUSaveConfigSwitch(fp, &FilterNbrSP);
+    CharSetSP.save(fp);
+    FilterNbrSP.save(fp);
 
     return true;
 }

--- a/drivers/filter_wheel/ifwoptec.h
+++ b/drivers/filter_wheel/ifwoptec.h
@@ -20,6 +20,10 @@
 
 #include "indifilterwheel.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+
 #define VERSION    0
 #define SUBVERSION 2
 
@@ -104,24 +108,19 @@ class FilterIFW : public INDI::FilterWheel
     bool GetFirmware();
 
     // Filter Wheel ID
-    ITextVectorProperty WheelIDTP;
-    IText WheelIDT[1] {};
+    INDI::PropertyText WheelIDTP {1};
 
     // Home function
-    ISwitchVectorProperty HomeSP;
-    ISwitch HomeS[1];
+    INDI::PropertySwitch HomeSP {1};
 
     //Simulation, number of filter function
-    ISwitchVectorProperty FilterNbrSP;
-    ISwitch FilterNbrS[4];
+    INDI::PropertySwitch FilterNbrSP {4};
 
     // CharSet unrestricted for FilterNames
-    ISwitchVectorProperty CharSetSP;
-    ISwitch CharSetS[2];
+    INDI::PropertySwitch CharSetSP {2};
 
     // Firmware of teh IFW
-    ITextVectorProperty FirmwareTP;
-    IText FirmwareT[1] {};
+    INDI::PropertyText FirmwareTP {1};
 
     //Filter position in simulation mode
     int actualSimFilter { 1 };

--- a/drivers/filter_wheel/manual_filter.h
+++ b/drivers/filter_wheel/manual_filter.h
@@ -20,6 +20,10 @@
 
 #include "indifilterwheel.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * @brief Manual filter enables users from changing filter wheels manually
  */
@@ -45,12 +49,9 @@ class ManualFilter : public INDI::FilterWheel
     virtual bool saveConfigItems(FILE *fp) override;
 
   private:
-    ISwitch FilterSetS[1];
-    ISwitchVectorProperty FilterSetSP;
+    INDI::PropertySwitch FilterSetSP {1};
 
-    INumber SyncN[1];
-    INumberVectorProperty SyncNP;
+    INDI::PropertyNumber SyncNP {1};
 
-    INumber MaxFiltersN[1];
-    INumberVectorProperty MaxFiltersNP;
+    INDI::PropertyNumber MaxFiltersNP {1};
 };

--- a/drivers/filter_wheel/qhycfw1.cpp
+++ b/drivers/filter_wheel/qhycfw1.cpp
@@ -87,7 +87,7 @@ void QHYCFW1::ISGetProperties(const char *dev)
     {
         double maxCount = 5;
         IUGetConfigNumber(getDeviceName(), "MAX_FILTER", "Count", &maxCount);
-        FilterSlotN[0].max = maxCount;
+        FilterSlotNP[0].setMax(maxCount);
         if (FilterNameTP->ntp != maxCount)
         {
             char filterName[MAXINDINAME];
@@ -107,22 +107,22 @@ void QHYCFW1::ISGetProperties(const char *dev)
                 snprintf(filterLabel, MAXINDILABEL, "Filter#%d", i + 1);
                 IUFillText(&FilterNameT[i], filterName, filterLabel, filterLabel);
             }
-            IUFillTextVector(FilterNameTP, FilterNameT, maxCount, m_defaultDevice->getDeviceName(), "FILTER_NAME", "Filter", FilterSlotNP.group, IP_RW, 0, IPS_IDLE);
+            IUFillTextVector(FilterNameTP, FilterNameT, maxCount, m_defaultDevice->getDeviceName(), "FILTER_NAME", "Filter", FilterSlotNP.getGroupName(), IP_RW, 0, IPS_IDLE);
         }
     }
-    defineProperty(&MaxFilterNP);
+    defineProperty(MaxFilterNP);
 }
 
 bool QHYCFW1::initProperties()
 {
     INDI::FilterWheel::initProperties();
 
-    IUFillNumber(&MaxFilterN[0], "Count", "Count", "%.f", 1, 16, 1, 5);
-    IUFillNumberVector(&MaxFilterNP, MaxFilterN, 1, getDeviceName(), "MAX_FILTER", "Filters", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    MaxFilterNP[0].fill("Count", "Count", "%.f", 1, 16, 1, 5);
+    MaxFilterNP.fill(getDeviceName(), "MAX_FILTER", "Filters", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     CurrentFilter      = 1;
-    FilterSlotN[0].min = 1;
-    FilterSlotN[0].max = 5;
+    FilterSlotNP[0].setMin(1);
+    FilterSlotNP[0].setMax(5);
 
     addAuxControls();
 
@@ -182,17 +182,17 @@ bool QHYCFW1::ISNewNumber(const char *dev, const char *name, double values[], ch
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, MaxFilterNP.name))
+        if (MaxFilterNP.isNameMatch(name))
         {
-            if (values[0] != MaxFilterN[0].value)
+            if (values[0] != MaxFilterNP[0].getValue())
             {
-                IUUpdateNumber(&MaxFilterNP, values, names, n);
+                MaxFilterNP.update(values, names, n);
                 saveConfig();
                 LOG_INFO("Max number of filters updated. You must reconnect for this change to take effect.");
             }
 
-            MaxFilterNP.s = IPS_OK;
-            IDSetNumber(&MaxFilterNP, nullptr);
+            MaxFilterNP.setState(IPS_OK);
+            MaxFilterNP.apply();
             return true;
         }
 
@@ -205,7 +205,7 @@ bool QHYCFW1::saveConfigItems(FILE *fp)
 {
     FilterWheel::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &MaxFilterNP);
+    MaxFilterNP.save(fp);
 
     return true;
 }

--- a/drivers/filter_wheel/qhycfw1.h
+++ b/drivers/filter_wheel/qhycfw1.h
@@ -22,6 +22,9 @@
 
 #include "indifilterwheel.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class QHYCFW1 : public INDI::FilterWheel
 {
     public:
@@ -42,6 +45,5 @@ class QHYCFW1 : public INDI::FilterWheel
         virtual bool SelectFilter(int) override;
 
     private:
-        INumber MaxFilterN[1];
-        INumberVectorProperty MaxFilterNP;
+        INDI::PropertyNumber MaxFilterNP {1};
 };

--- a/drivers/filter_wheel/qhycfw2.cpp
+++ b/drivers/filter_wheel/qhycfw2.cpp
@@ -85,7 +85,7 @@ void QHYCFW2::ISGetProperties(const char *dev)
     {
         double maxCount = 5;
         IUGetConfigNumber(getDeviceName(), "MAX_FILTER", "Count", &maxCount);
-        FilterSlotN[0].max = maxCount;
+        FilterSlotNP[0].setMax(maxCount);
         if (FilterNameTP->ntp != maxCount)
         {
             char filterName[MAXINDINAME];
@@ -105,22 +105,22 @@ void QHYCFW2::ISGetProperties(const char *dev)
                 snprintf(filterLabel, MAXINDILABEL, "Filter#%d", i + 1);
                 IUFillText(&FilterNameT[i], filterName, filterLabel, filterLabel);
             }
-            IUFillTextVector(FilterNameTP, FilterNameT, maxCount, m_defaultDevice->getDeviceName(), "FILTER_NAME", "Filter", FilterSlotNP.group, IP_RW, 0, IPS_IDLE);
+            IUFillTextVector(FilterNameTP, FilterNameT, maxCount, m_defaultDevice->getDeviceName(), "FILTER_NAME", "Filter", FilterSlotNP.getGroupName(), IP_RW, 0, IPS_IDLE);
         }
     }
-    defineProperty(&MaxFilterNP);
+    defineProperty(MaxFilterNP);
 }
 
 bool QHYCFW2::initProperties()
 {
     INDI::FilterWheel::initProperties();
 
-    IUFillNumber(&MaxFilterN[0], "Count", "Count", "%.f", 1, 16, 1, 5);
-    IUFillNumberVector(&MaxFilterNP, MaxFilterN, 1, getDeviceName(), "MAX_FILTER", "Filters", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    MaxFilterNP[0].fill("Count", "Count", "%.f", 1, 16, 1, 5);
+    MaxFilterNP.fill(getDeviceName(), "MAX_FILTER", "Filters", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     CurrentFilter      = 1;
-    FilterSlotN[0].min = 1;
-    FilterSlotN[0].max = 5;
+    FilterSlotNP[0].setMin(1);
+    FilterSlotNP[0].setMax(5);
 
     addAuxControls();
 
@@ -176,17 +176,17 @@ bool QHYCFW2::ISNewNumber(const char *dev, const char *name, double values[], ch
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, MaxFilterNP.name))
+        if (MaxFilterNP.isNameMatch(name))
         {
-            if (values[0] != MaxFilterN[0].value)
+            if (values[0] != MaxFilterNP[0].getValue())
             {
-                IUUpdateNumber(&MaxFilterNP, values, names, n);
+                MaxFilterNP.update(values, names, n);
                 saveConfig();
                 LOG_INFO("Max number of filters updated. You must reconnect for this change to take effect.");
             }
 
-            MaxFilterNP.s = IPS_OK;
-            IDSetNumber(&MaxFilterNP, nullptr);
+            MaxFilterNP.setState(IPS_OK);
+            MaxFilterNP.apply();
             return true;
         }
 
@@ -199,7 +199,7 @@ bool QHYCFW2::saveConfigItems(FILE *fp)
 {
     FilterWheel::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &MaxFilterNP);
+    MaxFilterNP.save(fp);
 
     return true;
 }

--- a/drivers/filter_wheel/qhycfw2.h
+++ b/drivers/filter_wheel/qhycfw2.h
@@ -22,6 +22,9 @@
 
 #include "indifilterwheel.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class QHYCFW2 : public INDI::FilterWheel
 {
     public:
@@ -42,6 +45,5 @@ class QHYCFW2 : public INDI::FilterWheel
         virtual bool SelectFilter(int) override;
 
     private:
-        INumber MaxFilterN[1];
-        INumberVectorProperty MaxFilterNP;
+        INDI::PropertyNumber MaxFilterNP {1};
 };

--- a/drivers/filter_wheel/qhycfw3.cpp
+++ b/drivers/filter_wheel/qhycfw3.cpp
@@ -83,8 +83,8 @@ bool QHYCFW3::initProperties()
     INDI::FilterWheel::initProperties();
 
     CurrentFilter      = 1;
-    FilterSlotN[0].min = 1;
-    FilterSlotN[0].max = 4;
+    FilterSlotNP[0].setMin(1);
+    FilterSlotNP[0].setMax(4);
 
     addAuxControls();
 
@@ -162,9 +162,9 @@ bool QHYCFW3::Handshake()
     LOGF_DEBUG("RES <%s>", res);
 
     if (res[0] == 'F')
-        FilterSlotN[0].max = 16;
+        FilterSlotNP[0].setMax(16);
     else
-        FilterSlotN[0].max = atoi(res) + 1;
+        FilterSlotNP[0].setMax(atoi(res) + 1);
 
     // Now get current position
     LOG_DEBUG("CMD <NOW>");
@@ -192,7 +192,7 @@ bool QHYCFW3::Handshake()
     LOGF_DEBUG("RES <%s>", res);
 
     CurrentFilter = atoi(res) + 1;
-    FilterSlotN[0].value = CurrentFilter;
+    FilterSlotNP[0].setValue(CurrentFilter);
 
     return true;
 }

--- a/drivers/filter_wheel/quantum_wheel.cpp
+++ b/drivers/filter_wheel/quantum_wheel.cpp
@@ -126,8 +126,8 @@ bool QFW::initProperties()
 
     serialConnection->setDefaultPort("/dev/ttyACM0");
 
-    FilterSlotN[0].min = 1;
-    FilterSlotN[0].max = 7;
+    FilterSlotNP[0].setMin(1);
+    FilterSlotNP[0].setMax(7);
     CurrentFilter      = 1;
 
     return true;

--- a/drivers/filter_wheel/trutech_wheel.h
+++ b/drivers/filter_wheel/trutech_wheel.h
@@ -22,6 +22,9 @@
 
 #include "indifilterwheel.h"
 
+/* Smart Widget-Property */
+#include "indipropertyswitch.h"
+
 class TruTech : public INDI::FilterWheel
 {
     public:
@@ -43,6 +46,5 @@ class TruTech : public INDI::FilterWheel
 
         bool home();
 
-        ISwitch HomeS[1];
-        ISwitchVectorProperty HomeSP;
+        INDI::PropertySwitch HomeSP {1};
 };

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -21,6 +21,11 @@
 
 #include "indibase/indifilterwheel.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class XAGYLWheel : public INDI::FilterWheel
 {
     public:
@@ -97,8 +102,7 @@ class XAGYLWheel : public INDI::FilterWheel
         //////////////////////////////////////////////////////////////////////
 
         // Firmware info
-        ITextVectorProperty FirmwareInfoTP;
-        IText FirmwareInfoT[3] {};
+        INDI::PropertyText FirmwareInfoTP {3};
         enum
         {
             FIRMWARE_PRODUCT,
@@ -107,8 +111,7 @@ class XAGYLWheel : public INDI::FilterWheel
         };
 
         // Settings
-        INumberVectorProperty SettingsNP;
-        INumber SettingsN[4];
+        INDI::PropertyNumber SettingsNP {4};
         enum
         {
             SETTING_SPEED,
@@ -122,8 +125,7 @@ class XAGYLWheel : public INDI::FilterWheel
         INumber *OffsetN { nullptr };
 
         // Reset
-        ISwitchVectorProperty ResetSP;
-        ISwitch ResetS[4];
+        INDI::PropertySwitch ResetSP {4};
         enum
         {
             COMMAND_REBOOT,

--- a/drivers/focuser/aaf2.cpp
+++ b/drivers/focuser/aaf2.cpp
@@ -83,20 +83,20 @@ bool AAF2::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Relative and absolute movement
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 100000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     addDebugControl();
 
@@ -109,13 +109,13 @@ bool AAF2::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
+        defineProperty(TemperatureNP);
 
         LOG_INFO("Focuser ready.");
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
+        deleteProperty(TemperatureNP.getName());
     }
 
     return true;
@@ -197,7 +197,7 @@ bool AAF2::readTemperature()
     int rc = sscanf(res, "C%d:OK", &temp);
     if (rc > 0)
         // Hundredth of a degree
-        TemperatureN[0].value = temp / 100.0;
+        TemperatureNP[0].setValue(temp / 100.0);
     else
     {
         LOGF_ERROR("Unknown error: focuser temperature value (%s)", res);
@@ -230,7 +230,7 @@ bool AAF2::readPosition()
     int rc = sscanf(res, "P%d:OK", &pos);
 
     if (rc > 0)
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     else
     {
         LOGF_ERROR("Unknown error: focuser position value (%s)", res);
@@ -285,17 +285,17 @@ IPState AAF2::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     int32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     // Clamp
-    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosN[0].max), newPosition));
+    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosNP[0].max), newPosition));
     if (MoveAbsFocuser(newPosition) != IPS_BUSY)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -311,32 +311,32 @@ void AAF2::TimerHit()
     bool rc = readPosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
     rc = readTemperature();
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }

--- a/drivers/focuser/aaf2.h
+++ b/drivers/focuser/aaf2.h
@@ -23,6 +23,9 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class AAF2 : public INDI::Focuser
 {
     public:
@@ -86,8 +89,7 @@ class AAF2 : public INDI::Focuser
         bool isMoving();        
 
         // Read Only Temperature Reporting
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         double targetPos { 0 }, lastPos { 0 }, lastTemperature { 0 };
 

--- a/drivers/focuser/activefocuser.cpp
+++ b/drivers/focuser/activefocuser.cpp
@@ -165,74 +165,74 @@ bool ActiveFocuser::initProperties() {
 
     // Adding version display
 
-    IUFillText(&HardwareVersionN[0], "Version infos", "", "1.04");
-    IUFillTextVector(&HardwareVersionNP, HardwareVersionN, 1, getDeviceName(), "HARDWARE_VERSION", "Hardware Version",
+    HardwareVersionNP[0].fill("Version infos", "", "1.04");
+    HardwareVersionNP.fill(getDeviceName(), "HARDWARE_VERSION", "Hardware Version",
                      MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     std::stringstream softwareVersionStream;
     softwareVersionStream << DRIVER_VERSION_MAJOR << "." << DRIVER_VERSION_MINOR;
 
-    IUFillText(&SoftwareVersionN[0], "Version infos", "", softwareVersionStream.str().c_str());
-    IUFillTextVector(&SoftwareVersionNP, SoftwareVersionN, 1, getDeviceName(), "SOFTWARE_VERSION", "Software Version",
+    SoftwareVersionNP[0].fill("Version infos", "", softwareVersionStream.str().c_str());
+    SoftwareVersionNP.fill(getDeviceName(), "SOFTWARE_VERSION", "Software Version",
                      MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Adding temperature sensor display
 
-    IUFillNumber(&AirTemperatureN[0], "AIR TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
-    IUFillNumberVector(&AirTemperatureNP, AirTemperatureN, 1, getDeviceName(), "AIR_TEMPERATURE", "Air Temperature",
+    AirTemperatureNP[0].fill("AIR TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
+    AirTemperatureNP.fill(getDeviceName(), "AIR_TEMPERATURE", "Air Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillNumber(&TubeTemperatureN[0], "TUBE TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
-    IUFillNumberVector(&TubeTemperatureNP, TubeTemperatureN, 1, getDeviceName(), "TUBE_TEMPERATURE", "Tube Temperature",
+    TubeTemperatureNP[0].fill("TUBE TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
+    TubeTemperatureNP.fill(getDeviceName(), "TUBE_TEMPERATURE", "Tube Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillNumber(&MirrorTemperatureN[0], "MIRROR TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
-    IUFillNumberVector(&MirrorTemperatureNP, MirrorTemperatureN, 1, getDeviceName(), "MIRROR_TEMPERATURE",
+    MirrorTemperatureNP[0].fill("MIRROR TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
+    MirrorTemperatureNP.fill(getDeviceName(), "MIRROR_TEMPERATURE",
                        "Mirror Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Adding FAN control button
 
-    IUFillSwitch(&FanS[0], "FAN_ON", "On", ISS_ON);
-    IUFillSwitch(&FanS[1], "FAN_OFF", "Off", ISS_OFF);
-    IUFillSwitchVector(&FanSP, FanS, 2, getDeviceName(), "FAN_STATE", "Fan", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60,
+    FanSP[0].fill("FAN_ON", "On", ISS_ON);
+    FanSP[1].fill("FAN_OFF", "Off", ISS_OFF);
+    FanSP.fill(getDeviceName(), "FAN_STATE", "Fan", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60,
                        IPS_IDLE);
 
     // Setting focus max position constant
 
-    FocusMaxPosN[0].value = MAX_TICKS;
-    FocusMaxPosNP.p = IP_RO;
-    strncpy(FocusMaxPosN[0].label, "Steps", MAXINDILABEL);
+    FocusMaxPosNP[0].setValue(MAX_TICKS);
+    FocusMaxPosNP.setPermission(IP_RO);
+    FocusMaxPosNP[0].setLabel("Steps");
 
     // Disabling focuser speed
 
-    FocusSpeedN[0].min = 0;
-    FocusSpeedN[0].max = 0;
-    FocusSpeedN[0].value = 1;
-    IUUpdateMinMax(&FocusSpeedNP);
+    FocusSpeedNP[0].setMin(0);
+    FocusSpeedNP[0].setMax(0);
+    FocusSpeedNP[0].setValue(1);
+    FocusSpeedNP.updateMinMax();
 
     // Setting default absolute position values
 
-    FocusAbsPosN[0].min = 0.;
-    FocusAbsPosN[0].max = MAX_TICKS;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step = 1000.;
-    strncpy(FocusAbsPosN[0].label, "Steps", MAXINDILABEL);
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(MAX_TICKS);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000.);
+    FocusAbsPosNP[0].setLabel("Steps");
 
 
     // Setting default relative position values
 
-    FocusRelPosN[0].min = 0.;
-    FocusRelPosN[0].max = 5000;
-    FocusRelPosN[0].value = 100;
-    FocusRelPosN[0].step = 1;
-    strncpy(FocusRelPosN[0].label, "Steps", MAXINDILABEL);
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(5000);
+    FocusRelPosNP[0].setValue(100);
+    FocusRelPosNP[0].setStep(1);
+    FocusRelPosNP[0].setLabel("Steps");
 
-    PresetN[0].max = MAX_TICKS;
-    PresetN[1].max = MAX_TICKS;
-    PresetN[2].max = MAX_TICKS;
+    PresetNP[0].setMax(MAX_TICKS);
+    PresetNP[1].setMax(MAX_TICKS);
+    PresetNP[2].setMax(MAX_TICKS);
 
-    internalTicks = FocusAbsPosN[0].value;
+    internalTicks = FocusAbsPosNP[0].getValue();
 
     setDefaultPollingPeriod(750);
 
@@ -248,21 +248,21 @@ bool ActiveFocuser::updateProperties() {
 
     if (hid_handle) {
 
-        defineProperty(&HardwareVersionNP);
-        defineProperty(&SoftwareVersionNP);
-        defineProperty(&AirTemperatureNP);
-        defineProperty(&TubeTemperatureNP);
-        defineProperty(&MirrorTemperatureNP);
-        defineProperty(&FanSP);
+        defineProperty(HardwareVersionNP);
+        defineProperty(SoftwareVersionNP);
+        defineProperty(AirTemperatureNP);
+        defineProperty(TubeTemperatureNP);
+        defineProperty(MirrorTemperatureNP);
+        defineProperty(FanSP);
 
     } else {
 
-        deleteProperty(HardwareVersionNP.name);
-        deleteProperty(SoftwareVersionNP.name);
-        deleteProperty(AirTemperatureNP.name);
-        deleteProperty(TubeTemperatureNP.name);
-        deleteProperty(MirrorTemperatureNP.name);
-        deleteProperty(FanSP.name);
+        deleteProperty(HardwareVersionNP.getName());
+        deleteProperty(SoftwareVersionNP.getName());
+        deleteProperty(AirTemperatureNP.getName());
+        deleteProperty(TubeTemperatureNP.getName());
+        deleteProperty(MirrorTemperatureNP.getName());
+        deleteProperty(FanSP.getName());
 
     }
 
@@ -274,11 +274,11 @@ bool ActiveFocuser::ISNewSwitch(const char *dev, const char *name, ISState *stat
 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0) {
 
-        if (strcmp(FanSP.name, name) == 0) {
+        if (FanSP.isNameMatch(name)) {
 
-            IUUpdateSwitch(&FanSP, states, names, n);
+            FanSP.update(states, names, n);
 
-            if (FanS[0].s == ISS_ON && !ActiveFocuserUtils::SystemState::GetIsFanOn()) {
+            if (FanSP[0].getState() == ISS_ON && !ActiveFocuserUtils::SystemState::GetIsFanOn()) {
 
                 if (hid_handle) {
 
@@ -292,7 +292,7 @@ bool ActiveFocuser::ISNewSwitch(const char *dev, const char *name, ISState *stat
 
                 }
 
-            } else if (FanS[0].s == ISS_OFF && ActiveFocuserUtils::SystemState::GetIsFanOn()) {
+            } else if (FanSP[0].getState() == ISS_OFF && ActiveFocuserUtils::SystemState::GetIsFanOn()) {
 
                 if (hid_handle) {
 
@@ -308,8 +308,8 @@ bool ActiveFocuser::ISNewSwitch(const char *dev, const char *name, ISState *stat
 
             }
 
-            FanSP.s = IPS_OK;
-            IDSetSwitch(&FanSP, nullptr);
+            FanSP.setState(IPS_OK);
+            FanSP.apply();
 
             return true;
 
@@ -401,8 +401,8 @@ IPState ActiveFocuser::MoveAbsFocuser(uint32_t targetTicks) {
 
 IPState ActiveFocuser::MoveRelFocuser(INDI::FocuserInterface::FocusDirection dir, uint32_t ticks) {
 
-    FocusRelPosN[0].value = ticks;
-    IDSetNumber(&FocusRelPosNP, nullptr);
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.apply();
 
     int relativeTicks = ((dir == FOCUS_INWARD ? ticks : -ticks));
 
@@ -421,42 +421,42 @@ void ActiveFocuser::TimerHit() {
     }else{
 
         MAX_TICKS = ActiveFocuserUtils::SystemState::GetSpan();
-        FocusMaxPosN[0].value = MAX_TICKS;
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP[0].setValue(MAX_TICKS);
+        FocusMaxPosNP.apply();
 
-        PresetN[0].max = MAX_TICKS;
-        PresetN[1].max = MAX_TICKS;
-        PresetN[2].max = MAX_TICKS;
+        PresetNP[0].setMax(MAX_TICKS);
+        PresetNP[1].setMax(MAX_TICKS);
+        PresetNP[2].setMax(MAX_TICKS);
 
-        HardwareVersionN[0].text = ActiveFocuserUtils::SystemState::GetHardwareRevision();
-        IDSetText(&HardwareVersionNP, nullptr);
+        HardwareVersionNP[0].text = ActiveFocuserUtils::SystemState::GetHardwareRevision();
+        HardwareVersionNP.apply();
 
-        FocusAbsPosN[0].value = ActiveFocuserUtils::SystemState::GetCurrentPositionStep();
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setValue(ActiveFocuserUtils::SystemState::GetCurrentPositionStep());
+        FocusAbsPosNP.apply();
 
-        internalTicks = FocusAbsPosN[0].value;
+        internalTicks = FocusAbsPosNP[0].getValue();
 
-        AirTemperatureN[0].value = ActiveFocuserUtils::SystemState::GetAirTemperature();
-        IDSetNumber(&AirTemperatureNP, nullptr);
-        TubeTemperatureN[0].value = ActiveFocuserUtils::SystemState::GetTubeTemperature();
-        IDSetNumber(&TubeTemperatureNP, nullptr);
-        MirrorTemperatureN[0].value = ActiveFocuserUtils::SystemState::GetMirrorTemperature();
-        IDSetNumber(&MirrorTemperatureNP, nullptr);
+        AirTemperatureNP[0].setValue(ActiveFocuserUtils::SystemState::GetAirTemperature());
+        AirTemperatureNP.apply();
+        TubeTemperatureNP[0].setValue(ActiveFocuserUtils::SystemState::GetTubeTemperature());
+        TubeTemperatureNP.apply();
+        MirrorTemperatureNP[0].setValue(ActiveFocuserUtils::SystemState::GetMirrorTemperature());
+        MirrorTemperatureNP.apply();
 
         if(ActiveFocuserUtils::SystemState::GetIsFanOn()){
-            FanS[0].s = ISS_ON;
-            IDSetSwitch(&FanSP, nullptr);
+            FanSP[0].setState(ISS_ON);
+            FanSP.apply();
         }else{
-            FanS[0].s = ISS_OFF;
-            IDSetSwitch(&FanSP, nullptr);
+            FanSP[0].setState(ISS_OFF);
+            FanSP.apply();
         }
 
         if(ActiveFocuserUtils::SystemState::GetIsMoving()){
-            FocusAbsPosNP.s = IPS_BUSY;
-            FocusRelPosNP.s = IPS_BUSY;
+            FocusAbsPosNP.setState(IPS_BUSY);
+            FocusRelPosNP.setState(IPS_BUSY);
         }else{
-            FocusAbsPosNP.s = IPS_IDLE;
-            FocusRelPosNP.s = IPS_IDLE;
+            FocusAbsPosNP.setState(IPS_IDLE);
+            FocusRelPosNP.setState(IPS_IDLE);
         }
 
         SetTimer(getCurrentPollingPeriod());

--- a/drivers/focuser/activefocuser.h
+++ b/drivers/focuser/activefocuser.h
@@ -23,6 +23,11 @@
 #include "hidapi.h"
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class ActiveFocuser : public INDI::Focuser {
 public:
 
@@ -64,27 +69,21 @@ private:
     double initTicks{0};
 
     // Hardware version display
-    ITextVectorProperty HardwareVersionNP;
-    IText HardwareVersionN[1];
+    INDI::PropertyText HardwareVersionNP {1};
 
     // Software version display
-    ITextVectorProperty SoftwareVersionNP;
-    IText SoftwareVersionN[1];
+    INDI::PropertyText SoftwareVersionNP {1};
 
     // Air Temperature in celsius degrees
-    INumberVectorProperty AirTemperatureNP;
-    INumber AirTemperatureN[1];
+    INDI::PropertyNumber AirTemperatureNP {1};
 
     // Mirror Temperature in celsius degrees
-    INumberVectorProperty MirrorTemperatureNP;
-    INumber MirrorTemperatureN[1];
+    INDI::PropertyNumber MirrorTemperatureNP {1};
 
     // Tube Temperature in celsius degrees
-    INumberVectorProperty TubeTemperatureNP;
-    INumber TubeTemperatureN[1];
+    INDI::PropertyNumber TubeTemperatureNP {1};
 
     // Fan State switch
-    ISwitch FanS[2];
-    ISwitchVectorProperty FanSP;
+    INDI::PropertySwitch FanSP {2};
 
 };

--- a/drivers/focuser/celestron.cpp
+++ b/drivers/focuser/celestron.cpp
@@ -87,56 +87,56 @@ bool CelestronSCT::initProperties()
     // Focuser backlash
     // CR this is a value, positive or negative to define the direction.  It will need to be implemented
     // in the driver.
-    FocusBacklashN[0].min = -500;
-    FocusBacklashN[0].max = 500;
-    FocusBacklashN[0].step = 1;
-    FocusBacklashN[0].value = 0;
+    FocusBacklashNP[0].setMin(-500);
+    FocusBacklashNP[0].setMax(500);
+    FocusBacklashNP[0].setStep(1);
+    FocusBacklashNP[0].setValue(0);
 
-    //    IUFillNumber(&FocusBacklashN[0], "STEPS", "Steps", "%.f", -500., 500., 1., 0.);
-    //    IUFillNumberVector(&FocusBacklashNP, FocusBacklashN, 1, getDeviceName(), "FOCUS_BACKLASH", "Backlash",
+    //    FocusBacklashNP[0].fill("STEPS", "Steps", "%.f", -500., 500., 1., 0.);
+    //    FocusBacklashNP.fill(getDeviceName(), "FOCUS_BACKLASH", "Backlash",
     //                       MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     // Focuser min limit
-    IUFillNumber(&FocusMinPosN[0], "FOCUS_MIN_VALUE", "Steps", "%.f", 0, 40000., 1., 0.);
-    IUFillNumberVector(&FocusMinPosNP, FocusMinPosN, 1, getDeviceName(), "FOCUS_MIN", "Min. Position",
+    FocusMinPosNP[0].fill("FOCUS_MIN_VALUE", "Steps", "%.f", 0, 40000., 1., 0.);
+    FocusMinPosNP.fill(getDeviceName(), "FOCUS_MIN", "Min. Position",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // focuser calibration
-    IUFillSwitch(&CalibrateS[0], "START", "Start Calibration", ISS_OFF);
-    IUFillSwitch(&CalibrateS[1], "STOP", "Stop Calibration", ISS_OFF);
-    IUFillSwitchVector(&CalibrateSP, CalibrateS, 2, getDeviceName(), "CALIBRATE", "Calibrate control",
+    CalibrateSP[0].fill("START", "Start Calibration", ISS_OFF);
+    CalibrateSP[1].fill("STOP", "Stop Calibration", ISS_OFF);
+    CalibrateSP.fill(getDeviceName(), "CALIBRATE", "Calibrate control",
                        MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillText(&CalibrateStateT[0], "CALIBRATE_STATE", "Calibrate state", "");
-    IUFillTextVector(&CalibrateStateTP, CalibrateStateT, 1, getDeviceName(), "CALIBRATE_STATE", "Calibrate State",
+    CalibrateStateTP[0].fill("CALIBRATE_STATE", "Calibrate state", "");
+    CalibrateStateTP.fill(getDeviceName(), "CALIBRATE_STATE", "Calibrate State",
                      MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Speed range
     // CR no need to have adjustable speed, how to remove?
-    FocusSpeedN[0].min   = 1;
-    FocusSpeedN[0].max   = 3;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(3);
+    FocusSpeedNP[0].setValue(1);
 
     // From online screenshots, seems maximum value is 60,000 steps
     // max and min positions can be read from a calibrated focuser
 
     // Relative Position Range
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 30000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(30000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
     // Absolute Postition Range
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 60000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(60000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     // Maximum Position Settings
-    FocusMaxPosN[0].max   = 60000;
-    FocusMaxPosN[0].min   = 1000;
-    FocusMaxPosN[0].value = 60000;
-    FocusMaxPosNP.p = IP_RO;
+    FocusMaxPosNP[0].setMax(60000);
+    FocusMaxPosNP[0].setMin(1000);
+    FocusMaxPosNP[0].setValue(60000);
+    FocusMaxPosNP.setPermission(IP_RO);
 
     // Poll every 500ms
     setDefaultPollingPeriod(500);
@@ -162,12 +162,12 @@ bool CelestronSCT::updateProperties()
 
     if (isConnected())
     {
-        //defineProperty(&FocusBacklashNP);
+        //defineProperty(FocusBacklashNP);
 
-        defineProperty(&FocusMinPosNP);
+        defineProperty(FocusMinPosNP);
 
-        defineProperty(&CalibrateSP);
-        defineProperty(&CalibrateStateTP);
+        defineProperty(CalibrateSP);
+        defineProperty(CalibrateStateTP);
 
         if (getStartupParameters())
             LOG_INFO("Celestron SCT focuser parameters updated, focuser ready for use.");
@@ -177,10 +177,10 @@ bool CelestronSCT::updateProperties()
     }
     else
     {
-        //deleteProperty(FocusBacklashNP.name);
-        deleteProperty(FocusMinPosNP.name);
-        deleteProperty(CalibrateSP.name);
-        deleteProperty(CalibrateStateTP.name);
+        //deleteProperty(FocusBacklashNP.getName());
+        deleteProperty(FocusMinPosNP.getName());
+        deleteProperty(CalibrateSP.getName());
+        deleteProperty(CalibrateStateTP.getName());
     }
 
     return true;
@@ -229,7 +229,7 @@ bool CelestronSCT::readPosition()
 
     int position = (reply[0] << 16) + (reply[1] << 8) + reply[2];
     LOGF_DEBUG("Position %i", position);
-    FocusAbsPosN[0].value = position;
+    FocusAbsPosNP[0].setValue(position);
     return true;
 }
 
@@ -251,18 +251,18 @@ bool CelestronSCT::readLimits()
     int lo = (reply[0] << 24) + (reply[1] << 16) + (reply[2] << 8) + reply[3];
     int hi = (reply[4] << 24) + (reply[5] << 16) + (reply[6] << 8) + reply[7];
 
-    FocusAbsPosN[0].max = hi;
-    FocusAbsPosN[0].min = lo;
-    FocusAbsPosNP.s = IPS_OK;
-    IUUpdateMinMax(&FocusAbsPosNP);
+    FocusAbsPosNP[0].setMax(hi);
+    FocusAbsPosNP[0].setMin(lo);
+    FocusAbsPosNP.setState(IPS_OK);
+    FocusAbsPosNP.updateMinMax();
 
-    FocusMaxPosN[0].value = hi;
-    FocusMaxPosNP.s = IPS_OK;
-    IDSetNumber(&FocusMaxPosNP, nullptr);
+    FocusMaxPosNP[0].setValue(hi);
+    FocusMaxPosNP.setState(IPS_OK);
+    FocusMaxPosNP.apply();
 
-    FocusMinPosN[0].value = lo;
-    FocusMinPosNP.s = IPS_OK;
-    IDSetNumber(&FocusMinPosNP, nullptr);
+    FocusMinPosNP[0].setValue(lo);
+    FocusMinPosNP.setState(IPS_OK);
+    FocusMinPosNP.apply();
 
     // check on integrity of values, they must be sensible and the range must be more than 2 turns
     if (hi > 0 && lo > 0 && hi - lo > 2000 && hi <= 60000 && lo < 50000)
@@ -285,12 +285,12 @@ bool CelestronSCT::readLimits()
 //    if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
 //    {
 //        // Backlash
-//        if (!strcmp(name, FocusBacklashNP.name))
+//        if (FocusBacklashNP.isNameMatch(name))
 //        {
 //            // just update the number
-//            IUUpdateNumber(&FocusBacklashNP, values, names, n);
-//            FocusBacklashNP.s = IPS_OK;
-//            IDSetNumber(&FocusBacklashNP, nullptr);
+//            FocusBacklashNP.update(values, names, n);
+//            FocusBacklashNP.setState(IPS_OK);
+//            FocusBacklashNP.apply();
 //            return true;
 //        }
 //    }
@@ -301,10 +301,10 @@ bool CelestronSCT::ISNewSwitch(const char * dev, const char * name, ISState *sta
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, CalibrateSP.name))
+        if (CalibrateSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&CalibrateSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&CalibrateSP);
+            CalibrateSP.update(states, names, n);
+            int index = CalibrateSP.findOnSwitchIndex();
             Aux::buffer data = {1};
             switch(index)
             {
@@ -324,8 +324,8 @@ bool CelestronSCT::ISNewSwitch(const char * dev, const char * name, ISState *sta
             }
             communicator.commandBlind(PortFD, Aux::Target::FOCUSER, Aux::Command::FOC_CALIB_ENABLE, data);
             usleep(500000);
-            CalibrateSP.s = IPS_BUSY;
-            IDSetSwitch(&CalibrateSP, nullptr);
+            CalibrateSP.setState(IPS_BUSY);
+            CalibrateSP.apply();
             return true;
         }
     }
@@ -337,7 +337,7 @@ bool CelestronSCT::getStartupParameters()
     bool rc1 = false, rc2 = false;
 
     if ( (rc1 = readPosition()))
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if ( !(rc2 = readLimits()))
     {
@@ -366,8 +366,8 @@ IPState CelestronSCT::MoveAbsFocuser(uint32_t targetTicks)
     }
 
     // the focuser seems happy to move 500 steps past the soft limit so don't check backlash
-    if (targetTicks > FocusMaxPosN[0].value ||
-            targetTicks < FocusMinPosN[0].value)
+    if (targetTicks > FocusMaxPosNP[0].value ||
+            targetTicks < FocusMinPosNP[0].getValue())
     {
         LOGF_ERROR("Move to %i not allowed because it is out of range", targetTicks);
         return IPS_ALERT;
@@ -376,13 +376,13 @@ IPState CelestronSCT::MoveAbsFocuser(uint32_t targetTicks)
     uint32_t position = targetTicks;
 
     // implement backlash
-    int delta = targetTicks - FocusAbsPosN[0].value;
-    if ((FocusBacklashN[0].value < 0 && delta > 0) ||
-            (FocusBacklashN[0].value > 0 && delta < 0))
+    int delta = targetTicks - FocusAbsPosNP[0].getValue();
+    if ((FocusBacklashNP[0].value < 0 && delta > 0) ||
+            (FocusBacklashNP[0].value > 0 && delta < 0))
     {
         backlashMove = true;
         finalPosition = position;
-        position -= FocusBacklashN[0].value;
+        position -= FocusBacklashNP[0].getValue();
     }
 
     if (!startMove(position))
@@ -410,12 +410,12 @@ IPState CelestronSCT::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     int32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     // Clamp
-    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosN[0].max), newPosition));
+    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosNP[0].max), newPosition));
     return MoveAbsFocuser(newPosition);
 }
 
@@ -428,16 +428,16 @@ void CelestronSCT::TimerHit()
     }
 
     // Check position
-    double lastPosition = FocusAbsPosN[0].value;
+    double lastPosition = FocusAbsPosNP[0].getValue();
     bool rc = readPosition();
     if (rc)
     {
         // Only update if there is actual change
-        if (fabs(lastPosition - FocusAbsPosN[0].value) > 1)
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+        if (fabs(lastPosition - FocusAbsPosNP[0].getValue()) > 1)
+            FocusAbsPosNP.apply();
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         // CR The backlash handling will probably have to be done here, if the move state
         // shows that a backlash move has been done then the final move needs to be started
@@ -459,10 +459,10 @@ void CelestronSCT::TimerHit()
             }
             else
             {
-                FocusAbsPosNP.s = IPS_OK;
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
-                IDSetNumber(&FocusRelPosNP, nullptr);
+                FocusAbsPosNP.setState(IPS_OK);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusAbsPosNP.apply();
+                FocusRelPosNP.apply();
                 LOG_INFO("Focuser reached requested position.");
             }
         }
@@ -484,18 +484,18 @@ void CelestronSCT::TimerHit()
             const char *msg = complete ? "Calibrate complete" : "Calibrate aborted";
             LOG_INFO(msg);
             calibrateInProgress = false;
-            CalibrateS[1].s = ISS_OFF;
-            CalibrateSP.s = IPS_OK;
-            //CalibrateStateT[0].text = (char *)msg;
-            IUSaveText(&CalibrateStateT[0], msg);
-            IDSetSwitch(&CalibrateSP, nullptr);
-            IDSetText(&CalibrateStateTP, nullptr);
+            CalibrateSP[1].setState(ISS_OFF);
+            CalibrateSP.setState(IPS_OK);
+            //CalibrateStateTP[0].text = (char *)msg;
+            CalibrateStateTP[0].setText(msg);
+            CalibrateSP.apply();
+            CalibrateStateTP.apply();
             // read the new limits
             if (complete && readLimits())
             {
-                IUUpdateMinMax(&FocusAbsPosNP);
-                IDSetNumber(&FocusMaxPosNP, nullptr);
-                IDSetNumber(&FocusMinPosNP, nullptr);
+                FocusAbsPosNP.updateMinMax();
+                FocusMaxPosNP.apply();
+                FocusMinPosNP.apply();
             }
         }
         else
@@ -505,8 +505,8 @@ void CelestronSCT::TimerHit()
                 calibrateState = state;
                 char str[20];
                 snprintf(str, 20, "Calibrate state %i", state);
-                CalibrateStateT[0].text = str;
-                IDSetText(&CalibrateStateTP, nullptr);
+                CalibrateStateTP[0].text = str;
+                CalibrateStateTP.apply();
             }
         }
     }

--- a/drivers/focuser/celestron.h
+++ b/drivers/focuser/celestron.h
@@ -27,6 +27,11 @@
 #include <chrono>
 #include "celestronauxpacket.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class CelestronSCT : public INDI::Focuser
 {
     public:
@@ -100,20 +105,17 @@ class CelestronSCT : public INDI::Focuser
         ///////////////////////////////////////////////////////////////////////////////
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////
-        //        INumber BacklashN[1];
-        //        INumberVectorProperty BacklashNP;
+        //        INDI::PropertyNumber BacklashNP {1};
+        //
 
-        INumber FocusMinPosN[1];
-        INumberVectorProperty FocusMinPosNP;
+        INDI::PropertyNumber FocusMinPosNP {1};
 
         bool backlashMove;      // set if a final move is needed
         uint32_t finalPosition;
 
-        ISwitch CalibrateS[2];
-        ISwitchVectorProperty CalibrateSP;
+        INDI::PropertySwitch CalibrateSP {2};
 
-        IText CalibrateStateT[1] {};
-        ITextVectorProperty CalibrateStateTP;
+        INDI::PropertyText CalibrateStateTP {1};
 
         bool calibrateInProgress;
         int calibrateState;

--- a/drivers/focuser/deepskydad_af1.cpp
+++ b/drivers/focuser/deepskydad_af1.cpp
@@ -83,57 +83,57 @@ bool DeepSkyDadAF1::initProperties()
     INDI::Focuser::initProperties();
 
     // Step Mode
-    IUFillSwitch(&StepModeS[EIGHT], "EIGHT", "Eight Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[QUARTER], "QUARTER", "Quarter Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[HALF], "HALF", "Half Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FULL], "FULL", "Full Step", ISS_OFF);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 4, getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    StepModeSP[EIGHT].fill("EIGHT", "Eight Step", ISS_OFF);
+    StepModeSP[QUARTER].fill("QUARTER", "Quarter Step", ISS_OFF);
+    StepModeSP[HALF].fill("HALF", "Half Step", ISS_OFF);
+    StepModeSP[FULL].fill("FULL", "Full Step", ISS_OFF);
+    StepModeSP.fill(getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min = 0.;
-    FocusRelPosN[0].max = 5000.;
-    FocusRelPosN[0].value = 0.;
-    FocusRelPosN[0].step = 10.;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(5000.);
+    FocusRelPosNP[0].setValue(0.);
+    FocusRelPosNP[0].setStep(10.);
 
-    FocusAbsPosN[0].min = 0.;
-    FocusAbsPosN[0].max = 100000.;
-    FocusAbsPosN[0].value = 50000.;
-    FocusAbsPosN[0].step = 500.;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(50000.);
+    FocusAbsPosNP[0].setStep(500.);
 
     // Max. movement
-    IUFillNumber(&FocusMaxMoveN[0], "MAX_MOVE", "Steps", "%7.0f", 0, 9999999, 100, 0);
-    IUFillNumberVector(&FocusMaxMoveNP, FocusMaxMoveN, 1, getDeviceName(), "FOCUS_MAX_MOVE", "Max. movement",
+    FocusMaxMoveNP[0].fill("MAX_MOVE", "Steps", "%7.0f", 0, 9999999, 100, 0);
+    FocusMaxMoveNP.fill(getDeviceName(), "FOCUS_MAX_MOVE", "Max. movement",
                        MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     // Settle buffer
-    IUFillNumber(&SettleBufferN[0], "SETTLE_BUFFER", "Period (ms)", "%5.0f", 0, 99999, 100, 0);
-    IUFillNumberVector(&SettleBufferNP, SettleBufferN, 1, getDeviceName(), "FOCUS_SETTLE_BUFFER", "Settle buffer",
+    SettleBufferNP[0].fill("SETTLE_BUFFER", "Period (ms)", "%5.0f", 0, 99999, 100, 0);
+    SettleBufferNP.fill(getDeviceName(), "FOCUS_SETTLE_BUFFER", "Settle buffer",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Idle coils timeout (ms)
-    IUFillNumber(&IdleCoilsTimeoutN[0], "IDLE_COILS_TIMEOUT", "Period (ms)", "%6.0f", 0, 999999, 1000, 60000);
-    IUFillNumberVector(&IdleCoilsTimeoutNP, IdleCoilsTimeoutN, 1, getDeviceName(), "FOCUS_IDLE_COILS_TIMEOUT", "Idle - coils timeout",
+    IdleCoilsTimeoutNP[0].fill("IDLE_COILS_TIMEOUT", "Period (ms)", "%6.0f", 0, 999999, 1000, 60000);
+    IdleCoilsTimeoutNP.fill(getDeviceName(), "FOCUS_IDLE_COILS_TIMEOUT", "Idle - coils timeout",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Coils mode
-    IUFillSwitch(&CoilsModeS[ALWAYS_ON], "ALWAYS_ON", "Always on", ISS_OFF);
-    IUFillSwitch(&CoilsModeS[IDLE_OFF], "IDLE_OFF", "Idle - off", ISS_OFF);
-    IUFillSwitch(&CoilsModeS[IDLE_COILS_TIMEOUT], "IDLE_COILS_TIMEOUT", "Idle - coils timeout (ms)", ISS_OFF);
-    IUFillSwitchVector(&CoilsModeSP, CoilsModeS, 3, getDeviceName(), "Coils mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    CoilsModeSP[ALWAYS_ON].fill("ALWAYS_ON", "Always on", ISS_OFF);
+    CoilsModeSP[IDLE_OFF].fill("IDLE_OFF", "Idle - off", ISS_OFF);
+    CoilsModeSP[IDLE_COILS_TIMEOUT].fill("IDLE_COILS_TIMEOUT", "Idle - coils timeout (ms)", ISS_OFF);
+    CoilsModeSP.fill(getDeviceName(), "Coils mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Current move
-    IUFillSwitch(&CurrentMoveS[CURRENT_25], "CMV_25", "25%", ISS_OFF);
-    IUFillSwitch(&CurrentMoveS[CURRENT_50], "CMV_50", "50%", ISS_OFF);
-    IUFillSwitch(&CurrentMoveS[CURRENT_75], "CMV_75", "75%", ISS_OFF);
-    IUFillSwitch(&CurrentMoveS[CURRENT_100], "CMV_100", "100%", ISS_OFF);
-    IUFillSwitchVector(&CurrentMoveSP, CurrentMoveS, 4, getDeviceName(), "Current - move", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    CurrentMoveSP[CURRENT_25].fill("CMV_25", "25%", ISS_OFF);
+    CurrentMoveSP[CURRENT_50].fill("CMV_50", "50%", ISS_OFF);
+    CurrentMoveSP[CURRENT_75].fill("CMV_75", "75%", ISS_OFF);
+    CurrentMoveSP[CURRENT_100].fill("CMV_100", "100%", ISS_OFF);
+    CurrentMoveSP.fill(getDeviceName(), "Current - move", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Current hold
-    IUFillSwitch(&CurrentHoldS[CURRENT_25], "CHD_25", "25%", ISS_OFF);
-    IUFillSwitch(&CurrentHoldS[CURRENT_50], "CHD_50", "50%", ISS_OFF);
-    IUFillSwitch(&CurrentHoldS[CURRENT_75], "CHD_75", "75%", ISS_OFF);
-    IUFillSwitch(&CurrentHoldS[CURRENT_100], "CHD_100", "100%", ISS_OFF);
-    IUFillSwitchVector(&CurrentHoldSP, CurrentHoldS, 4, getDeviceName(), "Current - hold", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    CurrentHoldSP[CURRENT_25].fill("CHD_25", "25%", ISS_OFF);
+    CurrentHoldSP[CURRENT_50].fill("CHD_50", "50%", ISS_OFF);
+    CurrentHoldSP[CURRENT_75].fill("CHD_75", "75%", ISS_OFF);
+    CurrentHoldSP[CURRENT_100].fill("CHD_100", "100%", ISS_OFF);
+    CurrentHoldSP.fill(getDeviceName(), "Current - hold", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     setDefaultPollingPeriod(500);
     addDebugControl();
@@ -147,13 +147,13 @@ bool DeepSkyDadAF1::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&FocusMaxMoveNP);
-        defineProperty(&StepModeSP);
-        defineProperty(&SettleBufferNP);
-        defineProperty(&CoilsModeSP);
-        defineProperty(&IdleCoilsTimeoutNP);
-        defineProperty(&CurrentMoveSP);
-        defineProperty(&CurrentHoldSP);
+        defineProperty(FocusMaxMoveNP);
+        defineProperty(StepModeSP);
+        defineProperty(SettleBufferNP);
+        defineProperty(CoilsModeSP);
+        defineProperty(IdleCoilsTimeoutNP);
+        defineProperty(CurrentMoveSP);
+        defineProperty(CurrentHoldSP);
 
         GetFocusParams();
 
@@ -161,13 +161,13 @@ bool DeepSkyDadAF1::updateProperties()
     }
     else
     {
-        deleteProperty(FocusMaxMoveNP.name);
-        deleteProperty(StepModeSP.name);
-        deleteProperty(SettleBufferNP.name);
-        deleteProperty(CoilsModeSP.name);
-        deleteProperty(IdleCoilsTimeoutNP.name);
-        deleteProperty(CurrentMoveSP.name);
-        deleteProperty(CurrentHoldSP.name);
+        deleteProperty(FocusMaxMoveNP.getName());
+        deleteProperty(StepModeSP.getName());
+        deleteProperty(SettleBufferNP.getName());
+        deleteProperty(CoilsModeSP.getName());
+        deleteProperty(IdleCoilsTimeoutNP.getName());
+        deleteProperty(CurrentMoveSP.getName());
+        deleteProperty(CurrentHoldSP.getName());
     }
 
     return true;
@@ -222,13 +222,13 @@ bool DeepSkyDadAF1::readStepMode()
         return false;
 
     if (strcmp(res, "(1)") == 0)
-        StepModeS[FULL].s = ISS_ON;
+        StepModeSP[FULL].setState(ISS_ON);
     else if (strcmp(res, "(2)") == 0)
-        StepModeS[HALF].s = ISS_ON;
+        StepModeSP[HALF].setState(ISS_ON);
     else if (strcmp(res, "(4)") == 0)
-        StepModeS[QUARTER].s = ISS_ON;
+        StepModeSP[QUARTER].setState(ISS_ON);
     else if (strcmp(res, "(8)") == 0)
-        StepModeS[EIGHT].s = ISS_ON;
+        StepModeSP[EIGHT].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser step value (%s)", res);
@@ -249,7 +249,7 @@ bool DeepSkyDadAF1::readPosition()
     int rc = sscanf(res, "(%d)", &pos);
 
     if (rc > 0)
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     else
     {
         LOGF_ERROR("Unknown error: focuser position value (%s)", res);
@@ -270,8 +270,8 @@ bool DeepSkyDadAF1::readMaxMovement()
     int rc = sscanf(res, "(%d)", &steps);
     if (rc > 0)
     {
-        FocusMaxMoveN[0].value = steps;
-        FocusMaxMoveNP.s = IPS_OK;
+        FocusMaxMoveNP[0].setValue(steps);
+        FocusMaxMoveNP.setState(IPS_OK);
     }
     else
     {
@@ -293,8 +293,8 @@ bool DeepSkyDadAF1::readMaxPosition()
     int rc = sscanf(res, "(%d)", &steps);
     if (rc > 0)
     {
-        FocusMaxPosN[0].value = steps;
-        FocusMaxPosNP.s = IPS_OK;
+        FocusMaxPosNP[0].setValue(steps);
+        FocusMaxPosNP.setState(IPS_OK);
     }
     else
     {
@@ -316,8 +316,8 @@ bool DeepSkyDadAF1::readSettleBuffer()
     int rc = sscanf(res, "(%d)", &settleBuffer);
     if (rc > 0)
     {
-        SettleBufferN[0].value = settleBuffer;
-        SettleBufferNP.s = settleBuffer > 0 ? IPS_OK : IPS_IDLE;
+        SettleBufferNP[0].setValue(settleBuffer);
+        SettleBufferNP.setState(settleBuffer > 0 ? IPS_OK : IPS_IDLE);
     }
     else
     {
@@ -339,8 +339,8 @@ bool DeepSkyDadAF1::readIdleCoilsTimeout()
     int rc = sscanf(res, "(%d)", &ms);
     if (rc > 0)
     {
-        IdleCoilsTimeoutN[0].value = ms;
-        IdleCoilsTimeoutNP.s = ms > 0 ? IPS_OK : IPS_IDLE;
+        IdleCoilsTimeoutNP[0].setValue(ms);
+        IdleCoilsTimeoutNP.setState(ms > 0 ? IPS_OK : IPS_IDLE);
     }
     else
     {
@@ -360,18 +360,18 @@ bool DeepSkyDadAF1::readCoilsMode()
 
     if (strcmp(res, "(0)") == 0)
     {
-        CoilsModeSP.s = IPS_IDLE;
-        CoilsModeS[IDLE_OFF].s = ISS_ON;
+        CoilsModeSP.setState(IPS_IDLE);
+        CoilsModeSP[IDLE_OFF].setState(ISS_ON);
     }
     else if (strcmp(res, "(1)") == 0)
     {
-        CoilsModeSP.s = IPS_OK;
-        CoilsModeS[ALWAYS_ON].s = ISS_ON;
+        CoilsModeSP.setState(IPS_OK);
+        CoilsModeSP[ALWAYS_ON].setState(ISS_ON);
     }
     else if (strcmp(res, "(2)") == 0)
     {
-        CoilsModeSP.s = IPS_IDLE;
-        CoilsModeS[IDLE_COILS_TIMEOUT].s = ISS_ON;
+        CoilsModeSP.setState(IPS_IDLE);
+        CoilsModeSP[IDLE_COILS_TIMEOUT].setState(ISS_ON);
     }
     else
     {
@@ -391,23 +391,23 @@ bool DeepSkyDadAF1::readCurrentMove()
 
     if (strcmp(res, "(25%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_25].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_25].setState(ISS_ON);
     }
     else if (strcmp(res, "(50%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_50].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_50].setState(ISS_ON);
     }
     else if (strcmp(res, "(75%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_75].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_75].setState(ISS_ON);
     }
     else if (strcmp(res, "(100%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_100].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_100].setState(ISS_ON);
     }
 
     else
@@ -428,23 +428,23 @@ bool DeepSkyDadAF1::readCurrentHold()
 
     if (strcmp(res, "(25%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_25].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_25].setState(ISS_ON);
     }
     else if (strcmp(res, "(50%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_50].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_50].setState(ISS_ON);
     }
     else if (strcmp(res, "(75%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_75].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_75].setState(ISS_ON);
     }
     else if (strcmp(res, "(100%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_100].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_100].setState(ISS_ON);
     }
 
     else
@@ -513,18 +513,18 @@ bool DeepSkyDadAF1::ISNewSwitch(const char * dev, const char * name, ISState * s
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Focus Step Mode
-        if (strcmp(StepModeSP.name, name) == 0)
+        if (StepModeSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int current_mode = StepModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&StepModeSP, states, names, n);
+            StepModeSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int target_mode = StepModeSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                StepModeSP.s = IPS_OK;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.setState(IPS_OK);
+                StepModeSP.apply();
                 return true;
             }
 
@@ -543,30 +543,30 @@ bool DeepSkyDadAF1::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&StepModeSP);
-                StepModeS[current_mode].s = ISS_ON;
-                StepModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.reset();
+                StepModeSP[current_mode].setState(ISS_ON);
+                StepModeSP.setState(IPS_ALERT);
+                StepModeSP.apply();
                 return false;
             }
 
-            StepModeSP.s = IPS_OK;
-            IDSetSwitch(&StepModeSP, nullptr);
+            StepModeSP.setState(IPS_OK);
+            StepModeSP.apply();
             return true;
         }
 
         // Coils mode
-        if (strcmp(CoilsModeSP.name, name) == 0)
+        if (CoilsModeSP.isNameMatch(name))
         {
-            int coilsModeCurrent = IUFindOnSwitchIndex(&CoilsModeSP);
+            int coilsModeCurrent = CoilsModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&CoilsModeSP, states, names, n);
+            CoilsModeSP.update(states, names, n);
 
-            int coilsModeTarget = IUFindOnSwitchIndex(&CoilsModeSP);
+            int coilsModeTarget = CoilsModeSP.findOnSwitchIndex();
 
             if (coilsModeCurrent == coilsModeTarget)
             {
-                IDSetSwitch(&CoilsModeSP, nullptr);
+                CoilsModeSP.apply();
                 return true;
             }
 
@@ -583,30 +583,30 @@ bool DeepSkyDadAF1::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&CoilsModeSP);
-                CoilsModeS[coilsModeCurrent].s = ISS_ON;
-                CoilsModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&CoilsModeSP, nullptr);
+                CoilsModeSP.reset();
+                CoilsModeSP[coilsModeCurrent].setState(ISS_ON);
+                CoilsModeSP.setState(IPS_ALERT);
+                CoilsModeSP.apply();
                 return false;
             }
 
-            CoilsModeSP.s = coilsModeTarget == 1 ? IPS_OK : IPS_IDLE;
-            IDSetSwitch(&CoilsModeSP, nullptr);
+            CoilsModeSP.setState(coilsModeTarget == 1 ? IPS_OK : IPS_IDLE);
+            CoilsModeSP.apply();
             return true;
         }
 
         // Current - move
-        if (strcmp(CurrentMoveSP.name, name) == 0)
+        if (CurrentMoveSP.isNameMatch(name))
         {
-            int current = IUFindOnSwitchIndex(&CurrentMoveSP);
+            int current = CurrentMoveSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&CurrentMoveSP, states, names, n);
+            CurrentMoveSP.update(states, names, n);
 
-            int targetCurrent = IUFindOnSwitchIndex(&CurrentMoveSP);
+            int targetCurrent = CurrentMoveSP.findOnSwitchIndex();
 
             if (current == targetCurrent)
             {
-                IDSetSwitch(&CurrentMoveSP, nullptr);
+                CurrentMoveSP.apply();
                 return true;
             }
 
@@ -633,30 +633,30 @@ bool DeepSkyDadAF1::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&CurrentMoveSP);
-                CurrentMoveS[current].s = ISS_ON;
-                CurrentMoveSP.s              = IPS_ALERT;
-                IDSetSwitch(&CurrentMoveSP, nullptr);
+                CurrentMoveSP.reset();
+                CurrentMoveSP[current].setState(ISS_ON);
+                CurrentMoveSP.setState(IPS_ALERT);
+                CurrentMoveSP.apply();
                 return false;
             }
 
-            CurrentMoveSP.s = IPS_OK;
-            IDSetSwitch(&CurrentMoveSP, nullptr);
+            CurrentMoveSP.setState(IPS_OK);
+            CurrentMoveSP.apply();
             return true;
         }
 
         // Current - hold
-        if (strcmp(CurrentHoldSP.name, name) == 0)
+        if (CurrentHoldSP.isNameMatch(name))
         {
-            int current = IUFindOnSwitchIndex(&CurrentHoldSP);
+            int current = CurrentHoldSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&CurrentHoldSP, states, names, n);
+            CurrentHoldSP.update(states, names, n);
 
-            int targetCurrent = IUFindOnSwitchIndex(&CurrentHoldSP);
+            int targetCurrent = CurrentHoldSP.findOnSwitchIndex();
 
             if (current == targetCurrent)
             {
-                IDSetSwitch(&CurrentHoldSP, nullptr);
+                CurrentHoldSP.apply();
                 return true;
             }
 
@@ -683,15 +683,15 @@ bool DeepSkyDadAF1::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&CurrentHoldSP);
-                CurrentHoldS[current].s = ISS_ON;
-                CurrentHoldSP.s              = IPS_ALERT;
-                IDSetSwitch(&CurrentHoldSP, nullptr);
+                CurrentHoldSP.reset();
+                CurrentHoldSP[current].setState(ISS_ON);
+                CurrentHoldSP.setState(IPS_ALERT);
+                CurrentHoldSP.apply();
                 return false;
             }
 
-            CurrentHoldSP.s = IPS_OK;
-            IDSetSwitch(&CurrentHoldSP, nullptr);
+            CurrentHoldSP.setState(IPS_OK);
+            CurrentHoldSP.apply();
             return true;
         }
     }
@@ -704,74 +704,74 @@ bool DeepSkyDadAF1::ISNewNumber(const char * dev, const char * name, double valu
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Settle buffer Settings
-        if (strcmp(name, SettleBufferNP.name) == 0)
+        if (SettleBufferNP.isNameMatch(name))
         {
-            IUUpdateNumber(&SettleBufferNP, values, names, n);
+            SettleBufferNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SBUF%06d]", static_cast<int>(SettleBufferN[0].value));
+            snprintf(cmd, DSD_RES, "[SBUF%06d]", static_cast<int>(SettleBufferNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                SettleBufferNP.s = IPS_ALERT;
+                SettleBufferNP.setState(IPS_ALERT);
                 return false;
             }
 
-            SettleBufferNP.s = IPS_OK;
-            IDSetNumber(&SettleBufferNP, nullptr);
+            SettleBufferNP.setState(IPS_OK);
+            SettleBufferNP.apply();
             return true;
         }
 
         // Idle coils timeout
-        if (strcmp(name, IdleCoilsTimeoutNP.name) == 0)
+        if (IdleCoilsTimeoutNP.isNameMatch(name))
         {
-            IUUpdateNumber(&IdleCoilsTimeoutNP, values, names, n);
+            IdleCoilsTimeoutNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SIDC%06d]", static_cast<int>(IdleCoilsTimeoutN[0].value));
+            snprintf(cmd, DSD_RES, "[SIDC%06d]", static_cast<int>(IdleCoilsTimeoutNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IdleCoilsTimeoutNP.s = IPS_ALERT;
+                IdleCoilsTimeoutNP.setState(IPS_ALERT);
                 return false;
             }
 
-            IdleCoilsTimeoutNP.s = IPS_OK;
-            IDSetNumber(&IdleCoilsTimeoutNP, nullptr);
+            IdleCoilsTimeoutNP.setState(IPS_OK);
+            IdleCoilsTimeoutNP.apply();
             return true;
         }
 
         // Max. position
-        if (strcmp(name, FocusMaxPosNP.name) == 0)
+        if (FocusMaxPosNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FocusMaxPosNP, values, names, n);
+            FocusMaxPosNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SMXP%d]", static_cast<int>(FocusMaxPosN[0].value));
+            snprintf(cmd, DSD_RES, "[SMXP%d]", static_cast<int>(FocusMaxPosNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                FocusMaxPosNP.s = IPS_ALERT;
+                FocusMaxPosNP.setState(IPS_ALERT);
                 return false;
             }
 
-            FocusMaxPosNP.s = IPS_OK;
-            IDSetNumber(&FocusMaxPosNP, nullptr);
+            FocusMaxPosNP.setState(IPS_OK);
+            FocusMaxPosNP.apply();
             return true;
         }
 
         // Max. movement
-        if (strcmp(name, FocusMaxMoveNP.name) == 0)
+        if (FocusMaxMoveNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FocusMaxMoveNP, values, names, n);
+            FocusMaxMoveNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SMXM%d]", static_cast<int>(FocusMaxMoveN[0].value));
+            snprintf(cmd, DSD_RES, "[SMXM%d]", static_cast<int>(FocusMaxMoveNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                FocusMaxMoveNP.s = IPS_ALERT;
+                FocusMaxMoveNP.setState(IPS_ALERT);
                 return false;
             }
 
-            FocusMaxMoveNP.s = IPS_OK;
-            IDSetNumber(&FocusMaxMoveNP, nullptr);
+            FocusMaxMoveNP.setState(IPS_OK);
+            FocusMaxMoveNP.apply();
             return true;
         }
     }
@@ -781,37 +781,37 @@ bool DeepSkyDadAF1::ISNewNumber(const char * dev, const char * name, double valu
 
 void DeepSkyDadAF1::GetFocusParams()
 {
-    IUResetSwitch(&StepModeSP);
-    IUResetSwitch(&CoilsModeSP);
-    IUResetSwitch(&CurrentMoveSP);
-    IUResetSwitch(&CurrentHoldSP);
+    StepModeSP.reset();
+    CoilsModeSP.reset();
+    CurrentMoveSP.reset();
+    CurrentHoldSP.reset();
 
     if (readPosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (readStepMode())
-        IDSetSwitch(&StepModeSP, nullptr);
+        StepModeSP.apply();
 
     if (readSettleBuffer())
-        IDSetNumber(&SettleBufferNP, nullptr);
+        SettleBufferNP.apply();
 
     if (readMaxPosition())
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP.apply();
 
     if (readMaxMovement())
-        IDSetNumber(&FocusMaxMoveNP, nullptr);
+        FocusMaxMoveNP.apply();
 
     if (readIdleCoilsTimeout())
-        IDSetNumber(&IdleCoilsTimeoutNP, nullptr);
+        IdleCoilsTimeoutNP.apply();
 
     if (readCoilsMode())
-        IDSetSwitch(&CoilsModeSP, nullptr);
+        CoilsModeSP.apply();
 
     if (readCurrentMove())
-        IDSetSwitch(&CurrentMoveSP, nullptr);
+        CurrentMoveSP.apply();
 
     if (readCurrentHold())
-        IDSetSwitch(&CurrentHoldSP, nullptr);
+        CurrentHoldSP.apply();
 }
 
 IPState DeepSkyDadAF1::MoveFocuser(FocusDirection dir, int speed, uint16_t duration)
@@ -822,7 +822,7 @@ IPState DeepSkyDadAF1::MoveFocuser(FocusDirection dir, int speed, uint16_t durat
     if (dir == FOCUS_INWARD)
         MoveFocuser(0);
     else
-        MoveFocuser(FocusMaxPosN[0].value);
+        MoveFocuser(FocusMaxPosNP[0].value);
 
     IEAddTimer(duration, &DeepSkyDadAF1::timedMoveHelper, this);
     return IPS_BUSY;
@@ -836,13 +836,13 @@ void DeepSkyDadAF1::timedMoveHelper(void * context)
 void DeepSkyDadAF1::timedMoveCallback()
 {
     AbortFocuser();
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocusRelPosNP.s = IPS_IDLE;
-    FocusTimerNP.s = IPS_IDLE;
-    FocusTimerN[0].value = 0;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
-    IDSetNumber(&FocusTimerNP, nullptr);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusRelPosNP.setState(IPS_IDLE);
+    FocusTimerNP.setState(IPS_IDLE);
+    FocusTimerNP[0].setValue(0);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
+    FocusTimerNP.apply();
 }
 
 
@@ -861,18 +861,18 @@ IPState DeepSkyDadAF1::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     int32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     // Clamp
-    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosN[0].max), newPosition));
+    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosNP[0].max), newPosition));
     if (!MoveFocuser(newPosition))
         return IPS_ALERT;
 
     // JM 2019-02-10: This is already set by the framework
-    //FocusRelPosN[0].value = ticks;
-    //FocusRelPosNP.s       = IPS_BUSY;
+    //FocusRelPosNP[0].setValue(ticks);
+    //FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -888,22 +888,22 @@ void DeepSkyDadAF1::TimerHit()
     bool rc = readPosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -920,13 +920,13 @@ bool DeepSkyDadAF1::saveConfigItems(FILE * fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &StepModeSP);
-    IUSaveConfigNumber(fp, &FocusMaxMoveNP);
-    IUSaveConfigNumber(fp, &SettleBufferNP);
-    IUSaveConfigSwitch(fp, &CoilsModeSP);
-    IUSaveConfigNumber(fp, &IdleCoilsTimeoutNP);
-    IUSaveConfigSwitch(fp, &CurrentMoveSP);
-    IUSaveConfigSwitch(fp, &CurrentHoldSP);
+    StepModeSP.save(fp);
+    FocusMaxMoveNP.save(fp);
+    SettleBufferNP.save(fp);
+    CoilsModeSP.save(fp);
+    IdleCoilsTimeoutNP.save(fp);
+    CurrentMoveSP.save(fp);
+    CurrentHoldSP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/deepskydad_af1.h
+++ b/drivers/focuser/deepskydad_af1.h
@@ -28,6 +28,10 @@
 
 #include <chrono>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class DeepSkyDadAF1 : public INDI::Focuser
 {
     public:
@@ -117,32 +121,25 @@ class DeepSkyDadAF1 : public INDI::Focuser
 
 
         // Step modes
-        ISwitch StepModeS[4];
-        ISwitchVectorProperty StepModeSP;
+        INDI::PropertySwitch StepModeSP {4};
 
         // Coils mode
-        ISwitch CoilsModeS[3];
-        ISwitchVectorProperty CoilsModeSP;
+        INDI::PropertySwitch CoilsModeSP {3};
 
         //Current move
-        ISwitch CurrentMoveS[4];
-        ISwitchVectorProperty CurrentMoveSP;
+        INDI::PropertySwitch CurrentMoveSP {4};
 
         //Current hold
-        ISwitch CurrentHoldS[4];
-        ISwitchVectorProperty CurrentHoldSP;
+        INDI::PropertySwitch CurrentHoldSP {4};
 
         // Max movement
-        INumber FocusMaxMoveN[1];
-        INumberVectorProperty FocusMaxMoveNP;
+        INDI::PropertyNumber FocusMaxMoveNP {1};
 
         // Settle buffer
-        INumber SettleBufferN[1];
-        INumberVectorProperty SettleBufferNP;
+        INDI::PropertyNumber SettleBufferNP {1};
 
         // Idle coils timeout (ms)
-        INumber IdleCoilsTimeoutN[1];
-        INumberVectorProperty IdleCoilsTimeoutNP;
+        INDI::PropertyNumber IdleCoilsTimeoutNP {1};
 
         // Response Buffer
 

--- a/drivers/focuser/deepskydad_af2.cpp
+++ b/drivers/focuser/deepskydad_af2.cpp
@@ -83,61 +83,61 @@ bool DeepSkyDadAF2::initProperties()
     INDI::Focuser::initProperties();
 
     // Step Mode
-    IUFillSwitch(&StepModeS[EIGHT], "EIGHT", "Eight Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[QUARTER], "QUARTER", "Quarter Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[HALF], "HALF", "Half Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FULL], "FULL", "Full Step", ISS_OFF);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 4, getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    StepModeSP[EIGHT].fill("EIGHT", "Eight Step", ISS_OFF);
+    StepModeSP[QUARTER].fill("QUARTER", "Quarter Step", ISS_OFF);
+    StepModeSP[HALF].fill("HALF", "Half Step", ISS_OFF);
+    StepModeSP[FULL].fill("FULL", "Full Step", ISS_OFF);
+    StepModeSP.fill(getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min = 0.;
-    FocusRelPosN[0].max = 5000.;
-    FocusRelPosN[0].value = 0.;
-    FocusRelPosN[0].step = 10.;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(5000.);
+    FocusRelPosNP[0].setValue(0.);
+    FocusRelPosNP[0].setStep(10.);
 
-    FocusAbsPosN[0].min = 0.;
-    FocusAbsPosN[0].max = 100000.;
-    FocusAbsPosN[0].value = 50000.;
-    FocusAbsPosN[0].step = 500.;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(50000.);
+    FocusAbsPosNP[0].setStep(500.);
 
     // Max. movement
-    IUFillNumber(&FocusMaxMoveN[0], "MAX_MOVE", "Steps", "%7.0f", 0, 9999999, 100, 0);
-    IUFillNumberVector(&FocusMaxMoveNP, FocusMaxMoveN, 1, getDeviceName(), "FOCUS_MAX_MOVE", "Max. movement",
+    FocusMaxMoveNP[0].fill("MAX_MOVE", "Steps", "%7.0f", 0, 9999999, 100, 0);
+    FocusMaxMoveNP.fill(getDeviceName(), "FOCUS_MAX_MOVE", "Max. movement",
                        MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     // Settle buffer
-    IUFillNumber(&SettleBufferN[0], "SETTLE_BUFFER", "Period (ms)", "%5.0f", 0, 99999, 100, 0);
-    IUFillNumberVector(&SettleBufferNP, SettleBufferN, 1, getDeviceName(), "FOCUS_SETTLE_BUFFER", "Settle buffer",
+    SettleBufferNP[0].fill("SETTLE_BUFFER", "Period (ms)", "%5.0f", 0, 99999, 100, 0);
+    SettleBufferNP.fill(getDeviceName(), "FOCUS_SETTLE_BUFFER", "Settle buffer",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Idle coils timeout (ms)
-    IUFillNumber(&IdleCoilsTimeoutN[0], "IDLE_COILS_TIMEOUT", "Period (ms)", "%6.0f", 0, 999999, 1000, 60000);
-    IUFillNumberVector(&IdleCoilsTimeoutNP, IdleCoilsTimeoutN, 1, getDeviceName(), "FOCUS_IDLE_COILS_TIMEOUT", "Idle - coils timeout",
+    IdleCoilsTimeoutNP[0].fill("IDLE_COILS_TIMEOUT", "Period (ms)", "%6.0f", 0, 999999, 1000, 60000);
+    IdleCoilsTimeoutNP.fill(getDeviceName(), "FOCUS_IDLE_COILS_TIMEOUT", "Idle - coils timeout",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Coils mode
-    IUFillSwitch(&CoilsModeS[ALWAYS_ON], "ALWAYS_ON", "Always on", ISS_OFF);
-    IUFillSwitch(&CoilsModeS[IDLE_OFF], "IDLE_OFF", "Idle - off", ISS_OFF);
-    IUFillSwitch(&CoilsModeS[IDLE_COILS_TIMEOUT], "IDLE_COILS_TIMEOUT", "Idle - coils timeout (ms)", ISS_OFF);
-    IUFillSwitchVector(&CoilsModeSP, CoilsModeS, 3, getDeviceName(), "Coils mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    CoilsModeSP[ALWAYS_ON].fill("ALWAYS_ON", "Always on", ISS_OFF);
+    CoilsModeSP[IDLE_OFF].fill("IDLE_OFF", "Idle - off", ISS_OFF);
+    CoilsModeSP[IDLE_COILS_TIMEOUT].fill("IDLE_COILS_TIMEOUT", "Idle - coils timeout (ms)", ISS_OFF);
+    CoilsModeSP.fill(getDeviceName(), "Coils mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Current move
-    IUFillSwitch(&CurrentMoveS[CURRENT_25], "CMV_25", "25%", ISS_OFF);
-    IUFillSwitch(&CurrentMoveS[CURRENT_50], "CMV_50", "50%", ISS_OFF);
-    IUFillSwitch(&CurrentMoveS[CURRENT_75], "CMV_75", "75%", ISS_OFF);
-    IUFillSwitch(&CurrentMoveS[CURRENT_100], "CMV_100", "100%", ISS_OFF);
-    IUFillSwitchVector(&CurrentMoveSP, CurrentMoveS, 4, getDeviceName(), "Current - move", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    CurrentMoveSP[CURRENT_25].fill("CMV_25", "25%", ISS_OFF);
+    CurrentMoveSP[CURRENT_50].fill("CMV_50", "50%", ISS_OFF);
+    CurrentMoveSP[CURRENT_75].fill("CMV_75", "75%", ISS_OFF);
+    CurrentMoveSP[CURRENT_100].fill("CMV_100", "100%", ISS_OFF);
+    CurrentMoveSP.fill(getDeviceName(), "Current - move", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Current hold
-    IUFillSwitch(&CurrentHoldS[CURRENT_25], "CHD_25", "25%", ISS_OFF);
-    IUFillSwitch(&CurrentHoldS[CURRENT_50], "CHD_50", "50%", ISS_OFF);
-    IUFillSwitch(&CurrentHoldS[CURRENT_75], "CHD_75", "75%", ISS_OFF);
-    IUFillSwitch(&CurrentHoldS[CURRENT_100], "CHD_100", "100%", ISS_OFF);
-    IUFillSwitchVector(&CurrentHoldSP, CurrentHoldS, 4, getDeviceName(), "Current - hold", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    CurrentHoldSP[CURRENT_25].fill("CHD_25", "25%", ISS_OFF);
+    CurrentHoldSP[CURRENT_50].fill("CHD_50", "50%", ISS_OFF);
+    CurrentHoldSP[CURRENT_75].fill("CHD_75", "75%", ISS_OFF);
+    CurrentHoldSP[CURRENT_100].fill("CHD_100", "100%", ISS_OFF);
+    CurrentHoldSP.fill(getDeviceName(), "Current - hold", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 	
 	// Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     setDefaultPollingPeriod(500);
@@ -152,15 +152,15 @@ bool DeepSkyDadAF2::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&FocusMaxMoveNP);
-        defineProperty(&StepModeSP);
-        defineProperty(&SettleBufferNP);
-        defineProperty(&CoilsModeSP);
-        defineProperty(&IdleCoilsTimeoutNP);
-        defineProperty(&CurrentMoveSP);
-        defineProperty(&CurrentHoldSP);
+        defineProperty(FocusMaxMoveNP);
+        defineProperty(StepModeSP);
+        defineProperty(SettleBufferNP);
+        defineProperty(CoilsModeSP);
+        defineProperty(IdleCoilsTimeoutNP);
+        defineProperty(CurrentMoveSP);
+        defineProperty(CurrentHoldSP);
 		
-        defineProperty(&TemperatureNP);
+        defineProperty(TemperatureNP);
 
         GetFocusParams();
 
@@ -168,14 +168,14 @@ bool DeepSkyDadAF2::updateProperties()
     }
     else
     {
-        deleteProperty(FocusMaxMoveNP.name);
-        deleteProperty(StepModeSP.name);
-        deleteProperty(SettleBufferNP.name);
-        deleteProperty(CoilsModeSP.name);
-        deleteProperty(IdleCoilsTimeoutNP.name);
-        deleteProperty(CurrentMoveSP.name);
-        deleteProperty(CurrentHoldSP.name);
-        deleteProperty(TemperatureNP.name);
+        deleteProperty(FocusMaxMoveNP.getName());
+        deleteProperty(StepModeSP.getName());
+        deleteProperty(SettleBufferNP.getName());
+        deleteProperty(CoilsModeSP.getName());
+        deleteProperty(IdleCoilsTimeoutNP.getName());
+        deleteProperty(CurrentMoveSP.getName());
+        deleteProperty(CurrentHoldSP.getName());
+        deleteProperty(TemperatureNP.getName());
     }
 
     return true;
@@ -230,13 +230,13 @@ bool DeepSkyDadAF2::readStepMode()
         return false;
 
     if (strcmp(res, "(1)") == 0)
-        StepModeS[FULL].s = ISS_ON;
+        StepModeSP[FULL].setState(ISS_ON);
     else if (strcmp(res, "(2)") == 0)
-        StepModeS[HALF].s = ISS_ON;
+        StepModeSP[HALF].setState(ISS_ON);
     else if (strcmp(res, "(4)") == 0)
-        StepModeS[QUARTER].s = ISS_ON;
+        StepModeSP[QUARTER].setState(ISS_ON);
     else if (strcmp(res, "(8)") == 0)
-        StepModeS[EIGHT].s = ISS_ON;
+        StepModeSP[EIGHT].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser step value (%s)", res);
@@ -257,7 +257,7 @@ bool DeepSkyDadAF2::readPosition()
     int rc = sscanf(res, "(%d)", &pos);
 
     if (rc > 0)
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     else
     {
         LOGF_ERROR("Unknown error: focuser position value (%s)", res);
@@ -278,8 +278,8 @@ bool DeepSkyDadAF2::readMaxMovement()
     int rc = sscanf(res, "(%d)", &steps);
     if (rc > 0)
     {
-        FocusMaxMoveN[0].value = steps;
-        FocusMaxMoveNP.s = IPS_OK;
+        FocusMaxMoveNP[0].setValue(steps);
+        FocusMaxMoveNP.setState(IPS_OK);
     }
     else
     {
@@ -301,8 +301,8 @@ bool DeepSkyDadAF2::readMaxPosition()
     int rc = sscanf(res, "(%d)", &steps);
     if (rc > 0)
     {
-        FocusMaxPosN[0].value = steps;
-        FocusMaxPosNP.s = IPS_OK;
+        FocusMaxPosNP[0].setValue(steps);
+        FocusMaxPosNP.setState(IPS_OK);
     }
     else
     {
@@ -324,8 +324,8 @@ bool DeepSkyDadAF2::readSettleBuffer()
     int rc = sscanf(res, "(%d)", &settleBuffer);
     if (rc > 0)
     {
-        SettleBufferN[0].value = settleBuffer;
-        SettleBufferNP.s = settleBuffer > 0 ? IPS_OK : IPS_IDLE;
+        SettleBufferNP[0].setValue(settleBuffer);
+        SettleBufferNP.setState(settleBuffer > 0 ? IPS_OK : IPS_IDLE);
     }
     else
     {
@@ -347,8 +347,8 @@ bool DeepSkyDadAF2::readIdleCoilsTimeout()
     int rc = sscanf(res, "(%d)", &ms);
     if (rc > 0)
     {
-        IdleCoilsTimeoutN[0].value = ms;
-        IdleCoilsTimeoutNP.s = ms > 0 ? IPS_OK : IPS_IDLE;
+        IdleCoilsTimeoutNP[0].setValue(ms);
+        IdleCoilsTimeoutNP.setState(ms > 0 ? IPS_OK : IPS_IDLE);
     }
     else
     {
@@ -368,18 +368,18 @@ bool DeepSkyDadAF2::readCoilsMode()
 
     if (strcmp(res, "(0)") == 0)
     {
-        CoilsModeSP.s = IPS_IDLE;
-        CoilsModeS[IDLE_OFF].s = ISS_ON;
+        CoilsModeSP.setState(IPS_IDLE);
+        CoilsModeSP[IDLE_OFF].setState(ISS_ON);
     }
     else if (strcmp(res, "(1)") == 0)
     {
-        CoilsModeSP.s = IPS_OK;
-        CoilsModeS[ALWAYS_ON].s = ISS_ON;
+        CoilsModeSP.setState(IPS_OK);
+        CoilsModeSP[ALWAYS_ON].setState(ISS_ON);
     }
     else if (strcmp(res, "(2)") == 0)
     {
-        CoilsModeSP.s = IPS_IDLE;
-        CoilsModeS[IDLE_COILS_TIMEOUT].s = ISS_ON;
+        CoilsModeSP.setState(IPS_IDLE);
+        CoilsModeSP[IDLE_COILS_TIMEOUT].setState(ISS_ON);
     }
     else
     {
@@ -399,23 +399,23 @@ bool DeepSkyDadAF2::readCurrentMove()
 
     if (strcmp(res, "(25%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_25].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_25].setState(ISS_ON);
     }
     else if (strcmp(res, "(50%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_50].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_50].setState(ISS_ON);
     }
     else if (strcmp(res, "(75%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_75].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_75].setState(ISS_ON);
     }
     else if (strcmp(res, "(100%)") == 0)
     {
-        CurrentMoveSP.s = IPS_OK;
-        CurrentMoveS[CURRENT_100].s = ISS_ON;
+        CurrentMoveSP.setState(IPS_OK);
+        CurrentMoveSP[CURRENT_100].setState(ISS_ON);
     }
 
     else
@@ -436,23 +436,23 @@ bool DeepSkyDadAF2::readCurrentHold()
 
     if (strcmp(res, "(25%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_25].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_25].setState(ISS_ON);
     }
     else if (strcmp(res, "(50%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_50].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_50].setState(ISS_ON);
     }
     else if (strcmp(res, "(75%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_75].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_75].setState(ISS_ON);
     }
     else if (strcmp(res, "(100%)") == 0)
     {
-        CurrentHoldSP.s = IPS_OK;
-        CurrentHoldS[CURRENT_100].s = ISS_ON;
+        CurrentHoldSP.setState(IPS_OK);
+        CurrentHoldSP[CURRENT_100].setState(ISS_ON);
     }
 
     else
@@ -474,7 +474,7 @@ bool DeepSkyDadAF2::readTemperature()
     double temp = 0;
     int rc = sscanf(res, "(%lf)", &temp);
     if (rc > 0) {
-        TemperatureN[0].value = temp;
+        TemperatureNP[0].setValue(temp);
     }
     else
     {
@@ -542,18 +542,18 @@ bool DeepSkyDadAF2::ISNewSwitch(const char * dev, const char * name, ISState * s
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Focus Step Mode
-        if (strcmp(StepModeSP.name, name) == 0)
+        if (StepModeSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int current_mode = StepModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&StepModeSP, states, names, n);
+            StepModeSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int target_mode = StepModeSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                StepModeSP.s = IPS_OK;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.setState(IPS_OK);
+                StepModeSP.apply();
                 return true;
             }
 
@@ -572,30 +572,30 @@ bool DeepSkyDadAF2::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&StepModeSP);
-                StepModeS[current_mode].s = ISS_ON;
-                StepModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.reset();
+                StepModeSP[current_mode].setState(ISS_ON);
+                StepModeSP.setState(IPS_ALERT);
+                StepModeSP.apply();
                 return false;
             }
 
-            StepModeSP.s = IPS_OK;
-            IDSetSwitch(&StepModeSP, nullptr);
+            StepModeSP.setState(IPS_OK);
+            StepModeSP.apply();
             return true;
         }
 
         // Coils mode
-        if (strcmp(CoilsModeSP.name, name) == 0)
+        if (CoilsModeSP.isNameMatch(name))
         {
-            int coilsModeCurrent = IUFindOnSwitchIndex(&CoilsModeSP);
+            int coilsModeCurrent = CoilsModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&CoilsModeSP, states, names, n);
+            CoilsModeSP.update(states, names, n);
 
-            int coilsModeTarget = IUFindOnSwitchIndex(&CoilsModeSP);
+            int coilsModeTarget = CoilsModeSP.findOnSwitchIndex();
 
             if (coilsModeCurrent == coilsModeTarget)
             {
-                IDSetSwitch(&CoilsModeSP, nullptr);
+                CoilsModeSP.apply();
                 return true;
             }
 
@@ -612,30 +612,30 @@ bool DeepSkyDadAF2::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&CoilsModeSP);
-                CoilsModeS[coilsModeCurrent].s = ISS_ON;
-                CoilsModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&CoilsModeSP, nullptr);
+                CoilsModeSP.reset();
+                CoilsModeSP[coilsModeCurrent].setState(ISS_ON);
+                CoilsModeSP.setState(IPS_ALERT);
+                CoilsModeSP.apply();
                 return false;
             }
 
-            CoilsModeSP.s = coilsModeTarget == 1 ? IPS_OK : IPS_IDLE;
-            IDSetSwitch(&CoilsModeSP, nullptr);
+            CoilsModeSP.setState(coilsModeTarget == 1 ? IPS_OK : IPS_IDLE);
+            CoilsModeSP.apply();
             return true;
         }
 
         // Current - move
-        if (strcmp(CurrentMoveSP.name, name) == 0)
+        if (CurrentMoveSP.isNameMatch(name))
         {
-            int current = IUFindOnSwitchIndex(&CurrentMoveSP);
+            int current = CurrentMoveSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&CurrentMoveSP, states, names, n);
+            CurrentMoveSP.update(states, names, n);
 
-            int targetCurrent = IUFindOnSwitchIndex(&CurrentMoveSP);
+            int targetCurrent = CurrentMoveSP.findOnSwitchIndex();
 
             if (current == targetCurrent)
             {
-                IDSetSwitch(&CurrentMoveSP, nullptr);
+                CurrentMoveSP.apply();
                 return true;
             }
 
@@ -662,30 +662,30 @@ bool DeepSkyDadAF2::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&CurrentMoveSP);
-                CurrentMoveS[current].s = ISS_ON;
-                CurrentMoveSP.s              = IPS_ALERT;
-                IDSetSwitch(&CurrentMoveSP, nullptr);
+                CurrentMoveSP.reset();
+                CurrentMoveSP[current].setState(ISS_ON);
+                CurrentMoveSP.setState(IPS_ALERT);
+                CurrentMoveSP.apply();
                 return false;
             }
 
-            CurrentMoveSP.s = IPS_OK;
-            IDSetSwitch(&CurrentMoveSP, nullptr);
+            CurrentMoveSP.setState(IPS_OK);
+            CurrentMoveSP.apply();
             return true;
         }
 
         // Current - hold
-        if (strcmp(CurrentHoldSP.name, name) == 0)
+        if (CurrentHoldSP.isNameMatch(name))
         {
-            int current = IUFindOnSwitchIndex(&CurrentHoldSP);
+            int current = CurrentHoldSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&CurrentHoldSP, states, names, n);
+            CurrentHoldSP.update(states, names, n);
 
-            int targetCurrent = IUFindOnSwitchIndex(&CurrentHoldSP);
+            int targetCurrent = CurrentHoldSP.findOnSwitchIndex();
 
             if (current == targetCurrent)
             {
-                IDSetSwitch(&CurrentHoldSP, nullptr);
+                CurrentHoldSP.apply();
                 return true;
             }
 
@@ -712,15 +712,15 @@ bool DeepSkyDadAF2::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&CurrentHoldSP);
-                CurrentHoldS[current].s = ISS_ON;
-                CurrentHoldSP.s              = IPS_ALERT;
-                IDSetSwitch(&CurrentHoldSP, nullptr);
+                CurrentHoldSP.reset();
+                CurrentHoldSP[current].setState(ISS_ON);
+                CurrentHoldSP.setState(IPS_ALERT);
+                CurrentHoldSP.apply();
                 return false;
             }
 
-            CurrentHoldSP.s = IPS_OK;
-            IDSetSwitch(&CurrentHoldSP, nullptr);
+            CurrentHoldSP.setState(IPS_OK);
+            CurrentHoldSP.apply();
             return true;
         }
     }
@@ -733,74 +733,74 @@ bool DeepSkyDadAF2::ISNewNumber(const char * dev, const char * name, double valu
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Settle buffer Settings
-        if (strcmp(name, SettleBufferNP.name) == 0)
+        if (SettleBufferNP.isNameMatch(name))
         {
-            IUUpdateNumber(&SettleBufferNP, values, names, n);
+            SettleBufferNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SBUF%06d]", static_cast<int>(SettleBufferN[0].value));
+            snprintf(cmd, DSD_RES, "[SBUF%06d]", static_cast<int>(SettleBufferNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                SettleBufferNP.s = IPS_ALERT;
+                SettleBufferNP.setState(IPS_ALERT);
                 return false;
             }
 
-            SettleBufferNP.s = IPS_OK;
-            IDSetNumber(&SettleBufferNP, nullptr);
+            SettleBufferNP.setState(IPS_OK);
+            SettleBufferNP.apply();
             return true;
         }
 
         // Idle coils timeout
-        if (strcmp(name, IdleCoilsTimeoutNP.name) == 0)
+        if (IdleCoilsTimeoutNP.isNameMatch(name))
         {
-            IUUpdateNumber(&IdleCoilsTimeoutNP, values, names, n);
+            IdleCoilsTimeoutNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SIDC%06d]", static_cast<int>(IdleCoilsTimeoutN[0].value));
+            snprintf(cmd, DSD_RES, "[SIDC%06d]", static_cast<int>(IdleCoilsTimeoutNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IdleCoilsTimeoutNP.s = IPS_ALERT;
+                IdleCoilsTimeoutNP.setState(IPS_ALERT);
                 return false;
             }
 
-            IdleCoilsTimeoutNP.s = IPS_OK;
-            IDSetNumber(&IdleCoilsTimeoutNP, nullptr);
+            IdleCoilsTimeoutNP.setState(IPS_OK);
+            IdleCoilsTimeoutNP.apply();
             return true;
         }
 
         // Max. position
-        if (strcmp(name, FocusMaxPosNP.name) == 0)
+        if (FocusMaxPosNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FocusMaxPosNP, values, names, n);
+            FocusMaxPosNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SMXP%d]", static_cast<int>(FocusMaxPosN[0].value));
+            snprintf(cmd, DSD_RES, "[SMXP%d]", static_cast<int>(FocusMaxPosNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                FocusMaxPosNP.s = IPS_ALERT;
+                FocusMaxPosNP.setState(IPS_ALERT);
                 return false;
             }
 
-            FocusMaxPosNP.s = IPS_OK;
-            IDSetNumber(&FocusMaxPosNP, nullptr);
+            FocusMaxPosNP.setState(IPS_OK);
+            FocusMaxPosNP.apply();
             return true;
         }
 
         // Max. movement
-        if (strcmp(name, FocusMaxMoveNP.name) == 0)
+        if (FocusMaxMoveNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FocusMaxMoveNP, values, names, n);
+            FocusMaxMoveNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SMXM%d]", static_cast<int>(FocusMaxMoveN[0].value));
+            snprintf(cmd, DSD_RES, "[SMXM%d]", static_cast<int>(FocusMaxMoveNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                FocusMaxMoveNP.s = IPS_ALERT;
+                FocusMaxMoveNP.setState(IPS_ALERT);
                 return false;
             }
 
-            FocusMaxMoveNP.s = IPS_OK;
-            IDSetNumber(&FocusMaxMoveNP, nullptr);
+            FocusMaxMoveNP.setState(IPS_OK);
+            FocusMaxMoveNP.apply();
             return true;
         }
 
@@ -811,40 +811,40 @@ bool DeepSkyDadAF2::ISNewNumber(const char * dev, const char * name, double valu
 
 void DeepSkyDadAF2::GetFocusParams()
 {
-    IUResetSwitch(&StepModeSP);
-    IUResetSwitch(&CoilsModeSP);
-    IUResetSwitch(&CurrentMoveSP);
-    IUResetSwitch(&CurrentHoldSP);
+    StepModeSP.reset();
+    CoilsModeSP.reset();
+    CurrentMoveSP.reset();
+    CurrentHoldSP.reset();
 
     if (readPosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (readStepMode())
-        IDSetSwitch(&StepModeSP, nullptr);
+        StepModeSP.apply();
 
     if (readSettleBuffer())
-        IDSetNumber(&SettleBufferNP, nullptr);
+        SettleBufferNP.apply();
 
     if (readMaxPosition())
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP.apply();
 
     if (readMaxMovement())
-        IDSetNumber(&FocusMaxMoveNP, nullptr);
+        FocusMaxMoveNP.apply();
 
     if (readIdleCoilsTimeout())
-        IDSetNumber(&IdleCoilsTimeoutNP, nullptr);
+        IdleCoilsTimeoutNP.apply();
 
     if (readCoilsMode())
-        IDSetSwitch(&CoilsModeSP, nullptr);
+        CoilsModeSP.apply();
 
     if (readCurrentMove())
-        IDSetSwitch(&CurrentMoveSP, nullptr);
+        CurrentMoveSP.apply();
 
     if (readCurrentHold())
-        IDSetSwitch(&CurrentHoldSP, nullptr);
+        CurrentHoldSP.apply();
 	
     if (readTemperature())
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 }
 
 IPState DeepSkyDadAF2::MoveFocuser(FocusDirection dir, int speed, uint16_t duration)
@@ -855,7 +855,7 @@ IPState DeepSkyDadAF2::MoveFocuser(FocusDirection dir, int speed, uint16_t durat
     if (dir == FOCUS_INWARD)
         MoveFocuser(0);
     else
-        MoveFocuser(FocusMaxPosN[0].value);
+        MoveFocuser(FocusMaxPosNP[0].value);
 
     IEAddTimer(duration, &DeepSkyDadAF2::timedMoveHelper, this);
     return IPS_BUSY;
@@ -869,13 +869,13 @@ void DeepSkyDadAF2::timedMoveHelper(void * context)
 void DeepSkyDadAF2::timedMoveCallback()
 {
     AbortFocuser();
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocusRelPosNP.s = IPS_IDLE;
-    FocusTimerNP.s = IPS_IDLE;
-    FocusTimerN[0].value = 0;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
-    IDSetNumber(&FocusTimerNP, nullptr);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusRelPosNP.setState(IPS_IDLE);
+    FocusTimerNP.setState(IPS_IDLE);
+    FocusTimerNP[0].setValue(0);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
+    FocusTimerNP.apply();
 }
 
 
@@ -894,18 +894,18 @@ IPState DeepSkyDadAF2::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     int32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     // Clamp
-    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosN[0].max), newPosition));
+    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosNP[0].max), newPosition));
     if (!MoveFocuser(newPosition))
         return IPS_ALERT;
 
     // JM 2019-02-10: This is already set by the framework
-    //FocusRelPosN[0].value = ticks;
-    //FocusRelPosNP.s       = IPS_BUSY;
+    //FocusRelPosNP[0].setValue(ticks);
+    //FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -921,22 +921,22 @@ void DeepSkyDadAF2::TimerHit()
     bool rc = readPosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -944,10 +944,10 @@ void DeepSkyDadAF2::TimerHit()
     rc = readTemperature();
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
@@ -963,13 +963,13 @@ bool DeepSkyDadAF2::saveConfigItems(FILE * fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &StepModeSP);
-    IUSaveConfigNumber(fp, &FocusMaxMoveNP);
-    IUSaveConfigNumber(fp, &SettleBufferNP);
-    IUSaveConfigSwitch(fp, &CoilsModeSP);
-    IUSaveConfigNumber(fp, &IdleCoilsTimeoutNP);
-    IUSaveConfigSwitch(fp, &CurrentMoveSP);
-    IUSaveConfigSwitch(fp, &CurrentHoldSP);
+    StepModeSP.save(fp);
+    FocusMaxMoveNP.save(fp);
+    SettleBufferNP.save(fp);
+    CoilsModeSP.save(fp);
+    IdleCoilsTimeoutNP.save(fp);
+    CurrentMoveSP.save(fp);
+    CurrentHoldSP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/deepskydad_af2.h
+++ b/drivers/focuser/deepskydad_af2.h
@@ -28,6 +28,10 @@
 
 #include <chrono>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class DeepSkyDadAF2 : public INDI::Focuser
 {
     public:
@@ -116,35 +120,27 @@ class DeepSkyDadAF2 : public INDI::Focuser
         double targetPos { 0 }, lastPos { 0 }, lastTemperature { 0 };
 
         // Step modes
-        ISwitch StepModeS[4];
-        ISwitchVectorProperty StepModeSP;
+        INDI::PropertySwitch StepModeSP {4};
 
         // Coils mode
-        ISwitch CoilsModeS[3];
-        ISwitchVectorProperty CoilsModeSP;
+        INDI::PropertySwitch CoilsModeSP {3};
 
         //Current move
-        ISwitch CurrentMoveS[4];
-        ISwitchVectorProperty CurrentMoveSP;
+        INDI::PropertySwitch CurrentMoveSP {4};
 
         //Current hold
-        ISwitch CurrentHoldS[4];
-        ISwitchVectorProperty CurrentHoldSP;
+        INDI::PropertySwitch CurrentHoldSP {4};
 
         // Max movement
-        INumber FocusMaxMoveN[1];
-        INumberVectorProperty FocusMaxMoveNP;
+        INDI::PropertyNumber FocusMaxMoveNP {1};
 
         // Settle buffer
-        INumber SettleBufferN[1];
-        INumberVectorProperty SettleBufferNP;
+        INDI::PropertyNumber SettleBufferNP {1};
 
         // Idle coils timeout (ms)
-        INumber IdleCoilsTimeoutN[1];
-        INumberVectorProperty IdleCoilsTimeoutNP;
+        INDI::PropertyNumber IdleCoilsTimeoutNP {1};
 		
-		INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+		INDI::PropertyNumber TemperatureNP {1};
 
         // Response Buffer
 

--- a/drivers/focuser/deepskydad_af3.cpp
+++ b/drivers/focuser/deepskydad_af3.cpp
@@ -84,78 +84,78 @@ bool DeepSkyDadAF3::initProperties()
     INDI::Focuser::initProperties();
 
     // Step Mode
-    IUFillSwitch(&StepModeS[S256], "S256", "1/256 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S128], "S128", "1/128 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S64], "S64", "1/64 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S32], "S32", "1/32 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S16], "S16", "1/16 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S8], "S8", "1/8 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S4], "S4", "1/4 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S2], "S2", "1/2 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[S1], "S1", "Full Step", ISS_OFF);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 9, getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    StepModeSP[S256].fill("S256", "1/256 Step", ISS_OFF);
+    StepModeSP[S128].fill("S128", "1/128 Step", ISS_OFF);
+    StepModeSP[S64].fill("S64", "1/64 Step", ISS_OFF);
+    StepModeSP[S32].fill("S32", "1/32 Step", ISS_OFF);
+    StepModeSP[S16].fill("S16", "1/16 Step", ISS_OFF);
+    StepModeSP[S8].fill("S8", "1/8 Step", ISS_OFF);
+    StepModeSP[S4].fill("S4", "1/4 Step", ISS_OFF);
+    StepModeSP[S2].fill("S2", "1/2 Step", ISS_OFF);
+    StepModeSP[S1].fill("S1", "Full Step", ISS_OFF);
+    StepModeSP.fill(getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Speed Mode
-    IUFillSwitch(&SpeedModeS[VERY_SLOW], "VERY_SLOW", "Very slow", ISS_OFF);
-    IUFillSwitch(&SpeedModeS[SLOW], "SLOW", "Slow", ISS_OFF);
-    IUFillSwitch(&SpeedModeS[MEDIUM], "MEDIUM", "Medium", ISS_OFF);
-    IUFillSwitch(&SpeedModeS[FAST], "FAST", "Fast", ISS_OFF);
-    IUFillSwitch(&SpeedModeS[VERY_FAST], "VERY_FAST", "Very fast", ISS_OFF);
-    IUFillSwitchVector(&SpeedModeSP, SpeedModeS, 5, getDeviceName(), "Speed Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    SpeedModeSP[VERY_SLOW].fill("VERY_SLOW", "Very slow", ISS_OFF);
+    SpeedModeSP[SLOW].fill("SLOW", "Slow", ISS_OFF);
+    SpeedModeSP[MEDIUM].fill("MEDIUM", "Medium", ISS_OFF);
+    SpeedModeSP[FAST].fill("FAST", "Fast", ISS_OFF);
+    SpeedModeSP[VERY_FAST].fill("VERY_FAST", "Very fast", ISS_OFF);
+    SpeedModeSP.fill(getDeviceName(), "Speed Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min = 0.;
-    FocusRelPosN[0].max = 50000.;
-    FocusRelPosN[0].value = 0.;
-    FocusRelPosN[0].step = 10.;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0.);
+    FocusRelPosNP[0].setStep(10.);
 
-    FocusAbsPosN[0].min = 0.;
-    FocusAbsPosN[0].max = 1000000.;
-    FocusAbsPosN[0].value = 50000.;
-    FocusAbsPosN[0].step = 5000.;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(1000000.);
+    FocusAbsPosNP[0].setValue(50000.);
+    FocusAbsPosNP[0].setStep(5000.);
 
-    FocusMaxPosN[0].min = 0.;
-    FocusMaxPosN[0].max = 1000000.;
-    FocusMaxPosN[0].value = 1000000.;
-    FocusMaxPosN[0].step = 5000.;
+    FocusMaxPosNP[0].setMin(0.);
+    FocusMaxPosNP[0].setMax(1000000.);
+    FocusMaxPosNP[0].setValue(1000000.);
+    FocusMaxPosNP[0].setStep(5000.);
 
-    FocusSyncN[0].min = 0.;
-    FocusSyncN[0].max = 1000000.;
-    FocusSyncN[0].value = 50000.;
-    FocusSyncN[0].step = 5000.;
+    FocusSyncNP[0].setMin(0.);
+    FocusSyncNP[0].setMax(1000000.);
+    FocusSyncNP[0].setValue(50000.);
+    FocusSyncNP[0].setStep(5000.);
 
-    FocusBacklashN[0].min = -1000;
-    FocusBacklashN[0].max = 1000;
-    FocusBacklashN[0].step = 1;
-    FocusBacklashN[0].value = 0;
+    FocusBacklashNP[0].setMin(-1000);
+    FocusBacklashNP[0].setMax(1000);
+    FocusBacklashNP[0].setStep(1);
+    FocusBacklashNP[0].setValue(0);
 
     // Max. movement
-    IUFillNumber(&FocusMaxMoveN[0], "MAX_MOVE", "Steps", "%7.0f", 0, 9999999, 100, 0);
-    IUFillNumberVector(&FocusMaxMoveNP, FocusMaxMoveN, 1, getDeviceName(), "FOCUS_MAX_MOVE", "Max. movement",
+    FocusMaxMoveNP[0].fill("MAX_MOVE", "Steps", "%7.0f", 0, 9999999, 100, 0);
+    FocusMaxMoveNP.fill(getDeviceName(), "FOCUS_MAX_MOVE", "Max. movement",
                        MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     // Settle buffer
-    IUFillNumber(&SettleBufferN[0], "SETTLE_BUFFER", "Period (ms)", "%5.0f", 0, 99999, 100, 0);
-    IUFillNumberVector(&SettleBufferNP, SettleBufferN, 1, getDeviceName(), "FOCUS_SETTLE_BUFFER", "Settle buffer",
+    SettleBufferNP[0].fill("SETTLE_BUFFER", "Period (ms)", "%5.0f", 0, 99999, 100, 0);
+    SettleBufferNP.fill(getDeviceName(), "FOCUS_SETTLE_BUFFER", "Settle buffer",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Motor move multiplier
-    IUFillNumber(&MoveCurrentMultiplierN[0], "MOTOR_MOVE_MULTIPLIER", "%", "%3.0f", 1, 100, 1, 90);
-    IUFillNumberVector(&MoveCurrentMultiplierNP, MoveCurrentMultiplierN, 1, getDeviceName(), "FOCUS_MMM",
+    MoveCurrentMultiplierNP[0].fill("MOTOR_MOVE_MULTIPLIER", "%", "%3.0f", 1, 100, 1, 90);
+    MoveCurrentMultiplierNP.fill(getDeviceName(), "FOCUS_MMM",
                        "Move current multiplier",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Motor hold multiplier
-    IUFillNumber(&HoldCurrentMultiplierN[0], "MOTOR_HOLD_MULTIPLIER", "%", "%3.0f", 1, 100, 1, 40);
-    IUFillNumberVector(&HoldCurrentMultiplierNP, HoldCurrentMultiplierN, 1, getDeviceName(), "FOCUS_MHM",
+    HoldCurrentMultiplierNP[0].fill("MOTOR_HOLD_MULTIPLIER", "%", "%3.0f", 1, 100, 1, 40);
+    HoldCurrentMultiplierNP.fill(getDeviceName(), "FOCUS_MHM",
                        "Hold current multiplier",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     setDefaultPollingPeriod(500);
@@ -170,13 +170,13 @@ bool DeepSkyDadAF3::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&FocusMaxMoveNP);
-        defineProperty(&StepModeSP);
-        defineProperty(&SpeedModeSP);
-        defineProperty(&SettleBufferNP);
-        defineProperty(&MoveCurrentMultiplierNP);
-        defineProperty(&HoldCurrentMultiplierNP);
-        defineProperty(&TemperatureNP);
+        defineProperty(FocusMaxMoveNP);
+        defineProperty(StepModeSP);
+        defineProperty(SpeedModeSP);
+        defineProperty(SettleBufferNP);
+        defineProperty(MoveCurrentMultiplierNP);
+        defineProperty(HoldCurrentMultiplierNP);
+        defineProperty(TemperatureNP);
 
         GetFocusParams();
 
@@ -184,13 +184,13 @@ bool DeepSkyDadAF3::updateProperties()
     }
     else
     {
-        deleteProperty(FocusMaxMoveNP.name);
-        deleteProperty(StepModeSP.name);
-        deleteProperty(SpeedModeSP.name);
-        deleteProperty(SettleBufferNP.name);
-        deleteProperty(MoveCurrentMultiplierNP.name);
-        deleteProperty(HoldCurrentMultiplierNP.name);
-        deleteProperty(TemperatureNP.name);
+        deleteProperty(FocusMaxMoveNP.getName());
+        deleteProperty(StepModeSP.getName());
+        deleteProperty(SpeedModeSP.getName());
+        deleteProperty(SettleBufferNP.getName());
+        deleteProperty(MoveCurrentMultiplierNP.getName());
+        deleteProperty(HoldCurrentMultiplierNP.getName());
+        deleteProperty(TemperatureNP.getName());
     }
 
     return true;
@@ -245,30 +245,30 @@ bool DeepSkyDadAF3::readStepMode()
         return false;
 
     if (strcmp(res, "(1)") == 0)
-        StepModeS[S1].s = ISS_ON;
+        StepModeSP[S1].setState(ISS_ON);
     else if (strcmp(res, "(2)") == 0)
-        StepModeS[S2].s = ISS_ON;
+        StepModeSP[S2].setState(ISS_ON);
     else if (strcmp(res, "(4)") == 0)
-        StepModeS[S4].s = ISS_ON;
+        StepModeSP[S4].setState(ISS_ON);
     else if (strcmp(res, "(8)") == 0)
-        StepModeS[S8].s = ISS_ON;
+        StepModeSP[S8].setState(ISS_ON);
     else if (strcmp(res, "(16)") == 0)
-        StepModeS[S16].s = ISS_ON;
+        StepModeSP[S16].setState(ISS_ON);
     else if (strcmp(res, "(32)") == 0)
-        StepModeS[S32].s = ISS_ON;
+        StepModeSP[S32].setState(ISS_ON);
     else if (strcmp(res, "(64)") == 0)
-        StepModeS[S64].s = ISS_ON;
+        StepModeSP[S64].setState(ISS_ON);
     else if (strcmp(res, "(128)") == 0)
-        StepModeS[S128].s = ISS_ON;
+        StepModeSP[S128].setState(ISS_ON);
     else if (strcmp(res, "(256)") == 0)
-        StepModeS[S256].s = ISS_ON;
+        StepModeSP[S256].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser step value (%s)", res);
         return false;
     }
 
-    StepModeSP.s = IPS_OK;
+    StepModeSP.setState(IPS_OK);
     return true;
 }
 
@@ -280,22 +280,22 @@ bool DeepSkyDadAF3::readSpeedMode()
         return false;
 
     if (strcmp(res, "(1)") == 0)
-        SpeedModeS[VERY_SLOW].s = ISS_ON;
+        SpeedModeSP[VERY_SLOW].setState(ISS_ON);
     else if (strcmp(res, "(2)") == 0)
-        SpeedModeS[SLOW].s = ISS_ON;
+        SpeedModeSP[SLOW].setState(ISS_ON);
     else if (strcmp(res, "(3)") == 0)
-        SpeedModeS[MEDIUM].s = ISS_ON;
+        SpeedModeSP[MEDIUM].setState(ISS_ON);
     else if (strcmp(res, "(4)") == 0)
-        SpeedModeS[FAST].s = ISS_ON;
+        SpeedModeSP[FAST].setState(ISS_ON);
     else if (strcmp(res, "(5)") == 0)
-        SpeedModeS[VERY_FAST].s = ISS_ON;
+        SpeedModeSP[VERY_FAST].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser speed value (%s)", res);
         return false;
     }
 
-    SpeedModeSP.s = IPS_OK;
+    SpeedModeSP.setState(IPS_OK);
     return true;
 }
 
@@ -310,7 +310,7 @@ bool DeepSkyDadAF3::readPosition()
     int rc = sscanf(res, "(%d)", &pos);
 
     if (rc > 0)
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     else
     {
         LOGF_ERROR("Unknown error: focuser position value (%s)", res);
@@ -331,8 +331,8 @@ bool DeepSkyDadAF3::readMaxMovement()
     int rc = sscanf(res, "(%d)", &steps);
     if (rc > 0)
     {
-        FocusMaxMoveN[0].value = steps;
-        FocusMaxMoveNP.s = IPS_OK;
+        FocusMaxMoveNP[0].setValue(steps);
+        FocusMaxMoveNP.setState(IPS_OK);
     }
     else
     {
@@ -354,8 +354,8 @@ bool DeepSkyDadAF3::readMaxPosition()
     int rc = sscanf(res, "(%d)", &steps);
     if (rc > 0)
     {
-        FocusMaxPosN[0].value = steps;
-        FocusMaxPosNP.s = IPS_OK;
+        FocusMaxPosNP[0].setValue(steps);
+        FocusMaxPosNP.setState(IPS_OK);
     }
     else
     {
@@ -377,8 +377,8 @@ bool DeepSkyDadAF3::readSettleBuffer()
     int rc = sscanf(res, "(%d)", &settleBuffer);
     if (rc > 0)
     {
-        SettleBufferN[0].value = settleBuffer;
-        SettleBufferNP.s = settleBuffer > 0 ? IPS_OK : IPS_IDLE;
+        SettleBufferNP[0].setValue(settleBuffer);
+        SettleBufferNP.setState(settleBuffer > 0 ? IPS_OK : IPS_IDLE);
     }
     else
     {
@@ -400,8 +400,8 @@ bool DeepSkyDadAF3::readMoveCurrentMultiplier()
     int rc = sscanf(res, "(%d)", &mcm);
     if (rc > 0)
     {
-        MoveCurrentMultiplierN[0].value = mcm;
-        MoveCurrentMultiplierNP.s = IPS_OK;
+        MoveCurrentMultiplierNP[0].setValue(mcm);
+        MoveCurrentMultiplierNP.setState(IPS_OK);
     }
     else
     {
@@ -423,8 +423,8 @@ bool DeepSkyDadAF3::readHoldCurrentMultiplier()
     int rc = sscanf(res, "(%d)", &hcm);
     if (rc > 0)
     {
-        HoldCurrentMultiplierN[0].value = hcm;
-        HoldCurrentMultiplierNP.s = IPS_OK;
+        HoldCurrentMultiplierNP[0].setValue(hcm);
+        HoldCurrentMultiplierNP.setState(IPS_OK);
     }
     else
     {
@@ -446,7 +446,7 @@ bool DeepSkyDadAF3::readTemperature()
     int rc = sscanf(res, "(%lf)", &temp);
     if (rc > 0)
     {
-        TemperatureN[0].value = temp;
+        TemperatureNP[0].setValue(temp);
     }
     else
     {
@@ -516,18 +516,18 @@ bool DeepSkyDadAF3::ISNewSwitch(const char * dev, const char * name, ISState * s
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Focus Step Mode
-        if (strcmp(StepModeSP.name, name) == 0)
+        if (StepModeSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int current_mode = StepModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&StepModeSP, states, names, n);
+            StepModeSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int target_mode = StepModeSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                StepModeSP.s = IPS_OK;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.setState(IPS_OK);
+                StepModeSP.apply();
                 return true;
             }
 
@@ -556,31 +556,31 @@ bool DeepSkyDadAF3::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&StepModeSP);
-                StepModeS[current_mode].s = ISS_ON;
-                StepModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.reset();
+                StepModeSP[current_mode].setState(ISS_ON);
+                StepModeSP.setState(IPS_ALERT);
+                StepModeSP.apply();
                 return false;
             }
 
-            StepModeSP.s = IPS_OK;
-            IDSetSwitch(&StepModeSP, nullptr);
+            StepModeSP.setState(IPS_OK);
+            StepModeSP.apply();
             return true;
         }
 
         // Focus Speed Mode
-        if (strcmp(SpeedModeSP.name, name) == 0)
+        if (SpeedModeSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&SpeedModeSP);
+            int current_mode = SpeedModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&SpeedModeSP, states, names, n);
+            SpeedModeSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&SpeedModeSP);
+            int target_mode = SpeedModeSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                SpeedModeSP.s = IPS_OK;
-                IDSetSwitch(&SpeedModeSP, nullptr);
+                SpeedModeSP.setState(IPS_OK);
+                SpeedModeSP.apply();
                 return true;
             }
 
@@ -601,15 +601,15 @@ bool DeepSkyDadAF3::ISNewSwitch(const char * dev, const char * name, ISState * s
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                IUResetSwitch(&SpeedModeSP);
-                SpeedModeS[current_mode].s = ISS_ON;
-                SpeedModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&SpeedModeSP, nullptr);
+                SpeedModeSP.reset();
+                SpeedModeSP[current_mode].setState(ISS_ON);
+                SpeedModeSP.setState(IPS_ALERT);
+                SpeedModeSP.apply();
                 return false;
             }
 
-            SpeedModeSP.s = IPS_OK;
-            IDSetSwitch(&SpeedModeSP, nullptr);
+            SpeedModeSP.setState(IPS_OK);
+            SpeedModeSP.apply();
             return true;
         }
     }
@@ -622,92 +622,92 @@ bool DeepSkyDadAF3::ISNewNumber(const char * dev, const char * name, double valu
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Settle buffer Settings
-        if (strcmp(name, SettleBufferNP.name) == 0)
+        if (SettleBufferNP.isNameMatch(name))
         {
-            IUUpdateNumber(&SettleBufferNP, values, names, n);
+            SettleBufferNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SBUF%06d]", static_cast<int>(SettleBufferN[0].value));
+            snprintf(cmd, DSD_RES, "[SBUF%06d]", static_cast<int>(SettleBufferNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                SettleBufferNP.s = IPS_ALERT;
+                SettleBufferNP.setState(IPS_ALERT);
                 return false;
             }
 
-            SettleBufferNP.s = IPS_OK;
-            IDSetNumber(&SettleBufferNP, nullptr);
+            SettleBufferNP.setState(IPS_OK);
+            SettleBufferNP.apply();
             return true;
         }
 
         // Move current multiplier
-        if (strcmp(name, MoveCurrentMultiplierNP.name) == 0)
+        if (MoveCurrentMultiplierNP.isNameMatch(name))
         {
-            IUUpdateNumber(&MoveCurrentMultiplierNP, values, names, n);
+            MoveCurrentMultiplierNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SMMM%03d]", static_cast<int>(MoveCurrentMultiplierN[0].value));
+            snprintf(cmd, DSD_RES, "[SMMM%03d]", static_cast<int>(MoveCurrentMultiplierNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                MoveCurrentMultiplierNP.s = IPS_ALERT;
+                MoveCurrentMultiplierNP.setState(IPS_ALERT);
                 return false;
             }
 
-            MoveCurrentMultiplierNP.s = IPS_OK;
-            IDSetNumber(&MoveCurrentMultiplierNP, nullptr);
+            MoveCurrentMultiplierNP.setState(IPS_OK);
+            MoveCurrentMultiplierNP.apply();
             return true;
         }
 
         // Hold current multiplier
-        if (strcmp(name, HoldCurrentMultiplierNP.name) == 0)
+        if (HoldCurrentMultiplierNP.isNameMatch(name))
         {
-            IUUpdateNumber(&HoldCurrentMultiplierNP, values, names, n);
+            HoldCurrentMultiplierNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SMHM%03d]", static_cast<int>(HoldCurrentMultiplierN[0].value));
+            snprintf(cmd, DSD_RES, "[SMHM%03d]", static_cast<int>(HoldCurrentMultiplierNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                HoldCurrentMultiplierNP.s = IPS_ALERT;
+                HoldCurrentMultiplierNP.setState(IPS_ALERT);
                 return false;
             }
 
-            HoldCurrentMultiplierNP.s = IPS_OK;
-            IDSetNumber(&HoldCurrentMultiplierNP, nullptr);
+            HoldCurrentMultiplierNP.setState(IPS_OK);
+            HoldCurrentMultiplierNP.apply();
             return true;
         }
 
         // Max. position
-        if (strcmp(name, FocusMaxPosNP.name) == 0)
+        if (FocusMaxPosNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FocusMaxPosNP, values, names, n);
+            FocusMaxPosNP.update(values, names, n);
             char cmd[DSD_RES] = {0};
-            snprintf(cmd, DSD_RES, "[SMXP%d]", static_cast<int>(FocusMaxPosN[0].value));
+            snprintf(cmd, DSD_RES, "[SMXP%d]", static_cast<int>(FocusMaxPosNP[0].value));
             bool rc = sendCommandSet(cmd);
             if (!rc)
             {
-                FocusMaxPosNP.s = IPS_ALERT;
+                FocusMaxPosNP.setState(IPS_ALERT);
                 return false;
             }
 
-            FocusMaxPosNP.s = IPS_OK;
-            IDSetNumber(&FocusMaxPosNP, nullptr);
+            FocusMaxPosNP.setState(IPS_OK);
+            FocusMaxPosNP.apply();
             return true;
         }
 
         // Max. movement
-        //        if (strcmp(name, FocusMaxMoveNP.name) == 0)
+        //        if (FocusMaxMoveNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&FocusMaxMoveNP, values, names, n);
+        //            FocusMaxMoveNP.update(values, names, n);
         //            char cmd[DSD_RES] = {0};
-        //            snprintf(cmd, DSD_RES, "[SMXM%d]", static_cast<int>(FocusMaxMoveN[0].value));
+        //            snprintf(cmd, DSD_RES, "[SMXM%d]", static_cast<int>(FocusMaxMoveNP[0].value));
         //            bool rc = sendCommandSet(cmd);
         //            if (!rc)
         //            {
-        //                FocusMaxMoveNP.s = IPS_ALERT;
+        //                FocusMaxMoveNP.setState(IPS_ALERT);
         //                return false;
         //            }
 
-        //            FocusMaxMoveNP.s = IPS_OK;
-        //            IDSetNumber(&FocusMaxMoveNP, nullptr);
+        //            FocusMaxMoveNP.setState(IPS_OK);
+        //            FocusMaxMoveNP.apply();
         //            return true;
         //        }
 
@@ -718,35 +718,35 @@ bool DeepSkyDadAF3::ISNewNumber(const char * dev, const char * name, double valu
 
 void DeepSkyDadAF3::GetFocusParams()
 {
-    IUResetSwitch(&StepModeSP);
-    IUResetSwitch(&SpeedModeSP);
+    StepModeSP.reset();
+    SpeedModeSP.reset();
 
     if (readPosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (readStepMode())
-        IDSetSwitch(&StepModeSP, nullptr);
+        StepModeSP.apply();
 
     if (readSpeedMode())
-        IDSetSwitch(&SpeedModeSP, nullptr);
+        SpeedModeSP.apply();
 
     if (readSettleBuffer())
-        IDSetNumber(&SettleBufferNP, nullptr);
+        SettleBufferNP.apply();
 
     if (readMoveCurrentMultiplier())
-        IDSetNumber(&MoveCurrentMultiplierNP, nullptr);
+        MoveCurrentMultiplierNP.apply();
 
     if (readHoldCurrentMultiplier())
-        IDSetNumber(&HoldCurrentMultiplierNP, nullptr);
+        HoldCurrentMultiplierNP.apply();
 
     if (readMaxPosition())
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP.apply();
 
     if (readMaxMovement())
-        IDSetNumber(&FocusMaxMoveNP, nullptr);
+        FocusMaxMoveNP.apply();
 
     if (readTemperature())
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 }
 
 IPState DeepSkyDadAF3::MoveFocuser(FocusDirection dir, int speed, uint16_t duration)
@@ -757,7 +757,7 @@ IPState DeepSkyDadAF3::MoveFocuser(FocusDirection dir, int speed, uint16_t durat
     if (dir == FOCUS_INWARD)
         MoveFocuser(0);
     else
-        MoveFocuser(FocusMaxPosN[0].value);
+        MoveFocuser(FocusMaxPosNP[0].value);
 
     IEAddTimer(duration, &DeepSkyDadAF3::timedMoveHelper, this);
     return IPS_BUSY;
@@ -771,13 +771,13 @@ void DeepSkyDadAF3::timedMoveHelper(void * context)
 void DeepSkyDadAF3::timedMoveCallback()
 {
     AbortFocuser();
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocusRelPosNP.s = IPS_IDLE;
-    FocusTimerNP.s = IPS_IDLE;
-    FocusTimerN[0].value = 0;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
-    IDSetNumber(&FocusTimerNP, nullptr);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusRelPosNP.setState(IPS_IDLE);
+    FocusTimerNP.setState(IPS_IDLE);
+    FocusTimerNP[0].setValue(0);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
+    FocusTimerNP.apply();
 }
 
 
@@ -785,8 +785,8 @@ IPState DeepSkyDadAF3::MoveAbsFocuser(uint32_t targetTicks)
 {
     targetPos = targetTicks;
 
-    double bcValue = FocusBacklashN[0].value;
-    int diff = targetTicks - FocusAbsPosN[0].value;
+    double bcValue = FocusBacklashNP[0].getValue();
+    int diff = targetTicks - FocusAbsPosNP[0].getValue();
     if ((diff > 0 && bcValue < 0) || (diff < 0 && bcValue > 0))
     {
         backlashComp = bcValue;
@@ -804,18 +804,18 @@ IPState DeepSkyDadAF3::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     int32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     // Clamp
-    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosN[0].max), newPosition));
+    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosNP[0].max), newPosition));
     if (!MoveAbsFocuser(newPosition))
         return IPS_ALERT;
 
     // JM 2019-02-10: This is already set by the framework
-    //FocusRelPosN[0].value = ticks;
-    //FocusRelPosNP.s       = IPS_BUSY;
+    //FocusRelPosNP[0].setValue(ticks);
+    //FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -831,22 +831,22 @@ void DeepSkyDadAF3::TimerHit()
     bool rc = readPosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
 
             if(moveAborted)
             {
@@ -871,10 +871,10 @@ void DeepSkyDadAF3::TimerHit()
     rc = readTemperature();
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.1 ) //more accurate update
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.1 ) //more accurate update
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
@@ -891,12 +891,12 @@ bool DeepSkyDadAF3::saveConfigItems(FILE * fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &StepModeSP);
-    IUSaveConfigSwitch(fp, &SpeedModeSP);
-    IUSaveConfigNumber(fp, &FocusMaxMoveNP);
-    IUSaveConfigNumber(fp, &SettleBufferNP);
-    IUSaveConfigNumber(fp, &MoveCurrentMultiplierNP);
-    IUSaveConfigNumber(fp, &HoldCurrentMultiplierNP);
+    StepModeSP.save(fp);
+    SpeedModeSP.save(fp);
+    FocusMaxMoveNP.save(fp);
+    SettleBufferNP.save(fp);
+    MoveCurrentMultiplierNP.save(fp);
+    HoldCurrentMultiplierNP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/deepskydad_af3.h
+++ b/drivers/focuser/deepskydad_af3.h
@@ -28,6 +28,10 @@
 
 #include <chrono>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class DeepSkyDadAF3 : public INDI::Focuser
 {
     public:
@@ -117,31 +121,24 @@ class DeepSkyDadAF3 : public INDI::Focuser
         bool moveAborted = false;
 
         // Step mode
-        ISwitch StepModeS[9];
-        ISwitchVectorProperty StepModeSP;
+        INDI::PropertySwitch StepModeSP {9};
 
         // Speed mode
-        ISwitch SpeedModeS[5];
-        ISwitchVectorProperty SpeedModeSP;
+        INDI::PropertySwitch SpeedModeSP {5};
 
         //Current move
-        INumber MoveCurrentMultiplierN[1];
-        INumberVectorProperty MoveCurrentMultiplierNP;
+        INDI::PropertyNumber MoveCurrentMultiplierNP {1};
 
         //Current hold
-        INumber HoldCurrentMultiplierN[1];
-        INumberVectorProperty HoldCurrentMultiplierNP;
+        INDI::PropertyNumber HoldCurrentMultiplierNP {1};
 
         // Max movement
-        INumber FocusMaxMoveN[1];
-        INumberVectorProperty FocusMaxMoveNP;
+        INDI::PropertyNumber FocusMaxMoveNP {1};
 
         // Settle buffer
-        INumber SettleBufferN[1];
-        INumberVectorProperty SettleBufferNP;
+        INDI::PropertyNumber SettleBufferNP {1};
 
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Response Buffer
 

--- a/drivers/focuser/dmfc.cpp
+++ b/drivers/focuser/dmfc.cpp
@@ -90,49 +90,49 @@ bool DMFC::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Max Speed
-    IUFillNumber(&MaxSpeedN[0], "Value", "", "%6.2f", 100, 1000., 100., 400.);
-    IUFillNumberVector(&MaxSpeedNP, MaxSpeedN, 1, getDeviceName(), "MaxSpeed", "", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
+    MaxSpeedNP[0].fill("Value", "", "%6.2f", 100, 1000., 100., 400.);
+    MaxSpeedNP.fill(getDeviceName(), "MaxSpeed", "", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Encoders
-    IUFillSwitch(&EncoderS[ENCODERS_ON], "On", "", ISS_ON);
-    IUFillSwitch(&EncoderS[ENCODERS_OFF], "Off", "", ISS_OFF);
-    IUFillSwitchVector(&EncoderSP, EncoderS, 2, getDeviceName(), "Encoders", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    EncoderSP[ENCODERS_ON].fill("On", "", ISS_ON);
+    EncoderSP[ENCODERS_OFF].fill("Off", "", ISS_OFF);
+    EncoderSP.fill(getDeviceName(), "Encoders", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Motor Modes
-    IUFillSwitch(&MotorTypeS[MOTOR_DC], "DC", "", ISS_OFF);
-    IUFillSwitch(&MotorTypeS[MOTOR_STEPPER], "Stepper", "", ISS_ON);
-    IUFillSwitchVector(&MotorTypeSP, MotorTypeS, 2, getDeviceName(), "Motor Type", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    MotorTypeSP[MOTOR_DC].fill("DC", "", ISS_OFF);
+    MotorTypeSP[MOTOR_STEPPER].fill("Stepper", "", ISS_ON);
+    MotorTypeSP.fill(getDeviceName(), "Motor Type", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // LED
-    IUFillSwitch(&LEDS[LED_OFF], "Off", "", ISS_ON);
-    IUFillSwitch(&LEDS[LED_ON], "On", "", ISS_OFF);
-    IUFillSwitchVector(&LEDSP, LEDS, 2, getDeviceName(), "LED", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    LEDSP[LED_OFF].fill("Off", "", ISS_ON);
+    LEDSP[LED_ON].fill("On", "", ISS_OFF);
+    LEDSP.fill(getDeviceName(), "LED", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Firmware Version
-    IUFillText(&FirmwareVersionT[0], "Version", "Version", "");
-    IUFillTextVector(&FirmwareVersionTP, FirmwareVersionT, 1, getDeviceName(), "Firmware", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    FirmwareVersionTP[0].fill("Version", "Version", "");
+    FirmwareVersionTP.fill(getDeviceName(), "Firmware", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Relative and absolute movement
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 100000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     // Backlash compensation
-    FocusBacklashN[0].min   = 1; // 0 is off.
-    FocusBacklashN[0].max   = 1000;
-    FocusBacklashN[0].value = 1;
-    FocusBacklashN[0].step  = 1;
+    FocusBacklashNP[0].setMin(1); // 0 is off.
+    FocusBacklashNP[0].setMax(1000);
+    FocusBacklashNP[0].setValue(1);
+    FocusBacklashNP[0].setStep(1);
 
     addDebugControl();
 
@@ -149,21 +149,21 @@ bool DMFC::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
-        defineProperty(&EncoderSP);
-        defineProperty(&MotorTypeSP);
-        defineProperty(&MaxSpeedNP);
-        defineProperty(&LEDSP);
-        defineProperty(&FirmwareVersionTP);
+        defineProperty(TemperatureNP);
+        defineProperty(EncoderSP);
+        defineProperty(MotorTypeSP);
+        defineProperty(MaxSpeedNP);
+        defineProperty(LEDSP);
+        defineProperty(FirmwareVersionTP);
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(EncoderSP.name);
-        deleteProperty(MotorTypeSP.name);
-        deleteProperty(MaxSpeedNP.name);
-        deleteProperty(LEDSP.name);
-        deleteProperty(FirmwareVersionTP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(EncoderSP.getName());
+        deleteProperty(MotorTypeSP.getName());
+        deleteProperty(MaxSpeedNP.getName());
+        deleteProperty(LEDSP.getName());
+        deleteProperty(FirmwareVersionTP.getName());
     }
 
     return true;
@@ -280,34 +280,34 @@ bool DMFC::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
         /////////////////////////////////////////////
         // Encoders
         /////////////////////////////////////////////
-        if (!strcmp(name, EncoderSP.name))
+        if (EncoderSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&EncoderSP, states, names, n);
-            bool rc = setEncodersEnabled(EncoderS[ENCODERS_ON].s == ISS_ON);
-            EncoderSP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&EncoderSP, nullptr);
+            EncoderSP.update(states, names, n);
+            bool rc = setEncodersEnabled(EncoderSP[ENCODERS_ON].getState() == ISS_ON);
+            EncoderSP.setState(rc ? IPS_OK : IPS_ALERT);
+            EncoderSP.apply();
             return true;
         }
         /////////////////////////////////////////////
         // LED
         /////////////////////////////////////////////
-        else if (!strcmp(name, LEDSP.name))
+        else if (LEDSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&LEDSP, states, names, n);
-            bool rc = setLedEnabled(LEDS[LED_ON].s == ISS_ON);
-            LEDSP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&LEDSP, nullptr);
+            LEDSP.update(states, names, n);
+            bool rc = setLedEnabled(LEDSP[LED_ON].getState() == ISS_ON);
+            LEDSP.setState(rc ? IPS_OK : IPS_ALERT);
+            LEDSP.apply();
             return true;
         }
         /////////////////////////////////////////////
         // Motor Type
         /////////////////////////////////////////////
-        if (!strcmp(name, MotorTypeSP.name))
+        if (MotorTypeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MotorTypeSP, states, names, n);
-            bool rc = setMotorType(MotorTypeS[MOTOR_DC].s == ISS_ON ? 0 : 1);
-            MotorTypeSP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&MotorTypeSP, nullptr);
+            MotorTypeSP.update(states, names, n);
+            bool rc = setMotorType(MotorTypeSP[MOTOR_DC].getState() == ISS_ON ? 0 : 1);
+            MotorTypeSP.setState(rc ? IPS_OK : IPS_ALERT);
+            MotorTypeSP.apply();
             return true;
         }
     }
@@ -322,12 +322,12 @@ bool DMFC::ISNewNumber(const char *dev, const char *name, double values[], char 
         /////////////////////////////////////////////
         // MaxSpeed
         /////////////////////////////////////////////
-        if (strcmp(name, MaxSpeedNP.name) == 0)
+        if (MaxSpeedNP.isNameMatch(name))
         {
-            IUUpdateNumber(&MaxSpeedNP, values, names, n);
-            bool rc = setMaxSpeed(MaxSpeedN[0].value);
-            MaxSpeedNP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetNumber(&MaxSpeedNP, nullptr);
+            MaxSpeedNP.update(values, names, n);
+            bool rc = setMaxSpeed(MaxSpeedNP[0].value);
+            MaxSpeedNP.setState(rc ? IPS_OK : IPS_ALERT);
+            MaxSpeedNP.apply();
             return true;
         }
     }
@@ -389,11 +389,11 @@ bool DMFC::updateFocusParams()
         return false;
     }
 
-    if (FirmwareVersionT[0].text == nullptr || strcmp(FirmwareVersionT[0].text, token))
+    if (FirmwareVersionTP[0].text == nullptr || strcmp(FirmwareVersionTP[0].getText(), token))
     {
-        IUSaveText(&FirmwareVersionT[0], token);
-        FirmwareVersionTP.s = IPS_OK;
-        IDSetText(&FirmwareVersionTP, nullptr);
+        FirmwareVersionTP[0].setText(token);
+        FirmwareVersionTP.setState(IPS_OK);
+        FirmwareVersionTP.apply();
     }
 
     // #3 Motor Type
@@ -408,11 +408,11 @@ bool DMFC::updateFocusParams()
     int motorType = atoi(token);
     if (motorType >= 0 && motorType <= 1)
     {
-        IUResetSwitch(&MotorTypeSP);
-        MotorTypeS[MOTOR_DC].s = (motorType == 0) ? ISS_ON : ISS_OFF;
-        MotorTypeS[MOTOR_STEPPER].s = (motorType == 1) ? ISS_ON : ISS_OFF;
-        MotorTypeSP.s = IPS_OK;
-        IDSetSwitch(&MotorTypeSP, nullptr);
+        MotorTypeSP.reset();
+        MotorTypeSP[MOTOR_DC].setState((motorType == 0) ? ISS_ON : ISS_OFF);
+        MotorTypeSP[MOTOR_STEPPER].setState((motorType == 1) ? ISS_ON : ISS_OFF);
+        MotorTypeSP.setState(IPS_OK);
+        MotorTypeSP.apply();
     }
 
     // #4 Temperature
@@ -427,16 +427,16 @@ bool DMFC::updateFocusParams()
     double temperature = atof(token);
     if (temperature == -127)
     {
-        TemperatureNP.s = IPS_ALERT;
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.setState(IPS_ALERT);
+        TemperatureNP.apply();
     }
     else
     {
-        if (fabs(temperature - TemperatureN[0].value) > TEMPERATURE_THRESHOLD)
+        if (fabs(temperature - TemperatureNP[0].getValue()) > TEMPERATURE_THRESHOLD)
         {
-            TemperatureN[0].value = temperature;
-            TemperatureNP.s = IPS_OK;
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP[0].setValue(temperature);
+            TemperatureNP.setState(IPS_OK);
+            TemperatureNP.apply();
         }
     }
 
@@ -450,10 +450,10 @@ bool DMFC::updateFocusParams()
     }
 
     currentPosition = atoi(token);
-    if (currentPosition != FocusAbsPosN[0].value)
+    if (currentPosition != FocusAbsPosNP[0].getValue())
     {
-        FocusAbsPosN[0].value = currentPosition;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setValue(currentPosition);
+        FocusAbsPosNP.apply();
     }
 
     // #6 Moving Status
@@ -479,10 +479,10 @@ bool DMFC::updateFocusParams()
     int ledStatus = atoi(token);
     if (ledStatus >= 0 && ledStatus <= 1)
     {
-        IUResetSwitch(&LEDSP);
-        LEDS[ledStatus].s = ISS_ON;
-        LEDSP.s = IPS_OK;
-        IDSetSwitch(&LEDSP, nullptr);
+        LEDSP.reset();
+        LEDSP[ledStatus].setState(ISS_ON);
+        LEDSP.setState(IPS_OK);
+        LEDSP.apply();
     }
 
     // #8 Reverse Status
@@ -497,11 +497,11 @@ bool DMFC::updateFocusParams()
     int reverseStatus = atoi(token);
     if (reverseStatus >= 0 && reverseStatus <= 1)
     {
-        IUResetSwitch(&FocusReverseSP);
-        FocusReverseS[INDI_ENABLED].s = (reverseStatus == 1) ? ISS_ON : ISS_OFF;
-        FocusReverseS[INDI_DISABLED].s = (reverseStatus == 0) ? ISS_ON : ISS_OFF;
-        FocusReverseSP.s = IPS_OK;
-        IDSetSwitch(&FocusReverseSP, nullptr);
+        FocusReverseSP.reset();
+        FocusReverseSP[INDI_ENABLED].setState((reverseStatus == 1) ? ISS_ON : ISS_OFF);
+        FocusReverseSP[INDI_DISABLED].setState((reverseStatus == 0) ? ISS_ON : ISS_OFF);
+        FocusReverseSP.setState(IPS_OK);
+        FocusReverseSP.apply();
     }
 
     // #9 Encoder status
@@ -516,10 +516,10 @@ bool DMFC::updateFocusParams()
     int encoderStatus = atoi(token);
     if (encoderStatus >= 0 && encoderStatus <= 1)
     {
-        IUResetSwitch(&EncoderSP);
-        EncoderS[encoderStatus].s = ISS_ON;
-        EncoderSP.s = IPS_OK;
-        IDSetSwitch(&EncoderSP, nullptr);
+        EncoderSP.reset();
+        EncoderSP[encoderStatus].setState(ISS_ON);
+        EncoderSP.setState(IPS_OK);
+        EncoderSP.apply();
     }
 
     // #10 Backlash
@@ -533,30 +533,30 @@ bool DMFC::updateFocusParams()
 
     int backlash = atoi(token);
     // If backlash is zero then compensation is disabled
-    if (backlash == 0 && FocusBacklashS[INDI_ENABLED].s == ISS_ON)
+    if (backlash == 0 && FocusBacklashSP[INDI_ENABLED].s == ISS_ON)
     {
         LOG_WARN("Backlash value is zero, disabling backlash switch...");
 
-        FocusBacklashS[INDI_ENABLED].s = ISS_OFF;
-        FocusBacklashS[INDI_DISABLED].s = ISS_ON;
-        FocusBacklashSP.s = IPS_IDLE;
-        IDSetSwitch(&FocusBacklashSP, nullptr);
+        FocusBacklashSP[INDI_ENABLED].setState(ISS_OFF);
+        FocusBacklashSP[INDI_DISABLED].setState(ISS_ON);
+        FocusBacklashSP.setState(IPS_IDLE);
+        FocusBacklashSP.apply();
     }
-    else if (backlash > 0 && (FocusBacklashS[INDI_DISABLED].s == ISS_ON || backlash != FocusBacklashN[0].value))
+    else if (backlash > 0 && (FocusBacklashSP[INDI_DISABLED].getState() == ISS_ON || backlash != FocusBacklashNP[0].getValue()))
     {
-        if (backlash != FocusBacklashN[0].value)
+        if (backlash != FocusBacklashNP[0].getValue())
         {
-            FocusBacklashN[0].value = backlash;
-            FocusBacklashNP.s = IPS_OK;
-            IDSetNumber(&FocusBacklashNP, nullptr);
+            FocusBacklashNP[0].setValue(backlash);
+            FocusBacklashNP.setState(IPS_OK);
+            FocusBacklashNP.apply();
         }
 
-        if (FocusBacklashS[INDI_DISABLED].s == ISS_ON)
+        if (FocusBacklashSP[INDI_DISABLED].getState() == ISS_ON)
         {
-            FocusBacklashS[INDI_ENABLED].s = ISS_OFF;
-            FocusBacklashS[INDI_DISABLED].s = ISS_ON;
-            FocusBacklashSP.s = IPS_IDLE;
-            IDSetSwitch(&FocusBacklashSP, nullptr);
+            FocusBacklashSP[INDI_ENABLED].setState(ISS_OFF);
+            FocusBacklashSP[INDI_DISABLED].setState(ISS_ON);
+            FocusBacklashSP.setState(IPS_IDLE);
+            FocusBacklashSP.apply();
         }
     }
 
@@ -688,7 +688,7 @@ bool DMFC::SetFocuserBacklashEnabled(bool enabled)
     if (!enabled)
         return SetFocuserBacklash(0);
 
-    return SetFocuserBacklash(FocusBacklashN[0].value > 0 ? FocusBacklashN[0].value : 1);
+    return SetFocuserBacklash(FocusBacklashNP[0].value > 0 ? FocusBacklashNP[0].value : 1);
 }
 
 bool DMFC::setMotorType(uint8_t type)
@@ -724,7 +724,7 @@ IPState DMFC::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -735,17 +735,17 @@ IPState DMFC::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     bool rc = false;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     rc = move(newPosition);
 
     if (!rc)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -762,14 +762,14 @@ void DMFC::TimerHit()
 
     if (rc)
     {
-        if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+        if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
         {
             if (isMoving == false)
             {
-                FocusAbsPosNP.s = IPS_OK;
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
-                IDSetNumber(&FocusRelPosNP, nullptr);
+                FocusAbsPosNP.setState(IPS_OK);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusAbsPosNP.apply();
+                FocusRelPosNP.apply();
                 LOG_INFO("Focuser reached requested position.");
             }
         }
@@ -785,10 +785,10 @@ bool DMFC::AbortFocuser()
 
     if (tty_write(PortFD, cmd, 2, &nbytes_written) == TTY_OK)
     {
-        FocusAbsPosNP.s = IPS_IDLE;
-        FocusRelPosNP.s = IPS_IDLE;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
-        IDSetNumber(&FocusRelPosNP, nullptr);
+        FocusAbsPosNP.setState(IPS_IDLE);
+        FocusRelPosNP.setState(IPS_IDLE);
+        FocusAbsPosNP.apply();
+        FocusRelPosNP.apply();
         return true;
     }
     else
@@ -799,10 +799,10 @@ bool DMFC::saveConfigItems(FILE *fp)
 {
     INDI::Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &EncoderSP);
-    IUSaveConfigSwitch(fp, &MotorTypeSP);
-    IUSaveConfigNumber(fp, &MaxSpeedNP);
-    IUSaveConfigSwitch(fp, &LEDSP);
+    EncoderSP.save(fp);
+    MotorTypeSP.save(fp);
+    MaxSpeedNP.save(fp);
+    LEDSP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/dmfc.h
+++ b/drivers/focuser/dmfc.h
@@ -22,6 +22,11 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class DMFC : public INDI::Focuser
 {
     public:
@@ -61,29 +66,23 @@ class DMFC : public INDI::Focuser
         bool isMoving = false;
 
         // Temperature probe
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Motor Mode
-        ISwitch MotorTypeS[2];
-        ISwitchVectorProperty MotorTypeSP;
+        INDI::PropertySwitch MotorTypeSP {2};
         enum { MOTOR_DC, MOTOR_STEPPER };
 
         // Rotator Encoders
-        ISwitch EncoderS[2];
-        ISwitchVectorProperty EncoderSP;
+        INDI::PropertySwitch EncoderSP {2};
         enum { ENCODERS_ON, ENCODERS_OFF };
 
         // LED
-        ISwitch LEDS[2];
-        ISwitchVectorProperty LEDSP;
+        INDI::PropertySwitch LEDSP {2};
         enum { LED_OFF, LED_ON };
 
         // Maximum Speed
-        INumber MaxSpeedN[1];
-        INumberVectorProperty MaxSpeedNP;
+        INDI::PropertyNumber MaxSpeedNP {1};
 
         // Firmware Version
-        IText FirmwareVersionT[1] {};
-        ITextVectorProperty FirmwareVersionTP;
+        INDI::PropertyText FirmwareVersionTP {1};
 };

--- a/drivers/focuser/fcusb.cpp
+++ b/drivers/focuser/fcusb.cpp
@@ -122,8 +122,8 @@ bool FCUSB::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    FocusSpeedN[0].min = 0;
-    FocusSpeedN[0].max = 255;
+    FocusSpeedNP[0].setMin(0);
+    FocusSpeedNP[0].setMax(255);
 
     // PWM Scaler
     IUFillSwitch(&PWMScalerS[0], "PWM_1_1", "1:1", ISS_ON);
@@ -157,7 +157,7 @@ void FCUSB::TimerHit()
     if (!isConnected())
         return;
 
-    if (FocusTimerNP.s == IPS_BUSY)
+    if (FocusTimerNP.getState() == IPS_BUSY)
     {
         struct timeval curtime, diff;
         gettimeofday(&curtime, nullptr);
@@ -167,8 +167,8 @@ void FCUSB::TimerHit()
         if (timeleft < 0)
             timeleft = 0;
 
-        FocusTimerN[0].value = timeleft;
-        IDSetNumber(&FocusTimerNP, nullptr);
+        FocusTimerNP[0].setValue(timeleft);
+        FocusTimerNP.apply();
 
         if (timeleft == 0)
             stop();
@@ -272,11 +272,11 @@ bool FCUSB::getStatus()
     }
 
     // Update speed (PWM) if it was changed.
-    if (fabs(FocusSpeedN[0].value - status[1]) > 0)
+    if (fabs(FocusSpeedNP[0].value - status[1]) > 0)
     {
-        FocusSpeedN[0].value = status[1];
-        LOGF_DEBUG("PWM: %d%", FocusSpeedN[0].value);
-        IDSetNumber(&FocusSpeedNP, nullptr);
+        FocusSpeedNP[0].setValue(status[1]);
+        LOGF_DEBUG("PWM: %d%", FocusSpeedNP[0].getValue());
+        FocusSpeedNP.apply();
     }
 
     return true;
@@ -292,18 +292,18 @@ bool FCUSB::AbortFocuser()
 
     if (rc)
     {
-        if (FocusTimerNP.s != IPS_IDLE)
+        if (FocusTimerNP.getState() != IPS_IDLE)
         {
-            FocusTimerNP.s = IPS_IDLE;
-            FocusTimerN[0].value = 0;
-            IDSetNumber(&FocusTimerNP, nullptr);
+            FocusTimerNP.setState(IPS_IDLE);
+            FocusTimerNP[0].setValue(0);
+            FocusTimerNP.apply();
         }
 
-        if (FocusMotionSP.s != IPS_IDLE)
+        if (FocusMotionSP.getState() != IPS_IDLE)
         {
-            IUResetSwitch(&FocusMotionSP);
-            FocusMotionSP.s = IPS_IDLE;
-            IDSetSwitch(&FocusMotionSP, nullptr);
+            FocusMotionSP.reset();
+            FocusMotionSP.setState(IPS_IDLE);
+            FocusMotionSP.apply();
         }
     }
 
@@ -320,18 +320,18 @@ bool FCUSB::stop()
 
     if (rc)
     {
-        if (FocusTimerNP.s != IPS_OK)
+        if (FocusTimerNP.getState() != IPS_OK)
         {
-            FocusTimerNP.s = IPS_OK;
-            FocusTimerN[0].value = 0;
-            IDSetNumber(&FocusTimerNP, nullptr);
+            FocusTimerNP.setState(IPS_OK);
+            FocusTimerNP[0].setValue(0);
+            FocusTimerNP.apply();
         }
 
-        if (FocusMotionSP.s != IPS_OK)
+        if (FocusMotionSP.getState() != IPS_OK)
         {
-            IUResetSwitch(&FocusMotionSP);
-            FocusMotionSP.s = IPS_OK;
-            IDSetSwitch(&FocusMotionSP, nullptr);
+            FocusMotionSP.reset();
+            FocusMotionSP.setState(IPS_OK);
+            FocusMotionSP.apply();
         }
     }
 
@@ -353,7 +353,7 @@ IPState FCUSB::MoveFocuser(FocusDirection dir, int speed, uint16_t duration)
 {
     FocusDirection targetDirection = dir;
 
-    if (FocusReverseS[INDI_ENABLED].s == ISS_ON)
+    if (FocusReverseSP[INDI_ENABLED].getState() == ISS_ON)
         targetDirection = (dir == FOCUS_INWARD) ? FOCUS_OUTWARD : FOCUS_INWARD;
 
     motorStatus = (targetDirection == FOCUS_INWARD) ? MOTOR_REV : MOTOR_FWD;

--- a/drivers/focuser/focus_simulator.h
+++ b/drivers/focuser/focus_simulator.h
@@ -20,6 +20,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * @brief The FocusSim class provides a simple Focuser simulator that can simulator the following devices:
  * + Absolute Focuser with encoders.
@@ -64,16 +68,13 @@ class FocusSim : public INDI::Focuser
         double initTicks { 0 };
 
         // Seeing in arcseconds
-        INumberVectorProperty SeeingNP;
-        INumber SeeingN[1];
+        INDI::PropertyNumber SeeingNP {1};
 
         // FWHM to be used by CCD driver to draw 'fuzzy' stars
-        INumberVectorProperty FWHMNP;
-        INumber FWHMN[1];
+        INDI::PropertyNumber FWHMNP {1};
 
         // Temperature in celcius degrees
-        INumberVectorProperty TemperatureNP;
-        INumber TemperatureN[1];
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Current mode of Focus simulator for testing purposes
         enum
@@ -84,6 +85,5 @@ class FocusSim : public INDI::Focuser
             MODE_TIMER,
             MODE_COUNT
         };
-        ISwitchVectorProperty ModeSP;
-        ISwitch ModeS[MODE_COUNT];
+        INDI::PropertySwitch ModeSP {MODE_COUNT};
 };

--- a/drivers/focuser/focuslynx.cpp
+++ b/drivers/focuser/focuslynx.cpp
@@ -237,7 +237,7 @@ bool FocusLynxF1::updateProperties()
         defineProperty(&HubTP);
         defineProperty(&WiredTP);
         defineProperty(&WifiTP);
-        defineProperty(&LedNP);
+        defineProperty(LedNP);
 
         if (getHubConfig())
             LOG_INFO("HUB parameters updated.");
@@ -252,7 +252,7 @@ bool FocusLynxF1::updateProperties()
         deleteProperty(HubTP.name);
         deleteProperty(WiredTP.name);
         deleteProperty(WifiTP.name);
-        deleteProperty(LedNP.name);
+        deleteProperty(LedNP.getName());
     }
     return true;
 }

--- a/drivers/focuser/focuslynxbase.cpp
+++ b/drivers/focuser/focuslynxbase.cpp
@@ -97,55 +97,55 @@ bool FocusLynxBase::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Enable/Disable temperature compensation
-    IUFillSwitch(&TemperatureCompensateS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "T. COMPENSATION", "T. Compensation",
+    TemperatureCompensateSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    TemperatureCompensateSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    TemperatureCompensateSP.fill(getDeviceName(), "T. COMPENSATION", "T. Compensation",
                        FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Enable/Disable temperature compensation on start
-    IUFillSwitch(&TemperatureCompensateOnStartS[0], "Enable", "Enable", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateOnStartS[1], "Disable", "Disable", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateOnStartSP, TemperatureCompensateOnStartS, 2, getDeviceName(),
+    TemperatureCompensateOnStartSP[0].fill("Enable", "Enable", ISS_OFF);
+    TemperatureCompensateOnStartSP[1].fill("Disable", "Disable", ISS_ON);
+    TemperatureCompensateOnStartSP.fill(getDeviceName(),
                        "T. COMPENSATION @START", "T. Compensation @Start", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Enable/Disable temperature Mode
-    IUFillSwitch(&TemperatureCompensateModeS[0], "A", "A", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[1], "B", "B", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[2], "C", "C", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[3], "D", "D", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[4], "E", "E", ISS_OFF);
-    IUFillSwitchVector(&TemperatureCompensateModeSP, TemperatureCompensateModeS, 5, getDeviceName(), "COMPENSATE MODE",
+    TemperatureCompensateModeSP[0].fill("A", "A", ISS_OFF);
+    TemperatureCompensateModeSP[1].fill("B", "B", ISS_OFF);
+    TemperatureCompensateModeSP[2].fill("C", "C", ISS_OFF);
+    TemperatureCompensateModeSP[3].fill("D", "D", ISS_OFF);
+    TemperatureCompensateModeSP[4].fill("E", "E", ISS_OFF);
+    TemperatureCompensateModeSP.fill(getDeviceName(), "COMPENSATE MODE",
                        "Compensate Mode", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&TemperatureParamN[0], "T. Coefficient", "", "%.f", -9999, 9999, 100., 0.);
-    IUFillNumber(&TemperatureParamN[1], "T. Intercept", "", "%.f", -32766, 32766, 100., 0.);
-    IUFillNumberVector(&TemperatureParamNP, TemperatureParamN, 2, getDeviceName(), "T. PARAMETERS", "Mode Parameters",
+    TemperatureParamNP[0].fill("T. Coefficient", "", "%.f", -9999, 9999, 100., 0.);
+    TemperatureParamNP[1].fill("T. Intercept", "", "%.f", -32766, 32766, 100., 0.);
+    TemperatureParamNP.fill(getDeviceName(), "T. PARAMETERS", "Mode Parameters",
                        FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Enable/Disable Sync Mandatory for relative focuser
-    IUFillSwitch(&SyncMandatoryS[INDI_ENABLED], "INDI_ENABLED", "Enabled", isSynced == false ? ISS_ON : ISS_OFF);
-    IUFillSwitch(&SyncMandatoryS[INDI_DISABLED], "INDI_DISABLED", "Disabled", isSynced == true ? ISS_ON : ISS_OFF);
-    IUFillSwitchVector(&SyncMandatorySP, SyncMandatoryS, 2, getDeviceName(), "SYNC MANDATORY", "Sync Mandatory",
+    SyncMandatorySP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", isSynced == false ? ISS_ON : ISS_OFF);
+    SyncMandatorySP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", isSynced == true ? ISS_ON : ISS_OFF);
+    SyncMandatorySP.fill(getDeviceName(), "SYNC MANDATORY", "Sync Mandatory",
                        FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Focuser Step Size
-    IUFillNumber(&StepSizeN[0], "10000*microns/step", "", "%.f", 0, 65535, 0., 0);
-    IUFillNumberVector(&StepSizeNP, StepSizeN, 1, getDeviceName(), "STEP SIZE", "Step Size", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
+    StepSizeNP[0].fill("10000*microns/step", "", "%.f", 0, 65535, 0., 0);
+    StepSizeNP.fill(getDeviceName(), "STEP SIZE", "Step Size", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Reset to Factory setting
-    IUFillSwitch(&ResetS[0], "Factory", "Factory", ISS_OFF);
-    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "RESET", "Reset", FOCUS_SETTINGS_TAB, IP_RW, ISR_ATMOST1, 0,
+    ResetSP[0].fill("Factory", "Factory", ISS_OFF);
+    ResetSP.fill(getDeviceName(), "RESET", "Reset", FOCUS_SETTINGS_TAB, IP_RW, ISR_ATMOST1, 0,
                        IPS_IDLE);
 
     // Go to home/center
-    IUFillSwitch(&GotoS[GOTO_CENTER], "Center", "Center", ISS_OFF);
-    IUFillSwitch(&GotoS[GOTO_HOME], "Home", "Home", ISS_OFF);
-    IUFillSwitchVector(&GotoSP, GotoS, 2, getDeviceName(), "GOTO", "Goto", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
+    GotoSP[GOTO_CENTER].fill("Center", "Center", ISS_OFF);
+    GotoSP[GOTO_HOME].fill("Home", "Home", ISS_OFF);
+    GotoSP.fill(getDeviceName(), "GOTO", "Goto", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // List all supported models
@@ -172,25 +172,25 @@ bool FocusLynxBase::initProperties()
                        IPS_IDLE);
 
     // Status indicators
-    IUFillLight(&StatusL[STATUS_MOVING], "Is Moving", "", IPS_IDLE);
-    IUFillLight(&StatusL[STATUS_HOMING], "Is Homing", "", IPS_IDLE);
-    IUFillLight(&StatusL[STATUS_HOMED], "Is Homed", "", IPS_IDLE);
-    IUFillLight(&StatusL[STATUS_FFDETECT], "FF Detect", "", IPS_IDLE);
-    IUFillLight(&StatusL[STATUS_TMPPROBE], "Tmp Probe", "", IPS_IDLE);
-    IUFillLight(&StatusL[STATUS_REMOTEIO], "Remote IO", "", IPS_IDLE);
-    IUFillLight(&StatusL[STATUS_HNDCTRL], "Hnd Ctrl", "", IPS_IDLE);
-    IUFillLight(&StatusL[STATUS_REVERSE], "Reverse", "", IPS_IDLE);
-    IUFillLightVector(&StatusLP, StatusL, 8, getDeviceName(), "STATUS", "Status", FOCUS_STATUS_TAB, IPS_IDLE);
+    StatusLP[STATUS_MOVING].fill("Is Moving", "", IPS_IDLE);
+    StatusLP[STATUS_HOMING].fill("Is Homing", "", IPS_IDLE);
+    StatusLP[STATUS_HOMED].fill("Is Homed", "", IPS_IDLE);
+    StatusLP[STATUS_FFDETECT].fill("FF Detect", "", IPS_IDLE);
+    StatusLP[STATUS_TMPPROBE].fill("Tmp Probe", "", IPS_IDLE);
+    StatusLP[STATUS_REMOTEIO].fill("Remote IO", "", IPS_IDLE);
+    StatusLP[STATUS_HNDCTRL].fill("Hnd Ctrl", "", IPS_IDLE);
+    StatusLP[STATUS_REVERSE].fill("Reverse", "", IPS_IDLE);
+    StatusLP.fill(getDeviceName(), "STATUS", "Status", FOCUS_STATUS_TAB, IPS_IDLE);
 
     // Focus name configure in the HUB
-    IUFillText(&HFocusNameT[0], "FocusName", "Focuser name", "");
-    IUFillTextVector(&HFocusNameTP, HFocusNameT, 1, getDeviceName(), "FOCUSNAME", "Focuser", FOCUS_SETTINGS_TAB, IP_RW, 0,
+    HFocusNameTP[0].fill("FocusName", "Focuser name", "");
+    HFocusNameTP.fill(getDeviceName(), "FOCUSNAME", "Focuser", FOCUS_SETTINGS_TAB, IP_RW, 0,
                      IPS_IDLE);
 
     // Led intensity value
-    IUFillNumber(&LedN[0], "Intensity", "", "%.f", 0, 100, 5., 0.);
-    IUFillNumberVector(&LedNP, LedN, 1, getDeviceName(), "LED", "Led", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
-    //simPosition = FocusAbsPosN[0].value;
+    LedNP[0].fill("Intensity", "", "%.f", 0, 100, 5., 0.);
+    LedNP.fill(getDeviceName(), "LED", "Led", FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
+    //simPosition = FocusAbsPosNP[0].getValue();
 
     addAuxControls();
 
@@ -219,32 +219,32 @@ bool FocusLynxBase::updateProperties()
 {
     // For absolute focusers the vector is set to RO, as we get value from the HUB
     if (isAbsolute == false)
-        FocusMaxPosNP.p = IP_RW;
+        FocusMaxPosNP.setPermission(IP_RW);
     else
-        FocusMaxPosNP.p = IP_RO;
+        FocusMaxPosNP.setPermission(IP_RO);
 
     INDI::Focuser::updateProperties();
 
     if (isConnected())
     {
-        defineProperty(&HFocusNameTP);
+        defineProperty(HFocusNameTP);
 
-        defineProperty(&TemperatureNP);
-        defineProperty(&TemperatureCompensateModeSP);
-        defineProperty(&TemperatureParamNP);
-        defineProperty(&TemperatureCompensateSP);
-        defineProperty(&TemperatureCompensateOnStartSP);
+        defineProperty(TemperatureNP);
+        defineProperty(TemperatureCompensateModeSP);
+        defineProperty(TemperatureParamNP);
+        defineProperty(TemperatureCompensateSP);
+        defineProperty(TemperatureCompensateOnStartSP);
 
-        //        defineProperty(&FocusBacklashSP);
-        //        defineProperty(&FocusBacklashNP);
+        //        defineProperty(FocusBacklashSP);
+        //        defineProperty(FocusBacklashNP);
 
-        //defineProperty(&MaxTravelNP);
+        //defineProperty(MaxTravelNP);
 
-        defineProperty(&StepSizeNP);
+        defineProperty(StepSizeNP);
 
-        defineProperty(&ResetSP);
-        //defineProperty(&ReverseSP);
-        defineProperty(&StatusLP);
+        defineProperty(ResetSP);
+        //defineProperty(ReverseSP);
+        defineProperty(StatusLP);
 
         if (getFocusConfig() && getFocusTemp())
             LOG_INFO("FocusLynx parameters updated, focuser ready for use.");
@@ -256,24 +256,24 @@ bool FocusLynxBase::updateProperties()
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(TemperatureCompensateModeSP.name);
-        deleteProperty(TemperatureCompensateSP.name);
-        deleteProperty(TemperatureParamNP.name);
-        deleteProperty(TemperatureCompensateOnStartSP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(TemperatureCompensateModeSP.getName());
+        deleteProperty(TemperatureCompensateSP.getName());
+        deleteProperty(TemperatureParamNP.getName());
+        deleteProperty(TemperatureCompensateOnStartSP.getName());
 
-        //        deleteProperty(FocusBacklashSP.name);
-        //        deleteProperty(FocusBacklashNP.name);
+        //        deleteProperty(FocusBacklashSP.getName());
+        //        deleteProperty(FocusBacklashNP.getName());
 
-        //deleteProperty(MaxTravelNP.name);
-        deleteProperty(StepSizeNP.name);
+        //deleteProperty(MaxTravelNP.getName());
+        deleteProperty(StepSizeNP.getName());
 
-        deleteProperty(ResetSP.name);
-        deleteProperty(GotoSP.name);
-        //deleteProperty(ReverseSP.name);
+        deleteProperty(ResetSP.getName());
+        deleteProperty(GotoSP.getName());
+        //deleteProperty(ReverseSP.getName());
 
-        deleteProperty(StatusLP.name);
-        deleteProperty(HFocusNameTP.name);
+        deleteProperty(StatusLP.getName());
+        deleteProperty(HFocusNameTP.getName());
     }
 
     return true;
@@ -334,148 +334,148 @@ bool FocusLynxBase::ISNewSwitch(const char *dev, const char *name, ISState *stat
         }
 
         // Temperature Compensation
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
-            if (setTemperatureCompensation(TemperatureCompensateS[0].s == ISS_ON))
+            int prevIndex = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
+            if (setTemperatureCompensation(TemperatureCompensateSP[0].getState() == ISS_ON))
             {
-                TemperatureCompensateSP.s = IPS_OK;
+                TemperatureCompensateSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateSP.s           = IPS_ALERT;
-                TemperatureCompensateS[prevIndex].s = ISS_ON;
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.apply();
             return true;
         }
 
         // Temperature Compensation on Start
-        if (!strcmp(TemperatureCompensateOnStartSP.name, name))
+        if (TemperatureCompensateOnStartSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&TemperatureCompensateOnStartSP);
-            IUUpdateSwitch(&TemperatureCompensateOnStartSP, states, names, n);
-            if (setTemperatureCompensationOnStart(TemperatureCompensateOnStartS[0].s == ISS_ON))
+            int prevIndex = TemperatureCompensateOnStartSP.findOnSwitchIndex();
+            TemperatureCompensateOnStartSP.update(states, names, n);
+            if (setTemperatureCompensationOnStart(TemperatureCompensateOnStartSP[0].getState() == ISS_ON))
             {
-                TemperatureCompensateOnStartSP.s = IPS_OK;
+                TemperatureCompensateOnStartSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&TemperatureCompensateOnStartSP);
-                TemperatureCompensateOnStartSP.s           = IPS_ALERT;
-                TemperatureCompensateOnStartS[prevIndex].s = ISS_ON;
+                TemperatureCompensateOnStartSP.reset();
+                TemperatureCompensateOnStartSP.setState(IPS_ALERT);
+                TemperatureCompensateOnStartSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&TemperatureCompensateOnStartSP, nullptr);
+            TemperatureCompensateOnStartSP.apply();
             return true;
         }
 
         // Temperature Compensation Mode
-        if (!strcmp(TemperatureCompensateModeSP.name, name))
+        if (TemperatureCompensateModeSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&TemperatureCompensateModeSP);
-            IUUpdateSwitch(&TemperatureCompensateModeSP, states, names, n);
-            char mode = IUFindOnSwitchIndex(&TemperatureCompensateModeSP) + 'A';
+            int prevIndex = TemperatureCompensateModeSP.findOnSwitchIndex();
+            TemperatureCompensateModeSP.update(states, names, n);
+            char mode = TemperatureCompensateModeSP.findOnSwitchIndex() + 'A';
             if (setTemperatureCompensationMode(mode))
             {
-                TemperatureCompensateModeSP.s = IPS_OK;
+                TemperatureCompensateModeSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&TemperatureCompensateModeSP);
-                TemperatureCompensateModeSP.s           = IPS_ALERT;
-                TemperatureCompensateModeS[prevIndex].s = ISS_ON;
+                TemperatureCompensateModeSP.reset();
+                TemperatureCompensateModeSP.setState(IPS_ALERT);
+                TemperatureCompensateModeSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&TemperatureCompensateModeSP, nullptr);
+            TemperatureCompensateModeSP.apply();
             return true;
         }
 
         // Backlash enable/disable
-        //        if (!strcmp(FocusBacklashSP.name, name))
+        //        if (FocusBacklashSP.isNameMatch(name))
         //        {
-        //            int prevIndex = IUFindOnSwitchIndex(&FocusBacklashSP);
-        //            IUUpdateSwitch(&FocusBacklashSP, states, names, n);
-        //            if (setBacklashCompensation(FocusBacklashS[INDI_ENABLED].s == ISS_ON))
+        //            int prevIndex = FocusBacklashSP.findOnSwitchIndex();
+        //            FocusBacklashSP.update(states, names, n);
+        //            if (setBacklashCompensation(FocusBacklashSP[INDI_ENABLED].getState() == ISS_ON))
         //            {
-        //                FocusBacklashSP.s = IPS_OK;
+        //                FocusBacklashSP.setState(IPS_OK);
         //            }
         //            else
         //            {
-        //                IUResetSwitch(&FocusBacklashSP);
-        //                FocusBacklashSP.s           = IPS_ALERT;
-        //                FocusBacklashS[prevIndex].s = ISS_ON;
+        //                FocusBacklashSP.reset();
+        //                FocusBacklashSP.setState(IPS_ALERT);
+        //                FocusBacklashSP[prevIndex].setState(ISS_ON);
         //            }
 
-        //            IDSetSwitch(&FocusBacklashSP, nullptr);
+        //            FocusBacklashSP.apply();
         //            return true;
         //        }
 
         // Reset to Factory setting
-        if (strcmp(ResetSP.name, name) == 0)
+        if (ResetSP.isNameMatch(name))
         {
-            IUResetSwitch(&ResetSP);
+            ResetSP.reset();
             if (resetFactory())
-                ResetSP.s = IPS_OK;
+                ResetSP.setState(IPS_OK);
             else
-                ResetSP.s = IPS_ALERT;
+                ResetSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&ResetSP, nullptr);
+            ResetSP.apply();
             return true;
         }
 
         // Go to home/center
-        if (!strcmp(GotoSP.name, name))
+        if (GotoSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&GotoSP, states, names, n);
+            GotoSP.update(states, names, n);
 
-            if (GotoS[GOTO_HOME].s == ISS_ON)
+            if (GotoSP[GOTO_HOME].getState() == ISS_ON)
             {
                 if (home())
-                    GotoSP.s = IPS_BUSY;
+                    GotoSP.setState(IPS_BUSY);
                 else
-                    GotoSP.s = IPS_ALERT;
+                    GotoSP.setState(IPS_ALERT);
             }
             else
             {
                 if (center())
-                    GotoSP.s = IPS_BUSY;
+                    GotoSP.setState(IPS_BUSY);
                 else
-                    GotoSP.s = IPS_ALERT;
+                    GotoSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&GotoSP, nullptr);
+            GotoSP.apply();
             return true;
         }
 
         // Reverse Direction
-        //        if (!strcmp(ReverseSP.name, name))
+        //        if (ReverseSP.isNameMatch(name))
         //        {
-        //            IUUpdateSwitch(&ReverseSP, states, names, n);
+        //            ReverseSP.update(states, names, n);
 
-        //            if (reverse(ReverseS[0].s == ISS_ON))
-        //                ReverseSP.s = IPS_OK;
+        //            if (reverse(ReverseSP[0].getState() == ISS_ON))
+        //                ReverseSP.setState(IPS_OK);
         //            else
-        //                ReverseSP.s = IPS_ALERT;
+        //                ReverseSP.setState(IPS_ALERT);
 
-        //            IDSetSwitch(&ReverseSP, nullptr);
+        //            ReverseSP.apply();
         //            return true;
         //        }
 
         // Sync Mandatory
-        if (!strcmp(SyncMandatorySP.name, name))
+        if (SyncMandatorySP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SyncMandatorySP, states, names, n);
+            SyncMandatorySP.update(states, names, n);
 
-            if (SyncMandatory(SyncMandatoryS[0].s == ISS_ON))
-                SyncMandatorySP.s = IPS_OK;
+            if (SyncMandatory(SyncMandatorySP[0].getState() == ISS_ON))
+                SyncMandatorySP.setState(IPS_OK);
             else
-                SyncMandatorySP.s = IPS_ALERT;
+                SyncMandatorySP.setState(IPS_ALERT);
 
-            IDSetSwitch(&SyncMandatorySP, nullptr);
+            SyncMandatorySP.apply();
             return true;
         }
     }
@@ -490,14 +490,14 @@ bool FocusLynxBase::ISNewText(const char *dev, const char *name, char *texts[], 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Set device nickname to the HUB itself
-        if (!strcmp(name, HFocusNameTP.name))
+        if (HFocusNameTP.isNameMatch(name))
         {
-            IUUpdateText(&HFocusNameTP, texts, names, n);
-            if (setDeviceNickname(HFocusNameT[0].text))
-                HFocusNameTP.s = IPS_OK;
+            HFocusNameTP.update(texts, names, n);
+            if (setDeviceNickname(HFocusNameTP[0].getText()))
+                HFocusNameTP.setState(IPS_OK);
             else
-                HFocusNameTP.s = IPS_ALERT;
-            IDSetText(&HFocusNameTP, nullptr);
+                HFocusNameTP.setState(IPS_ALERT);
+            HFocusNameTP.apply();
             return true;
         }
     }
@@ -512,113 +512,113 @@ bool FocusLynxBase::ISNewNumber(const char *dev, const char *name, double values
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Coefficient & Inceptions
-        if (!strcmp(TemperatureParamNP.name, name))
+        if (TemperatureParamNP.isNameMatch(name))
         {
-            IUUpdateNumber(&TemperatureParamNP, values, names, n);
+            TemperatureParamNP.update(values, names, n);
 
-            char mode = static_cast<char>(65 + IUFindOnSwitchIndex(&TemperatureCompensateModeSP));
-            if (!setTemperatureCompensationCoeff(mode, TemperatureParamN[0].value) ||
-                    !setTemperatureInceptions(mode, TemperatureParamN[1].value))
+            char mode = static_cast<char>(65 + TemperatureCompensateModeSP.findOnSwitchIndex());
+            if (!setTemperatureCompensationCoeff(mode, TemperatureParamNP[0].getValue()) ||
+                    !setTemperatureInceptions(mode, TemperatureParamNP[1].getValue()))
             {
                 LOG_ERROR("Failed to write temperature coefficient or intercept");
-                TemperatureParamNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureParamNP, nullptr);
+                TemperatureParamNP.setState(IPS_ALERT);
+                TemperatureParamNP.apply();
                 return false;
             }
 
-            TemperatureParamNP.s = IPS_OK;
+            TemperatureParamNP.setState(IPS_OK);
             getFocusTemp();
 
             return true;
         }
 
         // Backlash Value
-        //        if (!strcmp(FocusBacklashNP.name, name))
+        //        if (FocusBacklashNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&FocusBacklashNP, values, names, n);
-        //            if (setFocusBacklashSteps(FocusBacklashN[0].value) == false)
+        //            FocusBacklashNP.update(values, names, n);
+        //            if (setFocusBacklashSteps(FocusBacklashNP[0].value) == false)
         //            {
         //                LOG_ERROR("Failed to set temperature coefficients.");
-        //                FocusBacklashNP.s = IPS_ALERT;
-        //                IDSetNumber(&FocusBacklashNP, nullptr);
+        //                FocusBacklashNP.setState(IPS_ALERT);
+        //                FocusBacklashNP.apply();
         //                return false;
         //            }
 
-        //            FocusBacklashNP.s = IPS_OK;
-        //            IDSetNumber(&FocusBacklashNP, nullptr);
+        //            FocusBacklashNP.setState(IPS_OK);
+        //            FocusBacklashNP.apply();
         //            return true;
         //        }
 
         // Sync
-        //        if (strcmp(SyncNP.name, name) == 0)
+        //        if (SyncNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&SyncNP, values, names, n);
-        //            if (sync(SyncN[0].value) == false)
+        //            SyncNP.update(values, names, n);
+        //            if (sync(SyncNP[0].value) == false)
         //            {
         //                LOG_ERROR("Failed to set the actual value.");
-        //                SyncNP.s = IPS_ALERT;
-        //                IDSetNumber(&SyncNP, nullptr);
+        //                SyncNP.setState(IPS_ALERT);
+        //                SyncNP.apply();
         //                return false;
         //            }
         //            else
-        //                SyncNP.s = IPS_OK;
+        //                SyncNP.setState(IPS_OK);
 
-        //            IDSetNumber(&SyncNP, nullptr);
+        //            SyncNP.apply();
         //            return true;
         //        }
 
         // StepSize
-        if (strcmp(StepSizeNP.name, name) == 0)
+        if (StepSizeNP.isNameMatch(name))
         {
-            IUUpdateNumber(&StepSizeNP, values, names, n);
-            if (setStepSize(StepSizeN[0].value) == false)
+            StepSizeNP.update(values, names, n);
+            if (setStepSize(StepSizeNP[0].value) == false)
             {
                 LOG_ERROR("Failed to set the actual value.");
-                StepSizeNP.s = IPS_ALERT;
-                IDSetNumber(&StepSizeNP, nullptr);
+                StepSizeNP.setState(IPS_ALERT);
+                StepSizeNP.apply();
                 return false;
             }
             else
-                StepSizeNP.s = IPS_OK;
+                StepSizeNP.setState(IPS_OK);
 
-            IDSetNumber(&StepSizeNP, nullptr);
+            StepSizeNP.apply();
             return true;
         }
 
         // Max Travel if relative focusers
-        //        if (strcmp(MaxTravelNP.name, name) == 0)
+        //        if (MaxTravelNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&MaxTravelNP, values, names, n);
+        //            MaxTravelNP.update(values, names, n);
 
-        //            if (setMaxTravel(MaxTravelN[0].value) == false)
-        //                MaxTravelNP.s = IPS_ALERT;
+        //            if (setMaxTravel(MaxTravelNP[0].value) == false)
+        //                MaxTravelNP.setState(IPS_ALERT);
         //            else
         //            {
-        //                MaxTravelNP.s = IPS_OK;
-        //                FocusAbsPosN[0].max = SyncN[0].max = MaxTravelN[0].value;
-        //                FocusAbsPosN[0].step = SyncN[0].step = (MaxTravelN[0].value / 50.0);
+        //                MaxTravelNP.setState(IPS_OK);
+        //                FocusAbsPosNP[0].setMax(SyncNP[0].setMax(MaxTravelNP[0].value));
+        //                FocusAbsPosNP[0].setStep(SyncNP[0].setStep((MaxTravelNP[0].value / 50.0)));
 
-        //                IUUpdateMinMax(&FocusAbsPosNP);
-        //                IUUpdateMinMax(&SyncNP);
+        //                FocusAbsPosNP.updateMinMax();
+        //                SyncNP.updateMinMax();
 
-        //                IDSetNumber(&MaxTravelNP, nullptr);
+        //                MaxTravelNP.apply();
 
-        //                LOGF_INFO("Focuser absolute limits: min (%g) max (%g)", FocusAbsPosN[0].min,
-        //                       FocusAbsPosN[0].max);
+        //                LOGF_INFO("Focuser absolute limits: min (%g) max (%g)", FocusAbsPosNP[0].min,
+        //                       FocusAbsPosNP[0].max);
         //            }
         //            return true;
         //        }
 
         // Set LED intensity to the HUB itself via function setLedLevel()
-        if (!strcmp(LedNP.name, name))
+        if (LedNP.isNameMatch(name))
         {
-            IUUpdateNumber(&LedNP, values, names, n);
-            if (setLedLevel(LedN[0].value))
-                LedNP.s = IPS_OK;
+            LedNP.update(values, names, n);
+            if (setLedLevel(LedNP[0].value))
+                LedNP.setState(IPS_OK);
             else
-                LedNP.s = IPS_ALERT;
-            LOGF_INFO("Focuser LED level intensity : %f", LedN[0].value);
-            IDSetNumber(&LedNP, nullptr);
+                LedNP.setState(IPS_ALERT);
+            LOGF_INFO("Focuser LED level intensity : %f", LedNP[0].getValue());
+            LedNP.apply();
             return true;
         }
     }
@@ -759,11 +759,11 @@ bool FocusLynxBase::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUSaveText(&HFocusNameT[0], nickname);
-    IDSetText(&HFocusNameTP, nullptr);
+    HFocusNameTP[0].setText(nickname);
+    HFocusNameTP.apply();
 
-    HFocusNameTP.s = IPS_OK;
-    IDSetText(&HFocusNameTP, nullptr);
+    HFocusNameTP.setState(IPS_OK);
+    HFocusNameTP.apply();
 
     memset(response, 0, sizeof(response));
 
@@ -791,25 +791,25 @@ bool FocusLynxBase::getFocusConfig()
     rc = sscanf(response, "%16[^=]=%d", key, &maxPos);
     if (rc == 2)
     {
-        FocusAbsPosN[0].min = 0;
-        FocusAbsPosN[0].max = maxPos;
-        FocusAbsPosN[0].step = maxPos / 50.0;
+        FocusAbsPosNP[0].setMin(0);
+        FocusAbsPosNP[0].setMax(maxPos);
+        FocusAbsPosNP[0].setStep(maxPos / 50.0);
 
-        FocusSyncN[0].min = 0;
-        FocusSyncN[0].max = maxPos;
-        FocusSyncN[0].step = maxPos / 50.0;
+        FocusSyncNP[0].setMin(0);
+        FocusSyncNP[0].setMax(maxPos);
+        FocusSyncNP[0].setStep(maxPos / 50.0);
 
-        FocusRelPosN[0].min  = 0;
-        FocusRelPosN[0].max  = maxPos / 2;
-        FocusRelPosN[0].step = maxPos / 100.0;
+        FocusRelPosNP[0].setMin(0);
+        FocusRelPosNP[0].setMax(maxPos / 2);
+        FocusRelPosNP[0].setStep(maxPos / 100.0);
 
-        IUUpdateMinMax(&FocusAbsPosNP);
-        IUUpdateMinMax(&FocusRelPosNP);
-        IUUpdateMinMax(&FocusSyncNP);
+        FocusAbsPosNP.updateMinMax();
+        FocusRelPosNP.updateMinMax();
+        FocusSyncNP.updateMinMax();
 
-        FocusMaxPosNP.s = IPS_OK;
-        FocusMaxPosN[0].value = maxPos;
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP.setState(IPS_OK);
+        FocusMaxPosNP[0].setValue(maxPos);
+        FocusMaxPosNP.apply();
 
     }
     else
@@ -936,7 +936,7 @@ bool FocusLynxBase::getFocusConfig()
     // Backlash Compensation
     if (isSimulation())
     {
-        snprintf(response, 32, "BLC En = %d\n", FocusBacklashS[INDI_ENABLED].s == ISS_ON ? 1 : 0);
+        snprintf(response, 32, "BLC En = %d\n", FocusBacklashSP[INDI_ENABLED].getState() == ISS_ON ? 1 : 0);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -953,11 +953,11 @@ bool FocusLynxBase::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&FocusBacklashSP);
-    FocusBacklashS[INDI_ENABLED].s  = BLCCompensate ? ISS_ON : ISS_OFF;
-    FocusBacklashS[INDI_DISABLED].s = BLCCompensate ? ISS_OFF : ISS_ON;
-    FocusBacklashSP.s   = IPS_OK;
-    IDSetSwitch(&FocusBacklashSP, nullptr);
+    FocusBacklashSP.reset();
+    FocusBacklashSP[INDI_ENABLED].setState(BLCCompensate ? ISS_ON : ISS_OFF);
+    FocusBacklashSP[INDI_DISABLED].setState(BLCCompensate ? ISS_OFF : ISS_ON);
+    FocusBacklashSP.setState(IPS_OK);
+    FocusBacklashSP.apply();
 
     // Backlash Value
     memset(response, 0, sizeof(response));
@@ -980,9 +980,9 @@ bool FocusLynxBase::getFocusConfig()
     if (rc != 2)
         return false;
 
-    FocusBacklashN[0].value = BLCValue;
-    FocusBacklashNP.s       = IPS_OK;
-    IDSetNumber(&FocusBacklashNP, nullptr);
+    FocusBacklashNP[0].setValue(BLCValue);
+    FocusBacklashNP.setState(IPS_OK);
+    FocusBacklashNP.apply();
 
     // Led brightnesss
     memset(response, 0, sizeof(response));
@@ -1005,9 +1005,9 @@ bool FocusLynxBase::getFocusConfig()
     if (rc != 2)
         return false;
 
-    LedN[0].value = LEDBrightness;
-    LedNP.s       = IPS_OK;
-    IDSetNumber(&LedNP, nullptr);
+    LedNP[0].setValue(LEDBrightness);
+    LedNP.setState(IPS_OK);
+    LedNP.apply();
 
     // Temperature Compensation on Start
     if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1132,15 +1132,15 @@ bool FocusLynxBase::getFocusStatus()
         int rc            = sscanf(response, "%16[^=]=%f", key, &temperature);
         if (rc == 2)
         {
-            TemperatureN[0].value = temperature;
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP[0].setValue(temperature);
+            TemperatureNP.apply();
         }
         else
         {
-            if (TemperatureNP.s != IPS_ALERT)
+            if (TemperatureNP.getState() != IPS_ALERT)
             {
-                TemperatureNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureNP, nullptr);
+                TemperatureNP.setState(IPS_ALERT);
+                TemperatureNP.apply();
             }
         }
 
@@ -1164,8 +1164,8 @@ bool FocusLynxBase::getFocusStatus()
         rc               = sscanf(response, "%16[^=]=%d", key, &currPos);
         if (rc == 2)
         {
-            FocusAbsPosN[0].value = currPos;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP[0].setValue(currPos);
+            FocusAbsPosNP.apply();
         }
         else
             return false;
@@ -1209,7 +1209,7 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_MOVING].s = isMoving ? IPS_BUSY : IPS_IDLE;
+        StatusLP[STATUS_MOVING].setState(isMoving ? IPS_BUSY : IPS_IDLE);
 
         // #2 is Homing?
         memset(response, 0, sizeof(response));
@@ -1232,13 +1232,13 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_HOMING].s = _isHoming ? IPS_BUSY : IPS_IDLE;
+        StatusLP[STATUS_HOMING].setState(_isHoming ? IPS_BUSY : IPS_IDLE);
         // For relative focusers home is not applicable.
         if (isAbsolute == false)
-            StatusL[STATUS_HOMING].s = IPS_IDLE;
+            StatusLP[STATUS_HOMING].setState(IPS_IDLE);
 
         // We set that isHoming in process, but we don't set it to false here it must be reset in TimerHit
-        if (StatusL[STATUS_HOMING].s == IPS_BUSY)
+        if (StatusLP[STATUS_HOMING].getState() == IPS_BUSY)
             isHoming = true;
 
         // #3 is Homed?
@@ -1262,10 +1262,10 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_HOMED].s = isHomed ? IPS_OK : IPS_IDLE;
+        StatusLP[STATUS_HOMED].setState(isHomed ? IPS_OK : IPS_IDLE);
         // For relative focusers home is not applicable.
         if (isAbsolute == false)
-            StatusL[STATUS_HOMED].s = IPS_IDLE;
+            StatusLP[STATUS_HOMED].setState(IPS_IDLE);
 
         // #4 FF Detected?
         memset(response, 0, sizeof(response));
@@ -1288,7 +1288,7 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_FFDETECT].s = FFDetect ? IPS_OK : IPS_IDLE;
+        StatusLP[STATUS_FFDETECT].setState(FFDetect ? IPS_OK : IPS_IDLE);
 
         // #5 Temperature probe?
         memset(response, 0, sizeof(response));
@@ -1311,7 +1311,7 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_TMPPROBE].s = TmpProbe ? IPS_OK : IPS_IDLE;
+        StatusLP[STATUS_TMPPROBE].setState(TmpProbe ? IPS_OK : IPS_IDLE);
 
         // #6 Remote IO?
         memset(response, 0, sizeof(response));
@@ -1334,7 +1334,7 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_REMOTEIO].s = RemoteIO ? IPS_OK : IPS_IDLE;
+        StatusLP[STATUS_REMOTEIO].setState(RemoteIO ? IPS_OK : IPS_IDLE);
 
         // #7 Hand controller?
         memset(response, 0, sizeof(response));
@@ -1357,7 +1357,7 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_HNDCTRL].s = HndCtlr ? IPS_OK : IPS_IDLE;
+        StatusLP[STATUS_HNDCTRL].setState(HndCtlr ? IPS_OK : IPS_IDLE);
 
         // #8 Reverse?
         memset(response, 0, sizeof(response));
@@ -1380,20 +1380,20 @@ bool FocusLynxBase::getFocusStatus()
         if (rc != 2)
             return false;
 
-        StatusL[STATUS_REVERSE].s = reverse ? IPS_OK : IPS_IDLE;
+        StatusLP[STATUS_REVERSE].setState(reverse ? IPS_OK : IPS_IDLE);
 
         // If reverse is enable and switch shows disabled, let's change that
         // same thing is reverse is disabled but switch is enabled
-        if ((reverse && FocusReverseS[1].s == ISS_ON) || (!reverse && FocusReverseS[0].s == ISS_ON))
+        if ((reverse && FocusReverseSP[1].s == ISS_ON) || (!reverse && FocusReverseSP[0].s == ISS_ON))
         {
-            IUResetSwitch(&FocusReverseSP);
-            FocusReverseS[0].s = (reverse == 1) ? ISS_ON : ISS_OFF;
-            FocusReverseS[1].s = (reverse == 0) ? ISS_ON : ISS_OFF;
-            IDSetSwitch(&FocusReverseSP, nullptr);
+            FocusReverseSP.reset();
+            FocusReverseSP[0].setState((reverse == 1) ? ISS_ON : ISS_OFF);
+            FocusReverseSP[1].setState((reverse == 0) ? ISS_ON : ISS_OFF);
+            FocusReverseSP.apply();
         }
 
-        StatusLP.s = IPS_OK;
-        IDSetLight(&StatusLP, nullptr);
+        StatusLP.setState(IPS_OK);
+        StatusLP.apply();
 
         // END is reached
         memset(response, 0, sizeof(response));
@@ -1487,7 +1487,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature Compensation On?
         if (isSimulation())
         {
-            snprintf(response, 32, "TComp ON = %d\n", TemperatureCompensateS[0].s == ISS_ON ? 1 : 0);
+            snprintf(response, 32, "TComp ON = %d\n", TemperatureCompensateSP[0].getState() == ISS_ON ? 1 : 0);
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1504,11 +1504,11 @@ bool FocusLynxBase::getFocusTemp()
         if (rc != 2)
             return false;
 
-        IUResetSwitch(&TemperatureCompensateSP);
-        TemperatureCompensateS[0].s = TCompOn ? ISS_ON : ISS_OFF;
-        TemperatureCompensateS[1].s = TCompOn ? ISS_OFF : ISS_ON;
-        TemperatureCompensateSP.s   = IPS_OK;
-        IDSetSwitch(&TemperatureCompensateSP, nullptr);
+        TemperatureCompensateSP.reset();
+        TemperatureCompensateSP[0].setState(TCompOn ? ISS_ON : ISS_OFF);
+        TemperatureCompensateSP[1].setState(TCompOn ? ISS_OFF : ISS_ON);
+        TemperatureCompensateSP.setState(IPS_OK);
+        TemperatureCompensateSP.apply();
 
         memset(response, 0, sizeof(response));
 
@@ -1542,27 +1542,27 @@ bool FocusLynxBase::getFocusTemp()
             }
         }
 
-        IUResetSwitch(&TemperatureCompensateModeSP);
+        TemperatureCompensateModeSP.reset();
         int index = compensateMode - 'A';
         if (index >= 0 && index <= 5)
         {
-            TemperatureCompensateModeS[index].s = ISS_ON;
-            TemperatureCompensateModeSP.s       = IPS_OK;
+            TemperatureCompensateModeSP[index].setState(ISS_ON);
+            TemperatureCompensateModeSP.setState(IPS_OK);
         }
         else
         {
             LOGF_ERROR("Invalid index %d for compensation mode.", index);
-            TemperatureCompensateModeSP.s = IPS_ALERT;
+            TemperatureCompensateModeSP.setState(IPS_ALERT);
         }
 
-        IDSetSwitch(&TemperatureCompensateModeSP, nullptr);
+        TemperatureCompensateModeSP.apply();
 
 
         // Temperature Compensation on Start
         memset(response, 0, sizeof(response));
         if (isSimulation())
         {
-            snprintf(response, 32, "TC@Start = %d\n", TemperatureCompensateOnStartS[0].s == ISS_ON ? 1 : 0);
+            snprintf(response, 32, "TC@Start = %d\n", TemperatureCompensateOnStartSP[0].getState() == ISS_ON ? 1 : 0);
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1579,16 +1579,16 @@ bool FocusLynxBase::getFocusTemp()
         if (rc != 2)
             return false;
 
-        IUResetSwitch(&TemperatureCompensateOnStartSP);
-        TemperatureCompensateOnStartS[0].s = TCOnStart ? ISS_ON : ISS_OFF;
-        TemperatureCompensateOnStartS[1].s = TCOnStart ? ISS_OFF : ISS_ON;
-        TemperatureCompensateOnStartSP.s   = IPS_OK;
-        IDSetSwitch(&TemperatureCompensateOnStartSP, nullptr);
+        TemperatureCompensateOnStartSP.reset();
+        TemperatureCompensateOnStartSP[0].setState(TCOnStart ? ISS_ON : ISS_OFF);
+        TemperatureCompensateOnStartSP[1].setState(TCOnStart ? ISS_OFF : ISS_ON);
+        TemperatureCompensateOnStartSP.setState(IPS_OK);
+        TemperatureCompensateOnStartSP.apply();
 
         // Temperature Coeff A
         if (isSimulation())
         {
-            snprintf(response, 32, "TempCo A = %d\n", static_cast<int>(TemperatureParamN[0].value));
+            snprintf(response, 32, "TempCo A = %d\n", static_cast<int>(TemperatureParamNP[0].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1598,7 +1598,7 @@ bool FocusLynxBase::getFocusTemp()
             return false;
         }
 
-        if (TemperatureCompensateModeS[0].s == ISS_ON)
+        if (TemperatureCompensateModeSP[0].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1608,14 +1608,14 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[0].value = TCoeff;
+            TemperatureParamNP[0].setValue(TCoeff);
         }
         memset(response, 0, sizeof(response));
 
         // Temperature Coeff B
         if (isSimulation())
         {
-            snprintf(response, 32, "TempCo B = %d\n", static_cast<int>(TemperatureParamN[0].value));
+            snprintf(response, 32, "TempCo B = %d\n", static_cast<int>(TemperatureParamNP[0].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1624,7 +1624,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[1].s == ISS_ON)
+        if (TemperatureCompensateModeSP[1].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1634,7 +1634,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[0].value = TCoeff;
+            TemperatureParamNP[0].setValue(TCoeff);
         }
 
         memset(response, 0, sizeof(response));
@@ -1642,7 +1642,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature Coeff C
         if (isSimulation())
         {
-            snprintf(response, 32, "TempCo C = %d\n", static_cast<int>(TemperatureParamN[0].value));
+            snprintf(response, 32, "TempCo C = %d\n", static_cast<int>(TemperatureParamNP[0].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1651,7 +1651,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[2].s == ISS_ON)
+        if (TemperatureCompensateModeSP[2].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1661,7 +1661,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[0].value = TCoeff;
+            TemperatureParamNP[0].setValue(TCoeff);
         }
 
         memset(response, 0, sizeof(response));
@@ -1669,7 +1669,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature Coeff D
         if (isSimulation())
         {
-            snprintf(response, 32, "TempCo D = %d\n", static_cast<int>(TemperatureParamN[0].value));
+            snprintf(response, 32, "TempCo D = %d\n", static_cast<int>(TemperatureParamNP[0].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1678,7 +1678,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[3].s == ISS_ON)
+        if (TemperatureCompensateModeSP[3].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1688,7 +1688,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[0].value = TCoeff;
+            TemperatureParamNP[0].setValue(TCoeff);
         }
 
         memset(response, 0, sizeof(response));
@@ -1696,7 +1696,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature Coeff E
         if (isSimulation())
         {
-            snprintf(response, 32, "TempCo E = %d\n", static_cast<int>(TemperatureParamN[0].value));
+            snprintf(response, 32, "TempCo E = %d\n", static_cast<int>(TemperatureParamNP[0].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1705,7 +1705,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[4].s == ISS_ON)
+        if (TemperatureCompensateModeSP[4].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1715,7 +1715,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[0].value = TCoeff;
+            TemperatureParamNP[0].setValue(TCoeff);
         }
 
         memset(response, 0, sizeof(response));
@@ -1723,7 +1723,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature intercepts A
         if (isSimulation())
         {
-            snprintf(response, 32, "TempIn A = %d\n", static_cast<int>(TemperatureParamN[1].value));
+            snprintf(response, 32, "TempIn A = %d\n", static_cast<int>(TemperatureParamNP[1].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1732,7 +1732,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[0].s == ISS_ON)
+        if (TemperatureCompensateModeSP[0].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1742,7 +1742,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[1].value = TInter;
+            TemperatureParamNP[1].setValue(TInter);
         }
 
         memset(response, 0, sizeof(response));
@@ -1750,7 +1750,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature intercepts B
         if (isSimulation())
         {
-            snprintf(response, 32, "TempIn B = %d\n", static_cast<int>(TemperatureParamN[1].value));
+            snprintf(response, 32, "TempIn B = %d\n", static_cast<int>(TemperatureParamNP[1].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1759,7 +1759,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[1].s == ISS_ON)
+        if (TemperatureCompensateModeSP[1].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1769,7 +1769,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[1].value = TInter;
+            TemperatureParamNP[1].setValue(TInter);
         }
 
         memset(response, 0, sizeof(response));
@@ -1777,7 +1777,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature intercepts C
         if (isSimulation())
         {
-            snprintf(response, 32, "TempIn C = %d\n", static_cast<int>(TemperatureParamN[1].value));
+            snprintf(response, 32, "TempIn C = %d\n", static_cast<int>(TemperatureParamNP[1].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1786,7 +1786,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[2].s == ISS_ON)
+        if (TemperatureCompensateModeSP[2].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1796,7 +1796,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[1].value = TInter;
+            TemperatureParamNP[1].setValue(TInter);
         }
 
         memset(response, 0, sizeof(response));
@@ -1804,7 +1804,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature intercepts D
         if (isSimulation())
         {
-            snprintf(response, 32, "TempIn D = %d\n", static_cast<int>(TemperatureParamN[1].value));
+            snprintf(response, 32, "TempIn D = %d\n", static_cast<int>(TemperatureParamNP[1].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1813,7 +1813,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[3].s == ISS_ON)
+        if (TemperatureCompensateModeSP[3].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1823,7 +1823,7 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[1].value = TInter;
+            TemperatureParamNP[1].setValue(TInter);
         }
 
         memset(response, 0, sizeof(response));
@@ -1831,7 +1831,7 @@ bool FocusLynxBase::getFocusTemp()
         // Temperature intercepts E
         if (isSimulation())
         {
-            snprintf(response, 32, "TempIn E = %d\n", static_cast<int>(TemperatureParamN[1].value));
+            snprintf(response, 32, "TempIn E = %d\n", static_cast<int>(TemperatureParamNP[1].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1840,7 +1840,7 @@ bool FocusLynxBase::getFocusTemp()
             LOGF_ERROR("%s", errmsg);
             return false;
         }
-        if (TemperatureCompensateModeS[4].s == ISS_ON)
+        if (TemperatureCompensateModeSP[4].getState() == ISS_ON)
         {
             response[nbytes_read - 1] = '\0';
             LOGF_DEBUG("RES (%s)", response);
@@ -1850,18 +1850,18 @@ bool FocusLynxBase::getFocusTemp()
             if (rc != 2)
                 return false;
 
-            TemperatureParamN[1].value = TInter;
+            TemperatureParamNP[1].setValue(TInter);
         }
 
-        TemperatureParamNP.s = IPS_OK;
-        IDSetNumber(&TemperatureParamNP, nullptr);
+        TemperatureParamNP.setState(IPS_OK);
+        TemperatureParamNP.apply();
 
         memset(response, 0, sizeof(response));
 
         // StepSize
         if (isSimulation())
         {
-            snprintf(response, 32, "StepSize = %d\n", static_cast<int>(StepSizeN[0].value));
+            snprintf(response, 32, "StepSize = %d\n", static_cast<int>(StepSizeNP[0].value));
             nbytes_read = strlen(response);
         }
         else if ((errcode = tty_read_section(PortFD, response, 0xA, LYNXFOCUS_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1878,8 +1878,8 @@ bool FocusLynxBase::getFocusTemp()
         if (rc != 2)
             return false;
 
-        StepSizeN[0].value = valueStepSize;
-        IDSetNumber(&StepSizeNP, nullptr);
+        StepSizeNP[0].setValue(valueStepSize);
+        StepSizeNP.apply();
 
         memset(response, 0, sizeof(response));
 
@@ -2118,12 +2118,12 @@ bool FocusLynxBase::home()
         strncpy(response, "H", 16);
         nbytes_read              = strlen(response) + 1;
         targetPosition           = 0;
-        //FocusAbsPosN[0].value = MaxTravelN[0].value;
-        FocusAbsPosNP.s = IPS_OK;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        //FocusAbsPosNP[0].setValue(MaxTravelNP[0].getValue());
+        FocusAbsPosNP.setState(IPS_OK);
+        FocusAbsPosNP.apply();
         simStatus[STATUS_HOMING] = ISS_ON;
         simStatus[STATUS_HOMED] = ISS_OFF;
-        simPosition = FocusAbsPosN[0].value;
+        simPosition = FocusAbsPosNP[0].getValue();
     }
     else
     {
@@ -2151,8 +2151,8 @@ bool FocusLynxBase::home()
     {
         response[nbytes_read - 1] = '\0';
         LOGF_DEBUG("RES (%s)", response);
-        FocusAbsPosNP.s = IPS_BUSY;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.setState(IPS_BUSY);
+        FocusAbsPosNP.apply();
 
         isHoming = true;
         LOG_INFO("Focuser moving to home position...");
@@ -2178,7 +2178,7 @@ bool FocusLynxBase::center()
     int nbytes_written = 0;
 
     if (isAbsolute == false)
-        return (MoveAbsFocuser(FocusAbsPosN[0].max / 2) != IPS_ALERT);
+        return (MoveAbsFocuser(FocusAbsPosNP[0].getMax() / 2) != IPS_ALERT);
 
     memset(response, 0, sizeof(response));
 
@@ -2190,7 +2190,7 @@ bool FocusLynxBase::center()
         strncpy(response, "M", 16);
         nbytes_read              = strlen(response) + 1;
         simStatus[STATUS_MOVING] = ISS_ON;
-        targetPosition           = FocusAbsPosN[0].max / 2;
+        targetPosition           = FocusAbsPosNP[0].getMax() / 2;
     }
     else
     {
@@ -2221,8 +2221,8 @@ bool FocusLynxBase::center()
 
         LOG_INFO("Focuser moving to center position...");
 
-        FocusAbsPosNP.s = IPS_BUSY;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.setState(IPS_BUSY);
+        FocusAbsPosNP.apply();
 
         tcflush(PortFD, TCIFLUSH);
 
@@ -3152,7 +3152,7 @@ IPState FocusLynxBase::MoveAbsFocuser(uint32_t targetTicks)
         response[nbytes_read - 1] = '\0';
         LOGF_DEBUG("RES (%s)", response);
 
-        FocusAbsPosNP.s = IPS_BUSY;
+        FocusAbsPosNP.setState(IPS_BUSY);
 
         tcflush(PortFD, TCIFLUSH);
 
@@ -3177,9 +3177,9 @@ IPState FocusLynxBase::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     }
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     return MoveAbsFocuser(newPosition);
 }
@@ -3213,11 +3213,11 @@ void FocusLynxBase::TimerHit()
         return;
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (isSimulation())
         {
-            if (FocusAbsPosN[0].value < targetPosition)
+            if (FocusAbsPosNP[0].value < targetPosition)
                 simPosition += 100;
             else
                 simPosition -= 100;
@@ -3226,51 +3226,51 @@ void FocusLynxBase::TimerHit()
 
             if (std::abs(static_cast<int64_t>(simPosition) - static_cast<int64_t>(targetPosition)) < 100)
             {
-                FocusAbsPosN[0].value    = targetPosition;
-                simPosition              = FocusAbsPosN[0].value;
+                FocusAbsPosNP[0].setValue(targetPosition);
+                simPosition              = FocusAbsPosNP[0].getValue();
                 simStatus[STATUS_MOVING] = ISS_OFF;
-                StatusL[STATUS_MOVING].s = IPS_IDLE;
+                StatusLP[STATUS_MOVING].setState(IPS_IDLE);
                 if (simStatus[STATUS_HOMING] == ISS_ON)
                 {
-                    StatusL[STATUS_HOMED].s = IPS_OK;
-                    StatusL[STATUS_HOMING].s = IPS_IDLE;
+                    StatusLP[STATUS_HOMED].setState(IPS_OK);
+                    StatusLP[STATUS_HOMING].setState(IPS_IDLE);
                     simStatus[STATUS_HOMING] = ISS_OFF;
                     simStatus[STATUS_HOMED] = ISS_ON;
                 }
             }
             else
-                StatusL[STATUS_MOVING].s = IPS_BUSY;
-            IDSetLight(&StatusLP, nullptr);
+                StatusLP[STATUS_MOVING].setState(IPS_BUSY);
+            StatusLP.apply();
         }
 
-        if (isHoming && StatusL[STATUS_HOMED].s == IPS_OK)
+        if (isHoming && StatusLP[STATUS_HOMED].s == IPS_OK)
         {
             isHoming = false;
-            GotoSP.s = IPS_OK;
-            IUResetSwitch(&GotoSP);
-            GotoS[GOTO_HOME].s = ISS_ON;
-            IDSetSwitch(&GotoSP, nullptr);
-            FocusAbsPosNP.s = IPS_OK;
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            GotoSP.setState(IPS_OK);
+            GotoSP.reset();
+            GotoSP[GOTO_HOME].setState(ISS_ON);
+            GotoSP.apply();
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.apply();
             LOG_INFO("Focuser reached home position.");
             if (isSimulation())
                 center();
         }
-        else if (StatusL[STATUS_MOVING].s == IPS_IDLE)
+        else if (StatusLP[STATUS_MOVING].getState() == IPS_IDLE)
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            if (GotoSP.s == IPS_BUSY)
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            if (GotoSP.getState() == IPS_BUSY)
             {
-                IUResetSwitch(&GotoSP);
-                GotoSP.s = IPS_OK;
-                IDSetSwitch(&GotoSP, nullptr);
+                GotoSP.reset();
+                GotoSP.setState(IPS_OK);
+                GotoSP.apply();
             }
             LOG_INFO("Focuser reached requested position.");
         }
-        else if (StatusL[STATUS_MOVING].s == IPS_BUSY && focusMoveRequest > 0)
+        else if (StatusLP[STATUS_MOVING].getState() == IPS_BUSY && focusMoveRequest > 0)
         {
             float remaining = calcTimeLeft(focusMoveStart, focusMoveRequest);
 
@@ -3282,10 +3282,10 @@ void FocusLynxBase::TimerHit()
             }
         }
     }
-    if (StatusL[STATUS_HOMING].s == IPS_BUSY && GotoSP.s != IPS_BUSY)
+    if (StatusLP[STATUS_HOMING].getState() == IPS_BUSY && GotoSP.getState() != IPS_BUSY)
     {
-        GotoSP.s = IPS_BUSY;
-        IDSetSwitch(&GotoSP, nullptr);
+        GotoSP.setState(IPS_BUSY);
+        GotoSP.apply();
     }
 
     SetTimer(getCurrentPollingPeriod());
@@ -3341,19 +3341,19 @@ bool FocusLynxBase::AbortFocuser()
         response[nbytes_read - 1] = '\0';
         LOGF_DEBUG("RES (%s)", response);
 
-        if (FocusRelPosNP.s == IPS_BUSY)
+        if (FocusRelPosNP.getState() == IPS_BUSY)
         {
-            FocusRelPosNP.s = IPS_IDLE;
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocusRelPosNP.setState(IPS_IDLE);
+            FocusRelPosNP.apply();
         }
 
-        FocusTimerNP.s = IPS_IDLE;
-        FocusAbsPosNP.s = IPS_IDLE;
-        GotoSP.s = IPS_IDLE;
-        IUResetSwitch(&GotoSP);
-        IDSetNumber(&FocusTimerNP, nullptr);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
-        IDSetSwitch(&GotoSP, nullptr);
+        FocusTimerNP.setState(IPS_IDLE);
+        FocusAbsPosNP.setState(IPS_IDLE);
+        GotoSP.setState(IPS_IDLE);
+        GotoSP.reset();
+        FocusTimerNP.apply();
+        FocusAbsPosNP.apply();
+        GotoSP.apply();
 
         tcflush(PortFD, TCIFLUSH);
 
@@ -3391,18 +3391,18 @@ bool FocusLynxBase::saveConfigItems(FILE *fp)
     INDI::Focuser::saveConfigItems(fp);
 
     IUSaveConfigSwitch(fp, &ModelSP);
-    IUSaveConfigSwitch(fp, &TemperatureCompensateSP);
-    IUSaveConfigSwitch(fp, &TemperatureCompensateOnStartSP);
-    //IUSaveConfigSwitch(fp, &ReverseSP);
-    IUSaveConfigNumber(fp, &TemperatureNP);
-    IUSaveConfigSwitch(fp, &TemperatureCompensateModeSP);
-    //IUSaveConfigSwitch(fp, &FocusBacklashSP);
-    //IUSaveConfigNumber(fp, &FocusBacklashNP);
-    IUSaveConfigNumber(fp, &StepSizeNP);
+    TemperatureCompensateSP.save(fp);
+    TemperatureCompensateOnStartSP.save(fp);
+    //ReverseSP.save(fp);
+    TemperatureNP.save(fp);
+    TemperatureCompensateModeSP.save(fp);
+    //FocusBacklashSP.save(fp);
+    //FocusBacklashNP.save(fp);
+    StepSizeNP.save(fp);
     if (isAbsolute == false)
     {
-        //IUSaveConfigNumber(fp, &MaxTravelNP);
-        IUSaveConfigSwitch(fp, &SyncMandatorySP);
+        //MaxTravelNP.save(fp);
+        SyncMandatorySP.save(fp);
     }
     return true;
 }
@@ -3499,8 +3499,8 @@ int FocusLynxBase::getVersion(int *major, int *minor, int *sub)
 bool FocusLynxBase::checkIfAbsoluteFocuser()
 {
     const char *focusName = IUFindOnSwitch(&ModelSP)->label;
-    deleteProperty(GotoSP.name);
-    deleteProperty(SyncMandatorySP.name);
+    deleteProperty(GotoSP.getName());
+    deleteProperty(SyncMandatorySP.getName());
 
     // Check if we have absolute or relative focusers
     if (strstr(focusName, "TCF") ||
@@ -3509,26 +3509,26 @@ bool FocusLynxBase::checkIfAbsoluteFocuser()
             !strcmp(focusName, "FeatherTouch Motor Hi-Speed"))
     {
         LOG_DEBUG("Absolute focuser detected.");
-        GotoSP.nsp = 2;
+        GotoSP.resize(2);
         isAbsolute = true;
     }
     else
     {
         LOG_DEBUG("Relative focuser detected.");
-        GotoSP.nsp = 1;
+        GotoSP.resize(1);
 
-        SyncMandatoryS[0].s = ISS_OFF;
-        SyncMandatoryS[1].s = ISS_ON;
-        defineProperty(&SyncMandatorySP);
+        SyncMandatorySP[0].setState(ISS_OFF);
+        SyncMandatorySP[1].setState(ISS_ON);
+        defineProperty(SyncMandatorySP);
 
         ISState syncEnabled = ISS_OFF;
         if (IUGetConfigSwitch(getDeviceName(), "SYNC MANDATORY", "Enable", &syncEnabled) == 0)
         {
-            SyncMandatoryS[0].s = syncEnabled;
-            SyncMandatoryS[1].s = syncEnabled == ISS_ON ? ISS_OFF : ISS_ON;
+            SyncMandatorySP[0].setState(syncEnabled);
+            SyncMandatorySP[1].setState(syncEnabled == ISS_ON ? ISS_OFF : ISS_ON);
         }
 
-        if (SyncMandatoryS[0].s == ISS_ON)
+        if (SyncMandatorySP[0].getState() == ISS_ON)
             isSynced = false;
         else
             isSynced = true;
@@ -3536,7 +3536,7 @@ bool FocusLynxBase::checkIfAbsoluteFocuser()
         isAbsolute = false;
     }
 
-    defineProperty(&GotoSP);
+    defineProperty(GotoSP);
     return isAbsolute;
 }
 

--- a/drivers/focuser/focuslynxbase.h
+++ b/drivers/focuser/focuslynxbase.h
@@ -34,6 +34,12 @@
 #include <cmath>
 #include <cstring>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
+
 #define LYNXFOCUS_MAX_RETRIES          1
 #define LYNXFOCUS_TIMEOUT              3
 #define LYNXFOCUS_MAXBUF               16
@@ -129,8 +135,7 @@ class FocusLynxBase : public INDI::Focuser
         ISwitchVectorProperty ModelSP;
 
         // Led Intensity Value
-        INumber LedN[1];
-        INumberVectorProperty LedNP;
+        INDI::PropertyNumber LedNP {1};
 
         // Store version of the firmware from the HUB
         char version[16];
@@ -183,52 +188,41 @@ class FocusLynxBase : public INDI::Focuser
         // Properties
 
         // Set/Get Temperature
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Enable/Disable temperature compensation
-        ISwitch TemperatureCompensateS[2];
-        ISwitchVectorProperty TemperatureCompensateSP;
+        INDI::PropertySwitch TemperatureCompensateSP {2};
 
         // Enable/Disable temperature compensation on start
-        ISwitch TemperatureCompensateOnStartS[2];
-        ISwitchVectorProperty TemperatureCompensateOnStartSP;
+        INDI::PropertySwitch TemperatureCompensateOnStartSP {2};
 
         // Temperature Coefficient Mode
-        ISwitch TemperatureCompensateModeS[5];
-        ISwitchVectorProperty TemperatureCompensateModeSP;
+        INDI::PropertySwitch TemperatureCompensateModeSP {5};
 
         // Temperature coefficient and Intercept for selected mode
-        INumber TemperatureParamN[2];
-        INumberVectorProperty TemperatureParamNP;
+        INDI::PropertyNumber TemperatureParamNP {2};
 
         // Reset to Factory setting
-        ISwitch ResetS[1];
-        ISwitchVectorProperty ResetSP;
+        INDI::PropertySwitch ResetSP {1};
 
         // Go to home/center
-        ISwitch GotoS[2];
-        ISwitchVectorProperty GotoSP;
+        INDI::PropertySwitch GotoSP {2};
 
         // Status indicators
-        ILight StatusL[8];
-        ILightVectorProperty StatusLP;
+        INDI::PropertyLight StatusLP {8};
 
         // Max Travel for relative focusers
-        //    INumber MaxTravelN[1];
-        //    INumberVectorProperty MaxTravelNP;
+        //    INDI::PropertyNumber MaxTravelNP {1};
+        //
 
         // Focuser Step Size
-        INumber StepSizeN[1];
-        INumberVectorProperty StepSizeNP;
+        INDI::PropertyNumber StepSizeNP {1};
 
         // Focus name configure in the HUB
-        IText HFocusNameT[1] {};
-        ITextVectorProperty HFocusNameTP;
+        INDI::PropertyText HFocusNameTP {1};
 
         // Request mandatory action of sync from user
-        ISwitch SyncMandatoryS[2];
-        ISwitchVectorProperty SyncMandatorySP;
+        INDI::PropertySwitch SyncMandatorySP {2};
 
         bool isAbsolute;
         bool isSynced;

--- a/drivers/focuser/hitecastrodcfocuser.cpp
+++ b/drivers/focuser/hitecastrodcfocuser.cpp
@@ -138,8 +138,8 @@ bool HitecAstroDCFocuser::initProperties()
     addDebugControl();
     //addSimulationControl();
 
-    //    IUFillNumber(&MaxPositionN[0], "Steps", "", "%.f", 0, 500000, 0., 10000);
-    //    IUFillNumberVector(&MaxPositionNP, MaxPositionN, 1, getDeviceName(), "MAX_POSITION", "Max position",
+    //    MaxPositionNP[0].fill("Steps", "", "%.f", 0, 500000, 0., 10000);
+    //    MaxPositionNP.fill(getDeviceName(), "MAX_POSITION", "Max position",
     //                       FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     IUFillNumber(&SlewSpeedN[0], "Steps/sec", "", "%.f", 1, 100, 0., 50);
@@ -150,15 +150,15 @@ bool HitecAstroDCFocuser::initProperties()
     //    IUFillSwitchVector(&ReverseDirectionSP, ReverseDirectionS, 1, getDeviceName(), "REVERSE_DIRECTION",
     //                       "Reverse direction", OPTIONS_TAB, IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
 
-    FocusSpeedN[0].value = 100.;
-    FocusSpeedN[0].min   = 1.;
-    FocusSpeedN[0].max   = 100.;
-    FocusSpeedN[0].value = 100.;
+    FocusSpeedNP[0].setValue(100.);
+    FocusSpeedNP[0].setMin(1.);
+    FocusSpeedNP[0].setMax(100.);
+    FocusSpeedNP[0].setValue(100.);
 
-    FocusRelPosN[0].min   = 1;
-    FocusRelPosN[0].max   = 50000;
-    FocusRelPosN[0].step  = 1000;
-    FocusRelPosN[0].value = 1000;
+    FocusRelPosNP[0].setMin(1);
+    FocusRelPosNP[0].setMax(50000);
+    FocusRelPosNP[0].setStep(1000);
+    FocusRelPosNP[0].setValue(1000);
 
     setDefaultPollingPeriod(500);
 
@@ -171,13 +171,13 @@ bool HitecAstroDCFocuser::updateProperties()
 
     if (isConnected())
     {
-        //defineProperty(&MaxPositionNP);
+        //defineProperty(MaxPositionNP);
         defineProperty(&SlewSpeedNP);
         //defineProperty(&ReverseDirectionSP);
     }
     else
     {
-        //deleteProperty(MaxPositionNP.name);
+        //deleteProperty(MaxPositionNP.getName());
         deleteProperty(SlewSpeedNP.name);
         //deleteProperty(ReverseDirectionSP.name);
     }
@@ -212,11 +212,11 @@ bool HitecAstroDCFocuser::ISNewNumber(const char *dev, const char *name, double 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        //        if (strcmp(name, MaxPositionNP.name) == 0)
+        //        if (MaxPositionNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&MaxPositionNP, values, names, n);
-        //            MaxPositionNP.s = IPS_OK;
-        //            IDSetNumber(&MaxPositionNP, nullptr);
+        //            MaxPositionNP.update(values, names, n);
+        //            MaxPositionNP.setState(IPS_OK);
+        //            MaxPositionNP.apply();
         //            return true;
         //        }
         if (strcmp(name, SlewSpeedNP.name) == 0)
@@ -250,8 +250,8 @@ IPState HitecAstroDCFocuser::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
         return IPS_ALERT;
     }
 
-    //    FocusRelPosNP.s = IPS_BUSY;
-    //    IDSetNumber(&FocusRelPosNP, nullptr);
+    //    FocusRelPosNP.setState(IPS_BUSY);
+    //    FocusRelPosNP.apply();
 
     // JM 2017-03-16: iticks is not used, FIXME.
     //    if (dir == FOCUS_INWARD)
@@ -260,7 +260,7 @@ IPState HitecAstroDCFocuser::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     //    }
 
     //if (ReverseDirectionS[0].s == ISS_ON)
-    if (FocusReverseS[INDI_ENABLED].s == ISS_ON)
+    if (FocusReverseSP[INDI_ENABLED].getState() == ISS_ON)
     {
         dir = dir == FOCUS_INWARD ? FOCUS_OUTWARD : FOCUS_INWARD;
     }
@@ -294,7 +294,7 @@ IPState HitecAstroDCFocuser::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
         return IPS_ALERT;
     }
 
-    //FocusRelPosNP.s = IPS_BUSY;
+    //FocusRelPosNP.setState(IPS_BUSY);
 
     memset(command, 0, 8);
     hid_read_timeout(m_HIDHandle, command, 8, HID_TIMEOUT);
@@ -303,8 +303,8 @@ IPState HitecAstroDCFocuser::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 
     rval = command[1] == 0x21 ? IPS_OK : IPS_ALERT;
 
-    //FocusRelPosNP.s = rval;
-    //IDSetNumber(&FocusRelPosNP, nullptr);
+    //FocusRelPosNP.setState(rval);
+    //FocusRelPosNP.apply();
 
     return rval;
 }
@@ -322,10 +322,10 @@ IPState HitecAstroDCFocuser::MoveFocuser(FocusDirection dir, int speed, uint16_t
         return IPS_ALERT;
     }
 
-    FocusSpeedNP.s = IPS_BUSY;
-    IDSetNumber(&FocusSpeedNP, nullptr);
+    FocusSpeedNP.setState(IPS_BUSY);
+    FocusSpeedNP.apply();
 
-    if (FocusReverseS[INDI_ENABLED].s == ISS_ON)
+    if (FocusReverseSP[INDI_ENABLED].getState() == ISS_ON)
     {
         dir = (dir == FOCUS_INWARD) ? FOCUS_OUTWARD : FOCUS_INWARD;
     }
@@ -365,8 +365,8 @@ IPState HitecAstroDCFocuser::MoveFocuser(FocusDirection dir, int speed, uint16_t
 
     rval = command[1] == 0x24 ? IPS_OK : IPS_ALERT;
 
-    FocusSpeedNP.s = rval;
-    IDSetNumber(&FocusSpeedNP, nullptr);
+    FocusSpeedNP.setState(rval);
+    FocusSpeedNP.apply();
 
     m_Duration = duration;
     m_State    = SLEWING;
@@ -378,7 +378,7 @@ bool HitecAstroDCFocuser::saveConfigItems(FILE *fp)
 {
     INDI::Focuser::saveConfigItems(fp);
 
-    //IUSaveConfigNumber(fp, &MaxPositionNP);
+    //MaxPositionNP.save(fp);
     IUSaveConfigNumber(fp, &SlewSpeedNP);
     //IUSaveConfigSwitch(fp, &ReverseDirectionSP);
 

--- a/drivers/focuser/lakeside.cpp
+++ b/drivers/focuser/lakeside.cpp
@@ -112,83 +112,83 @@ bool Lakeside::initProperties()
     INDI::Focuser::initProperties();
 
     // Current Direction
-    //    IUFillSwitch(&MoveDirectionS[0], "Normal", "", ISS_ON);
-    //    IUFillSwitch(&MoveDirectionS[1], "Reverse", "", ISS_OFF);
-    //    IUFillSwitchVector(&MoveDirectionSP, MoveDirectionS, 2, getDeviceName(), "","Move Direction", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    //    MoveDirectionSP[0].fill("Normal", "", ISS_ON);
+    //    MoveDirectionSP[1].fill("Reverse", "", ISS_OFF);
+    //    MoveDirectionSP.fill(getDeviceName(), "","Move Direction", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Focuser temperature (degrees C) - read only
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%3.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature (C)", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%3.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature (C)", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Focuser temperature (Kelvin)- read only & only read once at connect
-    IUFillNumber(&TemperatureKN[0], "TEMPERATUREK", "Kelvin", "%3.2f", 0., 373.15, 0., 0.);
-    IUFillNumberVector(&TemperatureKNP, TemperatureKN, 1, getDeviceName(), "FOCUS_TEMPERATUREK", "Temperature (K)", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    TemperatureKNP[0].fill("TEMPERATUREK", "Kelvin", "%3.2f", 0., 373.15, 0., 0.);
+    TemperatureKNP.fill(getDeviceName(), "FOCUS_TEMPERATUREK", "Temperature (K)", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureTrackingS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&TemperatureTrackingS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&TemperatureTrackingSP, TemperatureTrackingS, 2, getDeviceName(), "Temperature Track", "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    TemperatureTrackingSP[0].fill("Enable", "", ISS_OFF);
+    TemperatureTrackingSP[1].fill("Disable", "", ISS_ON);
+    TemperatureTrackingSP.fill(getDeviceName(), "Temperature Track", "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Backlash 0-255
-    //    IUFillNumber(&FocusBacklashN[0], "BACKLASH", "(0-255)", "%.f", 0, 255, 0, 0);
-    //    IUFillNumberVector(&FocusBacklashNP, FocusBacklashN, 1, getDeviceName(), "BACKLASH", "Backlash", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
-    FocusBacklashN[0].min = 0;
-    FocusBacklashN[0].max = 255;
-    FocusBacklashN[0].step = 10;
-    FocusBacklashN[0].value = 0;
+    //    FocusBacklashNP[0].fill("BACKLASH", "(0-255)", "%.f", 0, 255, 0, 0);
+    //    FocusBacklashNP.fill(getDeviceName(), "BACKLASH", "Backlash", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
+    FocusBacklashNP[0].setMin(0);
+    FocusBacklashNP[0].setMax(255);
+    FocusBacklashNP[0].setStep(10);
+    FocusBacklashNP[0].setValue(0);
 
     // Maximum Travel - read only
-    //    IUFillNumber(&MaxTravelN[0], "MAXTRAVEL", "No. Steps", "%.f", 1, 65536, 0, 10000);
-    //    IUFillNumberVector(&MaxTravelNP, MaxTravelN, 1, getDeviceName(), "MAXTRAVEL", "Max travel(Via Ctrlr)", SETTINGS_TAB, IP_RO, 0, IPS_IDLE );
-    FocusMaxPosNP.p = IP_RO;
+    //    MaxTravelNP[0].fill("MAXTRAVEL", "No. Steps", "%.f", 1, 65536, 0, 10000);
+    //    MaxTravelNP.fill(getDeviceName(), "MAXTRAVEL", "Max travel(Via Ctrlr)", SETTINGS_TAB, IP_RO, 0, IPS_IDLE );
+    FocusMaxPosNP.setPermission(IP_RO);
 
     // Step Size - read only
-    IUFillNumber(&StepSizeN[0], "STEPSIZE", "No. Steps", "%.f", 1, 65536, 0, 1);
-    IUFillNumberVector(&StepSizeNP, StepSizeN, 1, getDeviceName(), "STEPSIZE", "Step Size(Via Ctrlr)", SETTINGS_TAB, IP_RO, 0, IPS_IDLE);
+    StepSizeNP[0].fill("STEPSIZE", "No. Steps", "%.f", 1, 65536, 0, 1);
+    StepSizeNP.fill(getDeviceName(), "STEPSIZE", "Step Size(Via Ctrlr)", SETTINGS_TAB, IP_RO, 0, IPS_IDLE);
 
     // Active Temperature Slope - select 1 or 2
-    IUFillSwitch(&ActiveTemperatureSlopeS[0], "Slope 1", "", ISS_ON);
-    IUFillSwitch(&ActiveTemperatureSlopeS[1], "Slope 2", "", ISS_OFF);
-    IUFillSwitchVector(&ActiveTemperatureSlopeSP, ActiveTemperatureSlopeS, 2, getDeviceName(), "Active Slope", "Active Slope", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    ActiveTemperatureSlopeSP[0].fill("Slope 1", "", ISS_ON);
+    ActiveTemperatureSlopeSP[1].fill("Slope 2", "", ISS_OFF);
+    ActiveTemperatureSlopeSP.fill(getDeviceName(), "Active Slope", "Active Slope", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Slope 1 : Directions
-    IUFillSwitch(&Slope1DirS[0], "0", "", ISS_ON);
-    IUFillSwitch(&Slope1DirS[1], "1", "", ISS_OFF);
-    IUFillSwitchVector(&Slope1DirSP, Slope1DirS, 2, getDeviceName(), "Slope 1 Direction", "Slope 1 Direction", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    Slope1DirSP[0].fill("0", "", ISS_ON);
+    Slope1DirSP[1].fill("1", "", ISS_OFF);
+    Slope1DirSP.fill(getDeviceName(), "Slope 1 Direction", "Slope 1 Direction", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Slope 1 : Slope Increments (counts per degree, 0.1 step increments
-    IUFillNumber(&Slope1IncN[0], "SLOPE1INC", "No. Steps (0-655356", "%.f", 0, 65536, 0, 0);
-    IUFillNumberVector(&Slope1IncNP, Slope1IncN, 1, getDeviceName(), "SLOPE1INC", "Slope1 Increments", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
+    Slope1IncNP[0].fill("SLOPE1INC", "No. Steps (0-655356", "%.f", 0, 65536, 0, 0);
+    Slope1IncNP.fill(getDeviceName(), "SLOPE1INC", "Slope1 Increments", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
 
     // slope 1 : Deadband - value between 0 and 255
-    IUFillNumber(&Slope1DeadbandN[0], "SLOPE1DEADBAND", "(0-255)", "%.f", 0, 255, 0, 0);
-    IUFillNumberVector(&Slope1DeadbandNP, Slope1DeadbandN, 1, getDeviceName(), "SLOPE1DEADBAND", "Slope 1 Deadband", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
+    Slope1DeadbandNP[0].fill("SLOPE1DEADBAND", "(0-255)", "%.f", 0, 255, 0, 0);
+    Slope1DeadbandNP.fill(getDeviceName(), "SLOPE1DEADBAND", "Slope 1 Deadband", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
 
     // Slope 1 : Time Period (Minutes, 0.1 step increments
-    IUFillNumber(&Slope1PeriodN[0], "SLOPE1PERIOD", "Minutes (0-99)", "%.f", 0, 99, 0, 0);
-    IUFillNumberVector(&Slope1PeriodNP, Slope1PeriodN, 1, getDeviceName(), "SLOPE1PERIOD", "Slope 1 Period", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
+    Slope1PeriodNP[0].fill("SLOPE1PERIOD", "Minutes (0-99)", "%.f", 0, 99, 0, 0);
+    Slope1PeriodNP.fill(getDeviceName(), "SLOPE1PERIOD", "Slope 1 Period", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
 
     // Slope 2 : Direction
-    IUFillSwitch(&Slope2DirS[0], "0", "", ISS_ON);
-    IUFillSwitch(&Slope2DirS[1], "1", "", ISS_OFF);
-    IUFillSwitchVector(&Slope2DirSP, Slope2DirS, 2, getDeviceName(), "Slope 2 Direction", "", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    Slope2DirSP[0].fill("0", "", ISS_ON);
+    Slope2DirSP[1].fill("1", "", ISS_OFF);
+    Slope2DirSP.fill(getDeviceName(), "Slope 2 Direction", "", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // slope 2 : Slope Increments (counts per degree, 0.1 step increments
-    IUFillNumber(&Slope2IncN[0], "SLOPE2INC", "No. Steps (0-65536)", "%.f", 0, 65536, 0, 0);
-    IUFillNumberVector(&Slope2IncNP, Slope2IncN, 1, getDeviceName(), "SLOPE2INC", "Slope 2 Increments", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
+    Slope2IncNP[0].fill("SLOPE2INC", "No. Steps (0-65536)", "%.f", 0, 65536, 0, 0);
+    Slope2IncNP.fill(getDeviceName(), "SLOPE2INC", "Slope 2 Increments", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
 
     // slope 2 : Deadband - value between 0 and 255
-    IUFillNumber(&Slope2DeadbandN[0], "SLOPE2DEADBAND", "Steps (0-255)", "%.f", 0, 255, 0, 0);
-    IUFillNumberVector(&Slope2DeadbandNP, Slope2DeadbandN, 1, getDeviceName(), "SLOPE2DEADBAND", "Slope 2 Deadband", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
+    Slope2DeadbandNP[0].fill("SLOPE2DEADBAND", "Steps (0-255)", "%.f", 0, 255, 0, 0);
+    Slope2DeadbandNP.fill(getDeviceName(), "SLOPE2DEADBAND", "Slope 2 Deadband", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
 
     // slope 2 : Time Period (Minutes, 0.1 step increments)
-    IUFillNumber(&Slope2PeriodN[0], "SLOPE2PERIOD", "Minutes (0-99)", "%.f", 0, 99, 0, 0);
-    IUFillNumberVector(&Slope2PeriodNP, Slope2PeriodN, 1, getDeviceName(), "SLOPE2PERIOD", "Slope 2 Period", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
+    Slope2PeriodNP[0].fill("SLOPE2PERIOD", "Minutes (0-99)", "%.f", 0, 99, 0, 0);
+    Slope2PeriodNP.fill(getDeviceName(), "SLOPE2PERIOD", "Slope 2 Period", SETTINGS_TAB, IP_RW, 0, IPS_IDLE );
 
-    FocusAbsPosN[0].min = 0.;
+    FocusAbsPosNP[0].setMin(0.);
 
     // shephpj - not used
-    //FocusAbsPosN[0].max = 65536.;
+    //FocusAbsPosNP[0].setMax(65536.);
 
     setDefaultPollingPeriod(1000);
 
@@ -204,22 +204,22 @@ bool Lakeside::updateProperties()
 
     if (isConnected())
     {
-        //defineProperty(&FocusBacklashNP);
-        //defineProperty(&MaxTravelNP);
-        defineProperty(&StepSizeNP);
-        defineProperty(&TemperatureNP);
-        defineProperty(&TemperatureKNP);
-        //defineProperty(&MoveDirectionSP);
-        defineProperty(&TemperatureTrackingSP);
-        defineProperty(&ActiveTemperatureSlopeSP);
-        defineProperty(&Slope1DirSP);
-        defineProperty(&Slope1IncNP);
-        defineProperty(&Slope1DeadbandNP);
-        defineProperty(&Slope1PeriodNP);
-        defineProperty(&Slope2DirSP);
-        defineProperty(&Slope2IncNP);
-        defineProperty(&Slope2DeadbandNP);
-        defineProperty(&Slope2PeriodNP);
+        //defineProperty(FocusBacklashNP);
+        //defineProperty(MaxTravelNP);
+        defineProperty(StepSizeNP);
+        defineProperty(TemperatureNP);
+        defineProperty(TemperatureKNP);
+        //defineProperty(MoveDirectionSP);
+        defineProperty(TemperatureTrackingSP);
+        defineProperty(ActiveTemperatureSlopeSP);
+        defineProperty(Slope1DirSP);
+        defineProperty(Slope1IncNP);
+        defineProperty(Slope1DeadbandNP);
+        defineProperty(Slope1PeriodNP);
+        defineProperty(Slope2DirSP);
+        defineProperty(Slope2IncNP);
+        defineProperty(Slope2DeadbandNP);
+        defineProperty(Slope2PeriodNP);
 
         GetFocusParams();
 
@@ -227,22 +227,22 @@ bool Lakeside::updateProperties()
     }
     else
     {
-        //deleteProperty(FocusBacklashNP.name);
-        //deleteProperty(MaxTravelNP.name);
-        deleteProperty(StepSizeNP.name);
-        //deleteProperty(MoveDirectionSP.name);
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(TemperatureKNP.name);
-        deleteProperty(TemperatureTrackingSP.name);
-        deleteProperty(ActiveTemperatureSlopeSP.name);
-        deleteProperty(Slope1DirSP.name);
-        deleteProperty(Slope1IncNP.name);
-        deleteProperty(Slope1DeadbandNP.name);
-        deleteProperty(Slope1PeriodNP.name);
-        deleteProperty(Slope2DirSP.name);
-        deleteProperty(Slope2IncNP.name);
-        deleteProperty(Slope2DeadbandNP.name);
-        deleteProperty(Slope2PeriodNP.name);
+        //deleteProperty(FocusBacklashNP.getName());
+        //deleteProperty(MaxTravelNP.getName());
+        deleteProperty(StepSizeNP.getName());
+        //deleteProperty(MoveDirectionSP.getName());
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(TemperatureKNP.getName());
+        deleteProperty(TemperatureTrackingSP.getName());
+        deleteProperty(ActiveTemperatureSlopeSP.getName());
+        deleteProperty(Slope1DirSP.getName());
+        deleteProperty(Slope1IncNP.getName());
+        deleteProperty(Slope1DeadbandNP.getName());
+        deleteProperty(Slope1PeriodNP.getName());
+        deleteProperty(Slope2DirSP.getName());
+        deleteProperty(Slope2IncNP.getName());
+        deleteProperty(Slope2DeadbandNP.getName());
+        deleteProperty(Slope2PeriodNP.getName());
     }
 
     return true;
@@ -422,7 +422,7 @@ bool Lakeside::updateMoveDirection()
         return false;
     }
 
-    //IUResetSwitch(&MoveDirectionSP);
+    //MoveDirectionSP.reset();
 
     // direction is in form Dnnnnn#
     // where nnnnn is 0 for normal or 1 for reversed
@@ -430,12 +430,12 @@ bool Lakeside::updateMoveDirection()
 
     if ( temp == 0)
     {
-        FocusReverseS[INDI_DISABLED].s = ISS_ON;
+        FocusReverseSP[INDI_DISABLED].setState(ISS_ON);
         LOGF_DEBUG("updateMoveDirection: Move Direction is (%d)", temp);
     }
     else if ( temp == 1)
     {
-        FocusReverseS[INDI_ENABLED].s = ISS_ON;
+        FocusReverseSP[INDI_ENABLED].setState(ISS_ON);
         LOGF_DEBUG("updateMoveDirection: Move Direction is (%d)", temp);
     }
     else
@@ -449,9 +449,9 @@ bool Lakeside::updateMoveDirection()
 
 // Decode contents of buffer
 // Returns:
-//          P : Position update found - FocusAbsPosN[0].value updated
-//          T : Temperature update found - TemperatureN[0].value
-//          K : Temperature in Kelvin update found - TemperatureKN[0].value
+//          P : Position update found - FocusAbsPosNP[0].value updated
+//          T : Temperature update found - TemperatureNP[0].value
+//          K : Temperature in Kelvin update found - TemperatureKNP[0].value
 //          D : DONE# received
 //          O : OK# received
 //          E : Error due to unknown/misformed command having been sent
@@ -483,7 +483,7 @@ char Lakeside::DecodeBuffer(char * in_response)
     // Temperature update is Tnnnnnn# where nnnnn is left space padded
     if (!strcmp("TN/A#", in_response))
     {
-        TemperatureNP.s = IPS_IDLE;
+        TemperatureNP.setState(IPS_IDLE);
         return 'T';
     }
     else
@@ -492,8 +492,8 @@ char Lakeside::DecodeBuffer(char * in_response)
         if (rc > 0)
         {
             // need to divide result by 2
-            TemperatureN[0].value = ((int) temp) / 2.0;
-            LOGF_DEBUG("DecodeBuffer: Result (%3.1f)", TemperatureN[0].value);
+            TemperatureNP[0].setValue(((int) temp) / 2.0);
+            LOGF_DEBUG("DecodeBuffer: Result (%3.1f)", TemperatureNP[0].getValue());
 
             return 'T';
         }
@@ -504,8 +504,8 @@ char Lakeside::DecodeBuffer(char * in_response)
     if (rc > 0)
     {
         // need to divide result by 2
-        TemperatureKN[0].value = ((int) temp) / 2.00;
-        LOGF_DEBUG("DecodeBuffer: Result (%3.2f)", TemperatureKN[0].value);
+        TemperatureKNP[0].setValue(((int) temp) / 2.00);
+        LOGF_DEBUG("DecodeBuffer: Result (%3.2f)", TemperatureKNP[0].getValue());
 
         return 'K';
     }
@@ -515,8 +515,8 @@ char Lakeside::DecodeBuffer(char * in_response)
     // focuser position returned Pnnnnn#
     if (rc > 0)
     {
-        FocusAbsPosN[0].value = pos;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setValue(pos);
+        FocusAbsPosNP.apply();
 
         LOGF_DEBUG("DecodeBuffer: Returned position (%d)", pos);
         return 'P';
@@ -666,7 +666,7 @@ bool Lakeside::updateBacklash()
 
     if ( temp >= 0)
     {
-        FocusBacklashN[0].value = temp;
+        FocusBacklashNP[0].setValue(temp);
         LOGF_DEBUG("updateBacklash: Backlash is (%d)", temp);
     }
     else
@@ -701,7 +701,7 @@ bool Lakeside::updateSlope1Inc()
 
     if ( temp >= 0)
     {
-        Slope1IncN[0].value = temp;
+        Slope1IncNP[0].setValue(temp);
         LOGF_DEBUG("updateSlope1Inc: Slope 1 Increments is (%d)", temp);
     }
     else
@@ -736,7 +736,7 @@ bool Lakeside::updateSlope2Inc()
 
     if ( temp >= 0)
     {
-        Slope2IncN[0].value = temp;
+        Slope2IncNP[0].setValue(temp);
         LOGF_DEBUG("updateSlope2Inc: Slope 2 Increments is (%d)", temp);
     }
     else
@@ -771,12 +771,12 @@ bool Lakeside::updateSlope1Dir()
 
     if ( temp == 0)
     {
-        Slope1DirS[0].s = ISS_ON;
+        Slope1DirSP[0].setState(ISS_ON);
         LOGF_DEBUG("updateSlope1Dir: Slope 1 Direction is (%d)", temp);
     }
     else if ( temp == 1)
     {
-        Slope1DirS[1].s = ISS_ON;
+        Slope1DirSP[1].setState(ISS_ON);
     }
     else
     {
@@ -810,12 +810,12 @@ bool Lakeside::updateSlope2Dir()
 
     if ( temp == 0)
     {
-        Slope2DirS[0].s = ISS_ON;
+        Slope2DirSP[0].setState(ISS_ON);
         LOGF_DEBUG("updateSlope2Dir: Slope 2 Direction is (%d)", temp);
     }
     else if ( temp == 1)
     {
-        Slope2DirS[1].s = ISS_ON;
+        Slope2DirSP[1].setState(ISS_ON);
     }
     else
     {
@@ -849,7 +849,7 @@ bool Lakeside::updateSlope1Deadband()
 
     if ( temp >= 0)
     {
-        Slope1DeadbandN[0].value = temp;
+        Slope1DeadbandNP[0].setValue(temp);
         LOGF_DEBUG("updateSlope1Deadband: Slope 1 Deadband is (%d)", temp);
     }
     else
@@ -884,7 +884,7 @@ bool Lakeside::updateSlope2Deadband()
 
     if ( temp >= 0)
     {
-        Slope2DeadbandN[0].value = temp;
+        Slope2DeadbandNP[0].setValue(temp);
         LOGF_DEBUG("updateSlope2Deadband: Slope 2 Deadband is (%d)", temp);
     }
     else
@@ -919,7 +919,7 @@ bool Lakeside::updateSlope1Period()
 
     if ( temp >= 0)
     {
-        Slope1PeriodN[0].value = temp;
+        Slope1PeriodNP[0].setValue(temp);
         LOGF_DEBUG("updateSlope1Period: Slope 1 Period is (%d)", temp);
     }
     else
@@ -954,7 +954,7 @@ bool Lakeside::updateSlope2Period()
 
     if ( temp >= 0)
     {
-        Slope2PeriodN[0].value = temp;
+        Slope2PeriodNP[0].setValue(temp);
         LOGF_DEBUG("updateSlope2Period: Slope 2 Period is (%d)", temp);
     }
     else
@@ -989,7 +989,7 @@ bool Lakeside::updateMaxTravel()
 
     if ( temp > 0)
     {
-        FocusMaxPosN[0].value = temp;
+        FocusMaxPosNP[0].setValue(temp);
         LOGF_DEBUG("updateMaxTravel: MaxTravel is (%d)", temp);
     }
     else
@@ -1026,7 +1026,7 @@ bool Lakeside::updateStepSize()
 
     if ( temp > 0)
     {
-        StepSizeN[0].value = temp;
+        StepSizeNP[0].setValue(temp);
         LOGF_DEBUG("updateStepSize: step size is (%d)", temp);
     }
     else
@@ -1055,13 +1055,13 @@ bool Lakeside::gotoPosition(uint32_t position)
     // Lakeside only uses move NNNNN steps - goto step not available.
     // calculate as steps to move = current position - new position
     // if -ve then move out, else +ve moves in
-    calc_steps = FocusAbsPosN[0].value - position;
+    calc_steps = FocusAbsPosNP[0].getValue() - position;
 
-    // MaxTravelN[0].value is set by "calibrate" via the control box, & read at connect
-    if ( position > FocusMaxPosN[0].value )
+    // MaxTravelNP[0].value is set by "calibrate" via the control box, & read at connect
+    if ( position > FocusMaxPosNP[0].getValue() )
     {
-        LOGF_ERROR("Position requested (%ld) is out of bounds between %g and %g", position, FocusAbsPosN[0].min, FocusMaxPosN[0].value);
-        FocusAbsPosNP.s = IPS_ALERT;
+        LOGF_ERROR("Position requested (%ld) is out of bounds between %g and %g", position, FocusAbsPosNP[0].min, FocusMaxPosNP[0].getValue());
+        FocusAbsPosNP.setState(IPS_ALERT);
         return false;
     }
 
@@ -1083,7 +1083,7 @@ bool Lakeside::gotoPosition(uint32_t position)
         {
             // Zero == no steps to move
             LOGF_DEBUG("MoveFocuser: No steps to move. calc_steps = %d", calc_steps);
-            FocusAbsPosNP.s = IPS_OK;
+            FocusAbsPosNP.setState(IPS_OK);
             return false;
         }
 
@@ -1092,14 +1092,14 @@ bool Lakeside::gotoPosition(uint32_t position)
 
     if (!SendCmd(cmd))
     {
-        FocusAbsPosNP.s = IPS_ALERT;
+        FocusAbsPosNP.setState(IPS_ALERT);
         return false;
     }
     else
         LOGF_DEBUG("MoveFocuser: Sent cmd (%s)", cmd);
 
     // At this point, the move command has been sent, so set BUSY & return true
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
     return true;
 }
 
@@ -1617,74 +1617,74 @@ bool Lakeside::ISNewSwitch (const char * dev, const char * name, ISState * state
     if(strcmp(dev, getDeviceName()) == 0)
     {
         // Move Direction
-        //        if (!strcmp(MoveDirectionSP.name, name))
+        //        if (MoveDirectionSP.isNameMatch(name))
         //        {
         //            bool rc=false;
-        //            int current_mode = IUFindOnSwitchIndex(&MoveDirectionSP);
-        //            IUUpdateSwitch(&MoveDirectionSP, states, names, n);
-        //            int target_mode = IUFindOnSwitchIndex(&MoveDirectionSP);
+        //            int current_mode = MoveDirectionSP.findOnSwitchIndex();
+        //            MoveDirectionSP.update(states, names, n);
+        //            int target_mode = MoveDirectionSP.findOnSwitchIndex();
         //            if (current_mode == target_mode)
         //            {
-        //                MoveDirectionSP.s = IPS_OK;
-        //                IDSetSwitch(&MoveDirectionSP, nullptr);
+        //                MoveDirectionSP.setState(IPS_OK);
+        //                MoveDirectionSP.apply();
         //            }
         //            // switch will be either 0 for normal or 1 for reverse
         //            rc = setMoveDirection(target_mode);
 
         //            if (rc == false)
         //            {
-        //                IUResetSwitch(&MoveDirectionSP);
-        //                MoveDirectionS[current_mode].s = ISS_ON;
-        //                MoveDirectionSP.s = IPS_ALERT;
-        //                IDSetSwitch(&MoveDirectionSP, nullptr);
+        //                MoveDirectionSP.reset();
+        //                MoveDirectionSP[current_mode].setState(ISS_ON);
+        //                MoveDirectionSP.setState(IPS_ALERT);
+        //                MoveDirectionSP.apply();
         //                return false;
         //            }
 
-        //            MoveDirectionSP.s = IPS_OK;
-        //            IDSetSwitch(&MoveDirectionSP, nullptr);
+        //            MoveDirectionSP.setState(IPS_OK);
+        //            MoveDirectionSP.apply();
         //            return true;
         //        }
 
         // Temperature Tracking
-        if (!strcmp(TemperatureTrackingSP.name, name))
+        if (TemperatureTrackingSP.isNameMatch(name))
         {
-            int last_index = IUFindOnSwitchIndex(&TemperatureTrackingSP);
-            IUUpdateSwitch(&TemperatureTrackingSP, states, names, n);
+            int last_index = TemperatureTrackingSP.findOnSwitchIndex();
+            TemperatureTrackingSP.update(states, names, n);
 
-            bool rc = setTemperatureTracking((TemperatureTrackingS[0].s == ISS_ON));
+            bool rc = setTemperatureTracking((TemperatureTrackingSP[0].getState() == ISS_ON));
 
             if (rc == false)
             {
-                TemperatureTrackingSP.s = IPS_ALERT;
-                IUResetSwitch(&TemperatureTrackingSP);
-                TemperatureTrackingS[last_index].s = ISS_ON;
-                IDSetSwitch(&TemperatureTrackingSP, nullptr);
+                TemperatureTrackingSP.setState(IPS_ALERT);
+                TemperatureTrackingSP.reset();
+                TemperatureTrackingSP[last_index].setState(ISS_ON);
+                TemperatureTrackingSP.apply();
                 return false;
             }
 
-            TemperatureTrackingSP.s = IPS_OK;
-            IDSetSwitch(&TemperatureTrackingSP, nullptr);
+            TemperatureTrackingSP.setState(IPS_OK);
+            TemperatureTrackingSP.apply();
 
             return true;
         }
 
         // Active Temperature Slope
-        if (!strcmp(ActiveTemperatureSlopeSP.name, name))
+        if (ActiveTemperatureSlopeSP.isNameMatch(name))
         {
             bool rc = false;
-            int current_slope = IUFindOnSwitchIndex(&ActiveTemperatureSlopeSP);
+            int current_slope = ActiveTemperatureSlopeSP.findOnSwitchIndex();
             // current slope Selection will be either 1 or 2
             // Need to add 1 to array index, as it starts at 0
             current_slope++;
-            IUUpdateSwitch(&ActiveTemperatureSlopeSP, states, names, n);
-            int target_slope = IUFindOnSwitchIndex(&ActiveTemperatureSlopeSP);
+            ActiveTemperatureSlopeSP.update(states, names, n);
+            int target_slope = ActiveTemperatureSlopeSP.findOnSwitchIndex();
             // target slope Selection will be either 1 or 2
             // Need to add 1 to array index, as it starts at 0
             target_slope++;
             if (current_slope == target_slope)
             {
-                ActiveTemperatureSlopeSP.s = IPS_OK;
-                IDSetSwitch(&ActiveTemperatureSlopeSP, nullptr);
+                ActiveTemperatureSlopeSP.setState(IPS_OK);
+                ActiveTemperatureSlopeSP.apply();
             }
 
             rc = setActiveTemperatureSlope(target_slope);
@@ -1692,82 +1692,82 @@ bool Lakeside::ISNewSwitch (const char * dev, const char * name, ISState * state
             if (rc == false)
             {
                 current_slope--;
-                IUResetSwitch(&ActiveTemperatureSlopeSP);
-                ActiveTemperatureSlopeS[current_slope].s = ISS_ON;
-                ActiveTemperatureSlopeSP.s = IPS_ALERT;
-                IDSetSwitch(&ActiveTemperatureSlopeSP, nullptr);
+                ActiveTemperatureSlopeSP.reset();
+                ActiveTemperatureSlopeSP[current_slope].setState(ISS_ON);
+                ActiveTemperatureSlopeSP.setState(IPS_ALERT);
+                ActiveTemperatureSlopeSP.apply();
                 return false;
             }
 
-            ActiveTemperatureSlopeSP.s = IPS_OK;
-            IDSetSwitch(&ActiveTemperatureSlopeSP, nullptr);
+            ActiveTemperatureSlopeSP.setState(IPS_OK);
+            ActiveTemperatureSlopeSP.apply();
             return true;
         }
 
         // Slope 1 direction - either 0 or 1
-        if (!strcmp(Slope1DirSP.name, name))
+        if (Slope1DirSP.isNameMatch(name))
         {
             bool rc = false;
-            int current_slope_dir1 = IUFindOnSwitchIndex(&Slope1DirSP);
+            int current_slope_dir1 = Slope1DirSP.findOnSwitchIndex();
             // current slope 1 Direction will be either 0 or 1
 
-            IUUpdateSwitch(&Slope1DirSP, states, names, n);
-            int target_slope_dir1 = IUFindOnSwitchIndex(&Slope1DirSP);
+            Slope1DirSP.update(states, names, n);
+            int target_slope_dir1 = Slope1DirSP.findOnSwitchIndex();
             // target slope Selection will be either 0 or 1
 
             if (current_slope_dir1 == target_slope_dir1)
             {
-                Slope1DirSP.s = IPS_OK;
-                IDSetSwitch(&Slope1DirSP, nullptr);
+                Slope1DirSP.setState(IPS_OK);
+                Slope1DirSP.apply();
             }
 
             rc = setSlope1Dir(target_slope_dir1);
 
             if (rc == false)
             {
-                IUResetSwitch(&Slope1DirSP);
-                Slope1DirS[current_slope_dir1].s = ISS_ON;
-                Slope1DirSP.s = IPS_ALERT;
-                IDSetSwitch(&Slope1DirSP, nullptr);
+                Slope1DirSP.reset();
+                Slope1DirSP[current_slope_dir1].setState(ISS_ON);
+                Slope1DirSP.setState(IPS_ALERT);
+                Slope1DirSP.apply();
                 return false;
             }
 
-            Slope1DirSP.s = IPS_OK;
-            IDSetSwitch(&Slope1DirSP, nullptr);
+            Slope1DirSP.setState(IPS_OK);
+            Slope1DirSP.apply();
             return true;
         }
     }
 
     // Slope 2 direction - either 0 or 1
-    if (!strcmp(Slope2DirSP.name, name))
+    if (Slope2DirSP.isNameMatch(name))
     {
         bool rc = false;
-        int current_slope_dir2 = IUFindOnSwitchIndex(&Slope2DirSP);
+        int current_slope_dir2 = Slope2DirSP.findOnSwitchIndex();
         // current slope 2 Direction will be either 0 or 1
 
-        IUUpdateSwitch(&Slope2DirSP, states, names, n);
-        int target_slope_dir2 = IUFindOnSwitchIndex(&Slope2DirSP);
+        Slope2DirSP.update(states, names, n);
+        int target_slope_dir2 = Slope2DirSP.findOnSwitchIndex();
         // target slope 2 Selection will be either 0 or 1
 
         if (current_slope_dir2 == target_slope_dir2)
         {
-            Slope2DirSP.s = IPS_OK;
-            IDSetSwitch(&Slope2DirSP, nullptr);
+            Slope2DirSP.setState(IPS_OK);
+            Slope2DirSP.apply();
         }
 
         rc = setSlope2Dir(target_slope_dir2);
 
         if (rc == false)
         {
-            IUResetSwitch(&Slope2DirSP);
-            Slope2DirS[current_slope_dir2].s = ISS_ON;
-            Slope2DirSP.s = IPS_ALERT;
-            IDSetSwitch(&Slope2DirSP, nullptr);
+            Slope2DirSP.reset();
+            Slope2DirSP[current_slope_dir2].setState(ISS_ON);
+            Slope2DirSP.setState(IPS_ALERT);
+            Slope2DirSP.apply();
             return false;
         }
 
-        Slope2DirSP.s = IPS_OK;
-        IDSetSwitch(&Slope2DirSP, nullptr);
+        Slope2DirSP.setState(IPS_OK);
+        Slope2DirSP.apply();
         return true;
     }
 
@@ -1784,16 +1784,16 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
     if(strcmp(dev, getDeviceName()) == 0)
     {
         //        // max travel - read only
-        //        if (!strcmp (name, MaxTravelNP.name))
+        //        if (MaxTravelNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&MaxTravelNP, values, names, n);
-        //            MaxTravelNP.s = IPS_OK;
-        //            IDSetNumber(&MaxTravelNP, nullptr);
+        //            MaxTravelNP.update(values, names, n);
+        //            MaxTravelNP.setState(IPS_OK);
+        //            MaxTravelNP.apply();
         //            return true;
         //        }
 
         // Backlash compensation
-        //        if (!strcmp (name, FocusBacklashNP.name))
+        //        if (FocusBacklashNP.isNameMatch(name))
         //        {
         //            int new_back = 0 ;
         //            int nset = 0;
@@ -1801,10 +1801,10 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         //            for (nset = i = 0; i < n; i++)
         //            {
         //                //Find numbers with the passed names in SetFocusBacklashNP property
-        //                INumber * eqp = IUFindNumber (&FocusBacklashNP, names[i]);
+        //                INumber * eqp = FocusBacklashNP.findWidgetByName(names[i]);
 
-        //                //If the number found is Backlash (FocusBacklashN[0]) then process it
-        //                if (eqp == &FocusBacklashN[0])
+        //                //If the number found is Backlash (FocusBacklashNP[0]) then process it
+        //                if (eqp == &FocusBacklashNP[0])
         //                {
 
         //                    new_back = (values[i]);
@@ -1816,29 +1816,29 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         //                {
 
         //                    // Set the Lakeside state to BUSY
-        //                    FocusBacklashNP.s = IPS_BUSY;
-        //                    IDSetNumber(&FocusBacklashNP, nullptr);
+        //                    FocusBacklashNP.setState(IPS_BUSY);
+        //                    FocusBacklashNP.apply();
 
         //                    if( !setBacklash(new_back))
         //                    {
 
-        //                        FocusBacklashNP.s = IPS_IDLE;
-        //                        IDSetNumber(&FocusBacklashNP, "Setting new backlash failed.");
+        //                        FocusBacklashNP.setState(IPS_IDLE);
+        //                        FocusBacklashNP.apply("Setting new backlash failed.");
 
         //                        return false ;
         //                    }
 
-        //                    FocusBacklashNP.s = IPS_OK;
-        //                    FocusBacklashN[0].value = new_back;
-        //                    IDSetNumber(&FocusBacklashNP, nullptr);
+        //                    FocusBacklashNP.setState(IPS_OK);
+        //                    FocusBacklashNP[0].setValue(new_back);
+        //                    FocusBacklashNP.apply();
 
         //                    return true;
         //                }
         //                else
         //                {
 
-        //                    FocusBacklashNP.s = IPS_IDLE;
-        //                    IDSetNumber(&FocusBacklashNP, "Need exactly one parameter.");
+        //                    FocusBacklashNP.setState(IPS_IDLE);
+        //                    FocusBacklashNP.apply("Need exactly one parameter.");
 
         //                    return false ;
         //                }
@@ -1847,16 +1847,16 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         //        }
 
         // Step size - read only
-        if (!strcmp (name, StepSizeNP.name))
+        if (StepSizeNP.isNameMatch(name))
         {
-            IUUpdateNumber(&StepSizeNP, values, names, n);
-            StepSizeNP.s = IPS_OK;
-            IDSetNumber(&StepSizeNP, nullptr);
+            StepSizeNP.update(values, names, n);
+            StepSizeNP.setState(IPS_OK);
+            StepSizeNP.apply();
             return true;
         }
 
         // Slope 1 Increments
-        if (!strcmp (name, Slope1IncNP.name))
+        if (Slope1IncNP.isNameMatch(name))
         {
             int new_Slope1Inc = 0 ;
             int nset = 0;
@@ -1864,10 +1864,10 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
             for (nset = i = 0; i < n; i++)
             {
                 //Find numbers with the passed names in SetSlope1IncNP property
-                INumber * eqp = IUFindNumber (&Slope1IncNP, names[i]);
+                INumber * eqp = Slope1IncNP.findWidgetByName(names[i]);
 
-                //If the number found is Slope1Inc (Slope1IncN[0]) then process it
-                if (eqp == &Slope1IncN[0])
+                //If the number found is Slope1Inc (Slope1IncNP[0]) then process it
+                if (eqp == &Slope1IncNP[0])
                 {
 
                     new_Slope1Inc = (values[i]);
@@ -1879,29 +1879,29 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
                 {
 
                     // Set the Lakeside state to BUSY
-                    Slope1IncNP.s = IPS_BUSY;
-                    IDSetNumber(&Slope1IncNP, nullptr);
+                    Slope1IncNP.setState(IPS_BUSY);
+                    Slope1IncNP.apply();
 
                     if( !setSlope1Inc(new_Slope1Inc))
                     {
 
-                        Slope1IncNP.s = IPS_IDLE;
-                        IDSetNumber(&Slope1IncNP, "Setting new Slope1 increment failed.");
+                        Slope1IncNP.setState(IPS_IDLE);
+                        Slope1IncNP.apply("Setting new Slope1 increment failed.");
 
                         return false ;
                     }
 
-                    Slope1IncNP.s = IPS_OK;
-                    Slope1IncN[0].value = new_Slope1Inc;
-                    IDSetNumber(&Slope1IncNP, nullptr) ;
+                    Slope1IncNP.setState(IPS_OK);
+                    Slope1IncNP[0].setValue(new_Slope1Inc);
+                    Slope1IncNP.apply(nullptr) ;
 
                     return true;
                 }
                 else
                 {
 
-                    Slope1IncNP.s = IPS_IDLE;
-                    IDSetNumber(&Slope1IncNP, "Need exactly one parameter.");
+                    Slope1IncNP.setState(IPS_IDLE);
+                    Slope1IncNP.apply("Need exactly one parameter.");
 
                     return false ;
                 }
@@ -1910,7 +1910,7 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         }
 
         // Slope 2 Increments
-        if (!strcmp (name, Slope2IncNP.name))
+        if (Slope2IncNP.isNameMatch(name))
         {
             int new_Slope2Inc = 0 ;
             int nset = 0;
@@ -1918,10 +1918,10 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
             for (nset = i = 0; i < n; i++)
             {
                 //Find numbers with the passed names in SetSlope2IncNP property
-                INumber * eqp = IUFindNumber (&Slope2IncNP, names[i]);
+                INumber * eqp = Slope2IncNP.findWidgetByName(names[i]);
 
-                //If the number found is Slope2Inc (Slope2IncN[0]) then process it
-                if (eqp == &Slope2IncN[0])
+                //If the number found is Slope2Inc (Slope2IncNP[0]) then process it
+                if (eqp == &Slope2IncNP[0])
                 {
 
                     new_Slope2Inc = (values[i]);
@@ -1933,29 +1933,29 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
                 {
 
                     // Set the Lakeside state to BUSY
-                    Slope2IncNP.s = IPS_BUSY;
-                    IDSetNumber(&Slope2IncNP, nullptr);
+                    Slope2IncNP.setState(IPS_BUSY);
+                    Slope2IncNP.apply();
 
                     if( !setSlope2Inc(new_Slope2Inc))
                     {
 
-                        Slope2IncNP.s = IPS_IDLE;
-                        IDSetNumber(&Slope2IncNP, "Setting new Slope2 increment failed.");
+                        Slope2IncNP.setState(IPS_IDLE);
+                        Slope2IncNP.apply("Setting new Slope2 increment failed.");
 
                         return false ;
                     }
 
-                    Slope2IncNP.s = IPS_OK;
-                    Slope2IncN[0].value = new_Slope2Inc;
-                    IDSetNumber(&Slope2IncNP, nullptr);
+                    Slope2IncNP.setState(IPS_OK);
+                    Slope2IncNP[0].setValue(new_Slope2Inc);
+                    Slope2IncNP.apply();
 
                     return true;
                 }
                 else
                 {
 
-                    Slope2IncNP.s = IPS_IDLE;
-                    IDSetNumber(&Slope2IncNP, "Need exactly one parameter.");
+                    Slope2IncNP.setState(IPS_IDLE);
+                    Slope2IncNP.apply("Need exactly one parameter.");
 
                     return false ;
                 }
@@ -1964,7 +1964,7 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         }
 
         // Slope 1 Deadband
-        if (!strcmp (name, Slope1DeadbandNP.name))
+        if (Slope1DeadbandNP.isNameMatch(name))
         {
             int new_Slope1Deadband = 0 ;
             int nset = 0;
@@ -1972,10 +1972,10 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
             for (nset = i = 0; i < n; i++)
             {
                 //Find numbers with the passed names in SetSlope1DeadbandNP property
-                INumber * eqp = IUFindNumber (&Slope1DeadbandNP, names[i]);
+                INumber * eqp = Slope1DeadbandNP.findWidgetByName(names[i]);
 
-                //If the number found is Slope1Deadband (Slope1DeadbandN[0]) then process it
-                if (eqp == &Slope1DeadbandN[0])
+                //If the number found is Slope1Deadband (Slope1DeadbandNP[0]) then process it
+                if (eqp == &Slope1DeadbandNP[0])
                 {
 
                     new_Slope1Deadband = (values[i]);
@@ -1987,29 +1987,29 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
                 {
 
                     // Set the Lakeside state to BUSY
-                    Slope1DeadbandNP.s = IPS_BUSY;
-                    IDSetNumber(&Slope1DeadbandNP, nullptr);
+                    Slope1DeadbandNP.setState(IPS_BUSY);
+                    Slope1DeadbandNP.apply();
 
                     if( !setSlope1Deadband(new_Slope1Deadband))
                     {
 
-                        Slope1DeadbandNP.s = IPS_IDLE;
-                        IDSetNumber(&Slope1DeadbandNP, "Setting new Slope 1 Deadband failed.");
+                        Slope1DeadbandNP.setState(IPS_IDLE);
+                        Slope1DeadbandNP.apply("Setting new Slope 1 Deadband failed.");
 
                         return false ;
                     }
 
-                    Slope1DeadbandNP.s = IPS_OK;
-                    Slope1DeadbandN[0].value = new_Slope1Deadband;
-                    IDSetNumber(&Slope1DeadbandNP, nullptr) ;
+                    Slope1DeadbandNP.setState(IPS_OK);
+                    Slope1DeadbandNP[0].setValue(new_Slope1Deadband);
+                    Slope1DeadbandNP.apply(nullptr) ;
 
                     return true;
                 }
                 else
                 {
 
-                    Slope1DeadbandNP.s = IPS_IDLE;
-                    IDSetNumber(&Slope1DeadbandNP, "Need exactly one parameter.");
+                    Slope1DeadbandNP.setState(IPS_IDLE);
+                    Slope1DeadbandNP.apply("Need exactly one parameter.");
 
                     return false ;
                 }
@@ -2018,7 +2018,7 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         }
 
         // Slope 2 Deadband
-        if (!strcmp (name, Slope2DeadbandNP.name))
+        if (Slope2DeadbandNP.isNameMatch(name))
         {
             int new_Slope2Deadband = 0 ;
             int nset = 0;
@@ -2026,10 +2026,10 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
             for (nset = i = 0; i < n; i++)
             {
                 //Find numbers with the passed names in SetSlope2DeadbandNP property
-                INumber * eqp = IUFindNumber (&Slope2DeadbandNP, names[i]);
+                INumber * eqp = Slope2DeadbandNP.findWidgetByName(names[i]);
 
-                //If the number found is Slope2Deadband (Slope2DeadbandN[0]) then process it
-                if (eqp == &Slope2DeadbandN[0])
+                //If the number found is Slope2Deadband (Slope2DeadbandNP[0]) then process it
+                if (eqp == &Slope2DeadbandNP[0])
                 {
 
                     new_Slope2Deadband = (values[i]);
@@ -2041,29 +2041,29 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
                 {
 
                     // Set the Lakeside state to BUSY
-                    Slope2DeadbandNP.s = IPS_BUSY;
-                    IDSetNumber(&Slope2DeadbandNP, nullptr);
+                    Slope2DeadbandNP.setState(IPS_BUSY);
+                    Slope2DeadbandNP.apply();
 
                     if( !setSlope2Deadband(new_Slope2Deadband))
                     {
 
-                        Slope2DeadbandNP.s = IPS_IDLE;
-                        IDSetNumber(&Slope2DeadbandNP, "Setting new Slope 2 Deadband failed.");
+                        Slope2DeadbandNP.setState(IPS_IDLE);
+                        Slope2DeadbandNP.apply("Setting new Slope 2 Deadband failed.");
 
                         return false ;
                     }
 
-                    Slope2DeadbandNP.s = IPS_OK;
-                    Slope2DeadbandN[0].value = new_Slope2Deadband;
-                    IDSetNumber(&Slope2DeadbandNP, nullptr) ;
+                    Slope2DeadbandNP.setState(IPS_OK);
+                    Slope2DeadbandNP[0].setValue(new_Slope2Deadband);
+                    Slope2DeadbandNP.apply(nullptr) ;
 
                     return true;
                 }
                 else
                 {
 
-                    Slope2DeadbandNP.s = IPS_IDLE;
-                    IDSetNumber(&Slope2DeadbandNP, "Need exactly one parameter.");
+                    Slope2DeadbandNP.setState(IPS_IDLE);
+                    Slope2DeadbandNP.apply("Need exactly one parameter.");
 
                     return false ;
                 }
@@ -2072,7 +2072,7 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         }
 
         // Slope 1 Period Minutes
-        if (!strcmp (name, Slope1PeriodNP.name))
+        if (Slope1PeriodNP.isNameMatch(name))
         {
             int new_Slope1Period = 0 ;
             int nset = 0;
@@ -2080,10 +2080,10 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
             for (nset = i = 0; i < n; i++)
             {
                 //Find numbers with the passed names in SetSlope1PeriodNP property
-                INumber * eqp = IUFindNumber (&Slope1PeriodNP, names[i]);
+                INumber * eqp = Slope1PeriodNP.findWidgetByName(names[i]);
 
-                //If the number found is Slope1Period (Slope1PeriodN[0]) then process it
-                if (eqp == &Slope1PeriodN[0])
+                //If the number found is Slope1Period (Slope1PeriodNP[0]) then process it
+                if (eqp == &Slope1PeriodNP[0])
                 {
 
                     new_Slope1Period = (values[i]);
@@ -2095,29 +2095,29 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
                 {
 
                     // Set the Lakeside state to BUSY
-                    Slope1PeriodNP.s = IPS_BUSY;
-                    IDSetNumber(&Slope1PeriodNP, nullptr);
+                    Slope1PeriodNP.setState(IPS_BUSY);
+                    Slope1PeriodNP.apply();
 
                     if( !setSlope1Period(new_Slope1Period))
                     {
 
-                        Slope1PeriodNP.s = IPS_IDLE;
-                        IDSetNumber(&Slope1PeriodNP, "Setting new Slope 1 Period failed.");
+                        Slope1PeriodNP.setState(IPS_IDLE);
+                        Slope1PeriodNP.apply("Setting new Slope 1 Period failed.");
 
                         return false ;
                     }
 
-                    Slope1PeriodNP.s = IPS_OK;
-                    Slope1PeriodN[0].value = new_Slope1Period;
-                    IDSetNumber(&Slope1PeriodNP, nullptr);
+                    Slope1PeriodNP.setState(IPS_OK);
+                    Slope1PeriodNP[0].setValue(new_Slope1Period);
+                    Slope1PeriodNP.apply();
 
                     return true;
                 }
                 else
                 {
 
-                    Slope1PeriodNP.s = IPS_IDLE;
-                    IDSetNumber(&Slope1PeriodNP, "Need exactly one parameter.");
+                    Slope1PeriodNP.setState(IPS_IDLE);
+                    Slope1PeriodNP.apply("Need exactly one parameter.");
 
                     return false ;
                 }
@@ -2126,7 +2126,7 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
         }
 
         // Slope 2 Period Minutes
-        if (!strcmp (name, Slope2PeriodNP.name))
+        if (Slope2PeriodNP.isNameMatch(name))
         {
             int new_Slope2Period = 0 ;
             int nset = 0;
@@ -2134,10 +2134,10 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
             for (nset = i = 0; i < n; i++)
             {
                 //Find numbers with the passed names in SetSlope2PeriodNP property
-                INumber * eqp = IUFindNumber (&Slope2PeriodNP, names[i]);
+                INumber * eqp = Slope2PeriodNP.findWidgetByName(names[i]);
 
-                //If the number found is Slope2Period (Slope2PeriodN[0]) then process it
-                if (eqp == &Slope2PeriodN[0])
+                //If the number found is Slope2Period (Slope2PeriodNP[0]) then process it
+                if (eqp == &Slope2PeriodNP[0])
                 {
 
                     new_Slope2Period = (values[i]);
@@ -2149,29 +2149,29 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
                 {
 
                     // Set the Lakeside state to BUSY
-                    Slope2PeriodNP.s = IPS_BUSY;
-                    IDSetNumber(&Slope2PeriodNP, nullptr);
+                    Slope2PeriodNP.setState(IPS_BUSY);
+                    Slope2PeriodNP.apply();
 
                     if( !setSlope2Period(new_Slope2Period))
                     {
 
-                        Slope2PeriodNP.s = IPS_IDLE;
-                        IDSetNumber(&Slope2PeriodNP, "Setting new Slope 2 Period failed.");
+                        Slope2PeriodNP.setState(IPS_IDLE);
+                        Slope2PeriodNP.apply("Setting new Slope 2 Period failed.");
 
                         return false ;
                     }
 
-                    Slope2PeriodNP.s = IPS_OK;
-                    Slope2PeriodN[0].value = new_Slope2Period;
-                    IDSetNumber(&Slope2PeriodNP, nullptr);
+                    Slope2PeriodNP.setState(IPS_OK);
+                    Slope2PeriodNP[0].setValue(new_Slope2Period);
+                    Slope2PeriodNP.apply();
 
                     return true;
                 }
                 else
                 {
 
-                    Slope2PeriodNP.s = IPS_IDLE;
-                    IDSetNumber(&Slope2PeriodNP, "Need exactly one parameter.");
+                    Slope2PeriodNP.setState(IPS_IDLE);
+                    Slope2PeriodNP.apply("Need exactly one parameter.");
 
                     return false ;
                 }
@@ -2189,56 +2189,56 @@ bool Lakeside::ISNewNumber (const char * dev, const char * name, double values[]
 void Lakeside::GetFocusParams ()
 {
     if (updatePosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (updateTemperature())
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 
     // This is currently the only time Kelvin is read - just a nice to have
     if (updateTemperatureK())
-        IDSetNumber(&TemperatureKNP, nullptr);
+        TemperatureKNP.apply();
 
     if (updateBacklash())
-        IDSetNumber(&FocusBacklashNP, nullptr);
+        FocusBacklashNP.apply();
 
     if (updateMaxTravel())
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP.apply();
 
     if (updateStepSize())
-        IDSetNumber(&StepSizeNP, nullptr);
+        StepSizeNP.apply();
 
     if (updateMoveDirection())
-        IDSetSwitch(&FocusReverseSP, nullptr);
+        FocusReverseSP.apply();
 
     if (updateSlope1Inc())
-        IDSetNumber(&Slope1IncNP, nullptr);
+        Slope1IncNP.apply();
 
     if (updateSlope2Inc())
-        IDSetNumber(&Slope2IncNP, nullptr);
+        Slope2IncNP.apply();
 
     if (updateSlope1Dir())
-        IDSetSwitch(&Slope1DirSP, nullptr);
+        Slope1DirSP.apply();
 
     if (updateSlope2Dir())
-        IDSetSwitch(&Slope2DirSP, nullptr);
+        Slope2DirSP.apply();
 
     if (updateSlope1Deadband())
-        IDSetNumber(&Slope1DeadbandNP, nullptr);
+        Slope1DeadbandNP.apply();
 
     if (updateSlope2Deadband())
-        IDSetNumber(&Slope2DeadbandNP, nullptr);
+        Slope2DeadbandNP.apply();
 
     if (updateSlope1Period())
-        IDSetNumber(&Slope1PeriodNP, nullptr);
+        Slope1PeriodNP.apply();
 
     if (updateSlope1Period())
-        IDSetNumber(&Slope2PeriodNP, nullptr);
+        Slope2PeriodNP.apply();
 
 }
 
 IPState Lakeside::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
-    return MoveAbsFocuser(dir == FOCUS_INWARD ? FocusAbsPosN[0].value - ticks : FocusAbsPosN[0].value + ticks);
+    return MoveAbsFocuser(dir == FOCUS_INWARD ? FocusAbsPosNP[0].getValue() - ticks : FocusAbsPosNP[0].getValue() + ticks);
 }
 
 //
@@ -2269,7 +2269,7 @@ void Lakeside::TimerHit()
     }
 
     // focuser supposedly moving...
-    if (FocusAbsPosNP.s == IPS_BUSY )
+    if (FocusAbsPosNP.getState() == IPS_BUSY )
     {
         // Get actual status from focuser
         // Note: GetLakesideStatus sends position count when moving.
@@ -2284,30 +2284,30 @@ void Lakeside::TimerHit()
         {
             // no longer moving, so reset state to IPS_OK or IDLE?
             // IPS_OK turns light green
-            FocusAbsPosNP.s = IPS_OK;
+            FocusAbsPosNP.setState(IPS_OK);
             // update position
             // This is necessary in case user clicks short step moves in quick succession
             // Lakeside will abort move if command received during move
             rc = updatePosition();
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            LOGF_INFO("Focuser reached requested position %.f", FocusAbsPosN[0].value);
+            FocusAbsPosNP.apply();
+            LOGF_INFO("Focuser reached requested position %.f", FocusAbsPosNP[0].getValue());
         }
     }
 
     // focuser not moving, get temperature updates instead
-    if (FocusAbsPosNP.s == IPS_OK || FocusAbsPosNP.s == IPS_IDLE)
+    if (FocusAbsPosNP.getState() == IPS_OK || FocusAbsPosNP.getState() == IPS_IDLE)
     {
         // Get a temperature
         rc = updateTemperature();
-        if (rc && fabs(lastTemperature - TemperatureN[0].value) > TEMPERATURE_THRESHOLD)
+        if (rc && fabs(lastTemperature - TemperatureNP[0].getValue()) > TEMPERATURE_THRESHOLD)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
     // IPS_ALERT - any alert situation generated
-    //    if ( FocusAbsPosNP.s == IPS_ALERT )
+    //    if ( FocusAbsPosNP.getState() == IPS_ALERT )
     //    {
     //        LOG_DEBUG("TimerHit: Focuser state = IPS_ALERT");
     //    }
@@ -2377,7 +2377,7 @@ bool Lakeside::GetLakesideStatus()
         rc = updatePosition();
 
         // IPS_IDLE turns off light, IPS_OK turns light green
-        FocusAbsPosNP.s = IPS_OK;
+        FocusAbsPosNP.setState(IPS_OK);
 
         // return false as focuser is not known to be moving
         return false;
@@ -2391,8 +2391,8 @@ bool Lakeside::GetLakesideStatus()
         rc = sscanf(resp, "P%5d#", &pos);
         LOGF_INFO("Focuser Moving... position : %d", pos);
         // Update current position
-        FocusAbsPosN[0].value = pos;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setValue(pos);
+        FocusAbsPosNP.apply();
 
         // return true as focuser IS moving
         return true;
@@ -2405,7 +2405,7 @@ bool Lakeside::GetLakesideStatus()
         // return false as focuser is not known to be moving
 
         // IPS_IDLE turns off light, IPS_OK turns light green
-        FocusAbsPosNP.s = IPS_OK;
+        FocusAbsPosNP.setState(IPS_OK);
 
         return false;
     }
@@ -2417,14 +2417,14 @@ bool Lakeside::GetLakesideStatus()
         // return false as focuser is not known to be moving
 
         // IPS_IDLE turns off light, IPS_OK turns light green
-        FocusAbsPosNP.s = IPS_OK;
+        FocusAbsPosNP.setState(IPS_OK);
 
         return false;
     }
 
     // At this point, something else is returned
     LOGF_DEBUG("GetLakesideStatus: Unknown response from buffer read : (%s)", resp);
-    FocusAbsPosNP.s = IPS_OK;
+    FocusAbsPosNP.setState(IPS_OK);
 
     // return false as focuser is not known to be moving
     return false;
@@ -2443,8 +2443,8 @@ bool Lakeside::AbortFocuser()
     if (SendCmd(cmd))
     {
         // IPS_IDLE turns off light, IPS_OK turns light green
-        FocusAbsPosNP.s = IPS_IDLE;
-        FocusAbsPosNP.s = IPS_OK;
+        FocusAbsPosNP.setState(IPS_IDLE);
+        FocusAbsPosNP.setState(IPS_OK);
         LOG_INFO("Focuser Abort Sent");
         return true;
     }

--- a/drivers/focuser/lakeside.h
+++ b/drivers/focuser/lakeside.h
@@ -27,6 +27,10 @@
 
 #include <cstdint>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class Lakeside : public INDI::Focuser
 {
     public:
@@ -104,53 +108,39 @@ class Lakeside : public INDI::Focuser
 
         void hexDump(char * buf, const char * data, int size);
 
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
-        INumber TemperatureKN[1];
-        INumberVectorProperty TemperatureKNP;
+        INDI::PropertyNumber TemperatureKNP {1};
 
-        //    ISwitch MoveDirectionS[2];
-        //    ISwitchVectorProperty MoveDirectionSP;
+        //    INDI::PropertySwitch MoveDirectionSP {2};
+        //
 
-        INumber StepSizeN[1];
-        INumberVectorProperty StepSizeNP;
+        INDI::PropertyNumber StepSizeNP {1};
 
-        //    INumber BacklashN[1];
-        //    INumberVectorProperty BacklashNP;
+        //    INDI::PropertyNumber BacklashNP {1};
+        //
 
-        INumber MaxTravelN[1];
-        INumberVectorProperty MaxTravelNP;
+        INDI::PropertyNumber MaxTravelNP {1};
 
-        ISwitch TemperatureTrackingS[2];
-        ISwitchVectorProperty TemperatureTrackingSP;
+        INDI::PropertySwitch TemperatureTrackingSP {2};
 
-        ISwitch ActiveTemperatureSlopeS[2];
-        ISwitchVectorProperty ActiveTemperatureSlopeSP;
+        INDI::PropertySwitch ActiveTemperatureSlopeSP {2};
 
-        INumber Slope1IncN[1];
-        INumberVectorProperty Slope1IncNP;
+        INDI::PropertyNumber Slope1IncNP {1};
 
-        ISwitch Slope1DirS[2];
-        ISwitchVectorProperty Slope1DirSP;
+        INDI::PropertySwitch Slope1DirSP {2};
 
-        INumber Slope1DeadbandN[1];
-        INumberVectorProperty Slope1DeadbandNP;
+        INDI::PropertyNumber Slope1DeadbandNP {1};
 
-        INumber Slope1PeriodN[1];
-        INumberVectorProperty Slope1PeriodNP;
+        INDI::PropertyNumber Slope1PeriodNP {1};
 
-        INumber Slope2IncN[1];
-        INumberVectorProperty Slope2IncNP;
+        INDI::PropertyNumber Slope2IncNP {1};
 
-        ISwitch Slope2DirS[2];
-        ISwitchVectorProperty Slope2DirSP;
+        INDI::PropertySwitch Slope2DirSP {2};
 
-        INumber Slope2DeadbandN[1];
-        INumberVectorProperty Slope2DeadbandNP;
+        INDI::PropertyNumber Slope2DeadbandNP {1};
 
-        INumber Slope2PeriodN[1];
-        INumberVectorProperty Slope2PeriodNP;
+        INDI::PropertyNumber Slope2PeriodNP {1};
 
         static constexpr const char *SETTINGS_TAB { "Settings" };
         static constexpr const double TEMPERATURE_THRESHOLD { 0.05 };

--- a/drivers/focuser/microtouch.cpp
+++ b/drivers/focuser/microtouch.cpp
@@ -83,57 +83,57 @@ bool Microtouch::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    FocusSpeedN[0].min   = 1;
-    FocusSpeedN[0].max   = 5;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(5);
+    FocusSpeedNP[0].setValue(1);
 
     /* Step Mode */
-    IUFillSwitch(&MotorSpeedS[0], "Normal", "", ISS_ON);
-    IUFillSwitch(&MotorSpeedS[1], "Fast", "", ISS_OFF);
-    IUFillSwitchVector(&MotorSpeedSP, MotorSpeedS, 2, getDeviceName(), "Motor Speed", "", OPTIONS_TAB, IP_RW,
+    MotorSpeedSP[0].fill("Normal", "", ISS_ON);
+    MotorSpeedSP[1].fill("Fast", "", ISS_OFF);
+    MotorSpeedSP.fill(getDeviceName(), "Motor Speed", "", OPTIONS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Focuser temperature */
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Maximum Travel
-//    IUFillNumber(&MaxTravelN[0], "MAXTRAVEL", "Maximum travel", "%6.0f", 1., 60000., 0., 10000.);
-//    IUFillNumberVector(&MaxTravelNP, MaxTravelN, 1, getDeviceName(), "FOCUS_MAXTRAVEL", "Max. travel", OPTIONS_TAB,
+//    MaxTravelNP[0].fill("MAXTRAVEL", "Maximum travel", "%6.0f", 1., 60000., 0., 10000.);
+//    MaxTravelNP.fill(getDeviceName(), "FOCUS_MAXTRAVEL", "Max. travel", OPTIONS_TAB,
 //                       IP_RW, 0, IPS_IDLE);
 
     // Temperature Settings
-    IUFillNumber(&TemperatureSettingN[0], "Calibration", "", "%6.2f", -20, 20, 0.01, 0);
-    IUFillNumber(&TemperatureSettingN[1], "Coefficient", "", "%6.2f", -20, 20, 0.01, 0);
-    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 2, getDeviceName(), "Temperature Settings", "",
+    TemperatureSettingNP[0].fill("Calibration", "", "%6.2f", -20, 20, 0.01, 0);
+    TemperatureSettingNP[1].fill("Coefficient", "", "%6.2f", -20, 20, 0.01, 0);
+    TemperatureSettingNP.fill(getDeviceName(), "Temperature Settings", "",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureCompensateS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "Temperature Compensate",
+    TemperatureCompensateSP[0].fill("Enable", "", ISS_OFF);
+    TemperatureCompensateSP[1].fill("Disable", "", ISS_ON);
+    TemperatureCompensateSP.fill(getDeviceName(), "Temperature Compensate",
                        "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Reset
-//    IUFillSwitch(&ResetS[0], "Zero", "", ISS_OFF);
-//    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "Reset", "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
+//    ResetSP[0].fill("Zero", "", ISS_OFF);
+//    ResetSP.fill(getDeviceName(), "Reset", "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
 //                       IPS_IDLE);
 
-//    IUFillNumber(&ResetToPosN[0], "Position", "", "%6.0f", 0, 60000, 1, 0);
-//    IUFillNumberVector(&ResetToPosNP, ResetToPosN, 1, getDeviceName(), "Reset to Position", "", MAIN_CONTROL_TAB, IP_RW,
+//    ResetToPosNP[0].fill("Position", "", "%6.0f", 0, 60000, 1, 0);
+//    ResetToPosNP.fill(getDeviceName(), "Reset to Position", "", MAIN_CONTROL_TAB, IP_RW,
 //                       0, IPS_IDLE);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 30000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000.;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(30000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000.);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 60000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000.;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(60000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000.);
 
     addDebugControl();
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
@@ -147,13 +147,13 @@ bool Microtouch::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
-        //defineProperty(&MaxTravelNP);
-        defineProperty(&MotorSpeedSP);
-        defineProperty(&TemperatureSettingNP);
-        defineProperty(&TemperatureCompensateSP);
-//        defineProperty(&ResetSP);
-//        defineProperty(&ResetToPosNP);
+        defineProperty(TemperatureNP);
+        //defineProperty(MaxTravelNP);
+        defineProperty(MotorSpeedSP);
+        defineProperty(TemperatureSettingNP);
+        defineProperty(TemperatureCompensateSP);
+//        defineProperty(ResetSP);
+//        defineProperty(ResetToPosNP);
 
         GetFocusParams();
 
@@ -161,13 +161,13 @@ bool Microtouch::updateProperties()
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-//        deleteProperty(MaxTravelNP.name);
-        deleteProperty(MotorSpeedSP.name);
-        deleteProperty(TemperatureSettingNP.name);
-        deleteProperty(TemperatureCompensateSP.name);
-//        deleteProperty(ResetSP.name);
-//        deleteProperty(ResetToPosNP.name);
+        deleteProperty(TemperatureNP.getName());
+//        deleteProperty(MaxTravelNP.getName());
+        deleteProperty(MotorSpeedSP.getName());
+        deleteProperty(TemperatureSettingNP.getName());
+        deleteProperty(TemperatureCompensateSP.getName());
+//        deleteProperty(ResetSP.getName());
+//        deleteProperty(ResetToPosNP.getName());
     }
 
     return true;
@@ -218,9 +218,9 @@ bool Microtouch::updateTemperature()
     LOGF_DEBUG("updateTemperature : RESP (%02X %02X %02X %02X %02X %02X)", resp[0], resp[1],
            resp[2], resp[3], resp[4], resp[5]);
 
-    TemperatureN[0].value        = raw_temp + raw_coeff;
-    TemperatureSettingN[0].value = raw_coeff;
-    TemperatureSettingN[1].value = tcomp_coeff;
+    TemperatureNP[0].setValue(raw_temp + raw_coeff);
+    TemperatureSettingNP[0].setValue(raw_coeff);
+    TemperatureSettingNP[1].setValue(tcomp_coeff);
 
     return true;
 }
@@ -231,7 +231,7 @@ bool Microtouch::updatePosition()
 
     if (WriteCmdGetResponse(CMD_GET_POSITION, read, 3))
     {
-        FocusAbsPosN[0].value = static_cast<double>(static_cast<uint8_t>(read[2]) << 8 | static_cast<uint8_t>(read[1]));
+        FocusAbsPosNP[0].setValue(static_cast<double>(static_cast<uint8_t>(read[2]) << 8 | static_cast<uint8_t>(read[1])));
         return true;
     }
 
@@ -274,7 +274,7 @@ bool Microtouch::updateSpeed()
         }
 
         currentSpeed = focus_speed;
-        FocusSpeedN[0].value = focus_speed;
+        FocusSpeedNP[0].setValue(focus_speed);
     }
     else
     {
@@ -287,14 +287,14 @@ bool Microtouch::updateSpeed()
 
 bool Microtouch::updateMotorSpeed()
 {
-    IUResetSwitch(&MotorSpeedSP);
+    MotorSpeedSP.reset();
 
     LOGF_DEBUG("MotorSpeed: %d.", WriteCmdGetByte(CMD_GET_MOTOR_SPEED));
 
     if (WriteCmdGetByte(CMD_GET_MOTOR_SPEED) == 8)
-        MotorSpeedS[0].s = ISS_ON;
+        MotorSpeedSP[0].setState(ISS_ON);
     else if (WriteCmdGetByte(CMD_GET_MOTOR_SPEED) == 4)
-        MotorSpeedS[1].s = ISS_ON;
+        MotorSpeedSP[1].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: updateMotorSpeed (%s)", WriteCmdGetByte(CMD_GET_MOTOR_SPEED));
@@ -350,7 +350,7 @@ bool Microtouch::MoveFocuser(unsigned int position)
 {
     LOGF_DEBUG("MoveFocuser to Position: %d", position);
 
-    if (position < FocusAbsPosN[0].min || position > FocusAbsPosN[0].max)
+    if (position < FocusAbsPosNP[0].min || position > FocusAbsPosNP[0].max)
     {
         LOGF_ERROR("Requested position value out of bound: %d", position);
         return false;
@@ -410,19 +410,19 @@ bool Microtouch::ISNewSwitch(const char *dev, const char *name, ISState *states,
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Focus Motor Speed
-        if (strcmp(MotorSpeedSP.name, name) == 0)
+        if (MotorSpeedSP.isNameMatch(name))
         {
             bool rc          = false;
-            int current_mode = IUFindOnSwitchIndex(&MotorSpeedSP);
+            int current_mode = MotorSpeedSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&MotorSpeedSP, states, names, n);
+            MotorSpeedSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&MotorSpeedSP);
+            int target_mode = MotorSpeedSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                MotorSpeedSP.s = IPS_OK;
-                IDSetSwitch(&MotorSpeedSP, nullptr);
+                MotorSpeedSP.setState(IPS_OK);
+                MotorSpeedSP.apply();
             }
 
             if (target_mode == 0)
@@ -432,49 +432,49 @@ bool Microtouch::ISNewSwitch(const char *dev, const char *name, ISState *states,
 
             if (!rc)
             {
-                IUResetSwitch(&MotorSpeedSP);
-                MotorSpeedS[current_mode].s = ISS_ON;
-                MotorSpeedSP.s              = IPS_ALERT;
-                IDSetSwitch(&MotorSpeedSP, nullptr);
+                MotorSpeedSP.reset();
+                MotorSpeedSP[current_mode].setState(ISS_ON);
+                MotorSpeedSP.setState(IPS_ALERT);
+                MotorSpeedSP.apply();
                 return false;
             }
 
-            MotorSpeedSP.s = IPS_OK;
-            IDSetSwitch(&MotorSpeedSP, nullptr);
+            MotorSpeedSP.setState(IPS_OK);
+            MotorSpeedSP.apply();
             return true;
         }
 
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int last_index = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
+            int last_index = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
 
-            bool rc = setTemperatureCompensation((TemperatureCompensateS[0].s == ISS_ON));
+            bool rc = setTemperatureCompensation((TemperatureCompensateSP[0].getState() == ISS_ON));
 
             if (!rc)
             {
-                TemperatureCompensateSP.s = IPS_ALERT;
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateS[last_index].s = ISS_ON;
-                IDSetSwitch(&TemperatureCompensateSP, nullptr);
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP[last_index].setState(ISS_ON);
+                TemperatureCompensateSP.apply();
                 return false;
             }
 
-            TemperatureCompensateSP.s = IPS_OK;
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.setState(IPS_OK);
+            TemperatureCompensateSP.apply();
             return true;
         }
 
-//        if (strcmp(ResetSP.name, name) == 0)
+//        if (ResetSP.isNameMatch(name))
 //        {
-//            IUResetSwitch(&ResetSP);
+//            ResetSP.reset();
 
 //            if (reset())
-//                ResetSP.s = IPS_OK;
+//                ResetSP.setState(IPS_OK);
 //            else
-//                ResetSP.s = IPS_ALERT;
+//                ResetSP.setState(IPS_ALERT);
 
-//            IDSetSwitch(&ResetSP, nullptr);
+//            ResetSP.apply();
 //            return true;
 //        }
     }
@@ -486,41 +486,41 @@ bool Microtouch::ISNewNumber(const char *dev, const char *name, double values[],
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-//        if (strcmp(name, MaxTravelNP.name) == 0)
+//        if (MaxTravelNP.isNameMatch(name))
 //        {
-//            IUUpdateNumber(&MaxTravelNP, values, names, n);
-//            MaxTravelNP.s = IPS_OK;
-//            IDSetNumber(&MaxTravelNP, nullptr);
+//            MaxTravelNP.update(values, names, n);
+//            MaxTravelNP.setState(IPS_OK);
+//            MaxTravelNP.apply();
 //            return true;
 //        }
 
-        if (strcmp(name, TemperatureSettingNP.name) == 0)
+        if (TemperatureSettingNP.isNameMatch(name))
         {
-            IUUpdateNumber(&TemperatureSettingNP, values, names, n);
-            if (!setTemperatureCalibration(TemperatureSettingN[0].value) ||
-                !setTemperatureCoefficient(TemperatureSettingN[1].value))
+            TemperatureSettingNP.update(values, names, n);
+            if (!setTemperatureCalibration(TemperatureSettingNP[0].value) ||
+                !setTemperatureCoefficient(TemperatureSettingNP[1].value))
             {
-                TemperatureSettingNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureSettingNP, nullptr);
+                TemperatureSettingNP.setState(IPS_ALERT);
+                TemperatureSettingNP.apply();
                 return false;
             }
 
-            TemperatureSettingNP.s = IPS_OK;
-            IDSetNumber(&TemperatureSettingNP, nullptr);
+            TemperatureSettingNP.setState(IPS_OK);
+            TemperatureSettingNP.apply();
         }
 
-//        if (strcmp(name, ResetToPosNP.name) == 0)
+//        if (ResetToPosNP.isNameMatch(name))
 //        {
-//            IUUpdateNumber(&ResetToPosNP, values, names, n);
-//            if (!reset(ResetToPosN[0].value))
+//            ResetToPosNP.update(values, names, n);
+//            if (!reset(ResetToPosNP[0].value))
 //            {
-//                ResetToPosNP.s = IPS_ALERT;
-//                IDSetNumber(&ResetToPosNP, nullptr);
+//                ResetToPosNP.setState(IPS_ALERT);
+//                ResetToPosNP.apply();
 //                return false;
 //            }
 
-//            ResetToPosNP.s = IPS_OK;
-//            IDSetNumber(&ResetToPosNP, nullptr);
+//            ResetToPosNP.setState(IPS_OK);
+//            ResetToPosNP.apply();
 //        }
     }
 
@@ -530,19 +530,19 @@ bool Microtouch::ISNewNumber(const char *dev, const char *name, double values[],
 void Microtouch::GetFocusParams()
 {
     if (updatePosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (updateTemperature())
     {
-        IDSetNumber(&TemperatureNP, nullptr);
-        IDSetNumber(&TemperatureSettingNP, nullptr);
+        TemperatureNP.apply();
+        TemperatureSettingNP.apply();
     }
 
     /*    if (updateSpeed())
-        IDSetNumber(&FocusSpeedNP, nullptr);
+        FocusSpeedNP.apply();
     */
     if (updateMotorSpeed())
-        IDSetSwitch(&MotorSpeedSP, nullptr);
+        MotorSpeedSP.apply();
 }
 
 bool Microtouch::SetFocuserSpeed(int speed)
@@ -556,8 +556,8 @@ bool Microtouch::SetFocuserSpeed(int speed)
 
     currentSpeed = speed;
 
-    FocusSpeedNP.s = IPS_OK;
-    IDSetNumber(&FocusSpeedNP, nullptr);
+    FocusSpeedNP.setState(IPS_OK);
+    FocusSpeedNP.apply();
 
     return true;
 }
@@ -578,7 +578,7 @@ IPState Microtouch::MoveFocuser(FocusDirection dir, int speed, uint16_t duration
     if (dir == FOCUS_INWARD)
         MoveFocuser(0);
     else
-        MoveFocuser(FocusAbsPosN[0].value + FocusMaxPosN[0].value - 1);
+        MoveFocuser(FocusAbsPosNP[0].value + FocusMaxPosNP[0].getValue() - 1);
 
     if (duration <= getCurrentPollingPeriod())
     {
@@ -601,7 +601,7 @@ IPState Microtouch::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -612,17 +612,17 @@ IPState Microtouch::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     bool rc            = false;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     rc = MoveFocuser(newPosition);
 
     if (!rc)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -638,46 +638,46 @@ void Microtouch::TimerHit()
 
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 1)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 1)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
     rc = updateTemperature();
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.01)
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.01)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
-    if (FocusTimerNP.s == IPS_BUSY)
+    if (FocusTimerNP.getState() == IPS_BUSY)
     {
         float remaining = CalcTimeLeft(focusMoveStart, focusMoveRequest);
         if (remaining <= 0)
         {
-            FocusTimerNP.s       = IPS_OK;
-            FocusTimerN[0].value = 0;
+            FocusTimerNP.setState(IPS_OK);
+            FocusTimerNP[0].setValue(0);
             AbortFocuser();
         }
         else
-            FocusTimerN[0].value = remaining * 1000.0;
-        IDSetNumber(&FocusTimerNP, nullptr);
+            FocusTimerNP[0].setValue(remaining * 1000.0);
+        FocusTimerNP.apply();
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -688,10 +688,10 @@ void Microtouch::TimerHit()
 bool Microtouch::AbortFocuser()
 {
     WriteCmd(CMD_HALT);
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocusRelPosNP.s = IPS_IDLE;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusRelPosNP.setState(IPS_IDLE);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
     return true;
 }
 

--- a/drivers/focuser/microtouch.h
+++ b/drivers/focuser/microtouch.h
@@ -23,6 +23,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 #define CMD_GET_STATUS      0x80
 #define CMD_RESET_POSITION  0x81
 #define CMD_IS_MOVING       0x82
@@ -96,24 +100,20 @@ class Microtouch : public INDI::Focuser
     struct timeval focusMoveStart { 0, 0 };
     float focusMoveRequest { 0 };
 
-    INumber TemperatureN[1];
-    INumberVectorProperty TemperatureNP;
+    INDI::PropertyNumber TemperatureNP {1};
 
-    ISwitch MotorSpeedS[2];
-    ISwitchVectorProperty MotorSpeedSP;
+    INDI::PropertySwitch MotorSpeedSP {2};
 
-//    INumber MaxTravelN[1];
-//    INumberVectorProperty MaxTravelNP;
+//    INDI::PropertyNumber MaxTravelNP {1};
+//
 
-    INumber TemperatureSettingN[2];
-    INumberVectorProperty TemperatureSettingNP;
+    INDI::PropertyNumber TemperatureSettingNP {2};
 
-    ISwitch TemperatureCompensateS[2];
-    ISwitchVectorProperty TemperatureCompensateSP;
+    INDI::PropertySwitch TemperatureCompensateSP {2};
 
-//    ISwitch ResetS[1];
-//    ISwitchVectorProperty ResetSP;
+//    INDI::PropertySwitch ResetSP {1};
+//
 
-//    INumber ResetToPosN[1];
-//    INumberVectorProperty ResetToPosNP;
+//    INDI::PropertyNumber ResetToPosNP {1};
+//
 };

--- a/drivers/focuser/moonlite.cpp
+++ b/drivers/focuser/moonlite.cpp
@@ -82,43 +82,43 @@ bool MoonLite::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    FocusSpeedN[0].min   = 1;
-    FocusSpeedN[0].max   = 5;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(5);
+    FocusSpeedNP[0].setValue(1);
 
     // Step Mode
-    IUFillSwitch(&StepModeS[FOCUS_HALF_STEP], "FOCUS_HALF_STEP", "Half Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FOCUS_FULL_STEP], "FOCUS_FULL_STEP", "Full Step", ISS_ON);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 2, getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    StepModeSP[FOCUS_HALF_STEP].fill("FOCUS_HALF_STEP", "Half Step", ISS_OFF);
+    StepModeSP[FOCUS_FULL_STEP].fill("FOCUS_FULL_STEP", "Full Step", ISS_ON);
+    StepModeSP.fill(getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Temperature Settings
-    IUFillNumber(&TemperatureSettingN[0], "Calibration", "", "%6.2f", -20, 20, 0.5, 0);
-    IUFillNumber(&TemperatureSettingN[1], "Coefficient", "", "%6.2f", -20, 20, 0.5, 0);
-    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 2, getDeviceName(), "T. Settings", "",
+    TemperatureSettingNP[0].fill("Calibration", "", "%6.2f", -20, 20, 0.5, 0);
+    TemperatureSettingNP[1].fill("Coefficient", "", "%6.2f", -20, 20, 0.5, 0);
+    TemperatureSettingNP.fill(getDeviceName(), "T. Settings", "",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureCompensateS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "T. Compensate",
+    TemperatureCompensateSP[0].fill("Enable", "", ISS_OFF);
+    TemperatureCompensateSP[1].fill("Disable", "", ISS_ON);
+    TemperatureCompensateSP.fill(getDeviceName(), "T. Compensate",
                        "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 100000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     setDefaultPollingPeriod(500);
     addDebugControl();
@@ -132,10 +132,10 @@ bool MoonLite::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
-        defineProperty(&StepModeSP);
-        defineProperty(&TemperatureSettingNP);
-        defineProperty(&TemperatureCompensateSP);
+        defineProperty(TemperatureNP);
+        defineProperty(StepModeSP);
+        defineProperty(TemperatureSettingNP);
+        defineProperty(TemperatureCompensateSP);
 
         GetFocusParams();
 
@@ -143,10 +143,10 @@ bool MoonLite::updateProperties()
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(StepModeSP.name);
-        deleteProperty(TemperatureSettingNP.name);
-        deleteProperty(TemperatureCompensateSP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(StepModeSP.getName());
+        deleteProperty(TemperatureSettingNP.getName());
+        deleteProperty(TemperatureCompensateSP.getName());
     }
 
     return true;
@@ -196,9 +196,9 @@ bool MoonLite::readStepMode()
         return false;
 
     if (strcmp(res, "FF#") == 0)
-        StepModeS[FOCUS_HALF_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_HALF_STEP].setState(ISS_ON);
     else if (strcmp(res, "00#") == 0)
-        StepModeS[FOCUS_FULL_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_FULL_STEP].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser step value (%s)", res);
@@ -233,7 +233,7 @@ bool MoonLite::readTemperature()
     int rc = sscanf(res, "%X", &temp);
     if (rc > 0)
         // Signed hex
-        TemperatureN[0].value = static_cast<int16_t>(temp) / 2.0;
+        TemperatureNP[0].setValue(static_cast<int16_t>(temp) / 2.0);
     else
     {
         LOGF_ERROR("Unknown error: focuser temperature value (%s)", res);
@@ -254,7 +254,7 @@ bool MoonLite::readPosition()
     int rc = sscanf(res, "%X#", &pos);
 
     if (rc > 0)
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     else
     {
         LOGF_ERROR("Unknown error: focuser position value (%s)", res);
@@ -282,7 +282,7 @@ bool MoonLite::readSpeed()
             speed >>= 1;
             focus_speed++;
         }
-        FocusSpeedN[0].value = focus_speed;
+        FocusSpeedNP[0].setValue(focus_speed);
     }
     else
     {
@@ -375,54 +375,54 @@ bool MoonLite::ISNewSwitch(const char * dev, const char * name, ISState * states
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Focus Step Mode
-        if (strcmp(StepModeSP.name, name) == 0)
+        if (StepModeSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int current_mode = StepModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&StepModeSP, states, names, n);
+            StepModeSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int target_mode = StepModeSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                StepModeSP.s = IPS_OK;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.setState(IPS_OK);
+                StepModeSP.apply();
             }
 
             bool rc = setStepMode(target_mode == 0 ? FOCUS_HALF_STEP : FOCUS_FULL_STEP);
             if (!rc)
             {
-                IUResetSwitch(&StepModeSP);
-                StepModeS[current_mode].s = ISS_ON;
-                StepModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.reset();
+                StepModeSP[current_mode].setState(ISS_ON);
+                StepModeSP.setState(IPS_ALERT);
+                StepModeSP.apply();
                 return false;
             }
 
-            StepModeSP.s = IPS_OK;
-            IDSetSwitch(&StepModeSP, nullptr);
+            StepModeSP.setState(IPS_OK);
+            StepModeSP.apply();
             return true;
         }
 
         // Temperature Compensation Mode
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int last_index = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
+            int last_index = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
 
-            bool rc = setTemperatureCompensation((TemperatureCompensateS[0].s == ISS_ON));
+            bool rc = setTemperatureCompensation((TemperatureCompensateSP[0].getState() == ISS_ON));
 
             if (!rc)
             {
-                TemperatureCompensateSP.s = IPS_ALERT;
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateS[last_index].s = ISS_ON;
-                IDSetSwitch(&TemperatureCompensateSP, nullptr);
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP[last_index].setState(ISS_ON);
+                TemperatureCompensateSP.apply();
                 return false;
             }
 
-            TemperatureCompensateSP.s = IPS_OK;
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.setState(IPS_OK);
+            TemperatureCompensateSP.apply();
             return true;
         }
     }
@@ -435,19 +435,19 @@ bool MoonLite::ISNewNumber(const char * dev, const char * name, double values[],
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Settings
-        if (strcmp(name, TemperatureSettingNP.name) == 0)
+        if (TemperatureSettingNP.isNameMatch(name))
         {
-            IUUpdateNumber(&TemperatureSettingNP, values, names, n);
-            if (!setTemperatureCalibration(TemperatureSettingN[0].value) ||
-                    !setTemperatureCoefficient(TemperatureSettingN[1].value))
+            TemperatureSettingNP.update(values, names, n);
+            if (!setTemperatureCalibration(TemperatureSettingNP[0].value) ||
+                    !setTemperatureCoefficient(TemperatureSettingNP[1].value))
             {
-                TemperatureSettingNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureSettingNP, nullptr);
+                TemperatureSettingNP.setState(IPS_ALERT);
+                TemperatureSettingNP.apply();
                 return false;
             }
 
-            TemperatureSettingNP.s = IPS_OK;
-            IDSetNumber(&TemperatureSettingNP, nullptr);
+            TemperatureSettingNP.setState(IPS_OK);
+            TemperatureSettingNP.apply();
             return true;
         }
     }
@@ -458,16 +458,16 @@ bool MoonLite::ISNewNumber(const char * dev, const char * name, double values[],
 void MoonLite::GetFocusParams()
 {
     if (readPosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (readTemperature())
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 
     if (readSpeed())
-        IDSetNumber(&FocusSpeedNP, nullptr);
+        FocusSpeedNP.apply();
 
     if (readStepMode())
-        IDSetSwitch(&StepModeSP, nullptr);
+        StepModeSP.apply();
 }
 
 bool MoonLite::SetFocuserSpeed(int speed)
@@ -477,7 +477,7 @@ bool MoonLite::SetFocuserSpeed(int speed)
 
 IPState MoonLite::MoveFocuser(FocusDirection dir, int speed, uint16_t duration)
 {
-    if (speed != static_cast<int>(FocusSpeedN[0].value))
+    if (speed != static_cast<int>(FocusSpeedNP[0].value))
     {
         if (!setSpeed(speed))
             return IPS_ALERT;
@@ -488,7 +488,7 @@ IPState MoonLite::MoveFocuser(FocusDirection dir, int speed, uint16_t duration)
     if (dir == FOCUS_INWARD)
         MoveFocuser(0);
     else
-        MoveFocuser(static_cast<uint32_t>(FocusMaxPosN[0].value));
+        MoveFocuser(static_cast<uint32_t>(FocusMaxPosNP[0].value));
 
     IEAddTimer(duration, &MoonLite::timedMoveHelper, this);
     return IPS_BUSY;
@@ -502,13 +502,13 @@ void MoonLite::timedMoveHelper(void * context)
 void MoonLite::timedMoveCallback()
 {
     AbortFocuser();
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocusRelPosNP.s = IPS_IDLE;
-    FocusTimerNP.s = IPS_IDLE;
-    FocusTimerN[0].value = 0;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
-    IDSetNumber(&FocusTimerNP, nullptr);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusRelPosNP.setState(IPS_IDLE);
+    FocusTimerNP.setState(IPS_IDLE);
+    FocusTimerNP[0].setValue(0);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
+    FocusTimerNP.apply();
 }
 
 IPState MoonLite::MoveAbsFocuser(uint32_t targetTicks)
@@ -525,15 +525,15 @@ IPState MoonLite::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
     // Clamp
     int32_t offset = ((dir == FOCUS_INWARD) ? -1 : 1) * static_cast<int32_t>(ticks);
-    int32_t newPosition = FocusAbsPosN[0].value + offset;
-    newPosition = std::max(static_cast<int32_t>(FocusAbsPosN[0].min), std::min(static_cast<int32_t>(FocusAbsPosN[0].max),
+    int32_t newPosition = FocusAbsPosNP[0].getValue() + offset;
+    newPosition = std::max(static_cast<int32_t>(FocusAbsPosNP[0].min), std::min(static_cast<int32_t>(FocusAbsPosNP[0].max),
                            newPosition));
 
     if (!MoveFocuser(newPosition))
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -546,32 +546,32 @@ void MoonLite::TimerHit()
     bool rc = readPosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = static_cast<uint32_t>(FocusAbsPosN[0].value);
+            FocusAbsPosNP.apply();
+            lastPos = static_cast<uint32_t>(FocusAbsPosNP[0].value);
         }
     }
 
     rc = readTemperature();
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = static_cast<uint32_t>(TemperatureN[0].value);
+            TemperatureNP.apply();
+            lastTemperature = static_cast<uint32_t>(TemperatureNP[0].value);
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = static_cast<uint32_t>(FocusAbsPosN[0].value);
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = static_cast<uint32_t>(FocusAbsPosNP[0].value);
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -588,7 +588,7 @@ bool MoonLite::saveConfigItems(FILE * fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &StepModeSP);
+    StepModeSP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/moonlite.h
+++ b/drivers/focuser/moonlite.h
@@ -24,6 +24,10 @@
 
 #include <chrono>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class MoonLite : public INDI::Focuser
 {
     public:
@@ -122,20 +126,16 @@ class MoonLite : public INDI::Focuser
         uint32_t targetPos { 0 }, lastPos { 0 }, lastTemperature { 0 };
 
         // Read Only Temperature Reporting
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Full/Half Step modes
-        ISwitch StepModeS[2];
-        ISwitchVectorProperty StepModeSP;
+        INDI::PropertySwitch StepModeSP {2};
 
         // Temperature Settings
-        INumber TemperatureSettingN[2];
-        INumberVectorProperty TemperatureSettingNP;
+        INDI::PropertyNumber TemperatureSettingNP {2};
 
         // Temperature Compensation Enable/Disable
-        ISwitch TemperatureCompensateS[2];
-        ISwitchVectorProperty TemperatureCompensateSP;
+        INDI::PropertySwitch TemperatureCompensateSP {2};
 
         // MoonLite Buffer
         static const uint8_t ML_RES { 32 };

--- a/drivers/focuser/moonlite_dro.cpp
+++ b/drivers/focuser/moonlite_dro.cpp
@@ -104,51 +104,51 @@ bool MoonLiteDRO::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    FocusSpeedN[0].min   = 1;
-    FocusSpeedN[0].max   = 5;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(5);
+    FocusSpeedNP[0].setValue(1);
 
     // Step Delay
-    IUFillNumber(&StepDelayN[0], "STEP_DELAY", "Delay", "%.f", 1, 5, 1., 1.);
-    IUFillNumberVector(&StepDelayNP, StepDelayN, 1, getDeviceName(), "FOCUS_STEP_DELAY", "Step",
+    StepDelayNP[0].fill("STEP_DELAY", "Delay", "%.f", 1, 5, 1., 1.);
+    StepDelayNP.fill(getDeviceName(), "FOCUS_STEP_DELAY", "Step",
                        SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Step Mode
-    IUFillSwitch(&StepModeS[FOCUS_HALF_STEP], "HALF_STEP", "Half Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FOCUS_FULL_STEP], "FULL_STEP", "Full Step", ISS_ON);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 2, getDeviceName(), "FOCUS_STEP_MODE", "Step Mode", SETTINGS_TAB, IP_RW,
+    StepModeSP[FOCUS_HALF_STEP].fill("HALF_STEP", "Half Step", ISS_OFF);
+    StepModeSP[FOCUS_FULL_STEP].fill("FULL_STEP", "Full Step", ISS_ON);
+    StepModeSP.fill(getDeviceName(), "FOCUS_STEP_MODE", "Step Mode", SETTINGS_TAB, IP_RW,
                        ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Temperature Settings
-    IUFillNumber(&TemperatureSettingN[0], "Calibration", "Calibration", "%6.2f", -20, 20, 0.5, 0);
-    IUFillNumber(&TemperatureSettingN[1], "Coefficient", "Coefficient", "%6.2f", -20, 20, 0.5, 0);
-    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 2, getDeviceName(), "FOCUS_TEMPERATURE_SETTINGS",
+    TemperatureSettingNP[0].fill("Calibration", "Calibration", "%6.2f", -20, 20, 0.5, 0);
+    TemperatureSettingNP[1].fill("Coefficient", "Coefficient", "%6.2f", -20, 20, 0.5, 0);
+    TemperatureSettingNP.fill(getDeviceName(), "FOCUS_TEMPERATURE_SETTINGS",
                        "T. Settings",
                        SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureCompensateS[0], "Enable", "Enable", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[1], "Disable", "Disable", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "FOCUS_TEMPERATURE_COMPENSATION",
+    TemperatureCompensateSP[0].fill("Enable", "Enable", ISS_OFF);
+    TemperatureCompensateSP[1].fill("Disable", "Disable", ISS_ON);
+    TemperatureCompensateSP.fill(getDeviceName(), "FOCUS_TEMPERATURE_COMPENSATION",
                        "T. Compensate", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Relative and absolute movement
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 100000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     setDefaultPollingPeriod(500);
     addDebugControl();
@@ -165,13 +165,13 @@ bool MoonLiteDRO::updateProperties()
         // Only display such properties for the first focuser only
         if (m_ID == 1)
         {
-            defineProperty(&TemperatureNP);
-            defineProperty(&TemperatureSettingNP);
-            defineProperty(&TemperatureCompensateSP);
+            defineProperty(TemperatureNP);
+            defineProperty(TemperatureSettingNP);
+            defineProperty(TemperatureCompensateSP);
         }
 
-        defineProperty(&StepDelayNP);
-        defineProperty(&StepModeSP);
+        defineProperty(StepDelayNP);
+        defineProperty(StepModeSP);
 
         GetFocusParams();
 
@@ -181,13 +181,13 @@ bool MoonLiteDRO::updateProperties()
     {
         if (m_ID == 1)
         {
-            deleteProperty(TemperatureNP.name);
-            deleteProperty(TemperatureSettingNP.name);
-            deleteProperty(TemperatureCompensateSP.name);
+            deleteProperty(TemperatureNP.getName());
+            deleteProperty(TemperatureSettingNP.getName());
+            deleteProperty(TemperatureCompensateSP.getName());
         }
 
-        deleteProperty(StepDelayNP.name);
-        deleteProperty(StepModeSP.name);
+        deleteProperty(StepDelayNP.getName());
+        deleteProperty(StepModeSP.getName());
     }
 
     return true;
@@ -375,7 +375,7 @@ bool MoonLiteDRO::updateStepDelay()
             focus_speed++;
         }
 
-        StepDelayN[0].value = focus_speed;
+        StepDelayNP[0].setValue(focus_speed);
     }
     else
     {
@@ -422,12 +422,12 @@ bool MoonLiteDRO::updateStepMode()
 
     LOGF_DEBUG("RES <%s>", resp);
 
-    IUResetSwitch(&StepModeSP);
+    StepModeSP.reset();
 
     if (strcmp(resp, "FF") == 0)
-        StepModeS[FOCUS_HALF_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_HALF_STEP].setState(ISS_ON);
     else if (strcmp(resp, "00") == 0)
-        StepModeS[FOCUS_FULL_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_FULL_STEP].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser step value (%s)", resp);
@@ -475,7 +475,7 @@ bool MoonLiteDRO::updateTemperature()
     if (rc > 0)
     {
         // Signed hex
-        TemperatureN[0].value = static_cast<int16_t>(temp) / 2.0;
+        TemperatureNP[0].setValue(static_cast<int16_t>(temp) / 2.0);
     }
     else
     {
@@ -525,7 +525,7 @@ bool MoonLiteDRO::updatePosition()
 
     if (rc > 0)
     {
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     }
     else
     {
@@ -656,7 +656,7 @@ bool MoonLiteDRO::gotoAbsPosition(unsigned int position)
     char errstr[MAXRBUF];
     char cmd[DRO_CMD] = {0};
 
-    if (position < FocusAbsPosN[0].min || position > FocusAbsPosN[0].max)
+    if (position < FocusAbsPosNP[0].min || position > FocusAbsPosNP[0].max)
     {
         LOGF_ERROR("Requested position value out of bound: %d", position);
         return false;
@@ -788,19 +788,19 @@ bool MoonLiteDRO::ISNewSwitch(const char *dev, const char *name, ISState *states
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Focus Step Mode
-        if (strcmp(StepModeSP.name, name) == 0)
+        if (StepModeSP.isNameMatch(name))
         {
             bool rc          = false;
-            int current_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int current_mode = StepModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&StepModeSP, states, names, n);
+            StepModeSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int target_mode = StepModeSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                StepModeSP.s = IPS_OK;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.setState(IPS_OK);
+                StepModeSP.apply();
             }
 
             if (target_mode == 0)
@@ -810,37 +810,37 @@ bool MoonLiteDRO::ISNewSwitch(const char *dev, const char *name, ISState *states
 
             if (!rc)
             {
-                IUResetSwitch(&StepModeSP);
-                StepModeS[current_mode].s = ISS_ON;
-                StepModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.reset();
+                StepModeSP[current_mode].setState(ISS_ON);
+                StepModeSP.setState(IPS_ALERT);
+                StepModeSP.apply();
                 return false;
             }
 
-            StepModeSP.s = IPS_OK;
-            IDSetSwitch(&StepModeSP, nullptr);
+            StepModeSP.setState(IPS_OK);
+            StepModeSP.apply();
             return true;
         }
 
         // Temperature Compensation
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int last_index = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
+            int last_index = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
 
-            bool rc = setTemperatureCompensation((TemperatureCompensateS[0].s == ISS_ON));
+            bool rc = setTemperatureCompensation((TemperatureCompensateSP[0].getState() == ISS_ON));
 
             if (!rc)
             {
-                TemperatureCompensateSP.s = IPS_ALERT;
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateS[last_index].s = ISS_ON;
-                IDSetSwitch(&TemperatureCompensateSP, nullptr);
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP[last_index].setState(ISS_ON);
+                TemperatureCompensateSP.apply();
                 return false;
             }
 
-            TemperatureCompensateSP.s = IPS_OK;
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.setState(IPS_OK);
+            TemperatureCompensateSP.apply();
             return true;
         }
     }
@@ -853,35 +853,35 @@ bool MoonLiteDRO::ISNewNumber(const char *dev, const char *name, double values[]
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Settings
-        if (strcmp(name, TemperatureSettingNP.name) == 0)
+        if (TemperatureSettingNP.isNameMatch(name))
         {
-            IUUpdateNumber(&TemperatureSettingNP, values, names, n);
-            if (!setTemperatureCalibration(TemperatureSettingN[0].value) ||
-                    !setTemperatureCoefficient(TemperatureSettingN[1].value))
+            TemperatureSettingNP.update(values, names, n);
+            if (!setTemperatureCalibration(TemperatureSettingNP[0].value) ||
+                    !setTemperatureCoefficient(TemperatureSettingNP[1].value))
             {
-                TemperatureSettingNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureSettingNP, nullptr);
+                TemperatureSettingNP.setState(IPS_ALERT);
+                TemperatureSettingNP.apply();
                 return false;
             }
 
-            TemperatureSettingNP.s = IPS_OK;
-            IDSetNumber(&TemperatureSettingNP, nullptr);
+            TemperatureSettingNP.setState(IPS_OK);
+            TemperatureSettingNP.apply();
             return true;
         }
 
         // Step Delay
-        if (strcmp(name, StepDelayNP.name) == 0)
+        if (StepDelayNP.isNameMatch(name))
         {
             if (setStepDelay(values[0]) == false)
             {
-                StepDelayNP.s = IPS_ALERT;
-                IDSetNumber(&StepDelayNP, nullptr);
+                StepDelayNP.setState(IPS_ALERT);
+                StepDelayNP.apply();
                 return false;
             }
 
-            IUUpdateNumber(&StepDelayNP, values, names, n);
-            StepDelayNP.s = IPS_OK;
-            IDSetNumber(&StepDelayNP, nullptr);
+            StepDelayNP.update(values, names, n);
+            StepDelayNP.setState(IPS_OK);
+            StepDelayNP.apply();
             return true;
         }
     }
@@ -892,16 +892,16 @@ bool MoonLiteDRO::ISNewNumber(const char *dev, const char *name, double values[]
 void MoonLiteDRO::GetFocusParams()
 {
     if (updatePosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (updateTemperature())
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 
     if (updateStepDelay())
-        IDSetNumber(&StepDelayNP, nullptr);
+        StepDelayNP.apply();
 
     if (updateStepMode())
-        IDSetSwitch(&StepModeSP, nullptr);
+        StepModeSP.apply();
 }
 
 IPState MoonLiteDRO::MoveAbsFocuser(uint32_t targetTicks)
@@ -915,7 +915,7 @@ IPState MoonLiteDRO::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -926,17 +926,17 @@ IPState MoonLiteDRO::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     bool rc            = false;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     rc = gotoAbsPosition(newPosition);
 
     if (!rc)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -952,10 +952,10 @@ void MoonLiteDRO::TimerHit()
     bool rc = updatePosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
@@ -965,23 +965,23 @@ void MoonLiteDRO::TimerHit()
         rc = updateTemperature();
         if (rc)
         {
-            if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
+            if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
             {
-                IDSetNumber(&TemperatureNP, nullptr);
-                lastTemperature = TemperatureN[0].value;
+                TemperatureNP.apply();
+                lastTemperature = TemperatureNP[0].getValue();
             }
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -1000,10 +1000,10 @@ bool MoonLiteDRO::AbortFocuser()
 
     if (tty_write_string(PortFD, cmd, &nbytes_written) == TTY_OK)
     {
-        FocusAbsPosNP.s = IPS_IDLE;
-        FocusRelPosNP.s = IPS_IDLE;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
-        IDSetNumber(&FocusRelPosNP, nullptr);
+        FocusAbsPosNP.setState(IPS_IDLE);
+        FocusRelPosNP.setState(IPS_IDLE);
+        FocusAbsPosNP.apply();
+        FocusRelPosNP.apply();
         return true;
     }
     else
@@ -1014,8 +1014,8 @@ bool MoonLiteDRO::saveConfigItems(FILE *fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &StepModeSP);
-    IUSaveConfigNumber(fp, &StepDelayNP);
+    StepModeSP.save(fp);
+    StepDelayNP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/moonlite_dro.h
+++ b/drivers/focuser/moonlite_dro.h
@@ -22,6 +22,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class MoonLiteDRO : public INDI::Focuser
 {
   public:
@@ -69,20 +73,15 @@ protected:
     double lastPos { 0 };
     double lastTemperature { 0 };
 
-    ISwitch StepModeS[2];
-    ISwitchVectorProperty StepModeSP;
+    INDI::PropertySwitch StepModeSP {2};
 
-    INumber StepDelayN[1];
-    INumberVectorProperty StepDelayNP;
+    INDI::PropertyNumber StepDelayNP {1};
 
-    INumber TemperatureSettingN[2];
-    INumberVectorProperty TemperatureSettingNP;
+    INDI::PropertyNumber TemperatureSettingNP {2};
 
-    INumber TemperatureN[1];
-    INumberVectorProperty TemperatureNP;
+    INDI::PropertyNumber TemperatureNP {1};
 
-    ISwitch TemperatureCompensateS[2];
-    ISwitchVectorProperty TemperatureCompensateSP;
+    INDI::PropertySwitch TemperatureCompensateSP {2};
 
     const uint8_t m_ID;
     static constexpr const uint8_t DRO_CMD = 16;

--- a/drivers/focuser/myfocuserpro2.cpp
+++ b/drivers/focuser/myfocuserpro2.cpp
@@ -88,97 +88,97 @@ bool MyFocuserPro2::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    FocusSpeedN[0].min   = 0;
-    FocusSpeedN[0].max   = 2;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(0);
+    FocusSpeedNP[0].setMax(2);
+    FocusSpeedNP[0].setValue(1);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0.;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0.);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 200000.;
-    FocusAbsPosN[0].value = 0.;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(200000.);
+    FocusAbsPosNP[0].setValue(0.);
+    FocusAbsPosNP[0].setStep(1000);
 
-    FocusMaxPosN[0].min   = 1024.;
-    FocusMaxPosN[0].max   = 200000.;
-    FocusMaxPosN[0].value = 0.;
-    FocusMaxPosN[0].step  = 1000;
+    FocusMaxPosNP[0].setMin(1024.);
+    FocusMaxPosNP[0].setMax(200000.);
+    FocusMaxPosNP[0].setValue(0.);
+    FocusMaxPosNP[0].setStep(1000);
 
     //Backlash
-    BacklashInStepsN[0].min   = 0;
-    BacklashInStepsN[0].max   = 512;
-    BacklashInStepsN[0].value = 0;
-    BacklashInStepsN[0].step  = 2;
+    BacklashInStepsNP[0].setMin(0);
+    BacklashInStepsNP[0].setMax(512);
+    BacklashInStepsNP[0].setValue(0);
+    BacklashInStepsNP[0].setStep(2);
 
-    BacklashOutStepsN[0].min   = 0;
-    BacklashOutStepsN[0].max   = 512;
-    BacklashOutStepsN[0].value = 0;
-    BacklashOutStepsN[0].step  = 2;
+    BacklashOutStepsNP[0].setMin(0);
+    BacklashOutStepsNP[0].setMax(512);
+    BacklashOutStepsNP[0].setValue(0);
+    BacklashOutStepsNP[0].setStep(2);
 
 
     // Backlash In
-    IUFillSwitch(&BacklashInS[INDI_ENABLED], "INDI_ENABLED", "On", ISS_OFF);
-    IUFillSwitch(&BacklashInS[INDI_DISABLED], "INDI_DISABLED", "Off", ISS_OFF);
-    IUFillSwitchVector(&BacklashInSP, BacklashInS, 2, getDeviceName(), "Backlash In", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    BacklashInSP[INDI_ENABLED].fill("INDI_ENABLED", "On", ISS_OFF);
+    BacklashInSP[INDI_DISABLED].fill("INDI_DISABLED", "Off", ISS_OFF);
+    BacklashInSP.fill(getDeviceName(), "Backlash In", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillNumber(&BacklashInStepsN[0], "Steps", "", "%3.0f", 0, 512, 2, 0);
-    IUFillNumberVector(&BacklashInStepsNP, BacklashInStepsN, 1, getDeviceName(), "Backlash-In", "", OPTIONS_TAB, IP_RW, 0,
+    BacklashInStepsNP[0].fill("Steps", "", "%3.0f", 0, 512, 2, 0);
+    BacklashInStepsNP.fill(getDeviceName(), "Backlash-In", "", OPTIONS_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // Backlash Out
-    IUFillSwitch(&BacklashOutS[INDI_ENABLED], "INDI_ENABLED", "On", ISS_OFF);
-    IUFillSwitch(&BacklashOutS[INDI_DISABLED], "INDI_DISABLED", "Off", ISS_OFF);
-    IUFillSwitchVector(&BacklashOutSP, BacklashOutS, 2, getDeviceName(), "Backlash Out", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    BacklashOutSP[INDI_ENABLED].fill("INDI_ENABLED", "On", ISS_OFF);
+    BacklashOutSP[INDI_DISABLED].fill("INDI_DISABLED", "Off", ISS_OFF);
+    BacklashOutSP.fill(getDeviceName(), "Backlash Out", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillNumber(&BacklashOutStepsN[0], "Steps", "", "%3.0f", 0, 512, 2, 0);
-    IUFillNumberVector(&BacklashOutStepsNP, BacklashOutStepsN, 1, getDeviceName(), "Backlash-Out", "", OPTIONS_TAB, IP_RW, 0,
+    BacklashOutStepsNP[0].fill("Steps", "", "%3.0f", 0, 512, 2, 0);
+    BacklashOutStepsNP.fill(getDeviceName(), "Backlash-Out", "", OPTIONS_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -40, 80., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", MAIN_CONTROL_TAB,
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -40, 80., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", MAIN_CONTROL_TAB,
                        IP_RO, 0, IPS_IDLE);
 
     // Temperature Settings
-    IUFillNumber(&TemperatureSettingN[0], "Coefficient", "", "%6.2f", 0, 50, 1, 0);
-    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 1, getDeviceName(), "T. Settings", "", OPTIONS_TAB, IP_RW, 0,
+    TemperatureSettingNP[0].fill("Coefficient", "", "%6.2f", 0, 50, 1, 0);
+    TemperatureSettingNP.fill(getDeviceName(), "T. Settings", "", OPTIONS_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureCompensateS[TEMP_COMPENSATE_ENABLE], "TEMP_COMPENSATE_ENABLE", "Enable", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[TEMP_COMPENSATE_DISABLE], "TEMP_COMPENSATE_DISABLE", "Disable", ISS_OFF);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "T. Compensate", "", OPTIONS_TAB,
+    TemperatureCompensateSP[TEMP_COMPENSATE_ENABLE].fill("TEMP_COMPENSATE_ENABLE", "Enable", ISS_OFF);
+    TemperatureCompensateSP[TEMP_COMPENSATE_DISABLE].fill("TEMP_COMPENSATE_DISABLE", "Disable", ISS_OFF);
+    TemperatureCompensateSP.fill(getDeviceName(), "T. Compensate", "", OPTIONS_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Step Mode
-    IUFillSwitch(&StepModeS[FOCUS_THIRTYSECOND_STEP], "FOCUS_THIRTYSECOND_STEP", "1/32 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FOCUS_SIXTEENTH_STEP], "FOCUS_SIXTEENTH_STEP", "1/16 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FOCUS_EIGHTH_STEP], "FOCUS_EIGHTH_STEP", "1/8 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FOCUS_QUARTER_STEP], "FOCUS_QUARTER_STEP", "1/4 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FOCUS_HALF_STEP], "FOCUS_HALF_STEP", "1/2 Step", ISS_OFF);
-    IUFillSwitch(&StepModeS[FOCUS_FULL_STEP], "FOCUS_FULL_STEP", "Full Step", ISS_OFF);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 6, getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    StepModeSP[FOCUS_THIRTYSECOND_STEP].fill("FOCUS_THIRTYSECOND_STEP", "1/32 Step", ISS_OFF);
+    StepModeSP[FOCUS_SIXTEENTH_STEP].fill("FOCUS_SIXTEENTH_STEP", "1/16 Step", ISS_OFF);
+    StepModeSP[FOCUS_EIGHTH_STEP].fill("FOCUS_EIGHTH_STEP", "1/8 Step", ISS_OFF);
+    StepModeSP[FOCUS_QUARTER_STEP].fill("FOCUS_QUARTER_STEP", "1/4 Step", ISS_OFF);
+    StepModeSP[FOCUS_HALF_STEP].fill("FOCUS_HALF_STEP", "1/2 Step", ISS_OFF);
+    StepModeSP[FOCUS_FULL_STEP].fill("FOCUS_FULL_STEP", "Full Step", ISS_OFF);
+    StepModeSP.fill(getDeviceName(), "Step Mode", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
 
-    IUFillSwitch(&CoilPowerS[COIL_POWER_ON], "COIL_POWER_ON", "On", ISS_OFF);
-    IUFillSwitch(&CoilPowerS[COIL_POWER_OFF], "COIL_POWER_OFF", "Off", ISS_OFF);
-    IUFillSwitchVector(&CoilPowerSP, CoilPowerS, 2, getDeviceName(), "Coil Power", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    CoilPowerSP[COIL_POWER_ON].fill("COIL_POWER_ON", "On", ISS_OFF);
+    CoilPowerSP[COIL_POWER_OFF].fill("COIL_POWER_OFF", "Off", ISS_OFF);
+    CoilPowerSP.fill(getDeviceName(), "Coil Power", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&DisplayS[DISPLAY_OFF], "DISPLAY_OFF", "Off", ISS_OFF);
-    IUFillSwitch(&DisplayS[DISPLAY_ON], "DISPLAY_ON", "On", ISS_OFF);
-    IUFillSwitchVector(&DisplaySP, DisplayS, 2, getDeviceName(), "Display", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    DisplaySP[DISPLAY_OFF].fill("DISPLAY_OFF", "Off", ISS_OFF);
+    DisplaySP[DISPLAY_ON].fill("DISPLAY_ON", "On", ISS_OFF);
+    DisplaySP.fill(getDeviceName(), "Display", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
 
-    IUFillSwitch(&GotoHomeS[0], "GOTO_HOME", "Go", ISS_OFF);
-    IUFillSwitchVector(&GotoHomeSP, GotoHomeS, 1, getDeviceName(), "Goto Home Position", "", MAIN_CONTROL_TAB, IP_RW,
+    GotoHomeSP[0].fill("GOTO_HOME", "Go", ISS_OFF);
+    GotoHomeSP.fill(getDeviceName(), "Goto Home Position", "", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
     setPollingPeriodRange(1000, 30000);
@@ -196,17 +196,17 @@ bool MyFocuserPro2::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&GotoHomeSP);
-        defineProperty(&TemperatureNP);
-        defineProperty(&TemperatureSettingNP);
-        defineProperty(&TemperatureCompensateSP);
-        defineProperty(&BacklashInSP);
-        defineProperty(&BacklashInStepsNP);
-        defineProperty(&BacklashOutSP);
-        defineProperty(&BacklashOutStepsNP);
-        defineProperty(&StepModeSP);
-        defineProperty(&DisplaySP);
-        defineProperty(&CoilPowerSP);
+        defineProperty(GotoHomeSP);
+        defineProperty(TemperatureNP);
+        defineProperty(TemperatureSettingNP);
+        defineProperty(TemperatureCompensateSP);
+        defineProperty(BacklashInSP);
+        defineProperty(BacklashInStepsNP);
+        defineProperty(BacklashOutSP);
+        defineProperty(BacklashOutStepsNP);
+        defineProperty(StepModeSP);
+        defineProperty(DisplaySP);
+        defineProperty(CoilPowerSP);
 
         setTemperatureCelsius();
 
@@ -214,17 +214,17 @@ bool MyFocuserPro2::updateProperties()
     }
     else
     {
-        deleteProperty(GotoHomeSP.name);
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(TemperatureSettingNP.name);
-        deleteProperty(TemperatureCompensateSP.name);
-        deleteProperty(BacklashInSP.name);
-        deleteProperty(BacklashInStepsNP.name);
-        deleteProperty(BacklashOutSP.name);
-        deleteProperty(BacklashOutStepsNP.name);
-        deleteProperty(StepModeSP.name);
-        deleteProperty(DisplaySP.name);
-        deleteProperty(CoilPowerSP.name);
+        deleteProperty(GotoHomeSP.getName());
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(TemperatureSettingNP.getName());
+        deleteProperty(TemperatureCompensateSP.getName());
+        deleteProperty(BacklashInSP.getName());
+        deleteProperty(BacklashInStepsNP.getName());
+        deleteProperty(BacklashOutSP.getName());
+        deleteProperty(BacklashOutStepsNP.getName());
+        deleteProperty(StepModeSP.getName());
+        deleteProperty(DisplaySP.getName());
+        deleteProperty(CoilPowerSP.getName());
     }
 
     return true;
@@ -344,9 +344,9 @@ bool MyFocuserPro2::readCoilPowerState()
     if (rc > 0)
 
         if(temp == 0)
-            CoilPowerS[COIL_POWER_OFF].s = ISS_ON;
+            CoilPowerSP[COIL_POWER_OFF].setState(ISS_ON);
         else if (temp == 1)
-            CoilPowerS[COIL_POWER_ON].s = ISS_ON;
+            CoilPowerSP[COIL_POWER_ON].setState(ISS_ON);
         else
         {
             LOGF_ERROR("Invalid Response: focuser Coil Power value (%s)", res);
@@ -377,11 +377,11 @@ bool MyFocuserPro2::readReverseDirection()
 
         if(temp == 0)
         {
-            FocusReverseS[INDI_DISABLED].s = ISS_ON;
+            FocusReverseSP[INDI_DISABLED].setState(ISS_ON);
         }
         else if (temp == 1)
         {
-            FocusReverseS[INDI_ENABLED].s = ISS_ON;
+            FocusReverseSP[INDI_ENABLED].setState(ISS_ON);
         }
         else
         {
@@ -405,17 +405,17 @@ bool MyFocuserPro2::readStepMode()
         return false;
 
     if (strcmp(res, "S1#") == 0)
-        StepModeS[FOCUS_FULL_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_FULL_STEP].setState(ISS_ON);
     else if (strcmp(res, "S2#") == 0)
-        StepModeS[FOCUS_HALF_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_HALF_STEP].setState(ISS_ON);
     else if (strcmp(res, "S4#") == 0)
-        StepModeS[FOCUS_QUARTER_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_QUARTER_STEP].setState(ISS_ON);
     else if (strcmp(res, "S8#") == 0)
-        StepModeS[FOCUS_EIGHTH_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_EIGHTH_STEP].setState(ISS_ON);
     else if (strcmp(res, "S16#") == 0)
-        StepModeS[FOCUS_SIXTEENTH_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_SIXTEENTH_STEP].setState(ISS_ON);
     else if (strcmp(res, "S32#") == 0)
-        StepModeS[FOCUS_THIRTYSECOND_STEP].s = ISS_ON;
+        StepModeSP[FOCUS_THIRTYSECOND_STEP].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser Step Mode value (%s)", res);
@@ -436,7 +436,7 @@ bool MyFocuserPro2::readTemperature()
     int rc = sscanf(res, "Z%lf#", &temp);
     if (rc > 0)
         // Signed hex
-        TemperatureN[0].value = temp;
+        TemperatureNP[0].setValue(temp);
     else
     {
         LOGF_ERROR("Unknown error: focuser temperature value (%s)", res);
@@ -460,9 +460,9 @@ bool MyFocuserPro2::readTempCompensateEnable()
     if (rc > 0)
 
         if(temp == 0)
-            TemperatureCompensateS[TEMP_COMPENSATE_DISABLE].s = ISS_ON;
+            TemperatureCompensateSP[TEMP_COMPENSATE_DISABLE].setState(ISS_ON);
         else if (temp == 1)
-            TemperatureCompensateS[TEMP_COMPENSATE_ENABLE].s = ISS_ON;
+            TemperatureCompensateSP[TEMP_COMPENSATE_ENABLE].setState(ISS_ON);
         else
         {
             LOGF_ERROR("Invalid Response: focuser T.Compensate value (%s)", res);
@@ -489,7 +489,7 @@ bool MyFocuserPro2::readPosition()
     int rc = sscanf(res, "%*c%d#", &pos);
 
     if (rc > 0)
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     else
     {
         LOGF_ERROR("Unknown error: focuser position value (%s)", res);
@@ -510,7 +510,7 @@ bool MyFocuserPro2::readTempeartureCoefficient()
     int rc = sscanf(res, "B%d#", &val);
 
     if (rc > 0)
-        TemperatureSettingN[0].value = val;
+        TemperatureSettingNP[0].setValue(val);
     else
     {
         LOGF_ERROR("Unknown error: Temperature Coefficient value (%s)", res);
@@ -532,7 +532,7 @@ bool MyFocuserPro2::readSpeed()
 
     if (rc > 0)
     {
-        FocusSpeedN[0].value = speed;
+        FocusSpeedNP[0].setValue(speed);
     }
     else
     {
@@ -555,7 +555,7 @@ bool MyFocuserPro2::readMaxPos()
 
     if (rc > 0)
     {
-        FocusMaxPosN[0].value = maxPos;
+        FocusMaxPosNP[0].setValue(maxPos);
         Focuser::SyncPresets(maxPos);
     }
     else
@@ -579,11 +579,11 @@ bool MyFocuserPro2::readBacklashInSteps()
 
     if (rc > 0)
     {
-        BacklashInStepsN[0].value = backlash;
+        BacklashInStepsNP[0].setValue(backlash);
     }
     else
     {
-        BacklashInStepsN[0].value = 0;
+        BacklashInStepsNP[0].setValue(0);
         LOGF_ERROR("Unknown error: focuser Backlash IN value (%s)", res);
         return false;
     }
@@ -604,9 +604,9 @@ bool MyFocuserPro2::readBacklashInEnabled()
     if (rc > 0)
     {
         if(temp == 0)
-            BacklashInS[INDI_DISABLED].s = ISS_ON;
+            BacklashInSP[INDI_DISABLED].setState(ISS_ON);
         else if (temp == 1)
-            BacklashInS[INDI_ENABLED].s = ISS_ON;
+            BacklashInSP[INDI_ENABLED].setState(ISS_ON);
         else
             LOGF_ERROR("Unknown Repsonse: focuser Backlash IN enabled (%s)", res);
         return false;
@@ -630,7 +630,7 @@ bool MyFocuserPro2::readBacklashOutSteps()
 
     if (rc > 0)
     {
-        BacklashOutStepsN[0].value = backlash;
+        BacklashOutStepsNP[0].setValue(backlash);
     }
     else
     {
@@ -654,9 +654,9 @@ bool MyFocuserPro2::readBacklashOutEnabled()
     if (rc > 0)
     {
         if(temp == 0)
-            BacklashOutS[INDI_DISABLED].s = ISS_ON;
+            BacklashOutSP[INDI_DISABLED].setState(ISS_ON);
         else if (temp == 1)
-            BacklashOutS[INDI_ENABLED].s = ISS_ON;
+            BacklashOutSP[INDI_ENABLED].setState(ISS_ON);
         else
             LOGF_ERROR("Unknown response: focuser Backlash OUT enabled (%s)", res);
         return false;
@@ -683,9 +683,9 @@ bool MyFocuserPro2::readDisplayVisible()
     if (rc > 0)
     {
         if(temp == 0)
-            DisplayS[DISPLAY_OFF].s = ISS_ON;
+            DisplaySP[DISPLAY_OFF].setState(ISS_ON);
         else if (temp == 1)
-            DisplayS[DISPLAY_ON].s = ISS_ON;
+            DisplaySP[DISPLAY_ON].setState(ISS_ON);
         else
         {
             LOGF_ERROR("Invalid Response: focuser Display value (%s)", res);
@@ -854,192 +854,192 @@ bool MyFocuserPro2::ISNewSwitch(const char * dev, const char * name, ISState * s
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Focus Step Mode
-        if (strcmp(StepModeSP.name, name) == 0)
+        if (StepModeSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int current_mode = StepModeSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&StepModeSP, states, names, n);
+            StepModeSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int target_mode = StepModeSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                StepModeSP.s = IPS_OK;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.setState(IPS_OK);
+                StepModeSP.apply();
             }
 
             bool rc = setStepMode(static_cast<FocusStepMode>(target_mode));
             if (!rc)
             {
-                IUResetSwitch(&StepModeSP);
-                StepModeS[current_mode].s = ISS_ON;
-                StepModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.reset();
+                StepModeSP[current_mode].setState(ISS_ON);
+                StepModeSP.setState(IPS_ALERT);
+                StepModeSP.apply();
                 return false;
             }
 
-            StepModeSP.s = IPS_OK;
-            IDSetSwitch(&StepModeSP, nullptr);
+            StepModeSP.setState(IPS_OK);
+            StepModeSP.apply();
             return true;
         }
 
         // Goto Home Position
-        if (strcmp(GotoHomeSP.name, name) == 0)
+        if (GotoHomeSP.isNameMatch(name))
         {
             bool rc = setGotoHome();
             if (!rc)
             {
-                IUResetSwitch(&GotoHomeSP);
-                CoilPowerSP.s              = IPS_ALERT;
-                IDSetSwitch(&GotoHomeSP, nullptr);
+                GotoHomeSP.reset();
+                CoilPowerSP.setState(IPS_ALERT);
+                GotoHomeSP.apply();
                 return false;
             }
 
-            GotoHomeSP.s = IPS_OK;
-            IDSetSwitch(&GotoHomeSP, nullptr);
+            GotoHomeSP.setState(IPS_OK);
+            GotoHomeSP.apply();
             return true;
         }
 
         // Coil Power Mode
-        if (strcmp(CoilPowerSP.name, name) == 0)
+        if (CoilPowerSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&CoilPowerSP);
+            int current_mode = CoilPowerSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&CoilPowerSP, states, names, n);
+            CoilPowerSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&CoilPowerSP);
+            int target_mode = CoilPowerSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                CoilPowerSP.s = IPS_OK;
-                IDSetSwitch(&CoilPowerSP, nullptr);
+                CoilPowerSP.setState(IPS_OK);
+                CoilPowerSP.apply();
             }
 
             bool rc = setCoilPowerState(static_cast<CoilPower>(target_mode));
             if (!rc)
             {
-                IUResetSwitch(&CoilPowerSP);
-                CoilPowerS[current_mode].s = ISS_ON;
-                CoilPowerSP.s              = IPS_ALERT;
-                IDSetSwitch(&CoilPowerSP, nullptr);
+                CoilPowerSP.reset();
+                CoilPowerSP[current_mode].setState(ISS_ON);
+                CoilPowerSP.setState(IPS_ALERT);
+                CoilPowerSP.apply();
                 return false;
             }
 
-            CoilPowerSP.s = IPS_OK;
-            IDSetSwitch(&CoilPowerSP, nullptr);
+            CoilPowerSP.setState(IPS_OK);
+            CoilPowerSP.apply();
             return true;
         }
 
 
         // Display Control
-        if (strcmp(DisplaySP.name, name) == 0)
+        if (DisplaySP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&DisplaySP);
+            int current_mode = DisplaySP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&DisplaySP, states, names, n);
+            DisplaySP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&DisplaySP);
+            int target_mode = DisplaySP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                DisplaySP.s = IPS_OK;
-                IDSetSwitch(&DisplaySP, nullptr);
+                DisplaySP.setState(IPS_OK);
+                DisplaySP.apply();
             }
 
             bool rc = setDisplayVisible(static_cast<DisplayMode>(target_mode));
             if (!rc)
             {
-                IUResetSwitch(&DisplaySP);
-                DisplayS[current_mode].s = ISS_ON;
-                DisplaySP.s              = IPS_ALERT;
-                IDSetSwitch(&DisplaySP, nullptr);
+                DisplaySP.reset();
+                DisplaySP[current_mode].setState(ISS_ON);
+                DisplaySP.setState(IPS_ALERT);
+                DisplaySP.apply();
                 return false;
             }
 
-            DisplaySP.s = IPS_OK;
-            IDSetSwitch(&DisplaySP, nullptr);
+            DisplaySP.setState(IPS_OK);
+            DisplaySP.apply();
             return true;
         }
 
         // Backlash In Enable
-        if (strcmp(BacklashInSP.name, name) == 0)
+        if (BacklashInSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&BacklashInSP);
+            int current_mode = BacklashInSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&BacklashInSP, states, names, n);
+            BacklashInSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&BacklashInSP);
+            int target_mode = BacklashInSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                BacklashInSP.s = IPS_OK;
-                IDSetSwitch(&BacklashInSP, nullptr);
+                BacklashInSP.setState(IPS_OK);
+                BacklashInSP.apply();
             }
 
             bool rc = setBacklashInEnabled(target_mode == INDI_ENABLED);
             if (!rc)
             {
-                IUResetSwitch(&BacklashInSP);
-                BacklashInS[current_mode].s = ISS_ON;
-                BacklashInSP.s              = IPS_ALERT;
-                IDSetSwitch(&BacklashInSP, nullptr);
+                BacklashInSP.reset();
+                BacklashInSP[current_mode].setState(ISS_ON);
+                BacklashInSP.setState(IPS_ALERT);
+                BacklashInSP.apply();
                 return false;
             }
 
-            BacklashInSP.s = IPS_OK;
-            IDSetSwitch(&BacklashInSP, nullptr);
+            BacklashInSP.setState(IPS_OK);
+            BacklashInSP.apply();
             return true;
         }
 
         // Backlash Out Enable
-        if (strcmp(BacklashOutSP.name, name) == 0)
+        if (BacklashOutSP.isNameMatch(name))
         {
-            int current_mode = IUFindOnSwitchIndex(&BacklashOutSP);
+            int current_mode = BacklashOutSP.findOnSwitchIndex();
 
-            IUUpdateSwitch(&BacklashOutSP, states, names, n);
+            BacklashOutSP.update(states, names, n);
 
-            int target_mode = IUFindOnSwitchIndex(&BacklashOutSP);
+            int target_mode = BacklashOutSP.findOnSwitchIndex();
 
             if (current_mode == target_mode)
             {
-                BacklashOutSP.s = IPS_OK;
-                IDSetSwitch(&BacklashOutSP, nullptr);
+                BacklashOutSP.setState(IPS_OK);
+                BacklashOutSP.apply();
             }
 
             bool rc = setBacklashOutEnabled(target_mode == INDI_ENABLED);
             if (!rc)
             {
-                IUResetSwitch(&BacklashOutSP);
-                BacklashOutS[current_mode].s = ISS_ON;
-                BacklashOutSP.s              = IPS_ALERT;
-                IDSetSwitch(&BacklashOutSP, nullptr);
+                BacklashOutSP.reset();
+                BacklashOutSP[current_mode].setState(ISS_ON);
+                BacklashOutSP.setState(IPS_ALERT);
+                BacklashOutSP.apply();
                 return false;
             }
 
-            BacklashOutSP.s = IPS_OK;
-            IDSetSwitch(&BacklashOutSP, nullptr);
+            BacklashOutSP.setState(IPS_OK);
+            BacklashOutSP.apply();
             return true;
         }
 
         // Temperature Compensation Mode
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int last_index = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
+            int last_index = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
 
-            bool rc = setTemperatureCompensation((TemperatureCompensateS[0].s == ISS_ON));
+            bool rc = setTemperatureCompensation((TemperatureCompensateSP[0].getState() == ISS_ON));
 
             if (!rc)
             {
-                TemperatureCompensateSP.s = IPS_ALERT;
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateS[last_index].s = ISS_ON;
-                IDSetSwitch(&TemperatureCompensateSP, nullptr);
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP[last_index].setState(ISS_ON);
+                TemperatureCompensateSP.apply();
                 return false;
             }
 
-            TemperatureCompensateSP.s = IPS_OK;
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.setState(IPS_OK);
+            TemperatureCompensateSP.apply();
             return true;
         }
     }
@@ -1052,50 +1052,50 @@ bool MyFocuserPro2::ISNewNumber(const char * dev, const char * name, double valu
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Settings
-        if (strcmp(name, TemperatureSettingNP.name) == 0)
+        if (TemperatureSettingNP.isNameMatch(name))
         {
-            IUUpdateNumber(&TemperatureSettingNP, values, names, n);
-            if (!setTemperatureCoefficient(TemperatureSettingN[0].value))
+            TemperatureSettingNP.update(values, names, n);
+            if (!setTemperatureCoefficient(TemperatureSettingNP[0].value))
             {
-                TemperatureSettingNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureSettingNP, nullptr);
+                TemperatureSettingNP.setState(IPS_ALERT);
+                TemperatureSettingNP.apply();
                 return false;
             }
 
-            TemperatureSettingNP.s = IPS_OK;
-            IDSetNumber(&TemperatureSettingNP, nullptr);
+            TemperatureSettingNP.setState(IPS_OK);
+            TemperatureSettingNP.apply();
             return true;
         }
 
         // Backlash In
-        if (strcmp(name, BacklashInStepsNP.name) == 0)
+        if (BacklashInStepsNP.isNameMatch(name))
         {
-            IUUpdateNumber(&BacklashInStepsNP, values, names, n);
-            if (!setBacklashInSteps(BacklashInStepsN[0].value))
+            BacklashInStepsNP.update(values, names, n);
+            if (!setBacklashInSteps(BacklashInStepsNP[0].value))
             {
-                BacklashInStepsNP.s = IPS_ALERT;
-                IDSetNumber(&BacklashInStepsNP, nullptr);
+                BacklashInStepsNP.setState(IPS_ALERT);
+                BacklashInStepsNP.apply();
                 return false;
             }
 
-            BacklashInStepsNP.s = IPS_OK;
-            IDSetNumber(&BacklashInStepsNP, nullptr);
+            BacklashInStepsNP.setState(IPS_OK);
+            BacklashInStepsNP.apply();
             return true;
         }
 
         // Backlash Out
-        if (strcmp(name, BacklashOutStepsNP.name) == 0)
+        if (BacklashOutStepsNP.isNameMatch(name))
         {
-            IUUpdateNumber(&BacklashOutStepsNP, values, names, n);
-            if (!setBacklashOutSteps(BacklashOutStepsN[0].value))
+            BacklashOutStepsNP.update(values, names, n);
+            if (!setBacklashOutSteps(BacklashOutStepsNP[0].value))
             {
-                BacklashOutStepsNP.s = IPS_ALERT;
-                IDSetNumber(&BacklashOutStepsNP, nullptr);
+                BacklashOutStepsNP.setState(IPS_ALERT);
+                BacklashOutStepsNP.apply();
                 return false;
             }
 
-            BacklashOutStepsNP.s = IPS_OK;
-            IDSetNumber(&BacklashOutStepsNP, nullptr);
+            BacklashOutStepsNP.setState(IPS_OK);
+            BacklashOutStepsNP.apply();
             return true;
         }
 
@@ -1145,7 +1145,7 @@ bool MyFocuserPro2::SetFocuserMaxPosition(uint32_t maxPos)
 
 IPState MyFocuserPro2::MoveFocuser(FocusDirection dir, int speed, uint16_t duration)
 {
-    if (speed != static_cast<int>(FocusSpeedN[0].value))
+    if (speed != static_cast<int>(FocusSpeedNP[0].value))
     {
         if (!setSpeed(speed))
             return IPS_ALERT;
@@ -1156,7 +1156,7 @@ IPState MyFocuserPro2::MoveFocuser(FocusDirection dir, int speed, uint16_t durat
     if (dir == FOCUS_INWARD)
         MoveFocuser(0);
     else
-        MoveFocuser(FocusMaxPosN[0].value);
+        MoveFocuser(FocusMaxPosNP[0].value);
 
     IEAddTimer(duration, &MyFocuserPro2::timedMoveHelper, this);
     return IPS_BUSY;
@@ -1170,13 +1170,13 @@ void MyFocuserPro2::timedMoveHelper(void * context)
 void MyFocuserPro2::timedMoveCallback()
 {
     AbortFocuser();
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocusRelPosNP.s = IPS_IDLE;
-    FocusTimerNP.s = IPS_IDLE;
-    FocusTimerN[0].value = 0;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
-    IDSetNumber(&FocusTimerNP, nullptr);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusRelPosNP.setState(IPS_IDLE);
+    FocusTimerNP.setState(IPS_IDLE);
+    FocusTimerNP[0].setValue(0);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
+    FocusTimerNP.apply();
 }
 
 IPState MyFocuserPro2::MoveAbsFocuser(uint32_t targetTicks)
@@ -1194,17 +1194,17 @@ IPState MyFocuserPro2::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     int32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     // Clamp
-    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosN[0].max), newPosition));
+    newPosition = std::max(0, std::min(static_cast<int32_t>(FocusAbsPosNP[0].max), newPosition));
     if (!MoveFocuser(newPosition))
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -1220,32 +1220,32 @@ void MyFocuserPro2::TimerHit()
     bool rc = readPosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
     rc = readTemperature();
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -1262,7 +1262,7 @@ bool MyFocuserPro2::saveConfigItems(FILE * fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &StepModeSP);
+    StepModeSP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/myfocuserpro2.h
+++ b/drivers/focuser/myfocuserpro2.h
@@ -27,6 +27,10 @@
 
 #include <chrono>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class MyFocuserPro2 : public INDI::Focuser
 {
     public:
@@ -174,52 +178,40 @@ class MyFocuserPro2 : public INDI::Focuser
         double targetPos { 0 }, lastPos { 0 }, lastTemperature { 0 };
 
         // Read Only Temperature Reporting
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Full/Half...32th Step modes
-        ISwitch StepModeS[6];
-        ISwitchVectorProperty StepModeSP;
+        INDI::PropertySwitch StepModeSP {6};
 
         // Backlash In settings
-        INumber BacklashInStepsN[1];
-        INumberVectorProperty BacklashInStepsNP;
+        INDI::PropertyNumber BacklashInStepsNP {1};
 
         // Backlash Out Setting
-        INumber BacklashOutStepsN[1];
-        INumberVectorProperty BacklashOutStepsNP;
+        INDI::PropertyNumber BacklashOutStepsNP {1};
 
         // Temperature Settings
-        INumber TemperatureSettingN[1];
-        INumberVectorProperty TemperatureSettingNP;
+        INDI::PropertyNumber TemperatureSettingNP {1};
 
         // Temperature Compensation Enable/Disable
-        ISwitch TemperatureCompensateS[2];
-        ISwitchVectorProperty TemperatureCompensateSP;
+        INDI::PropertySwitch TemperatureCompensateSP {2};
 
         //Display On Off
-        ISwitch DisplayS[2];
-        ISwitchVectorProperty DisplaySP;
+        INDI::PropertySwitch DisplaySP {2};
 
         //Goto Home Position
-        ISwitch GotoHomeS[1];
-        ISwitchVectorProperty GotoHomeSP;
+        INDI::PropertySwitch GotoHomeSP {1};
 
         //CoilPower On Off
-        ISwitch CoilPowerS[2];
-        ISwitchVectorProperty CoilPowerSP;
+        INDI::PropertySwitch CoilPowerSP {2};
 
         //Backlash In Enable
-        ISwitch BacklashInS[2];
-        ISwitchVectorProperty BacklashInSP;
+        INDI::PropertySwitch BacklashInSP {2};
 
         //Backlash Out Enable
-        ISwitch BacklashOutS[2];
-        ISwitchVectorProperty BacklashOutSP;
+        INDI::PropertySwitch BacklashOutSP {2};
 
         //Focus Speed
-        ISwitch FocusSpeedS[3];
-        ISwitchVectorProperty FocusSpeedSP;
+        INDI::PropertySwitch FocusSpeedSP {3};
 
         // MyFocuserPro2 Buffer
         static const uint8_t ML_RES { 32 };

--- a/drivers/focuser/nfocus.h
+++ b/drivers/focuser/nfocus.h
@@ -23,6 +23,9 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 /**
  * @brief The NFocus class Handles communication and control with nFocus DC focuser
  *
@@ -75,11 +78,9 @@ class NFocus : public INDI::Focuser
         /////////////////////////////////////////////////////////////////////////////
         /// Properties
         /////////////////////////////////////////////////////////////////////////////
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
-        INumber SettingsN[3];
-        INumberVectorProperty SettingsNP;
+        INDI::PropertyNumber SettingsNP {3};
         enum
         {
             SETTING_ON_TIME,

--- a/drivers/focuser/nstep.cpp
+++ b/drivers/focuser/nstep.cpp
@@ -83,67 +83,67 @@ bool NStep::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -100, 100, 0, 0);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -100, 100, 0, 0);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Compensation Modes
-    IUFillSwitch(&CompensationModeS[COMPENSATION_MODE_OFF], "COMPENSATION_MODE_OFF", "Off", ISS_ON);
-    IUFillSwitch(&CompensationModeS[COMPENSATION_MODE_ONE_SHOT], "COMPENSATION_MODE_ONE_SHOT", "One shot", ISS_OFF);
-    IUFillSwitch(&CompensationModeS[COMPENSATION_MODE_AUTO], "COMPENSATION_MODE_AUTO", "Auto", ISS_OFF);
-    IUFillSwitchVector(&CompensationModeSP, CompensationModeS, 3, getDeviceName(), "COMPENSATION_MODE", "Mode",
+    CompensationModeSP[COMPENSATION_MODE_OFF].fill("COMPENSATION_MODE_OFF", "Off", ISS_ON);
+    CompensationModeSP[COMPENSATION_MODE_ONE_SHOT].fill("COMPENSATION_MODE_ONE_SHOT", "One shot", ISS_OFF);
+    CompensationModeSP[COMPENSATION_MODE_AUTO].fill("COMPENSATION_MODE_AUTO", "Auto", ISS_OFF);
+    CompensationModeSP.fill(getDeviceName(), "COMPENSATION_MODE", "Mode",
                        COMPENSATION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_OK);
 
     // Prime for Manual
-    IUFillSwitch(&PrimeManualS[0], "MANUAL_MODE_PRIME", "Prime Manual Mode", ISS_OFF);
-    IUFillSwitchVector(&PrimeManualSP, PrimeManualS, 1, getDeviceName(), "COMPENSATION_PRIME", "Prime",
+    PrimeManualSP[0].fill("MANUAL_MODE_PRIME", "Prime Manual Mode", ISS_OFF);
+    PrimeManualSP.fill(getDeviceName(), "COMPENSATION_PRIME", "Prime",
                        COMPENSATION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_OK);
 
     // Compensation Settings
-    IUFillNumber(&CompensationSettingsN[COMPENSATION_SETTING_CHANGE], "COMPENSATION_SETTING_CHANGE", "Delta T. (C)", "%.1f", -99, 99, 0.1, 0);
-    IUFillNumber(&CompensationSettingsN[COMPENSATION_SETTING_STEP], "COMPENSATION_SETTING_STEP", "Steps per Delta", "%.0f", 0, 999, 1, 0);
-    IUFillNumber(&CompensationSettingsN[COMPENSATION_SETTING_BACKLASH], "COMPENSATION_SETTING_BACKLASH", "Backlash steps", "%.0f", 0, 999, 1, 0);
-    IUFillNumber(&CompensationSettingsN[COMPENSATION_SETTING_TIMER], "COMPENSATION_SETTING_TIMER", "Averaged Time (s)", "%.0f", 0, 75, 1, 0);
-    IUFillNumberVector(&CompensationSettingsNP, CompensationSettingsN, 4, getDeviceName(), "COMPENSATION_SETTING", "Settings",
+    CompensationSettingsNP[COMPENSATION_SETTING_CHANGE].fill("COMPENSATION_SETTING_CHANGE", "Delta T. (C)", "%.1f", -99, 99, 0.1, 0);
+    CompensationSettingsNP[COMPENSATION_SETTING_STEP].fill("COMPENSATION_SETTING_STEP", "Steps per Delta", "%.0f", 0, 999, 1, 0);
+    CompensationSettingsNP[COMPENSATION_SETTING_BACKLASH].fill("COMPENSATION_SETTING_BACKLASH", "Backlash steps", "%.0f", 0, 999, 1, 0);
+    CompensationSettingsNP[COMPENSATION_SETTING_TIMER].fill("COMPENSATION_SETTING_TIMER", "Averaged Time (s)", "%.0f", 0, 75, 1, 0);
+    CompensationSettingsNP.fill(getDeviceName(), "COMPENSATION_SETTING", "Settings",
                        COMPENSATION_TAB, IP_RW, 0, IPS_OK);
 
     // Stepping Modes
-    IUFillSwitch(&SteppingModeS[STEPPING_WAVE], "STEPPING_WAVE", "Wave", ISS_OFF);
-    IUFillSwitch(&SteppingModeS[STEPPING_HALF], "STEPPING_HALF", "Half", ISS_OFF);
-    IUFillSwitch(&SteppingModeS[STEPPING_FULL], "STEPPING_FULL", "Full", ISS_ON);
-    IUFillSwitchVector(&SteppingModeSP, SteppingModeS, 3, getDeviceName(), "STEPPING_MODE", "Mode",
+    SteppingModeSP[STEPPING_WAVE].fill("STEPPING_WAVE", "Wave", ISS_OFF);
+    SteppingModeSP[STEPPING_HALF].fill("STEPPING_HALF", "Half", ISS_OFF);
+    SteppingModeSP[STEPPING_FULL].fill("STEPPING_FULL", "Full", ISS_ON);
+    SteppingModeSP.fill(getDeviceName(), "STEPPING_MODE", "Mode",
                        STEPPING_TAB, IP_RW, ISR_1OFMANY, 0, IPS_OK);
 
     // Stepping Phase
-    IUFillNumber(&SteppingPhaseN[0], "PHASES", "Wiring", "%.f", 0, 2, 1, 0);
-    IUFillNumberVector(&SteppingPhaseNP, SteppingPhaseN, 1, getDeviceName(), "STEPPING_PHASE", "Phase",
+    SteppingPhaseNP[0].fill("PHASES", "Wiring", "%.f", 0, 2, 1, 0);
+    SteppingPhaseNP.fill(getDeviceName(), "STEPPING_PHASE", "Phase",
                        STEPPING_TAB, IP_RW, 0, IPS_OK);
 
     // Max Speed
-    IUFillNumber(&MaxSpeedN[0], "RATE", "Rate", "%.f", 1, 254, 10, 0);
-    IUFillNumberVector(&MaxSpeedNP, MaxSpeedN, 1, getDeviceName(), "MAX_SPEED", "Max Speed",
+    MaxSpeedNP[0].fill("RATE", "Rate", "%.f", 1, 254, 10, 0);
+    MaxSpeedNP.fill(getDeviceName(), "MAX_SPEED", "Max Speed",
                        MAIN_CONTROL_TAB, IP_RW, 0, IPS_OK);
 
     // Coil Energized Status
-    IUFillSwitch(&CoilStatusS[COIL_ENERGIZED_OFF], "COIL_ENERGIZED_OFF", "De-energized", ISS_OFF);
-    IUFillSwitch(&CoilStatusS[COIL_ENERGIZED_ON], "COIL_ENERGIZED_OFF", "Energized", ISS_OFF);
-    IUFillSwitchVector(&CoilStatusSP, CoilStatusS, 2, getDeviceName(), "COIL_MODE", "Coil After Move",
+    CoilStatusSP[COIL_ENERGIZED_OFF].fill("COIL_ENERGIZED_OFF", "De-energized", ISS_OFF);
+    CoilStatusSP[COIL_ENERGIZED_ON].fill("COIL_ENERGIZED_OFF", "Energized", ISS_OFF);
+    CoilStatusSP.fill(getDeviceName(), "COIL_MODE", "Coil After Move",
                        OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_OK);
 
     addDebugControl();
 
     // Set limits as per documentation
-    FocusAbsPosN[0].min  = 0;
-    FocusAbsPosN[0].max  = 999999;
-    FocusAbsPosN[0].step = 1000;
+    FocusAbsPosNP[0].setMin(0);
+    FocusAbsPosNP[0].setMax(999999);
+    FocusAbsPosNP[0].setStep(1000);
 
-    FocusRelPosN[0].min  = 0;
-    FocusRelPosN[0].max  = 999;
-    FocusRelPosN[0].step = 100;
+    FocusRelPosNP[0].setMin(0);
+    FocusRelPosNP[0].setMax(999);
+    FocusRelPosNP[0].setStep(100);
 
-    FocusSpeedN[0].min  = 1;
-    FocusSpeedN[0].max  = 254;
-    FocusSpeedN[0].step = 10;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(254);
+    FocusSpeedNP[0].setStep(10);
 
     return true;
 }
@@ -167,18 +167,18 @@ bool NStep::updateProperties()
     if (isConnected())
     {
         if (readTemperature())
-            defineProperty(&TemperatureNP);
+            defineProperty(TemperatureNP);
 
         bool rc = getStartupValues();
 
         // Settings
-        defineProperty(&MaxSpeedNP);
-        defineProperty(&CompensationModeSP);
-        defineProperty(&PrimeManualSP);
-        defineProperty(&CompensationSettingsNP);
-        defineProperty(&SteppingModeSP);
-        defineProperty(&SteppingPhaseNP);
-        defineProperty(&CoilStatusSP);
+        defineProperty(MaxSpeedNP);
+        defineProperty(CompensationModeSP);
+        defineProperty(PrimeManualSP);
+        defineProperty(CompensationSettingsNP);
+        defineProperty(SteppingModeSP);
+        defineProperty(SteppingPhaseNP);
+        defineProperty(CoilStatusSP);
 
         if (rc)
             LOG_INFO("NStep is ready.");
@@ -187,16 +187,16 @@ bool NStep::updateProperties()
     }
     else
     {
-        if (TemperatureNP.s == IPS_OK)
-            deleteProperty(TemperatureNP.name);
+        if (TemperatureNP.getState() == IPS_OK)
+            deleteProperty(TemperatureNP.getName());
 
-        deleteProperty(MaxSpeedNP.name);
-        deleteProperty(CompensationModeSP.name);
-        deleteProperty(PrimeManualSP.name);
-        deleteProperty(CompensationSettingsNP.name);
-        deleteProperty(SteppingModeSP.name);
-        deleteProperty(SteppingPhaseNP.name);
-        deleteProperty(CoilStatusSP.name);
+        deleteProperty(MaxSpeedNP.getName());
+        deleteProperty(CompensationModeSP.getName());
+        deleteProperty(PrimeManualSP.getName());
+        deleteProperty(CompensationSettingsNP.getName());
+        deleteProperty(SteppingModeSP.getName());
+        deleteProperty(SteppingPhaseNP.getName());
+        deleteProperty(CoilStatusSP.getName());
     }
 
     return true;
@@ -289,25 +289,25 @@ bool NStep::ISNewNumber(const char *dev, const char *name, double values[], char
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Compensation Settings
-        if (!strcmp(name, CompensationSettingsNP.name))
+        if (CompensationSettingsNP.isNameMatch(name))
         {
             // Extract values
             int change = 0, step = 0, backlash = 0, timer = 0;
             for (int i = 0; i < n; i++)
             {
-                if (!strcmp(names[i], CompensationSettingsN[COMPENSATION_SETTING_CHANGE].name))
+                if (!strcmp(names[i], CompensationSettingsNP[COMPENSATION_SETTING_CHANGE].getName()))
                 {
                     change = values[i];
                 }
-                else if (!strcmp(names[i], CompensationSettingsN[COMPENSATION_SETTING_STEP].name))
+                else if (!strcmp(names[i], CompensationSettingsNP[COMPENSATION_SETTING_STEP].getName()))
                 {
                     step = values[i];
                 }
-                else if (!strcmp(names[i], CompensationSettingsN[COMPENSATION_SETTING_BACKLASH].name))
+                else if (!strcmp(names[i], CompensationSettingsNP[COMPENSATION_SETTING_BACKLASH].getName()))
                 {
                     backlash = values[i];
                 }
-                else if (!strcmp(names[i], CompensationSettingsN[COMPENSATION_SETTING_TIMER].name))
+                else if (!strcmp(names[i], CompensationSettingsNP[COMPENSATION_SETTING_TIMER].getName()))
                 {
                     timer = values[i];
                 }
@@ -316,52 +316,52 @@ bool NStep::ISNewNumber(const char *dev, const char *name, double values[], char
             // Try to update settings
             if (setCompensationSettings(change, step, backlash, timer))
             {
-                IUUpdateNumber(&CompensationSettingsNP, values, names, n);
-                CompensationSettingsNP.s = IPS_OK;
+                CompensationSettingsNP.update(values, names, n);
+                CompensationSettingsNP.setState(IPS_OK);
             }
             else
             {
-                CompensationSettingsNP.s = IPS_ALERT;
+                CompensationSettingsNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&CompensationSettingsNP, nullptr);
+            CompensationSettingsNP.apply();
             return true;
         }
 
 
         // Stepping Phase
-        if (!strcmp(name, SteppingPhaseNP.name))
+        if (SteppingPhaseNP.isNameMatch(name))
         {
             if (setSteppingPhase(static_cast<uint8_t>(values[0])))
             {
-                IUUpdateNumber(&SteppingPhaseNP, values, names, n);
-                SteppingPhaseNP.s = IPS_OK;
+                SteppingPhaseNP.update(values, names, n);
+                SteppingPhaseNP.setState(IPS_OK);
             }
             else
-                SteppingPhaseNP.s = IPS_ALERT;
+                SteppingPhaseNP.setState(IPS_ALERT);
 
-            IDSetNumber(&SteppingPhaseNP, nullptr);
+            SteppingPhaseNP.apply();
             return true;
         }
 
         // Max Speed
-        if (!strcmp(name, MaxSpeedNP.name))
+        if (MaxSpeedNP.isNameMatch(name))
         {
             if (setMaxSpeed(static_cast<uint8_t>(values[0])))
             {
-                IUUpdateNumber(&MaxSpeedNP, values, names, n);
-                MaxSpeedNP.s = IPS_OK;
+                MaxSpeedNP.update(values, names, n);
+                MaxSpeedNP.setState(IPS_OK);
 
                 // We must update the Min/Max of focus speed
-                FocusSpeedN[0].max = values[0];
-                IUUpdateMinMax(&FocusSpeedNP);
+                FocusSpeedNP[0].setMax(values[0]);
+                FocusSpeedNP.updateMinMax();
             }
             else
             {
-                MaxSpeedNP.s = IPS_ALERT;
+                MaxSpeedNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&MaxSpeedNP, nullptr);
+            MaxSpeedNP.apply();
             return true;
         }
     }
@@ -374,14 +374,14 @@ bool NStep::ISNewSwitch(const char * dev, const char * name, ISState * states, c
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Compensation Mode
-        if (!strcmp(name, CompensationModeSP.name))
+        if (CompensationModeSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&CompensationModeSP);
-            IUUpdateSwitch(&CompensationModeSP, states, names, n);
-            int mode = IUFindOnSwitchIndex(&CompensationModeSP);
+            int prevIndex = CompensationModeSP.findOnSwitchIndex();
+            CompensationModeSP.update(states, names, n);
+            int mode = CompensationModeSP.findOnSwitchIndex();
             if (setCompensationMode(mode))
             {
-                CompensationModeSP.s = IPS_OK;
+                CompensationModeSP.setState(IPS_OK);
                 // If it was set to one shot, we put it back to off?
                 switch (mode)
                 {
@@ -390,8 +390,8 @@ bool NStep::ISNewSwitch(const char * dev, const char * name, ISState * states, c
                         break;
 
                     case COMPENSATION_MODE_ONE_SHOT:
-                        IUResetSwitch(&CompensationModeSP);
-                        CompensationModeS[COMPENSATION_MODE_OFF].s = ISS_ON;
+                        CompensationModeSP.reset();
+                        CompensationModeSP[COMPENSATION_MODE_OFF].setState(ISS_ON);
                         LOG_INFO("One shot compensation applied.");
                         break;
 
@@ -402,44 +402,44 @@ bool NStep::ISNewSwitch(const char * dev, const char * name, ISState * states, c
             }
             else
             {
-                IUResetSwitch(&CompensationModeSP);
-                CompensationModeS[prevIndex].s = ISS_ON;
-                CompensationModeSP.s = IPS_ALERT;
+                CompensationModeSP.reset();
+                CompensationModeSP[prevIndex].setState(ISS_ON);
+                CompensationModeSP.setState(IPS_ALERT);
                 LOG_ERROR("Failed to change temperature compensation mode.");
             }
 
-            IDSetSwitch(&CompensationModeSP, nullptr);
+            CompensationModeSP.apply();
             return true;
         }
 
         // Manual Prime
-        if (!strcmp(name, PrimeManualSP.name))
+        if (PrimeManualSP.isNameMatch(name))
         {
             sendCommand(":TI");
-            PrimeManualSP.s = IPS_OK;
-            IDSetSwitch(&PrimeManualSP, nullptr);
+            PrimeManualSP.setState(IPS_OK);
+            PrimeManualSP.apply();
             LOG_INFO("Prime for manual complete. Click One Shot to apply manual compensation once.");
             return true;
         }
 
         // Stepping Mode
-        if (!strcmp(name, SteppingModeSP.name))
+        if (SteppingModeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SteppingModeSP, states, names, n);
-            SteppingModeSP.s = IPS_OK;
-            IDSetSwitch(&SteppingModeSP, nullptr);
+            SteppingModeSP.update(states, names, n);
+            SteppingModeSP.setState(IPS_OK);
+            SteppingModeSP.apply();
             return true;
         }
 
         // Coil Status after Move is done
-        if (!strcmp(name, CoilStatusSP.name))
+        if (CoilStatusSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&CoilStatusSP);
-            IUUpdateSwitch(&CoilStatusSP, states, names, n);
-            int state = IUFindOnSwitchIndex(&CoilStatusSP);
+            int prevIndex = CoilStatusSP.findOnSwitchIndex();
+            CoilStatusSP.update(states, names, n);
+            int state = CoilStatusSP.findOnSwitchIndex();
             if (setCoilStatus(state))
             {
-                CoilStatusSP.s = IPS_OK;
+                CoilStatusSP.setState(IPS_OK);
                 if (state == COIL_ENERGIZED_ON)
                     LOG_WARN("Coil shall be kept energized after motion is complete. Watch for motor heating!");
                 else
@@ -447,13 +447,13 @@ bool NStep::ISNewSwitch(const char * dev, const char * name, ISState * states, c
             }
             else
             {
-                IUResetSwitch(&CoilStatusSP);
-                CoilStatusS[prevIndex].s = ISS_ON;
-                CoilStatusSP.s = IPS_ALERT;
+                CoilStatusSP.reset();
+                CoilStatusSP[prevIndex].setState(ISS_ON);
+                CoilStatusSP.setState(IPS_ALERT);
                 LOG_ERROR("Failed to update coil energization status.");
             }
 
-            IDSetSwitch(&CoilStatusSP, nullptr);
+            CoilStatusSP.apply();
             return true;
         }
     }
@@ -472,14 +472,14 @@ bool NStep::getStartupValues()
 
 IPState NStep::MoveAbsFocuser(uint32_t targetTicks)
 {
-    m_TargetDiff = targetTicks - FocusAbsPosN[0].value;
+    m_TargetDiff = targetTicks - FocusAbsPosNP[0].getValue();
     return IPS_BUSY;
 }
 
 IPState NStep::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
     m_TargetDiff = ticks * ((dir == FOCUS_INWARD) ? -1 : 1);
-    return MoveAbsFocuser(FocusAbsPosN[0].value + m_TargetDiff);
+    return MoveAbsFocuser(FocusAbsPosNP[0].value + m_TargetDiff);
 }
 
 bool NStep::AbortFocuser()
@@ -492,21 +492,21 @@ void NStep::TimerHit()
     if (isConnected() == false)
         return;
 
-    double currentPosition = FocusAbsPosN[0].value;
+    double currentPosition = FocusAbsPosNP[0].getValue();
 
     readPosition();
 
     // Check if we have a pending motion
     // and if we STOPPED, then let's take the next action
-    if ( (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY) && isMoving() == false)
+    if ( (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY) && isMoving() == false)
     {
         // Are we done moving?
         if (m_TargetDiff == 0)
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
         }
         else
         {
@@ -515,21 +515,21 @@ void NStep::TimerHit()
             // therefore for larger movements, we break it down.
             int nextMotion = (std::abs(m_TargetDiff) > 999) ? 999 : std::abs(m_TargetDiff);
             int direction = m_TargetDiff > 0 ? FOCUS_OUTWARD : FOCUS_INWARD;
-            int mode = IUFindOnSwitchIndex(&SteppingModeSP);
+            int mode = SteppingModeSP.findOnSwitchIndex();
             char cmd[NSTEP_LEN] = {0};
             snprintf(cmd, NSTEP_LEN, ":F%d%d%03d#", direction, mode, nextMotion);
             if (sendCommand(cmd) == false)
             {
                 LOG_ERROR("Failed to issue motion command.");
-                if (FocusRelPosNP.s == IPS_BUSY)
+                if (FocusRelPosNP.getState() == IPS_BUSY)
                 {
-                    FocusRelPosNP.s = IPS_ALERT;
-                    IDSetNumber(&FocusRelPosNP, nullptr);
+                    FocusRelPosNP.setState(IPS_ALERT);
+                    FocusRelPosNP.apply();
                 }
-                if (FocusAbsPosNP.s == IPS_BUSY)
+                if (FocusAbsPosNP.getState() == IPS_BUSY)
                 {
-                    FocusAbsPosNP.s = IPS_ALERT;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
+                    FocusAbsPosNP.setState(IPS_ALERT);
+                    FocusAbsPosNP.apply();
                 }
             }
             else
@@ -540,17 +540,17 @@ void NStep::TimerHit()
         }
         // Check if can update the absolute position in case it changed.
     }
-    else if (currentPosition != FocusAbsPosN[0].value)
+    else if (currentPosition != FocusAbsPosNP[0].getValue())
     {
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
     }
 
     // Read temperature
-    if (TemperatureNP.s == IPS_OK && m_TemperatureCounter++ == NSTEP_TEMPERATURE_FREQ)
+    if (TemperatureNP.getState() == IPS_OK && m_TemperatureCounter++ == NSTEP_TEMPERATURE_FREQ)
     {
         m_TemperatureCounter = 0;
         if (readTemperature())
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP.apply();
     }
 
     SetTimer(getCurrentPollingPeriod());
@@ -584,8 +584,8 @@ bool NStep::readTemperature()
     if (temperature < -80)
         return false;
 
-    TemperatureN[0].value = temperature;
-    TemperatureNP.s = IPS_OK;
+    TemperatureNP[0].setValue(temperature);
+    TemperatureNP.setState(IPS_OK);
 
     return true;
 }
@@ -603,7 +603,7 @@ bool NStep::readPosition()
     if (pos == 1e6)
         return false;
 
-    FocusAbsPosN[0].value = pos;
+    FocusAbsPosNP[0].setValue(pos);
 
     return true;
 }
@@ -623,9 +623,9 @@ bool NStep::readCompensationInfo()
     sscanf(res, "%d", &state);
     if (state == 1e6)
         return false;
-    IUResetSwitch(&CompensationModeSP);
-    CompensationModeS[state].s = ISS_ON;
-    CompensationModeSP.s = IPS_OK;
+    CompensationModeSP.reset();
+    CompensationModeSP[state].setState(ISS_ON);
+    CompensationModeSP.setState(IPS_OK);
 
     // Change
     memset(res, 0, NSTEP_LEN);
@@ -638,7 +638,7 @@ bool NStep::readCompensationInfo()
     sscanf(res, "%d", &change);
     if (change == 1e6)
         return false;
-    CompensationSettingsN[COMPENSATION_SETTING_CHANGE].value = change;
+    CompensationSettingsNP[COMPENSATION_SETTING_CHANGE].setValue(change);
 
     // Step
     memset(res, 0, NSTEP_LEN);
@@ -651,7 +651,7 @@ bool NStep::readCompensationInfo()
     sscanf(res, "%d", &step);
     if (step == 1e6)
         return false;
-    CompensationSettingsN[COMPENSATION_SETTING_STEP].value = step;
+    CompensationSettingsNP[COMPENSATION_SETTING_STEP].setValue(step);
 
     // Backlash
     memset(res, 0, NSTEP_LEN);
@@ -664,7 +664,7 @@ bool NStep::readCompensationInfo()
     sscanf(res, "%d", &backlash);
     if (backlash == 1e6)
         return false;
-    CompensationSettingsN[COMPENSATION_SETTING_BACKLASH].value = backlash;
+    CompensationSettingsNP[COMPENSATION_SETTING_BACKLASH].setValue(backlash);
 
     // Timer
     memset(res, 0, NSTEP_LEN);
@@ -677,8 +677,8 @@ bool NStep::readCompensationInfo()
     sscanf(res, "%d", &timer);
     if (timer == 1e6)
         return false;
-    CompensationSettingsN[COMPENSATION_SETTING_TIMER].value = timer;
-    CompensationSettingsNP.s = IPS_OK;
+    CompensationSettingsNP[COMPENSATION_SETTING_TIMER].setValue(timer);
+    CompensationSettingsNP.setState(IPS_OK);
 
     return true;
 
@@ -703,14 +703,14 @@ bool NStep::readSpeedInfo()
     if (current_step == 1e6)
         return false;
 
-    MaxSpeedN[0].value = 254 - max_step + 1;
-    MaxSpeedNP.s = IPS_OK;
+    MaxSpeedNP[0].setValue(254 - max_step + 1);
+    MaxSpeedNP.setState(IPS_OK);
 
     // nStep defines speed step rates from 1 to 254
     // when 1 being the fastest, so for speed we flip the values
-    FocusSpeedN[0].max   = 254 - max_step + 1;
-    FocusSpeedN[0].value = 254 - current_step + 1;
-    FocusSpeedNP.s = IPS_OK;
+    FocusSpeedNP[0].setMax(254 - max_step + 1);
+    FocusSpeedNP[0].setValue(254 - current_step + 1);
+    FocusSpeedNP.setState(IPS_OK);
 
     return true;
 }
@@ -728,8 +728,8 @@ bool NStep::readSteppingInfo()
     if (phase == 1e6)
         return false;
 
-    SteppingPhaseN[0].value = phase;
-    SteppingPhaseNP.s = IPS_OK;
+    SteppingPhaseNP[0].setValue(phase);
+    SteppingPhaseNP.setState(IPS_OK);
 
     return true;
 }
@@ -741,11 +741,11 @@ bool NStep::readCoilStatus()
     if (sendCommand(":RC", res, 3, 1) == false)
         return false;
 
-    IUResetSwitch(&CoilStatusSP);
+    CoilStatusSP.reset();
 
-    CoilStatusS[COIL_ENERGIZED_OFF].s = (res[0] == '0') ? ISS_ON : ISS_OFF;
-    CoilStatusS[COIL_ENERGIZED_ON].s  = (res[0] == '0') ? ISS_OFF : ISS_ON;
-    CoilStatusSP.s = IPS_OK;
+    CoilStatusSP[COIL_ENERGIZED_OFF].setState((res[0] == '0') ? ISS_ON : ISS_OFF);
+    CoilStatusSP[COIL_ENERGIZED_ON].setState((res[0] == '0') ? ISS_OFF : ISS_ON);
+    CoilStatusSP.setState(IPS_OK);
 
     return true;
 }
@@ -828,9 +828,9 @@ bool NStep::saveConfigItems(FILE *fp)
 {
     INDI::Focuser::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &CompensationSettingsNP);
-    IUSaveConfigSwitch(fp, &CompensationModeSP);
-    IUSaveConfigSwitch(fp, &SteppingModeSP);
+    CompensationSettingsNP.save(fp);
+    CompensationModeSP.save(fp);
+    SteppingModeSP.save(fp);
 
     return true;
 }

--- a/drivers/focuser/nstep.h
+++ b/drivers/focuser/nstep.h
@@ -25,6 +25,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class NStep : public INDI::Focuser
 {
     public:
@@ -56,11 +60,9 @@ class NStep : public INDI::Focuser
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////
 
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
-        ISwitch CompensationModeS[3];
-        ISwitchVectorProperty CompensationModeSP;
+        INDI::PropertySwitch CompensationModeSP {3};
         enum
         {
             COMPENSATION_MODE_OFF,
@@ -68,8 +70,7 @@ class NStep : public INDI::Focuser
             COMPENSATION_MODE_AUTO,
         };
 
-        INumber CompensationSettingsN[4];
-        INumberVectorProperty CompensationSettingsNP;
+        INDI::PropertyNumber CompensationSettingsNP {4};
         enum
         {
             COMPENSATION_SETTING_CHANGE,
@@ -78,11 +79,9 @@ class NStep : public INDI::Focuser
             COMPENSATION_SETTING_TIMER,
         };
 
-        ISwitch PrimeManualS[1];
-        ISwitchVectorProperty PrimeManualSP;
+        INDI::PropertySwitch PrimeManualSP {1};
 
-        ISwitch SteppingModeS[3];
-        ISwitchVectorProperty SteppingModeSP;
+        INDI::PropertySwitch SteppingModeSP {3};
         enum
         {
             STEPPING_WAVE,
@@ -90,19 +89,16 @@ class NStep : public INDI::Focuser
             STEPPING_FULL,
         };
 
-        ISwitch CoilStatusS[2];
-        ISwitchVectorProperty CoilStatusSP;
+        INDI::PropertySwitch CoilStatusSP {2};
         enum
         {
             COIL_ENERGIZED_OFF,
             COIL_ENERGIZED_ON,
         };
 
-        INumber SteppingPhaseN[1];
-        INumberVectorProperty SteppingPhaseNP;
+        INDI::PropertyNumber SteppingPhaseNP {1};
 
-        INumber MaxSpeedN[1];
-        INumberVectorProperty MaxSpeedNP;
+        INDI::PropertyNumber MaxSpeedNP {1};
 
         ///////////////////////////////////////////////////////////////////////////////
         /// Read Data From Controller

--- a/drivers/focuser/onfocus.h
+++ b/drivers/focuser/onfocus.h
@@ -22,6 +22,10 @@
 
 #include "indibase/indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class OnFocus : public INDI::Focuser
 {
 public:
@@ -54,10 +58,8 @@ private:
     bool MoveMyFocuser(uint32_t position);
     bool setMaxPos(uint32_t maxPos);
 
-    INumber MaxPosN[1];
-    INumberVectorProperty MaxPosNP;
-    ISwitch SetZeroS[1];
-    ISwitchVectorProperty SetZeroSP;
+    INDI::PropertyNumber MaxPosNP {1};
+    INDI::PropertySwitch SetZeroSP {1};
 };
 
 #endif // ONFOCUS_H

--- a/drivers/focuser/planewave_efa.cpp
+++ b/drivers/focuser/planewave_efa.cpp
@@ -93,59 +93,59 @@ bool EFA::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser Information
-    IUFillText(&InfoT[INFO_VERSION], "INFO_VERSION", "Version", "NA");
-    IUFillTextVector(&InfoTP, InfoT, 1, getDeviceName(), "INFO", "Info", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
+    InfoTP[INFO_VERSION].fill("INFO_VERSION", "Version", "NA");
+    InfoTP.fill(getDeviceName(), "INFO", "Info", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[TEMPERATURE_PRIMARY], "TEMPERATURE_PRIMARY", "Primary (c)", "%.2f", -50, 70., 0., 0.);
-    IUFillNumber(&TemperatureN[TEMPERATURE_AMBIENT], "TEMPERATURE_AMBIENT", "Ambient (c)", "%.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 2, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[TEMPERATURE_PRIMARY].fill("TEMPERATURE_PRIMARY", "Primary (c)", "%.2f", -50, 70., 0., 0.);
+    TemperatureNP[TEMPERATURE_AMBIENT].fill("TEMPERATURE_AMBIENT", "Ambient (c)", "%.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Fan Control
-    IUFillSwitch(&FanStateS[FAN_ON], "FAN_ON", "On", ISS_OFF);
-    IUFillSwitch(&FanStateS[FAN_OFF], "FAN_OFF", "Off", ISS_ON);
-    IUFillSwitchVector(&FanStateSP, FanStateS, 2, getDeviceName(), "FOCUS_FAN", "Fans", FAN_TAB, IP_RW, ISR_1OFMANY, 0,
+    FanStateSP[FAN_ON].fill("FAN_ON", "On", ISS_OFF);
+    FanStateSP[FAN_OFF].fill("FAN_OFF", "Off", ISS_ON);
+    FanStateSP.fill(getDeviceName(), "FOCUS_FAN", "Fans", FAN_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Fan Control Mode
-    IUFillSwitch(&FanControlS[FAN_MANUAL], "FAN_MANUAL", "Manual", ISS_ON);
-    IUFillSwitch(&FanControlS[FAN_AUTOMATIC_ABSOLUTE], "FAN_AUTOMATIC_ABSOLUTE", "Auto. Absolute", ISS_OFF);
-    IUFillSwitch(&FanControlS[FAN_AUTOMATIC_RELATIVE], "FAN_AUTOMATIC_RELATIVE", "Auto. Relative", ISS_OFF);
-    IUFillSwitchVector(&FanControlSP, FanControlS, 3, getDeviceName(), "FOCUS_FAN_CONTROL", "Control Mode", FAN_TAB, IP_RW,
+    FanControlSP[FAN_MANUAL].fill("FAN_MANUAL", "Manual", ISS_ON);
+    FanControlSP[FAN_AUTOMATIC_ABSOLUTE].fill("FAN_AUTOMATIC_ABSOLUTE", "Auto. Absolute", ISS_OFF);
+    FanControlSP[FAN_AUTOMATIC_RELATIVE].fill("FAN_AUTOMATIC_RELATIVE", "Auto. Relative", ISS_OFF);
+    FanControlSP.fill(getDeviceName(), "FOCUS_FAN_CONTROL", "Control Mode", FAN_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Fan Control Parameters
-    IUFillNumber(&FanControlN[FAN_MAX_ABSOLUTE], "FAN_MAX_ABSOLUTE", "Max Primary (c)", "%.2f", 0, 50., 5., 25.);
-    IUFillNumber(&FanControlN[FAN_MAX_RELATIVE], "FAN_MAX_RELATIVE", "Max Relative (c)", "%.2f", 0., 30., 1., 2.5);
-    IUFillNumber(&FanControlN[FAN_DEADZONE], "FAN_DEADZONE", "Deadzone (c)", "%.2f", 0.1, 10, 0.5, 0.5);
-    IUFillNumberVector(&FanControlNP, FanControlN, 3, getDeviceName(), "FOCUS_FAN_PARAMS", "Control Params",
+    FanControlNP[FAN_MAX_ABSOLUTE].fill("FAN_MAX_ABSOLUTE", "Max Primary (c)", "%.2f", 0, 50., 5., 25.);
+    FanControlNP[FAN_MAX_RELATIVE].fill("FAN_MAX_RELATIVE", "Max Relative (c)", "%.2f", 0., 30., 1., 2.5);
+    FanControlNP[FAN_DEADZONE].fill("FAN_DEADZONE", "Deadzone (c)", "%.2f", 0.1, 10, 0.5, 0.5);
+    FanControlNP.fill(getDeviceName(), "FOCUS_FAN_PARAMS", "Control Params",
                        FAN_TAB, IP_RW, 0, IPS_IDLE);
 
     // Fan Off on Disconnect
-    IUFillSwitch(&FanDisconnectS[FAN_OFF_ON_DISCONNECT], "FAN_OFF_ON_DISCONNECT", "Switch Off", ISS_ON);
-    IUFillSwitchVector(&FanDisconnectSP, FanDisconnectS, 1, getDeviceName(), "FOCUS_FAN_DISCONNECT", "On Disconnect", FAN_TAB,
+    FanDisconnectSP[FAN_OFF_ON_DISCONNECT].fill("FAN_OFF_ON_DISCONNECT", "Switch Off", ISS_ON);
+    FanDisconnectSP.fill(getDeviceName(), "FOCUS_FAN_DISCONNECT", "On Disconnect", FAN_TAB,
                        IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
 
     // Calibration Control
-    IUFillSwitch(&CalibrationStateS[CALIBRATION_ON], "CALIBRATION_ON", "Calibrated", ISS_OFF);
-    IUFillSwitch(&CalibrationStateS[CALIBRATION_OFF], "CALIBRATION_OFF", "Not Calibrated", ISS_ON);
-    IUFillSwitchVector(&CalibrationStateSP, CalibrationStateS, 2, getDeviceName(), "FOCUS_CALIBRATION", "Calibration",
+    CalibrationStateSP[CALIBRATION_ON].fill("CALIBRATION_ON", "Calibrated", ISS_OFF);
+    CalibrationStateSP[CALIBRATION_OFF].fill("CALIBRATION_OFF", "Not Calibrated", ISS_ON);
+    CalibrationStateSP.fill(getDeviceName(), "FOCUS_CALIBRATION", "Calibration",
                        MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Setup limits
-    FocusMaxPosN[0].value = 1e7;
-    FocusMaxPosN[0].max   = 1e7;
-    FocusMaxPosN[0].step  = FocusMaxPosN[0].max / 50;
+    FocusMaxPosNP[0].setValue(1e7);
+    FocusMaxPosNP[0].setMax(1e7);
+    FocusMaxPosNP[0].setStep(FocusMaxPosNP[0].getMax() / 50);
 
-    FocusAbsPosN[0].max   = 1e7;
-    FocusAbsPosN[0].step  = FocusAbsPosN[0].max / 50;
+    FocusAbsPosNP[0].setMax(1e7);
+    FocusAbsPosNP[0].setStep(FocusAbsPosNP[0].getMax() / 50);
 
-    FocusSyncN[0].max     = 1e7;
-    FocusSyncN[0].step    = FocusSyncN[0].max / 50;
+    FocusSyncNP[0].setMax(1e7);
+    FocusSyncNP[0].setStep(FocusSyncNP[0].getMax() / 50);
 
-    FocusRelPosN[0].max   = FocusAbsPosN[0].max / 2;
-    FocusRelPosN[0].step  = FocusRelPosN[0].max / 50;
+    FocusRelPosNP[0].setMax(FocusAbsPosNP[0].getMax() / 2);
+    FocusRelPosNP[0].setStep(FocusRelPosNP[0].getMax() / 50);
 
     addAuxControls();
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
@@ -165,28 +165,28 @@ bool EFA::updateProperties()
     {
         getStartupValues();
 
-        defineProperty(&InfoTP);
-        defineProperty(&CalibrationStateSP);
+        defineProperty(InfoTP);
+        defineProperty(CalibrationStateSP);
 
         // Fan
-        defineProperty(&FanStateSP);
-        defineProperty(&FanControlSP);
-        loadConfig(true, FanControlSP.name);
-        defineProperty(&FanDisconnectSP);
+        defineProperty(FanStateSP);
+        defineProperty(FanControlSP);
+        loadConfig(true, FanControlSP.getName());
+        defineProperty(FanDisconnectSP);
 
-        defineProperty(&TemperatureNP);
+        defineProperty(TemperatureNP);
     }
     else
     {
-        deleteProperty(InfoTP.name);
-        deleteProperty(CalibrationStateSP.name);
+        deleteProperty(InfoTP.getName());
+        deleteProperty(CalibrationStateSP.getName());
 
-        deleteProperty(FanStateSP.name);
-        deleteProperty(FanControlSP.name);
-        deleteProperty(FanControlNP.name);
-        deleteProperty(FanDisconnectSP.name);
+        deleteProperty(FanStateSP.getName());
+        deleteProperty(FanControlSP.getName());
+        deleteProperty(FanControlNP.getName());
+        deleteProperty(FanDisconnectSP.getName());
 
-        deleteProperty(TemperatureNP.name);
+        deleteProperty(TemperatureNP.getName());
     }
 
     return true;
@@ -197,7 +197,7 @@ bool EFA::updateProperties()
 /////////////////////////////////////////////////////////////////////////////
 bool EFA::Disconnect()
 {
-    if (FanDisconnectS[FAN_OFF_ON_DISCONNECT].s == ISS_ON)
+    if (FanDisconnectSP[FAN_OFF_ON_DISCONNECT].getState() == ISS_ON)
         setFanEnabled(false);
 
     return INDI::Focuser::Disconnect();
@@ -223,7 +223,7 @@ bool EFA::Handshake()
         return false;
 
     version = std::to_string(res[5]) + "." + std::to_string(res[6]);
-    IUSaveText(&InfoT[INFO_VERSION], version.c_str());
+    InfoTP[INFO_VERSION].setText(version);
 
     LOGF_INFO("Detected version %s", version.c_str());
 
@@ -246,78 +246,78 @@ bool EFA::ISNewSwitch(const char *dev, const char *name, ISState *states, char *
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Calibration State
-        if (!strcmp(CalibrationStateSP.name, name))
+        if (CalibrationStateSP.isNameMatch(name))
         {
-            bool enabled = strcmp(CalibrationStateS[CALIBRATION_ON].name, IUFindOnSwitchName(states, names, n)) == 0;
+            bool enabled = strcmp(CalibrationStateSP[CALIBRATION_ON].getName(), IUFindOnSwitchName(states, names, n)) == 0;
             if (setCalibrationEnabled(enabled))
             {
-                IUUpdateSwitch(&CalibrationStateSP, states, names, n);
-                CalibrationStateSP.s = IPS_OK;
+                CalibrationStateSP.update(states, names, n);
+                CalibrationStateSP.setState(IPS_OK);
             }
             else
             {
-                CalibrationStateSP.s = IPS_ALERT;
+                CalibrationStateSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&CalibrationStateSP, nullptr);
+            CalibrationStateSP.apply();
             return true;
         }
         // Fan State
-        else if (!strcmp(FanStateSP.name, name))
+        else if (FanStateSP.isNameMatch(name))
         {
-            if (FanControlS[FAN_MANUAL].s == ISS_OFF)
+            if (FanControlSP[FAN_MANUAL].getState() == ISS_OFF)
             {
-                FanStateSP.s = IPS_IDLE;
+                FanStateSP.setState(IPS_IDLE);
                 LOG_WARN("Cannot control fan while manual control is turned off.");
-                IDSetSwitch(&FanControlSP, nullptr);
+                FanControlSP.apply();
                 return true;
             }
 
-            bool enabled = strcmp(FanStateS[FAN_ON].name, IUFindOnSwitchName(states, names, n)) == 0;
+            bool enabled = strcmp(FanStateSP[FAN_ON].getName(), IUFindOnSwitchName(states, names, n)) == 0;
             if (setFanEnabled(enabled))
             {
-                IUUpdateSwitch(&FanStateSP, states, names, n);
-                FanStateSP.s = enabled ? IPS_OK : IPS_IDLE;
+                FanStateSP.update(states, names, n);
+                FanStateSP.setState(enabled ? IPS_OK : IPS_IDLE);
             }
             else
             {
-                FanStateSP.s = IPS_ALERT;
+                FanStateSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&FanStateSP, nullptr);
+            FanStateSP.apply();
             return true;
         }
         // Fan Control
-        else if (!strcmp(FanControlSP.name, name))
+        else if (FanControlSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FanControlSP, states, names, n);
-            if (FanControlS[FAN_MANUAL].s == ISS_ON)
+            FanControlSP.update(states, names, n);
+            if (FanControlSP[FAN_MANUAL].getState() == ISS_ON)
             {
-                deleteProperty(FanControlNP.name);
+                deleteProperty(FanControlNP.getName());
                 LOG_INFO("Fan is now controlled manually.");
             }
             else
             {
                 LOG_INFO("Fan is now controlled automatically per the control parameters.");
-                defineProperty(&FanControlNP);
+                defineProperty(FanControlNP);
             }
 
-            FanControlSP.s = IPS_OK;
-            IDSetSwitch(&FanControlSP, nullptr);
+            FanControlSP.setState(IPS_OK);
+            FanControlSP.apply();
             return true;
         }
         // Fan Disconnect
-        else if (!strcmp(FanDisconnectSP.name, name))
+        else if (FanDisconnectSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FanDisconnectSP, states, names, n);
+            FanDisconnectSP.update(states, names, n);
 
-            if (FanDisconnectS[FAN_OFF_ON_DISCONNECT].s == ISS_ON)
+            if (FanDisconnectSP[FAN_OFF_ON_DISCONNECT].getState() == ISS_ON)
                 LOG_INFO("Fan shall be turned off upon device disconnection.");
             else
                 LOG_INFO("Fan shall left as-is upon device disconnection.");
 
-            FanDisconnectSP.s = IPS_OK;
-            IDSetSwitch(&FanDisconnectSP, nullptr);
+            FanDisconnectSP.setState(IPS_OK);
+            FanDisconnectSP.apply();
             return true;
         }
     }
@@ -333,11 +333,11 @@ bool EFA::ISNewNumber(const char *dev, const char *name, double values[], char *
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Fan Params
-        if (!strcmp(FanControlNP.name, name))
+        if (FanControlNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FanControlNP, values, names, n);
-            FanControlNP.s = IPS_OK;
-            IDSetNumber(&FanControlNP, nullptr);
+            FanControlNP.update(values, names, n);
+            FanControlNP.setState(IPS_OK);
+            FanControlNP.apply();
             return true;
         }
     }
@@ -397,12 +397,12 @@ IPState EFA::MoveAbsFocuser(uint32_t targetTicks)
 IPState EFA::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
     int direction = (dir == FOCUS_INWARD) ? -1 : 1;
-    int reversed = (FocusReverseS[INDI_ENABLED].s == ISS_ON) ? -1 : 1;
+    int reversed = (FocusReverseSP[INDI_ENABLED].getState() == ISS_ON) ? -1 : 1;
     int relative = static_cast<int>(ticks);
-    int targetAbsPosition = FocusAbsPosN[0].value + (relative * direction * reversed);
+    int targetAbsPosition = FocusAbsPosNP[0].getValue() + (relative * direction * reversed);
 
-    targetAbsPosition = std::min(static_cast<uint32_t>(FocusAbsPosN[0].max),
-                                 static_cast<uint32_t>(std::max(static_cast<int>(FocusAbsPosN[0].min), targetAbsPosition)));
+    targetAbsPosition = std::min(static_cast<uint32_t>(FocusAbsPosNP[0].max),
+                                 static_cast<uint32_t>(std::max(static_cast<int>(FocusAbsPosNP[0].min), targetAbsPosition)));
 
     return MoveAbsFocuser(targetAbsPosition);
 }
@@ -421,41 +421,41 @@ void EFA::TimerHit()
     {
         // Send temperature is above threshold
         bool aboveThreshold = false;
-        for (int i = 0; i < TemperatureNP.nnp; i++)
+        for (size_t i = 0; i < TemperatureNP.size(); i++)
         {
-            if (std::fabs(TemperatureN[i].value - m_LastTemperature[i]) > TEMPERATURE_THRESHOLD)
+            if (std::fabs(TemperatureNP[i].value - m_LastTemperature[i]) > TEMPERATURE_THRESHOLD)
             {
                 aboveThreshold = true;
-                m_LastTemperature[i] = TemperatureN[i].value;
+                m_LastTemperature[i] = TemperatureNP[i].getValue();
             }
         }
 
         if (aboveThreshold)
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP.apply();
 
 
-        if (FanControlS[FAN_MANUAL].s == ISS_OFF)
+        if (FanControlSP[FAN_MANUAL].getState() == ISS_OFF)
         {
             bool turnOn = false, turnOff = false;
-            const bool isFanOn = FanStateS[FAN_ON].s == ISS_ON;
+            const bool isFanOn = FanStateSP[FAN_ON].getState() == ISS_ON;
 
             // Check if we need to do automatic regulation of fan
-            if (FanControlS[FAN_AUTOMATIC_ABSOLUTE].s == ISS_ON)
+            if (FanControlSP[FAN_AUTOMATIC_ABSOLUTE].getState() == ISS_ON)
             {
                 // Adjust delta for deadzone
-                double min_delta = FanControlN[FAN_MAX_ABSOLUTE].value - FanControlN[FAN_DEADZONE].value;
-                double max_delta = FanControlN[FAN_MAX_ABSOLUTE].value + FanControlN[FAN_DEADZONE].value;
+                double min_delta = FanControlNP[FAN_MAX_ABSOLUTE].getValue() - FanControlNP[FAN_DEADZONE].value;
+                double max_delta = FanControlNP[FAN_MAX_ABSOLUTE].getValue() + FanControlNP[FAN_DEADZONE].value;
 
-                turnOn = TemperatureN[TEMPERATURE_PRIMARY].value > max_delta;
-                turnOff = TemperatureN[TEMPERATURE_PRIMARY].value < min_delta;
+                turnOn = TemperatureNP[TEMPERATURE_PRIMARY].getValue() > max_delta;
+                turnOff = TemperatureNP[TEMPERATURE_PRIMARY].getValue() < min_delta;
             }
-            else if (FanControlS[FAN_AUTOMATIC_RELATIVE].s == ISS_ON)
+            else if (FanControlSP[FAN_AUTOMATIC_RELATIVE].getState() == ISS_ON)
             {
                 // Temperature delta
-                double tDiff = TemperatureN[TEMPERATURE_PRIMARY].value - TemperatureN[TEMPERATURE_AMBIENT].value;
+                double tDiff = TemperatureNP[TEMPERATURE_PRIMARY].getValue() - TemperatureNP[TEMPERATURE_AMBIENT].value;
                 // Adjust delta for deadzone
-                double min_delta = FanControlN[FAN_MAX_RELATIVE].value - FanControlN[FAN_DEADZONE].value;
-                double max_delta = FanControlN[FAN_MAX_RELATIVE].value + FanControlN[FAN_DEADZONE].value;
+                double min_delta = FanControlNP[FAN_MAX_RELATIVE].getValue() - FanControlNP[FAN_DEADZONE].value;
+                double max_delta = FanControlNP[FAN_MAX_RELATIVE].getValue() + FanControlNP[FAN_DEADZONE].value;
 
                 // Check if we need to turn off/on fan
                 turnOn = tDiff > max_delta;
@@ -465,39 +465,39 @@ void EFA::TimerHit()
             if (isFanOn && turnOff)
             {
                 setFanEnabled(false);
-                FanStateS[FAN_ON].s = ISS_OFF;
-                FanStateS[FAN_OFF].s = ISS_ON;
-                FanStateSP.s = IPS_IDLE;
-                IDSetSwitch(&FanStateSP, nullptr);
+                FanStateSP[FAN_ON].setState(ISS_OFF);
+                FanStateSP[FAN_OFF].setState(ISS_ON);
+                FanStateSP.setState(IPS_IDLE);
+                FanStateSP.apply();
             }
             else if (!isFanOn && turnOn)
             {
                 setFanEnabled(true);
-                FanStateS[FAN_ON].s = ISS_ON;
-                FanStateS[FAN_OFF].s = ISS_OFF;
-                FanStateSP.s = IPS_OK;
-                IDSetSwitch(&FanStateSP, nullptr);
+                FanStateSP[FAN_ON].setState(ISS_ON);
+                FanStateSP[FAN_OFF].setState(ISS_OFF);
+                FanStateSP.setState(IPS_OK);
+                FanStateSP.apply();
             }
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (isGOTOComplete())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
             LOG_INFO("Focuser reached requested position.");
         }
         else
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP.apply();
     }
-    else if (std::fabs(FocusAbsPosN[0].value - m_LastPosition) > 0)
+    else if (std::fabs(FocusAbsPosNP[0].value - m_LastPosition) > 0)
     {
-        m_LastPosition = FocusAbsPosN[0].value;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        m_LastPosition = FocusAbsPosNP[0].getValue();
+        FocusAbsPosNP.apply();
     }
 
     SetTimer(getCurrentPollingPeriod());
@@ -551,10 +551,10 @@ bool EFA::saveConfigItems(FILE * fp)
 {
     INDI::Focuser::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &FanControlSP);
-    if (FanControlNP.s == IPS_OK)
-        IUSaveConfigNumber(fp, &FanControlNP);
-    IUSaveConfigSwitch(fp, &FanDisconnectSP);
+    FanControlSP.save(fp);
+    if (FanControlNP.getState() == IPS_OK)
+        FanControlNP.save(fp);
+    FanDisconnectSP.save(fp);
     return true;
 }
 
@@ -570,19 +570,19 @@ void EFA::getStartupValues()
 
     if (readMaxSlewLimit())
     {
-        FocusAbsPosN[0].max = FocusMaxPosN[0].max;
-        FocusAbsPosN[0].step = FocusAbsPosN[0].max / 50;
+        FocusAbsPosNP[0].setMax(FocusMaxPosNP[0].max);
+        FocusAbsPosNP[0].setStep(FocusAbsPosNP[0].getMax() / 50);
 
-        FocusRelPosN[0].value = FocusAbsPosN[0].max / 50;
-        FocusRelPosN[0].max = FocusAbsPosN[0].max / 2;
-        FocusRelPosN[0].step = FocusRelPosN[0].max / 50;
+        FocusRelPosNP[0].setValue(FocusAbsPosNP[0].getMax() / 50);
+        FocusRelPosNP[0].setMax(FocusAbsPosNP[0].getMax() / 2);
+        FocusRelPosNP[0].setStep(FocusRelPosNP[0].getMax() / 50);
 
-        FocusMaxPosN[0].value = FocusMaxPosN[0].max;
-        FocusMaxPosN[0].step = FocusMaxPosN[0].max / 50;
+        FocusMaxPosNP[0].setValue(FocusMaxPosNP[0].max);
+        FocusMaxPosNP[0].setStep(FocusMaxPosNP[0].getMax() / 50);
 
-        IUUpdateMinMax(&FocusRelPosNP);
-        IUUpdateMinMax(&FocusAbsPosNP);
-        IUUpdateMinMax(&FocusMaxPosNP);
+        FocusRelPosNP.updateMinMax();
+        FocusAbsPosNP.updateMinMax();
+        FocusMaxPosNP.updateMinMax();
     }
 }
 
@@ -682,7 +682,7 @@ bool EFA::readPosition()
     if (!sendCommand(cmd, res, 6, 9))
         return false;
 
-    FocusAbsPosN[0].value = res[5] << 16 | res[6] << 8 | res[7];
+    FocusAbsPosNP[0].setValue(res[5] << 16 | res[6] << 8 | res[7]);
     return true;
 }
 
@@ -706,7 +706,7 @@ bool EFA::readMaxSlewLimit()
     uint32_t limit = res[5] << 16 | res[6] << 8 | res[7];
     if (limit > 0)
     {
-        FocusMaxPosN[0].max = limit;
+        FocusMaxPosNP[0].setMax(limit);
         return true;
     }
 
@@ -774,8 +774,8 @@ bool EFA::readFanState()
 
     bool enabled = (res[5] == 0);
 
-    FanStateS[FAN_ON].s  = enabled ? ISS_ON : ISS_OFF;
-    FanStateS[FAN_OFF].s = enabled ? ISS_OFF : ISS_ON;
+    FanStateSP[FAN_ON].setState(enabled ? ISS_ON : ISS_OFF);
+    FanStateSP[FAN_OFF].setState(enabled ? ISS_OFF : ISS_ON);
 
     return true;
 }
@@ -821,8 +821,8 @@ bool EFA::readCalibrationState()
 
     bool enabled = (res[5] == 1);
 
-    CalibrationStateS[CALIBRATION_ON].s  = enabled ? ISS_ON : ISS_OFF;
-    CalibrationStateS[CALIBRATION_OFF].s = enabled ? ISS_OFF : ISS_ON;
+    CalibrationStateSP[CALIBRATION_ON].setState(enabled ? ISS_ON : ISS_OFF);
+    CalibrationStateSP[CALIBRATION_OFF].setState(enabled ? ISS_OFF : ISS_ON);
 
     return true;
 }
@@ -847,7 +847,7 @@ bool EFA::readTemperature()
         if (!sendCommand(cmd, res, 7, 8))
             return false;
 
-        TemperatureN[i].value = calculateTemperature(res[5], res[6]);
+        TemperatureNP[i].setValue(calculateTemperature(res[5], res[6]));
     }
 
     return true;

--- a/drivers/focuser/planewave_efa.h
+++ b/drivers/focuser/planewave_efa.h
@@ -27,6 +27,11 @@
 
 #include <map>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class EFA : public INDI::Focuser
 {
     public:
@@ -120,8 +125,7 @@ class EFA : public INDI::Focuser
         ///////////////////////////////////////////////////////////////////////////////////
 
         // Focuser Informatin
-        ITextVectorProperty InfoTP;
-        IText InfoT[1] {};
+        INDI::PropertyText InfoTP {1};
         enum
         {
             INFO_VERSION
@@ -129,8 +133,7 @@ class EFA : public INDI::Focuser
 
 
         // FAN State
-        ISwitchVectorProperty FanStateSP;
-        ISwitch FanStateS[2];
+        INDI::PropertySwitch FanStateSP {2};
         enum
         {
             FAN_ON,
@@ -138,8 +141,7 @@ class EFA : public INDI::Focuser
         };
 
         // Fan Control Mode
-        ISwitchVectorProperty FanControlSP;
-        ISwitch FanControlS[3];
+        INDI::PropertySwitch FanControlSP {3};
         enum
         {
             FAN_MANUAL,
@@ -148,8 +150,7 @@ class EFA : public INDI::Focuser
         };
 
         // Fan Control Parameters
-        INumberVectorProperty FanControlNP;
-        INumber FanControlN[3];
+        INDI::PropertyNumber FanControlNP {3};
         enum
         {
             FAN_MAX_ABSOLUTE,
@@ -158,16 +159,14 @@ class EFA : public INDI::Focuser
         };
 
         // Fan Off on Disconnect
-        ISwitchVectorProperty FanDisconnectSP;
-        ISwitch FanDisconnectS[1];
+        INDI::PropertySwitch FanDisconnectSP {1};
         enum
         {
             FAN_OFF_ON_DISCONNECT
         };
 
         // Calibration State
-        ISwitchVectorProperty CalibrationStateSP;
-        ISwitch CalibrationStateS[2];
+        INDI::PropertySwitch CalibrationStateSP {2};
         enum
         {
             CALIBRATION_ON,
@@ -175,8 +174,7 @@ class EFA : public INDI::Focuser
         };
 
         // Read Only Temperature Reporting
-        INumberVectorProperty TemperatureNP;
-        INumber TemperatureN[2];
+        INDI::PropertyNumber TemperatureNP {2};
         enum
         {
             TEMPERATURE_PRIMARY,

--- a/drivers/focuser/rainbowRSF.h
+++ b/drivers/focuser/rainbowRSF.h
@@ -23,6 +23,10 @@
 #include <memory>
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class RainbowRSF : public INDI::Focuser
 {
     public:
@@ -64,11 +68,8 @@ class RainbowRSF : public INDI::Focuser
         ///////////////////////////////////////////////////////////////////////////////
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////
-        ISwitchVectorProperty GoHomeSP;
-        ISwitch GoHomeS[1];
-
-        INumberVectorProperty TemperatureNP;
-        INumber TemperatureN[1];
+        INDI::PropertySwitch GoHomeSP {1};
+        INDI::PropertyNumber TemperatureNP {1};
 
         uint32_t m_TargetPosition { 0 };
         uint32_t m_LastPosition { 0 };

--- a/drivers/focuser/rbfocus.cpp
+++ b/drivers/focuser/rbfocus.cpp
@@ -61,31 +61,31 @@ bool RBFOCUS::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillSwitch(&focuserHoldS[HOLD_ON], "HOLD_ON", "Hold Enabled", ISS_OFF);
-    IUFillSwitch(&focuserHoldS[HOLD_OFF], "HOLD_OFF", "Hold Disabled", ISS_OFF);
-    IUFillSwitchVector(&focuserHoldSP, focuserHoldS, 2, getDeviceName(), "Focuser Hold", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    focuserHoldSP[HOLD_ON].fill("HOLD_ON", "Hold Enabled", ISS_OFF);
+    focuserHoldSP[HOLD_OFF].fill("HOLD_OFF", "Hold Disabled", ISS_OFF);
+    focuserHoldSP.fill(getDeviceName(), "Focuser Hold", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&dirS[NORMAL], "NORMAL", "Normal", ISS_OFF);
-    IUFillSwitch(&dirS[REVERSED], "REVERSED", "Reverse", ISS_OFF);
-    IUFillSwitchVector(&dirSP, dirS, 2, getDeviceName(), "Direction", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
+    dirSP[NORMAL].fill("NORMAL", "Normal", ISS_OFF);
+    dirSP[REVERSED].fill("REVERSED", "Reverse", ISS_OFF);
+    dirSP.fill(getDeviceName(), "Direction", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
 
     // Relative and absolute movement
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0.;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0.);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 100000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
 
     return true;
@@ -97,16 +97,16 @@ bool RBFOCUS::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
-        defineProperty(&focuserHoldSP);
-        defineProperty(&dirSP);
+        defineProperty(TemperatureNP);
+        defineProperty(focuserHoldSP);
+        defineProperty(dirSP);
         LOG_INFO("Focuser ready.");
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(focuserHoldSP.name);
-        deleteProperty(dirSP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(focuserHoldSP.getName());
+        deleteProperty(dirSP.getName());
     }
 
     return true;
@@ -190,7 +190,7 @@ bool RBFOCUS::readTemperature()
        int rc = sscanf(res, "C%d#", &temp);
        if (rc > 0)
            // Hundredth of a degree
-           TemperatureN[0].value = temp / 100.0;
+           TemperatureNP[0].setValue(temp / 100.0);
        else
        {
            LOGF_ERROR("Unknown error: focuser temperature value (%s)", res);
@@ -214,12 +214,12 @@ bool RBFOCUS::readHold()
 
         if(strcmp(res, "Enable")==0)
         {
-            focuserHoldS[HOLD_ON].s = ISS_ON;
+            focuserHoldSP[HOLD_ON].setState(ISS_ON);
 
         }
         else if (strcmp(res, "Disable")==0)
         {
-            focuserHoldS[HOLD_OFF].s = ISS_ON;
+            focuserHoldSP[HOLD_OFF].setState(ISS_ON);
 
 
         }
@@ -238,12 +238,12 @@ bool RBFOCUS::readDir()
 
         if(strcmp(res, "Reversed")==0)
         {
-            dirS[REVERSED].s = ISS_ON;
+            dirSP[REVERSED].setState(ISS_ON);
 
         }
         else if (strcmp(res, "Normal")==0)
         {
-            dirS[NORMAL].s = ISS_ON;
+            dirSP[NORMAL].setState(ISS_ON);
 
 
         }
@@ -263,7 +263,7 @@ bool RBFOCUS::readPosition()
     int rc = sscanf(res, "%d#", &pos);
 
     if (rc > 0)
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     else
     {
         return false;
@@ -299,7 +299,7 @@ bool RBFOCUS::MaxPos(){
     int rc = sscanf(res, "%u#", &mPos);
      if (rc >0){
 
-        FocusMaxPosN[0].value = mPos;
+        FocusMaxPosNP[0].setValue(mPos);
         RBFOCUS::SyncPresets(mPos);
        }else
      {
@@ -358,30 +358,30 @@ void RBFOCUS::TimerHit()
     bool rc = readPosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
     rc = readTemperature();
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY)
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -402,61 +402,61 @@ bool RBFOCUS::setDir()
     return sendCommand("D#");
 }
 bool RBFOCUS::ISNewSwitch(const char * dev, const char * name, ISState * states, char * names[], int n){
-    if (strcmp(focuserHoldSP.name, name) == 0)
+    if (focuserHoldSP.isNameMatch(name))
     {
-        int current_mode = IUFindOnSwitchIndex(&focuserHoldSP);
+        int current_mode = focuserHoldSP.findOnSwitchIndex();
 
-        IUUpdateSwitch(&focuserHoldSP, states, names, n);
+        focuserHoldSP.update(states, names, n);
 
-        int target_mode = IUFindOnSwitchIndex(&focuserHoldSP);
+        int target_mode = focuserHoldSP.findOnSwitchIndex();
 
         if (current_mode == target_mode)
         {
-            focuserHoldSP.s = IPS_OK;
-            IDSetSwitch(&focuserHoldSP, nullptr);
+            focuserHoldSP.setState(IPS_OK);
+            focuserHoldSP.apply();
         }
 
         bool rc = setHold();
         if (!rc)
         {
-            IUResetSwitch(&focuserHoldSP);
-            focuserHoldS[current_mode].s = ISS_ON;
-            focuserHoldSP.s              = IPS_ALERT;
-            IDSetSwitch(&focuserHoldSP, nullptr);
+            focuserHoldSP.reset();
+            focuserHoldSP[current_mode].setState(ISS_ON);
+            focuserHoldSP.setState(IPS_ALERT);
+            focuserHoldSP.apply();
             return false;
         }
 
-        focuserHoldSP.s = IPS_OK;
-        IDSetSwitch(&focuserHoldSP, nullptr);
+        focuserHoldSP.setState(IPS_OK);
+        focuserHoldSP.apply();
         return true;
     }
 
-    if (strcmp(dirSP.name, name) == 0)
+    if (dirSP.isNameMatch(name))
     {
-        int current_mode = IUFindOnSwitchIndex(&dirSP);
+        int current_mode = dirSP.findOnSwitchIndex();
 
-        IUUpdateSwitch(&dirSP, states, names, n);
+        dirSP.update(states, names, n);
 
-        int target_mode = IUFindOnSwitchIndex(&dirSP);
+        int target_mode = dirSP.findOnSwitchIndex();
 
         if (current_mode == target_mode)
         {
-            dirSP.s = IPS_OK;
-            IDSetSwitch(&dirSP, nullptr);
+            dirSP.setState(IPS_OK);
+            dirSP.apply();
         }
 
         bool rc = setDir();
         if (!rc)
         {
-            IUResetSwitch(&dirSP);
-            dirS[current_mode].s = ISS_ON;
-            dirSP.s              = IPS_ALERT;
-            IDSetSwitch(&dirSP, nullptr);
+            dirSP.reset();
+            dirSP[current_mode].setState(ISS_ON);
+            dirSP.setState(IPS_ALERT);
+            dirSP.apply();
             return false;
         }
 
-        dirSP.s = IPS_OK;
-        IDSetSwitch(&dirSP, nullptr);
+        dirSP.setState(IPS_OK);
+        dirSP.apply();
         return true;
     }
 

--- a/drivers/focuser/rbfocus.h
+++ b/drivers/focuser/rbfocus.h
@@ -5,6 +5,10 @@
 #include "indifocuser.h"
 #include <chrono>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class RBFOCUS : public INDI::Focuser
 {
     public:
@@ -73,12 +77,9 @@ class RBFOCUS : public INDI::Focuser
         bool isMoving();
         bool MaxPos();
         // Read Only Temperature Reporting
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
-        ISwitch focuserHoldS[2];
-        ISwitchVectorProperty focuserHoldSP;
-        ISwitch dirS[3];
-        ISwitchVectorProperty dirSP;
+        INDI::PropertyNumber TemperatureNP {1};
+        INDI::PropertySwitch focuserHoldSP {2};
+        INDI::PropertySwitch dirSP {3};
         double targetPos { 0 }, lastPos { 0 };
         double lastTemperature { 0 };
 

--- a/drivers/focuser/robofocus.cpp
+++ b/drivers/focuser/robofocus.cpp
@@ -33,19 +33,19 @@
 #define BACKLASH_READOUT  99999
 #define MAXTRAVEL_READOUT 99999
 
-#define currentSpeed            SpeedN[0].value
-#define currentPosition         FocusAbsPosN[0].value
-#define currentTemperature      TemperatureN[0].value
-#define currentBacklash         FocusBacklashN[0].value
-#define currentDuty             SettingsN[0].value
-#define currentDelay            SettingsN[1].value
-#define currentTicks            SettingsN[2].value
-#define currentRelativeMovement FocusRelPosN[0].value
-#define currentAbsoluteMovement FocusAbsPosN[0].value
-#define currentSetBacklash      SetBacklashN[0].value
-#define currentMinPosition      MinMaxPositionN[0].value
-#define currentMaxPosition      MinMaxPositionN[1].value
-#define currentMaxTravel        FocusMaxPosN[0].value
+#define currentSpeed            SpeedNP[0].value
+#define currentPosition         FocusAbsPosNP[0].value
+#define currentTemperature      TemperatureNP[0].value
+#define currentBacklash         FocusBacklashNP[0].value
+#define currentDuty             SettingsNP[0].value
+#define currentDelay            SettingsNP[1].value
+#define currentTicks            SettingsNP[2].value
+#define currentRelativeMovement FocusRelPosNP[0].value
+#define currentAbsoluteMovement FocusAbsPosNP[0].value
+#define currentSetBacklash      SetBacklashNP[0].value
+#define currentMinPosition      MinMaxPositionNP[0].value
+#define currentMaxPosition      MinMaxPositionNP[1].value
+#define currentMaxTravel        FocusMaxPosNP[0].value
 
 #define SETTINGS_TAB "Settings"
 
@@ -99,64 +99,64 @@ bool RoboFocus::initProperties()
     INDI::Focuser::initProperties();
 
     /* Focuser temperature */
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", 0, 65000., 0., 10000.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", 0, 65000., 0., 10000.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     /* Settings of the Robofocus */
-    IUFillNumber(&SettingsN[0], "Duty cycle", "Duty cycle", "%6.0f", 0., 255., 0., 1.0);
-    IUFillNumber(&SettingsN[1], "Step Delay", "Step delay", "%6.0f", 0., 255., 0., 1.0);
-    IUFillNumber(&SettingsN[2], "Motor Steps", "Motor steps per tick", "%6.0f", 0., 255., 0., 1.0);
-    IUFillNumberVector(&SettingsNP, SettingsN, 3, getDeviceName(), "FOCUS_SETTINGS", "Settings", SETTINGS_TAB, IP_RW, 0,
+    SettingsNP[0].fill("Duty cycle", "Duty cycle", "%6.0f", 0., 255., 0., 1.0);
+    SettingsNP[1].fill("Step Delay", "Step delay", "%6.0f", 0., 255., 0., 1.0);
+    SettingsNP[2].fill("Motor Steps", "Motor steps per tick", "%6.0f", 0., 255., 0., 1.0);
+    SettingsNP.fill(getDeviceName(), "FOCUS_SETTINGS", "Settings", SETTINGS_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     /* Power Switches of the Robofocus */
-    IUFillSwitch(&PowerSwitchesS[0], "1", "Switch 1", ISS_OFF);
-    IUFillSwitch(&PowerSwitchesS[1], "2", "Switch 2", ISS_OFF);
-    IUFillSwitch(&PowerSwitchesS[2], "3", "Switch 3", ISS_OFF);
-    IUFillSwitch(&PowerSwitchesS[3], "4", "Switch 4", ISS_ON);
-    IUFillSwitchVector(&PowerSwitchesSP, PowerSwitchesS, 4, getDeviceName(), "SWTICHES", "Power", SETTINGS_TAB, IP_RW,
+    PowerSwitchesSP[0].fill("1", "Switch 1", ISS_OFF);
+    PowerSwitchesSP[1].fill("2", "Switch 2", ISS_OFF);
+    PowerSwitchesSP[2].fill("3", "Switch 3", ISS_OFF);
+    PowerSwitchesSP[3].fill("4", "Switch 4", ISS_ON);
+    PowerSwitchesSP.fill(getDeviceName(), "SWTICHES", "Power", SETTINGS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Robofocus should stay within these limits */
-    IUFillNumber(&MinMaxPositionN[0], "MINPOS", "Minimum Tick", "%6.0f", 1., 65000., 0., 100.);
-    IUFillNumber(&MinMaxPositionN[1], "MAXPOS", "Maximum Tick", "%6.0f", 1., 65000., 0., 55000.);
-    IUFillNumberVector(&MinMaxPositionNP, MinMaxPositionN, 2, getDeviceName(), "FOCUS_MINMAXPOSITION", "Extrema",
+    MinMaxPositionNP[0].fill("MINPOS", "Minimum Tick", "%6.0f", 1., 65000., 0., 100.);
+    MinMaxPositionNP[1].fill("MAXPOS", "Maximum Tick", "%6.0f", 1., 65000., 0., 55000.);
+    MinMaxPositionNP.fill(getDeviceName(), "FOCUS_MINMAXPOSITION", "Extrema",
                        SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillNumber(&MaxTravelN[0], "MAXTRAVEL", "Maximum travel", "%6.0f", 1., 64000., 0., 10000.);
-    IUFillNumberVector(&MaxTravelNP, MaxTravelN, 1, getDeviceName(), "FOCUS_MAXTRAVEL", "Max. travel", SETTINGS_TAB,
+    MaxTravelNP[0].fill("MAXTRAVEL", "Maximum travel", "%6.0f", 1., 64000., 0., 10000.);
+    MaxTravelNP.fill(getDeviceName(), "FOCUS_MAXTRAVEL", "Max. travel", SETTINGS_TAB,
                        IP_RW, 0, IPS_IDLE);
 
     // Cannot change maximum position
-    FocusMaxPosNP.p = IP_RO;
-    FocusMaxPosN[0].value = 64000;
+    FocusMaxPosNP.setPermission(IP_RO);
+    FocusMaxPosNP[0].setValue(64000);
 
     /* Set Robofocus position register to this position */
-    //    IUFillNumber(&SetRegisterPositionN[0], "SETPOS", "Position", "%6.0f", 0, 64000., 0., 0.);
-    //    IUFillNumberVector(&SetRegisterPositionNP, SetRegisterPositionN, 1, getDeviceName(), "FOCUS_REGISTERPOSITION",
+    //    SetRegisterPositionNP[0].fill("SETPOS", "Position", "%6.0f", 0, 64000., 0., 0.);
+    //    SetRegisterPositionNP.fill(getDeviceName(), "FOCUS_REGISTERPOSITION",
     //                       "Sync", SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     /* Backlash */
-    //    IUFillNumber(&SetBacklashN[0], "SETBACKLASH", "Backlash", "%6.0f", -255., 255., 0., 0.);
-    //    IUFillNumberVector(&FocusBacklashNP, SetBacklashN, 1, getDeviceName(), "FOCUS_BACKLASH", "Set Register", SETTINGS_TAB,
+    //    SetBacklashNP[0].fill("SETBACKLASH", "Backlash", "%6.0f", -255., 255., 0., 0.);
+    //    FocusBacklashNP.fill(getDeviceName(), "FOCUS_BACKLASH", "Set Register", SETTINGS_TAB,
     //                       IP_RW, 0, IPS_IDLE);
 
-    FocusBacklashN[0].min = -255;
-    FocusBacklashN[0].max = 255;
-    FocusBacklashN[0].step = 10;
-    FocusBacklashN[0].value = 0;
+    FocusBacklashNP[0].setMin(-255);
+    FocusBacklashNP[0].setMax(255);
+    FocusBacklashNP[0].setStep(10);
+    FocusBacklashNP[0].setValue(0);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 5000.;
-    FocusRelPosN[0].value = 100;
-    FocusRelPosN[0].step  = 100;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(5000.);
+    FocusRelPosNP[0].setValue(100);
+    FocusRelPosNP[0].setStep(100);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 64000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(64000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     simulatedTemperature = 600.0;
     simulatedPosition    = 20000;
@@ -173,15 +173,15 @@ bool RoboFocus::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
-        defineProperty(&PowerSwitchesSP);
-        defineProperty(&SettingsNP);
-        defineProperty(&MinMaxPositionNP);
-        defineProperty(&MaxTravelNP);
-        //        defineProperty(&SetRegisterPositionNP);
-        //defineProperty(&FocusBacklashNP);
-        //        defineProperty(&FocusRelPosNP);
-        //        defineProperty(&FocusAbsPosNP);
+        defineProperty(TemperatureNP);
+        defineProperty(PowerSwitchesSP);
+        defineProperty(SettingsNP);
+        defineProperty(MinMaxPositionNP);
+        defineProperty(MaxTravelNP);
+        //        defineProperty(SetRegisterPositionNP);
+        //defineProperty(FocusBacklashNP);
+        //        defineProperty(FocusRelPosNP);
+        //        defineProperty(FocusAbsPosNP);
 
         GetFocusParams();
 
@@ -189,15 +189,15 @@ bool RoboFocus::updateProperties()
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(SettingsNP.name);
-        deleteProperty(PowerSwitchesSP.name);
-        deleteProperty(MinMaxPositionNP.name);
-        deleteProperty(MaxTravelNP.name);
-        //        deleteProperty(SetRegisterPositionNP.name);
-        //deleteProperty(FocusBacklashNP.name);
-        //        deleteProperty(FocusRelPosNP.name);
-        //        deleteProperty(FocusAbsPosNP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(SettingsNP.getName());
+        deleteProperty(PowerSwitchesSP.getName());
+        deleteProperty(MinMaxPositionNP.getName());
+        deleteProperty(MaxTravelNP.getName());
+        //        deleteProperty(SetRegisterPositionNP.getName());
+        //deleteProperty(FocusBacklashNP.getName());
+        //        deleteProperty(FocusRelPosNP.getName());
+        //        deleteProperty(FocusAbsPosNP.getName());
     }
 
     return true;
@@ -211,7 +211,7 @@ bool RoboFocus::Handshake()
     {
         timerID = SetTimer(getCurrentPollingPeriod());
         LOG_INFO("Simulated Robofocus is online. Getting focus parameters...");
-        FocusAbsPosN[0].value = simulatedPosition;
+        FocusAbsPosNP[0].setValue(simulatedPosition);
         updateRFFirmware(firmeware);
         return true;
     }
@@ -323,11 +323,11 @@ int RoboFocus::ReadResponse(char *buf)
                     motion = 0x49;
                     LOG_INFO("Moving inward...");
 
-                    if (FocusAbsPosNP.s != IPS_BUSY)
+                    if (FocusAbsPosNP.getState() != IPS_BUSY)
                     {
                         externalMotion  = true;
-                        FocusAbsPosNP.s = IPS_BUSY;
-                        IDSetNumber(&FocusAbsPosNP, nullptr);
+                        FocusAbsPosNP.setState(IPS_BUSY);
+                        FocusAbsPosNP.apply();
                     }
                 }
                 //usleep(100000);
@@ -340,11 +340,11 @@ int RoboFocus::ReadResponse(char *buf)
                     motion = 0x4F;
                     LOG_INFO("Moving outward...");
 
-                    if (FocusAbsPosNP.s != IPS_BUSY)
+                    if (FocusAbsPosNP.getState() != IPS_BUSY)
                     {
                         externalMotion  = true;
-                        FocusAbsPosNP.s = IPS_BUSY;
-                        IDSetNumber(&FocusAbsPosNP, nullptr);
+                        FocusAbsPosNP.setState(IPS_BUSY);
+                        FocusAbsPosNP.apply();
                     }
                 }
                 //usleep(100000);
@@ -368,8 +368,8 @@ int RoboFocus::ReadResponse(char *buf)
                     // If we set it busy due to external motion, let's set it to OK
                     if (externalMotion)
                     {
-                        FocusAbsPosNP.s = IPS_OK;
-                        IDSetNumber(&FocusAbsPosNP, nullptr);
+                        FocusAbsPosNP.setState(IPS_OK);
+                        FocusAbsPosNP.apply();
                     }
                 }
 
@@ -455,7 +455,7 @@ int RoboFocus::updateRFBacklash(double *value)
 
     if (isSimulation())
     {
-        *value = FocusBacklashN[0].value;
+        *value = FocusBacklashNP[0].getValue();
         return 0;
     }
 
@@ -952,7 +952,7 @@ bool RoboFocus::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, PowerSwitchesSP.name) == 0)
+        if (PowerSwitchesSP.isNameMatch(name))
         {
             int ret      = -1;
             int nset     = 0;
@@ -966,35 +966,35 @@ bool RoboFocus::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
             ISwitch *sp;
 
-            PowerSwitchesSP.s = IPS_BUSY;
-            IDSetSwitch(&PowerSwitchesSP, nullptr);
+            PowerSwitchesSP.setState(IPS_BUSY);
+            PowerSwitchesSP.apply();
 
             for (nset = i = 0; i < n; i++)
             {
                 /* Find numbers with the passed names in the SettingsNP property */
-                sp = IUFindSwitch(&PowerSwitchesSP, names[i]);
+                sp = PowerSwitchesSP.findWidgetByName(names[i]);
 
-                /* If the state found is  (PowerSwitchesS[0]) then process it */
+                /* If the state found is  (PowerSwitchesSP[0]) then process it */
 
-                if (sp == &PowerSwitchesS[0])
+                if (sp == &PowerSwitchesSP[0])
                 {
                     new_s  = (states[i]);
                     new_sn = 0;
                     nset++;
                 }
-                else if (sp == &PowerSwitchesS[1])
+                else if (sp == &PowerSwitchesSP[1])
                 {
                     new_s  = (states[i]);
                     new_sn = 1;
                     nset++;
                 }
-                else if (sp == &PowerSwitchesS[2])
+                else if (sp == &PowerSwitchesSP[2])
                 {
                     new_s  = (states[i]);
                     new_sn = 2;
                     nset++;
                 }
-                else if (sp == &PowerSwitchesS[3])
+                else if (sp == &PowerSwitchesSP[3])
                 {
                     new_s  = (states[i]);
                     new_sn = 3;
@@ -1007,17 +1007,17 @@ bool RoboFocus::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
                 if ((ret = updateRFPowerSwitches(new_s, new_sn, &cur_s1LL, &cur_s2LR, &cur_s3RL, &cur_s4RR)) < 0)
                 {
-                    PowerSwitchesSP.s = IPS_ALERT;
-                    IDSetSwitch(&PowerSwitchesSP, "Unknown error while reading  Robofocus power switch settings");
+                    PowerSwitchesSP.setState(IPS_ALERT);
+                    PowerSwitchesSP.apply("Unknown error while reading  Robofocus power switch settings");
                     return true;
                 }
             }
             else
             {
                 /* Set property state to idle */
-                PowerSwitchesSP.s = IPS_IDLE;
+                PowerSwitchesSP.setState(IPS_IDLE);
 
-                IDSetNumber(&SettingsNP, "Power switch settings absent or bogus.");
+                SettingsNP.apply("Power switch settings absent or bogus.");
                 return true;
             }
         }
@@ -1032,7 +1032,7 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, SettingsNP.name) == 0)
+        if (SettingsNP.isNameMatch(name))
         {
             /* new speed */
             double new_duty  = 0;
@@ -1043,20 +1043,20 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
             for (nset = i = 0; i < n; i++)
             {
                 /* Find numbers with the passed names in the SettingsNP property */
-                INumber *eqp = IUFindNumber(&SettingsNP, names[i]);
+                INumber *eqp = SettingsNP.findWidgetByName(names[i]);
 
-                /* If the number found is  (SettingsN[0]) then process it */
-                if (eqp == &SettingsN[0])
+                /* If the number found is  (SettingsNP[0]) then process it */
+                if (eqp == &SettingsNP[0])
                 {
                     new_duty = (values[i]);
                     nset += static_cast<int>(new_duty >= 0 && new_duty <= 255);
                 }
-                else if (eqp == &SettingsN[1])
+                else if (eqp == &SettingsNP[1])
                 {
                     new_delay = (values[i]);
                     nset += static_cast<int>(new_delay >= 0 && new_delay <= 255);
                 }
-                else if (eqp == &SettingsN[2])
+                else if (eqp == &SettingsNP[2])
                 {
                     new_ticks = (values[i]);
                     nset += static_cast<int>(new_ticks >= 0 && new_ticks <= 255);
@@ -1067,13 +1067,13 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
             if (nset == 3)
             {
                 /* Set the robofocus state to BUSY */
-                SettingsNP.s = IPS_BUSY;
+                SettingsNP.setState(IPS_BUSY);
 
-                IDSetNumber(&SettingsNP, nullptr);
+                SettingsNP.apply();
 
                 if ((ret = updateRFMotorSettings(&new_duty, &new_delay, &new_ticks)) < 0)
                 {
-                    IDSetNumber(&SettingsNP, "Changing to new settings failed");
+                    SettingsNP.apply("Changing to new settings failed");
                     return false;
                 }
 
@@ -1081,22 +1081,22 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
                 currentDelay = new_delay;
                 currentTicks = new_ticks;
 
-                SettingsNP.s = IPS_OK;
-                IDSetNumber(&SettingsNP, "Motor settings are now  %3.0f %3.0f %3.0f", currentDuty, currentDelay,
+                SettingsNP.setState(IPS_OK);
+                SettingsNP.apply("Motor settings are now  %3.0f %3.0f %3.0f", currentDuty, currentDelay,
                             currentTicks);
                 return true;
             }
             else
             {
                 /* Set property state to idle */
-                SettingsNP.s = IPS_IDLE;
+                SettingsNP.setState(IPS_IDLE);
 
-                IDSetNumber(&SettingsNP, "Settings absent or bogus.");
+                SettingsNP.apply("Settings absent or bogus.");
                 return false;
             }
         }
 
-        //        if (strcmp(name, FocusBacklashNP.name) == 0)
+        //        if (FocusBacklashNP.isNameMatch(name))
         //        {
         //            double new_back = 0;
         //            int nset        = 0;
@@ -1105,10 +1105,10 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
         //            for (nset = i = 0; i < n; i++)
         //            {
         //                /* Find numbers with the passed names in the FocusBacklashNP property */
-        //                INumber *eqp = IUFindNumber(&FocusBacklashNP, names[i]);
+        //                INumber *eqp = FocusBacklashNP.findWidgetByName(names[i]);
 
-        //                /* If the number found is SetBacklash (SetBacklashN[0]) then process it */
-        //                if (eqp == &SetBacklashN[0])
+        //                /* If the number found is SetBacklash (SetBacklashNP[0]) then process it */
+        //                if (eqp == &SetBacklashNP[0])
         //                {
         //                    new_back = (values[i]);
 
@@ -1119,33 +1119,33 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
         //                if (nset == 1)
         //                {
         //                    /* Set the robofocus state to BUSY */
-        //                    FocusBacklashNP.s = IPS_BUSY;
-        //                    IDSetNumber(&FocusBacklashNP, nullptr);
+        //                    FocusBacklashNP.setState(IPS_BUSY);
+        //                    FocusBacklashNP.apply();
 
         //                    if ((ret = updateRFBacklash(&new_back)) < 0)
         //                    {
-        //                        FocusBacklashNP.s = IPS_IDLE;
-        //                        IDSetNumber(&FocusBacklashNP, "Setting new backlash failed.");
+        //                        FocusBacklashNP.setState(IPS_IDLE);
+        //                        FocusBacklashNP.apply("Setting new backlash failed.");
 
         //                        return false;
         //                    }
 
         //                    currentSetBacklash = new_back;
-        //                    FocusBacklashNP.s    = IPS_OK;
-        //                    IDSetNumber(&FocusBacklashNP, "Backlash is now  %3.0f", currentSetBacklash);
+        //                    FocusBacklashNP.setState(IPS_OK);
+        //                    FocusBacklashNP.apply("Backlash is now  %3.0f", currentSetBacklash);
         //                    return true;
         //                }
         //                else
         //                {
-        //                    FocusBacklashNP.s = IPS_IDLE;
-        //                    IDSetNumber(&FocusBacklashNP, "Need exactly one parameter.");
+        //                    FocusBacklashNP.setState(IPS_IDLE);
+        //                    FocusBacklashNP.apply("Need exactly one parameter.");
 
         //                    return false;
         //                }
         //            }
         //        }
 
-        if (strcmp(name, MinMaxPositionNP.name) == 0)
+        if (MinMaxPositionNP.isNameMatch(name))
         {
             /* new positions */
             double new_min = 0;
@@ -1154,15 +1154,15 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
             for (nset = i = 0; i < n; i++)
             {
                 /* Find numbers with the passed names in the MinMaxPositionNP property */
-                INumber *mmpp = IUFindNumber(&MinMaxPositionNP, names[i]);
+                INumber *mmpp = MinMaxPositionNP.findWidgetByName(names[i]);
 
-                /* If the number found is  (MinMaxPositionN[0]) then process it */
-                if (mmpp == &MinMaxPositionN[0])
+                /* If the number found is  (MinMaxPositionNP[0]) then process it */
+                if (mmpp == &MinMaxPositionNP[0])
                 {
                     new_min = (values[i]);
                     nset += static_cast<int>(new_min >= 1 && new_min <= 65000);
                 }
-                else if (mmpp == &MinMaxPositionN[1])
+                else if (mmpp == &MinMaxPositionNP[1])
                 {
                     new_max = (values[i]);
                     nset += static_cast<int>(new_max >= 1 && new_max <= 65000);
@@ -1173,28 +1173,28 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
             if (nset == 2)
             {
                 /* Set the robofocus state to BUSY */
-                MinMaxPositionNP.s = IPS_BUSY;
+                MinMaxPositionNP.setState(IPS_BUSY);
 
                 currentMinPosition = new_min;
                 currentMaxPosition = new_max;
 
-                MinMaxPositionNP.s = IPS_OK;
-                IDSetNumber(&MinMaxPositionNP, "Minimum and Maximum settings are now  %3.0f %3.0f", currentMinPosition,
+                MinMaxPositionNP.setState(IPS_OK);
+                MinMaxPositionNP.apply("Minimum and Maximum settings are now  %3.0f %3.0f", currentMinPosition,
                             currentMaxPosition);
                 return true;
             }
             else
             {
                 /* Set property state to idle */
-                MinMaxPositionNP.s = IPS_IDLE;
+                MinMaxPositionNP.setState(IPS_IDLE);
 
-                IDSetNumber(&MinMaxPositionNP, "Minimum and maximum limits absent or bogus.");
+                MinMaxPositionNP.apply("Minimum and maximum limits absent or bogus.");
 
                 return false;
             }
         }
 
-        if (strcmp(name, MaxTravelNP.name) == 0)
+        if (MaxTravelNP.isNameMatch(name))
         {
             double new_maxt = 0;
             int ret         = -1;
@@ -1202,10 +1202,10 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
             for (nset = i = 0; i < n; i++)
             {
                 /* Find numbers with the passed names in the MinMaxPositionNP property */
-                INumber *mmpp = IUFindNumber(&MaxTravelNP, names[i]);
+                INumber *mmpp = MaxTravelNP.findWidgetByName(names[i]);
 
-                /* If the number found is  (MaxTravelN[0]) then process it */
-                if (mmpp == &MaxTravelN[0])
+                /* If the number found is  (MaxTravelNP[0]) then process it */
+                if (mmpp == &MaxTravelNP[0])
                 {
                     new_maxt = (values[i]);
                     nset += static_cast<int>(new_maxt >= 1 && new_maxt <= 64000);
@@ -1214,32 +1214,32 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
             /* Did we process the one number? */
             if (nset == 1)
             {
-                IDSetNumber(&MinMaxPositionNP, nullptr);
+                MinMaxPositionNP.apply();
 
                 if ((ret = updateRFMaxPosition(&new_maxt)) < 0)
                 {
-                    MaxTravelNP.s = IPS_IDLE;
-                    IDSetNumber(&MaxTravelNP, "Changing to new maximum travel failed");
+                    MaxTravelNP.setState(IPS_IDLE);
+                    MaxTravelNP.apply("Changing to new maximum travel failed");
                     return false;
                 }
 
                 currentMaxTravel = new_maxt;
-                MaxTravelNP.s    = IPS_OK;
-                IDSetNumber(&MaxTravelNP, "Maximum travel is now  %3.0f", currentMaxTravel);
+                MaxTravelNP.setState(IPS_OK);
+                MaxTravelNP.apply("Maximum travel is now  %3.0f", currentMaxTravel);
                 return true;
             }
             else
             {
                 /* Set property state to idle */
 
-                MaxTravelNP.s = IPS_IDLE;
-                IDSetNumber(&MaxTravelNP, "Maximum travel absent or bogus.");
+                MaxTravelNP.setState(IPS_IDLE);
+                MaxTravelNP.apply("Maximum travel absent or bogus.");
 
                 return false;
             }
         }
 
-        //        if (strcmp(name, SetRegisterPositionNP.name) == 0)
+        //        if (SetRegisterPositionNP.isNameMatch(name))
         //        {
         //            double new_apos = 0;
         //            int nset        = 0;
@@ -1248,10 +1248,10 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
         //            for (nset = i = 0; i < n; i++)
         //            {
         //                /* Find numbers with the passed names in the SetRegisterPositionNP property */
-        //                INumber *srpp = IUFindNumber(&SetRegisterPositionNP, names[i]);
+        //                INumber *srpp = SetRegisterPositionNP.findWidgetByName(names[i]);
 
-        //                /* If the number found is SetRegisterPosition (SetRegisterPositionN[0]) then process it */
-        //                if (srpp == &SetRegisterPositionN[0])
+        //                /* If the number found is SetRegisterPosition (SetRegisterPositionNP[0]) then process it */
+        //                if (srpp == &SetRegisterPositionNP[0])
         //                {
         //                    new_apos = (values[i]);
 
@@ -1263,72 +1263,71 @@ bool RoboFocus::ISNewNumber(const char *dev, const char *name, double values[], 
         //                {
         //                    if ((new_apos < currentMinPosition) || (new_apos > currentMaxPosition))
         //                    {
-        //                        SetRegisterPositionNP.s = IPS_ALERT;
-        //                        IDSetNumber(&SetRegisterPositionNP, "Value out of limits  %5.0f", new_apos);
+        //                        SetRegisterPositionNP.setState(IPS_ALERT);
+        //                        SetRegisterPositionNP.apply("Value out of limits  %5.0f", new_apos);
         //                        return false;
         //                    }
 
         //                    /* Set the robofocus state to BUSY */
-        //                    SetRegisterPositionNP.s = IPS_BUSY;
-        //                    IDSetNumber(&SetRegisterPositionNP, nullptr);
+        //                    SetRegisterPositionNP.setState(IPS_BUSY);
+        //                    SetRegisterPositionNP.apply();
 
         //                    if ((ret = updateRFSetPosition(&new_apos)) < 0)
         //                    {
-        //                        SetRegisterPositionNP.s = IPS_OK;
-        //                        IDSetNumber(&SetRegisterPositionNP,
-        //                                    "Read out of the set position to %3d failed. Trying to recover the position", ret);
+        //                        SetRegisterPositionNP.setState(IPS_OK);
+        //                        SetRegisterPositionNP.apply(//                                    "Read out of the set position to %3d failed. Trying to recover the position", ret);
 
         //                        if ((ret = updateRFPosition(&currentPosition)) < 0)
         //                        {
-        //                            FocusAbsPosNP.s = IPS_ALERT;
-        //                            IDSetNumber(&FocusAbsPosNP, "Unknown error while reading  Robofocus position: %d", ret);
+        //                            FocusAbsPosNP.setState(IPS_ALERT);
+        //                            FocusAbsPosNP.apply("Unknown error while reading  Robofocus position: %d", ret);
 
-        //                            SetRegisterPositionNP.s = IPS_IDLE;
-        //                            IDSetNumber(&SetRegisterPositionNP, "Relative movement failed.");
+        //                            SetRegisterPositionNP.setState(IPS_IDLE);
+        //                            SetRegisterPositionNP.apply("Relative movement failed.");
         //                        }
 
-        //                        SetRegisterPositionNP.s = IPS_OK;
-        //                        IDSetNumber(&SetRegisterPositionNP, nullptr);
+        //                        SetRegisterPositionNP.setState(IPS_OK);
+        //                        SetRegisterPositionNP.apply();
 
-        //                        FocusAbsPosNP.s = IPS_OK;
-        //                        IDSetNumber(&FocusAbsPosNP, "Robofocus position recovered %5.0f", currentPosition);
+        //                        FocusAbsPosNP.setState(IPS_OK);
+        //                        FocusAbsPosNP.apply("Robofocus position recovered %5.0f", currentPosition);
         //                        LOG_DEBUG("Robofocus position recovered resuming normal operation");
         //                        /* We have to leave here, because new_apos is not set */
         //                        return true;
         //                    }
         //                    currentPosition         = new_apos;
-        //                    SetRegisterPositionNP.s = IPS_OK;
-        //                    IDSetNumber(&SetRegisterPositionNP, "Robofocus register set to %5.0f", currentPosition);
+        //                    SetRegisterPositionNP.setState(IPS_OK);
+        //                    SetRegisterPositionNP.apply("Robofocus register set to %5.0f", currentPosition);
 
-        //                    FocusAbsPosNP.s = IPS_OK;
-        //                    IDSetNumber(&FocusAbsPosNP, "Robofocus position is now %5.0f", currentPosition);
+        //                    FocusAbsPosNP.setState(IPS_OK);
+        //                    FocusAbsPosNP.apply("Robofocus position is now %5.0f", currentPosition);
 
         //                    return true;
         //                }
         //                else
         //                {
-        //                    SetRegisterPositionNP.s = IPS_IDLE;
-        //                    IDSetNumber(&SetRegisterPositionNP, "Need exactly one parameter.");
+        //                    SetRegisterPositionNP.setState(IPS_IDLE);
+        //                    SetRegisterPositionNP.apply("Need exactly one parameter.");
 
         //                    return false;
         //                }
 
         //                if ((ret = updateRFPosition(&currentPosition)) < 0)
         //                {
-        //                    FocusAbsPosNP.s = IPS_ALERT;
+        //                    FocusAbsPosNP.setState(IPS_ALERT);
         //                    LOGF_ERROR("Unknown error while reading  Robofocus position: %d", ret);
-        //                    IDSetNumber(&FocusAbsPosNP, nullptr);
+        //                    FocusAbsPosNP.apply();
 
         //                    return false;
         //                }
 
-        //                SetRegisterPositionNP.s       = IPS_OK;
-        //                SetRegisterPositionN[0].value = currentPosition;
-        //                IDSetNumber(&SetRegisterPositionNP, "Robofocus has accepted new register setting");
+        //                SetRegisterPositionNP.setState(IPS_OK);
+        //                SetRegisterPositionNP[0].setValue(currentPosition);
+        //                SetRegisterPositionNP.apply("Robofocus has accepted new register setting");
 
-        //                FocusAbsPosNP.s = IPS_OK;
+        //                FocusAbsPosNP.setState(IPS_OK);
         //                LOGF_INFO("Robofocus new position %5.0f", currentPosition);
-        //                IDSetNumber(&FocusAbsPosNP, nullptr);
+        //                FocusAbsPosNP.apply();
 
         //                return true;
         //            }
@@ -1348,89 +1347,89 @@ void RoboFocus::GetFocusParams()
 
     if ((ret = updateRFPosition(&currentPosition)) < 0)
     {
-        FocusAbsPosNP.s = IPS_ALERT;
+        FocusAbsPosNP.setState(IPS_ALERT);
         LOGF_ERROR("Unknown error while reading  Robofocus position: %d", ret);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
         return;
     }
 
-    FocusAbsPosNP.s = IPS_OK;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
+    FocusAbsPosNP.setState(IPS_OK);
+    FocusAbsPosNP.apply();
 
     if ((ret = updateRFTemperature(&currentTemperature)) < 0)
     {
-        TemperatureNP.s = IPS_ALERT;
+        TemperatureNP.setState(IPS_ALERT);
         LOG_ERROR("Unknown error while reading Robofocus temperature.");
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
         return;
     }
 
-    TemperatureNP.s = IPS_OK;
-    IDSetNumber(&TemperatureNP, nullptr);
+    TemperatureNP.setState(IPS_OK);
+    TemperatureNP.apply();
 
     currentBacklash = BACKLASH_READOUT;
     if ((ret = updateRFBacklash(&currentBacklash)) < 0)
     {
-        FocusBacklashNP.s = IPS_ALERT;
+        FocusBacklashNP.setState(IPS_ALERT);
         LOG_ERROR("Unknown error while reading Robofocus backlash.");
-        IDSetNumber(&FocusBacklashNP, nullptr);
+        FocusBacklashNP.apply();
         return;
     }
-    FocusBacklashNP.s = IPS_OK;
-    IDSetNumber(&FocusBacklashNP, nullptr);
+    FocusBacklashNP.setState(IPS_OK);
+    FocusBacklashNP.apply();
 
     currentDuty = currentDelay = currentTicks = 0;
 
     if ((ret = updateRFMotorSettings(&currentDuty, &currentDelay, &currentTicks)) < 0)
     {
-        SettingsNP.s = IPS_ALERT;
+        SettingsNP.setState(IPS_ALERT);
         LOG_ERROR("Unknown error while reading Robofocus motor settings.");
-        IDSetNumber(&SettingsNP, nullptr);
+        SettingsNP.apply();
         return;
     }
 
-    SettingsNP.s = IPS_OK;
-    IDSetNumber(&SettingsNP, nullptr);
+    SettingsNP.setState(IPS_OK);
+    SettingsNP.apply();
 
     if ((ret = updateRFPowerSwitches(-1, -1, &cur_s1LL, &cur_s2LR, &cur_s3RL, &cur_s4RR)) < 0)
     {
-        PowerSwitchesSP.s = IPS_ALERT;
+        PowerSwitchesSP.setState(IPS_ALERT);
         LOG_ERROR("Unknown error while reading Robofocus power switch settings.");
-        IDSetSwitch(&PowerSwitchesSP, nullptr);
+        PowerSwitchesSP.apply();
         return;
     }
 
-    PowerSwitchesS[0].s = PowerSwitchesS[1].s = PowerSwitchesS[2].s = PowerSwitchesS[3].s = ISS_OFF;
+    PowerSwitchesSP[0].setState(PowerSwitchesSP[1].s = PowerSwitchesSP[2].s = PowerSwitchesSP[3].s = ISS_OFF);
 
     if (cur_s1LL == ISS_ON)
     {
-        PowerSwitchesS[0].s = ISS_ON;
+        PowerSwitchesSP[0].setState(ISS_ON);
     }
     if (cur_s2LR == ISS_ON)
     {
-        PowerSwitchesS[1].s = ISS_ON;
+        PowerSwitchesSP[1].setState(ISS_ON);
     }
     if (cur_s3RL == ISS_ON)
     {
-        PowerSwitchesS[2].s = ISS_ON;
+        PowerSwitchesSP[2].setState(ISS_ON);
     }
     if (cur_s4RR == ISS_ON)
     {
-        PowerSwitchesS[3].s = ISS_ON;
+        PowerSwitchesSP[3].setState(ISS_ON);
     }
-    PowerSwitchesSP.s = IPS_OK;
-    IDSetSwitch(&PowerSwitchesSP, nullptr);
+    PowerSwitchesSP.setState(IPS_OK);
+    PowerSwitchesSP.apply();
 
     //    currentMaxTravel = MAXTRAVEL_READOUT;
     //    if ((ret = updateRFMaxPosition(&currentMaxTravel)) < 0)
     //    {
-    //        MaxTravelNP.s = IPS_ALERT;
+    //        MaxTravelNP.setState(IPS_ALERT);
     //        LOG_ERROR("Unknown error while reading Robofocus maximum travel");
-    //        IDSetNumber(&MaxTravelNP, nullptr);
+    //        MaxTravelNP.apply();
     //        return;
     //    }
-    //    MaxTravelNP.s = IPS_OK;
-    //    IDSetNumber(&MaxTravelNP, nullptr);
+    //    MaxTravelNP.setState(IPS_OK);
+    //    MaxTravelNP.apply();
 }
 
 IPState RoboFocus::MoveAbsFocuser(uint32_t targetTicks)
@@ -1438,7 +1437,7 @@ IPState RoboFocus::MoveAbsFocuser(uint32_t targetTicks)
     int ret   = -1;
     targetPos = targetTicks;
 
-    if (targetTicks < FocusAbsPosN[0].min || targetTicks > FocusAbsPosN[0].max)
+    if (targetTicks < FocusAbsPosNP[0].min || targetTicks > FocusAbsPosNP[0].max)
     {
         LOG_DEBUG("Error, requested position is out of range.");
         return IPS_ALERT;
@@ -1457,13 +1456,13 @@ IPState RoboFocus::MoveAbsFocuser(uint32_t targetTicks)
 
 IPState RoboFocus::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
-    return MoveAbsFocuser(FocusAbsPosN[0].value + (ticks * (dir == FOCUS_INWARD ? -1 : 1)));
+    return MoveAbsFocuser(FocusAbsPosNP[0].value + (ticks * (dir == FOCUS_INWARD ? -1 : 1)));
 }
 
 bool RoboFocus::saveConfigItems(FILE *fp)
 {
-    IUSaveConfigNumber(fp, &SettingsNP);
-    IUSaveConfigNumber(fp, &FocusBacklashNP);
+    SettingsNP.save(fp);
+    FocusBacklashNP.save(fp);
 
     return INDI::Focuser::saveConfigItems(fp);
 }
@@ -1476,17 +1475,17 @@ void RoboFocus::TimerHit()
     double prevPos = currentPosition;
     double newPos  = 0;
 
-    if (FocusAbsPosNP.s == IPS_OK || FocusAbsPosNP.s == IPS_IDLE)
+    if (FocusAbsPosNP.getState() == IPS_OK || FocusAbsPosNP.getState() == IPS_IDLE)
     {
         int rc = updateRFPosition(&newPos);
         if (rc >= 0)
         {
             currentPosition = newPos;
             if (prevPos != currentPosition)
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusAbsPosNP.apply();
         }
     }
-    else if (FocusAbsPosNP.s == IPS_BUSY)
+    else if (FocusAbsPosNP.getState() == IPS_BUSY)
     {
         float newPos            = 0;
         int nbytes_read         = 0;
@@ -1509,9 +1508,9 @@ void RoboFocus::TimerHit()
         }
         else if (nbytes_read < 0)
         {
-            FocusAbsPosNP.s = IPS_ALERT;
+            FocusAbsPosNP.setState(IPS_ALERT);
             LOG_ERROR("Read error! Reconnect and try again.");
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP.apply();
             return;
         }
 
@@ -1519,17 +1518,17 @@ void RoboFocus::TimerHit()
 
         if (currentPosition == targetPos)
         {
-            FocusAbsPosNP.s = IPS_OK;
+            FocusAbsPosNP.setState(IPS_OK);
 
-            if (FocusRelPosNP.s == IPS_BUSY)
+            if (FocusRelPosNP.getState() == IPS_BUSY)
             {
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusRelPosNP, nullptr);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusRelPosNP.apply();
             }
         }
 
-        IDSetNumber(&FocusAbsPosNP, nullptr);
-        if (FocusAbsPosNP.s == IPS_BUSY)
+        FocusAbsPosNP.apply();
+        if (FocusAbsPosNP.getState() == IPS_BUSY)
         {
             timerID = SetTimer(250);
             return;

--- a/drivers/focuser/robofocus.h
+++ b/drivers/focuser/robofocus.h
@@ -23,6 +23,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class RoboFocus : public INDI::Focuser
 {
     public:
@@ -71,30 +75,22 @@ class RoboFocus : public INDI::Focuser
         double simulatedTemperature { 0 };
         double simulatedPosition { 0 };
 
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
-        INumber SettingsN[3];
-        INumberVectorProperty SettingsNP;
+        INDI::PropertyNumber SettingsNP {3};
 
-        ISwitch PowerSwitchesS[4];
-        ISwitchVectorProperty PowerSwitchesSP;
+        INDI::PropertySwitch PowerSwitchesSP {4};
 
-        INumber MinMaxPositionN[2];
-        INumberVectorProperty MinMaxPositionNP;
+        INDI::PropertyNumber MinMaxPositionNP {2};
 
-        INumber MaxTravelN[1];
-        INumberVectorProperty MaxTravelNP;
+        INDI::PropertyNumber MaxTravelNP {1};
 
-        INumber SetRegisterPositionN[1];
-        INumberVectorProperty SetRegisterPositionNP;
+        INDI::PropertyNumber SetRegisterPositionNP {1};
 
-        INumber RelMovementN[1];
-        INumberVectorProperty RelMovementNP;
+        INDI::PropertyNumber RelMovementNP {1};
 
-        INumber AbsMovementN[1];
-        INumberVectorProperty AbsMovementNP;
+        INDI::PropertyNumber AbsMovementNP {1};
 
-        //    INumber SetBacklashN[1];
-        //    INumberVectorProperty SetBacklashNP;
+        //    INDI::PropertyNumber SetBacklashNP {1};
+        //
 };

--- a/drivers/focuser/sestosenso.cpp
+++ b/drivers/focuser/sestosenso.cpp
@@ -125,42 +125,42 @@ bool SestoSenso::initProperties()
     INDI::Focuser::initProperties();
 
     // Firmware Information
-    IUFillText(&FirmwareT[0], "VERSION", "Version", "");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "FOCUS_FIRMWARE", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    FirmwareTP[0].fill("VERSION", "Version", "");
+    FirmwareTP.fill(getDeviceName(), "FOCUS_FIRMWARE", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Focuser calibration
-    IUFillText(&CalibrationMessageT[0], "CALIBRATION", "Calibration stage", "");
-    IUFillTextVector(&CalibrationMessageTP, CalibrationMessageT, 1, getDeviceName(), "CALIBRATION_MESSAGE", "Calibration", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    CalibrationMessageTP[0].fill("CALIBRATION", "Calibration stage", "");
+    CalibrationMessageTP.fill(getDeviceName(), "CALIBRATION_MESSAGE", "Calibration", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillSwitch(&CalibrationS[CALIBRATION_START], "CALIBRATION_START", "Start", ISS_OFF);
-    IUFillSwitch(&CalibrationS[CALIBRATION_NEXT], "CALIBRATION_NEXT", "Next", ISS_OFF);
-    IUFillSwitchVector(&CalibrationSP, CalibrationS, 2, getDeviceName(), "FOCUS_CALIBRATION", "Calibration", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    CalibrationSP[CALIBRATION_START].fill("CALIBRATION_START", "Start", ISS_OFF);
+    CalibrationSP[CALIBRATION_NEXT].fill("CALIBRATION_NEXT", "Next", ISS_OFF);
+    CalibrationSP.fill(getDeviceName(), "FOCUS_CALIBRATION", "Calibration", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&FastMoveS[FASTMOVE_IN], "FASTMOVE_IN", "Move In", ISS_OFF);
-    IUFillSwitch(&FastMoveS[FASTMOVE_OUT], "FASTMOVE_OUT", "Move out", ISS_OFF);
-    IUFillSwitch(&FastMoveS[FASTMOVE_STOP], "FASTMOVE_STOP", "Stop", ISS_OFF);
-    IUFillSwitchVector(&FastMoveSP, FastMoveS, 3, getDeviceName(), "FAST_MOVE", "Calibration Move", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    FastMoveSP[FASTMOVE_IN].fill("FASTMOVE_IN", "Move In", ISS_OFF);
+    FastMoveSP[FASTMOVE_OUT].fill("FASTMOVE_OUT", "Move out", ISS_OFF);
+    FastMoveSP[FASTMOVE_STOP].fill("FASTMOVE_STOP", "Stop", ISS_OFF);
+    FastMoveSP.fill(getDeviceName(), "FAST_MOVE", "Calibration Move", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     //
     // Override the default Max. Position to make it Read-Only
-    IUFillNumberVector(&FocusMaxPosNP, FocusMaxPosN, 1, getDeviceName(), "FOCUS_MAX", "Max. Position", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    FocusMaxPosNP.fill(getDeviceName(), "FOCUS_MAX", "Max. Position", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Relative and absolute movement
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 200000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(200000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
-    FocusMaxPosN[0].value = 2097152;
+    FocusMaxPosNP[0].setValue(2097152);
 
     addAuxControls();
 
@@ -177,11 +177,11 @@ bool SestoSenso::updateProperties()
     {
         // Only define temperature if there is a probe
         if (updateTemperature())
-            defineProperty(&TemperatureNP);
-        defineProperty(&FirmwareTP);
-        IUSaveText(&CalibrationMessageT[0], "Press START to begin the Calibration");
-        defineProperty(&CalibrationMessageTP);
-        defineProperty(&CalibrationSP);
+            defineProperty(TemperatureNP);
+        defineProperty(FirmwareTP);
+        CalibrationMessageTP[0].setText("Press START to begin the Calibration");
+        defineProperty(CalibrationMessageTP);
+        defineProperty(CalibrationSP);
 
         if (getStartupValues())
             LOG_INFO("SestoSenso parameters updated, focuser ready for use.");
@@ -190,11 +190,11 @@ bool SestoSenso::updateProperties()
     }
     else
     {
-        if (TemperatureNP.s == IPS_OK)
-            deleteProperty(TemperatureNP.name);
-        deleteProperty(FirmwareTP.name);
-        deleteProperty(CalibrationMessageTP.name);
-        deleteProperty(CalibrationSP.name);
+        if (TemperatureNP.getState() == IPS_OK)
+            deleteProperty(TemperatureNP.getName());
+        deleteProperty(FirmwareTP.getName());
+        deleteProperty(CalibrationMessageTP.getName());
+        deleteProperty(CalibrationSP.getName());
     }
 
     return true;
@@ -236,7 +236,7 @@ bool SestoSenso::Ack()
     else if (sendCommand("#QF!", res) == false)
         return false;
 
-    IUSaveText(&FirmwareT[0], res);
+    FirmwareTP[0].setText(res);
 
     return true;
 }
@@ -264,8 +264,8 @@ bool SestoSenso::updateTemperature()
     if (temperature > 90)
         return false;
 
-    TemperatureN[0].value = temperature;
-    TemperatureNP.s = IPS_OK;
+    TemperatureNP[0].setValue(temperature);
+    TemperatureNP.setState(IPS_OK);
 
     return true;
 }
@@ -286,29 +286,29 @@ bool SestoSenso::updateMaxLimit()
 
     if (maxLimit > 0)
     {
-        FocusMaxPosN[0].max = maxLimit;
-        if (FocusMaxPosN[0].value > maxLimit)
-            FocusMaxPosN[0].value = maxLimit;
+        FocusMaxPosNP[0].setMax(maxLimit);
+        if (FocusMaxPosNP[0].value > maxLimit)
+            FocusMaxPosNP[0].setValue(maxLimit);
 
-        FocusAbsPosN[0].min   = 0;
-        FocusAbsPosN[0].max   = maxLimit;
-        FocusAbsPosN[0].value = 0;
-        FocusAbsPosN[0].step  = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
+        FocusAbsPosNP[0].setMin(0);
+        FocusAbsPosNP[0].setMax(maxLimit);
+        FocusAbsPosNP[0].setValue(0);
+        FocusAbsPosNP[0].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
 
-        FocusRelPosN[0].min   = 0.;
-        FocusRelPosN[0].max   = FocusAbsPosN[0].step * 10;
-        FocusRelPosN[0].value = 0;
-        FocusRelPosN[0].step  = FocusAbsPosN[0].step;
+        FocusRelPosNP[0].setMin(0.);
+        FocusRelPosNP[0].setMax(FocusAbsPosNP[0].step * 10);
+        FocusRelPosNP[0].setValue(0);
+        FocusRelPosNP[0].setStep(FocusAbsPosNP[0].step);
 
-        IUUpdateMinMax(&FocusAbsPosNP);
-        IUUpdateMinMax(&FocusRelPosNP);
+        FocusAbsPosNP.updateMinMax();
+        FocusRelPosNP.updateMinMax();
 
-        FocusMaxPosNP.s = IPS_OK;
-        IUUpdateMinMax(&FocusMaxPosNP);
+        FocusMaxPosNP.setState(IPS_OK);
+        FocusMaxPosNP.updateMinMax();
         return true;
     }
 
-    FocusMaxPosNP.s = IPS_ALERT;
+    FocusMaxPosNP.setState(IPS_ALERT);
     return false;
 }
 
@@ -316,20 +316,20 @@ bool SestoSenso::updatePosition()
 {
     char res[SESTO_LEN] = {0};
     if (isSimulation())
-        snprintf(res, SESTO_LEN, "%d", static_cast<uint32_t>(FocusAbsPosN[0].value));
+        snprintf(res, SESTO_LEN, "%d", static_cast<uint32_t>(FocusAbsPosNP[0].value));
     else if (sendCommand("#QP!", res) == false)
         return false;
 
     try
     {
-        FocusAbsPosN[0].value = std::stoi(res);
-        FocusAbsPosNP.s = IPS_OK;
+        FocusAbsPosNP[0].setValue(std::stoi(res));
+        FocusAbsPosNP.setState(IPS_OK);
         return true;
     }
     catch(...)
     {
         LOGF_WARN("Failed to process position response: %s (%d bytes)", res, strlen(res));
-        FocusAbsPosNP.s = IPS_ALERT;
+        FocusAbsPosNP.setState(IPS_ALERT);
         return false;
     }
 }
@@ -340,7 +340,7 @@ bool SestoSenso::isMotionComplete()
 
     if (isSimulation())
     {
-        int32_t nextPos = FocusAbsPosN[0].value;
+        int32_t nextPos = FocusAbsPosNP[0].getValue();
         int32_t targPos = static_cast<int32_t>(targetPos);
 
         if (targPos > nextPos)
@@ -352,8 +352,8 @@ bool SestoSenso::isMotionComplete()
             nextPos = targetPos;
         else if (nextPos < 0)
             nextPos = 0;
-        else if (nextPos > FocusAbsPosN[0].max)
-            nextPos = FocusAbsPosN[0].max;
+        else if (nextPos > FocusAbsPosNP[0].max)
+            nextPos = FocusAbsPosNP[0].getMax();
 
         snprintf(res, SESTO_LEN, "%d", nextPos);
     }
@@ -375,7 +375,7 @@ bool SestoSenso::isMotionComplete()
             try
             {
                 uint32_t newPos = std::stoi(res);
-                FocusAbsPosN[0].value = newPos;
+                FocusAbsPosNP[0].setValue(newPos);
             }
             catch (...)
             {
@@ -394,18 +394,18 @@ bool SestoSenso::ISNewSwitch(const char *dev, const char *name, ISState *states,
     {
 
         // Calibrate focuser
-        if (!strcmp(name, CalibrationSP.name))
+        if (CalibrationSP.isNameMatch(name))
         {
             char res[SESTO_LEN] = {0};
             int current_switch = 0;
 
-            CalibrationSP.s = IPS_BUSY;
-            //IDSetSwitch(&CalibrationSP, nullptr);
-            IUUpdateSwitch(&CalibrationSP, states, names, n);
+            CalibrationSP.setState(IPS_BUSY);
+            //CalibrationSP.apply();
+            CalibrationSP.update(states, names, n);
 
-            current_switch = IUFindOnSwitchIndex(&CalibrationSP);
-            CalibrationS[current_switch].s = ISS_ON;
-            IDSetSwitch(&CalibrationSP, nullptr);
+            current_switch = CalibrationSP.findOnSwitchIndex();
+            CalibrationSP[current_switch].setState(ISS_ON);
+            CalibrationSP.apply();
 
             if (current_switch == CALIBRATION_START)
             {
@@ -413,8 +413,8 @@ bool SestoSenso::ISNewSwitch(const char *dev, const char *name, ISState *states,
                 {
                     // Start the calibration process
                     LOG_INFO("Start Calibration");
-                    CalibrationSP.s = IPS_BUSY;
-                    IDSetSwitch(&CalibrationSP, nullptr);
+                    CalibrationSP.setState(IPS_BUSY);
+                    CalibrationSP.apply();
 
                     //
                     // Unlock the motor to allow manual movement of the focuser
@@ -422,8 +422,8 @@ bool SestoSenso::ISNewSwitch(const char *dev, const char *name, ISState *states,
                     if (sendCommand("#MF!") == false)
                         return false;
 
-                    IUSaveText(&CalibrationMessageT[0], "Move focuser manually to the middle then press NEXT");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Move focuser manually to the middle then press NEXT");
+                    CalibrationMessageTP.apply();
 
                     // Set next step
                     cStage = GoToMiddle;
@@ -431,17 +431,17 @@ bool SestoSenso::ISNewSwitch(const char *dev, const char *name, ISState *states,
                 else
                 {
                     LOG_INFO("Already started calibration. Proceed to next step.");
-                    IUSaveText(&CalibrationMessageT[0], "Already started. Proceed to NEXT.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Already started. Proceed to NEXT.");
+                    CalibrationMessageTP.apply();
                 }
             }
             else if (current_switch == CALIBRATION_NEXT)
             {
                 if (cStage == GoToMiddle)
                 {
-                    defineProperty(&FastMoveSP);
-                    IUSaveText(&CalibrationMessageT[0], "Move In/Move Out/Stop to MIN position then press NEXT");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    defineProperty(FastMoveSP);
+                    CalibrationMessageTP[0].setText("Move In/Move Out/Stop to MIN position then press NEXT");
+                    CalibrationMessageTP.apply();
                     cStage = GoMinimum;
                 }
                 else if (cStage == GoMinimum)
@@ -450,8 +450,8 @@ bool SestoSenso::ISNewSwitch(const char *dev, const char *name, ISState *states,
                     if (sendCommand("#Sm;0!") == false)
                         return false;
 
-                    IUSaveText(&CalibrationMessageT[0], "Move In/Move Out/Stop to MAX position then press NEXT");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Move In/Move Out/Stop to MAX position then press NEXT");
+                    CalibrationMessageTP.apply();
                     cStage = GoMaximum;
                 }
                 else if (cStage == GoMaximum)
@@ -471,49 +471,49 @@ bool SestoSenso::ISNewSwitch(const char *dev, const char *name, ISState *states,
                     sscanf(res, "SM;%d!", &maxLimit);
                     LOGF_INFO("MAX setting is %d", maxLimit);
 
-                    FocusMaxPosN[0].max = maxLimit;
-                    FocusMaxPosN[0].value = maxLimit;
+                    FocusMaxPosNP[0].setMax(maxLimit);
+                    FocusMaxPosNP[0].setValue(maxLimit);
 
-                    FocusAbsPosN[0].min   = 0;
-                    FocusAbsPosN[0].max   = maxLimit;
-                    FocusAbsPosN[0].value = maxLimit;
-                    FocusAbsPosN[0].step  = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
+                    FocusAbsPosNP[0].setMin(0);
+                    FocusAbsPosNP[0].setMax(maxLimit);
+                    FocusAbsPosNP[0].setValue(maxLimit);
+                    FocusAbsPosNP[0].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
 
-                    FocusRelPosN[0].min   = 0.;
-                    FocusRelPosN[0].max   = FocusAbsPosN[0].step * 10;
-                    FocusRelPosN[0].value = 0;
-                    FocusRelPosN[0].step  = FocusAbsPosN[0].step;
+                    FocusRelPosNP[0].setMin(0.);
+                    FocusRelPosNP[0].setMax(FocusAbsPosNP[0].step * 10);
+                    FocusRelPosNP[0].setValue(0);
+                    FocusRelPosNP[0].setStep(FocusAbsPosNP[0].step);
 
-                    IUUpdateMinMax(&FocusAbsPosNP);
-                    IUUpdateMinMax(&FocusRelPosNP);
-                    FocusMaxPosNP.s = IPS_OK;
-                    IUUpdateMinMax(&FocusMaxPosNP);
+                    FocusAbsPosNP.updateMinMax();
+                    FocusRelPosNP.updateMinMax();
+                    FocusMaxPosNP.setState(IPS_OK);
+                    FocusMaxPosNP.updateMinMax();
 
-                    IUSaveText(&CalibrationMessageT[0], "Calibration Completed.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Calibration Completed.");
+                    CalibrationMessageTP.apply();
 
-                    deleteProperty(FastMoveSP.name);
+                    deleteProperty(FastMoveSP.getName());
                     cStage = Complete;
 
                     LOG_INFO("Calibration completed");
-                    CalibrationSP.s = IPS_OK;
-                    IDSetSwitch(&CalibrationSP, nullptr);
-                    CalibrationS[current_switch].s = ISS_OFF;
-                    IDSetSwitch(&CalibrationSP, nullptr);
+                    CalibrationSP.setState(IPS_OK);
+                    CalibrationSP.apply();
+                    CalibrationSP[current_switch].setState(ISS_OFF);
+                    CalibrationSP.apply();
                 }
                 else
                 {
-                    IUSaveText(&CalibrationMessageT[0], "Calibration not in process");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Calibration not in process");
+                    CalibrationMessageTP.apply();
                 }
 
             }
             return true;
         }
-        else if (!strcmp(name, FastMoveSP.name))
+        else if (FastMoveSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FastMoveSP, states, names, n);
-            int current_switch = IUFindOnSwitchIndex(&FastMoveSP);
+            FastMoveSP.update(states, names, n);
+            int current_switch = FastMoveSP.findOnSwitchIndex();
 
             switch (current_switch)
             {
@@ -539,8 +539,8 @@ bool SestoSenso::ISNewSwitch(const char *dev, const char *name, ISState *states,
                     break;
             }
 
-            FastMoveSP.s = IPS_BUSY;
-            IDSetSwitch(&FastMoveSP, nullptr);
+            FastMoveSP.setState(IPS_BUSY);
+            FastMoveSP.apply();
             return true;
         }
 
@@ -568,9 +568,9 @@ IPState SestoSenso::MoveAbsFocuser(uint32_t targetTicks)
 
 IPState SestoSenso::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
-    int reversed = (IUFindOnSwitchIndex(&FocusReverseSP) == INDI_ENABLED) ? -1 : 1;
+    int reversed = (FocusReverseSP.findOnSwitchIndex() == INDI_ENABLED) ? -1 : 1;
     int relativeTicks =  ((dir == FOCUS_INWARD) ? -ticks : ticks) * reversed;
-    double newPosition = FocusAbsPosN[0].value + relativeTicks;
+    double newPosition = FocusAbsPosNP[0].getValue() + relativeTicks;
 
     bool rc = MoveAbsFocuser(newPosition);
 
@@ -604,18 +604,18 @@ void SestoSenso::checkMotionProgressCallback()
 {
     if (isMotionComplete())
     {
-        FocusAbsPosNP.s = IPS_OK;
-        FocusRelPosNP.s = IPS_OK;
-        IDSetNumber(&FocusRelPosNP, nullptr);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
-        lastPos = FocusAbsPosN[0].value;
+        FocusAbsPosNP.setState(IPS_OK);
+        FocusRelPosNP.setState(IPS_OK);
+        FocusRelPosNP.apply();
+        FocusAbsPosNP.apply();
+        lastPos = FocusAbsPosNP[0].getValue();
         LOG_INFO("Focuser reached requested position.");
         return;
     }
     else
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
-    lastPos = FocusAbsPosN[0].value;
+    lastPos = FocusAbsPosNP[0].getValue();
 
     IERmTimer(m_MotionProgressTimerID);
     m_MotionProgressTimerID = IEAddTimer(10, &SestoSenso::checkMotionProgressHelper, this);
@@ -623,7 +623,7 @@ void SestoSenso::checkMotionProgressCallback()
 
 void SestoSenso::TimerHit()
 {
-    if (!isConnected() || FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY || CalibrationSP.s == IPS_BUSY)
+    if (!isConnected() || FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY || CalibrationSP.getState() == IPS_BUSY)
     {
         SetTimer(getCurrentPollingPeriod());
         return;
@@ -632,10 +632,10 @@ void SestoSenso::TimerHit()
     bool rc = updatePosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 0)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 0)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
@@ -644,10 +644,10 @@ void SestoSenso::TimerHit()
         rc = updateTemperature();
         if (rc)
         {
-            if (fabs(lastTemperature - TemperatureN[0].value) >= 0.1)
+            if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.1)
             {
-                IDSetNumber(&TemperatureNP, nullptr);
-                lastTemperature = TemperatureN[0].value;
+                TemperatureNP.apply();
+                lastTemperature = TemperatureNP[0].getValue();
             }
         }
         m_TemperatureCounter = 0;   // Reset the counter
@@ -660,7 +660,7 @@ bool SestoSenso::getStartupValues()
 {
     bool rc1 = updatePosition();
     if (rc1)
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (updateMaxLimit() == false)
         LOG_WARN("Check you have the latest SestoSenso firmware. Focuser requires calibration.");

--- a/drivers/focuser/sestosenso.h
+++ b/drivers/focuser/sestosenso.h
@@ -22,6 +22,11 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class SestoSenso : public INDI::Focuser
 {
     public:
@@ -68,22 +73,18 @@ class SestoSenso : public INDI::Focuser
         double lastTemperature { 0 };
         uint16_t m_TemperatureCounter { 0 };
 
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
-        IText FirmwareT[1] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {1};
 
-        ISwitch CalibrationS[2];
-        ISwitchVectorProperty CalibrationSP;
+        INDI::PropertySwitch CalibrationSP {2};
         enum
         {
             CALIBRATION_START,
             CALIBRATION_NEXT
         };
 
-        ISwitch FastMoveS[3];
-        ISwitchVectorProperty FastMoveSP;
+        INDI::PropertySwitch FastMoveSP {3};
         enum
         {
             FASTMOVE_IN,
@@ -91,8 +92,7 @@ class SestoSenso : public INDI::Focuser
             FASTMOVE_STOP
         };
 
-        IText CalibrationMessageT[1] {};
-        ITextVectorProperty CalibrationMessageTP;
+        INDI::PropertyText CalibrationMessageTP {1};
 
         typedef enum { Idle, GoToMiddle, GoMinimum, GoMaximum, Complete } CalibrationStage;
         CalibrationStage cStage { Idle };

--- a/drivers/focuser/sestosenso2.cpp
+++ b/drivers/focuser/sestosenso2.cpp
@@ -110,111 +110,111 @@ bool SestoSenso2::initProperties()
     setConnectionParams();
 
     // Firmware information
-    IUFillText(&FirmwareT[FIRMWARE_SN], "SERIALNUMBER", "Serial Number", "");
-    IUFillText(&FirmwareT[FIRMWARE_VERSION], "VERSION", "Version", "");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 2, getDeviceName(), "FOCUS_FIRMWARE", "Firmware", CONNECTION_TAB, IP_RO, 0,
+    FirmwareTP[FIRMWARE_SN].fill("SERIALNUMBER", "Serial Number", "");
+    FirmwareTP[FIRMWARE_VERSION].fill("VERSION", "Version", "");
+    FirmwareTP.fill(getDeviceName(), "FOCUS_FIRMWARE", "Firmware", CONNECTION_TAB, IP_RO, 0,
                      IPS_IDLE);
 
     // Voltage Information
-    IUFillNumber(&VoltageInN[0], "VOLTAGEIN", "Volts", "%.2f", 0, 100, 0., 0.);
-    IUFillNumberVector(&VoltageInNP, VoltageInN, 1, getDeviceName(), "VOLTAGE_IN", "Voltage in", ENVIRONMENT_TAB, IP_RO, 0,
+    VoltageInNP[0].fill("VOLTAGEIN", "Volts", "%.2f", 0, 100, 0., 0.);
+    VoltageInNP.fill(getDeviceName(), "VOLTAGE_IN", "Voltage in", ENVIRONMENT_TAB, IP_RO, 0,
                        IPS_IDLE);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[TEMPERATURE_MOTOR], "TEMPERATURE", "Motor (c)", "%.2f", -50, 70., 0., 0.);
-    IUFillNumber(&TemperatureN[TEMPERATURE_EXTERNAL], "TEMPERATURE_ETX", "External (c)", "%.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 2, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", ENVIRONMENT_TAB,
+    TemperatureNP[TEMPERATURE_MOTOR].fill("TEMPERATURE", "Motor (c)", "%.2f", -50, 70., 0., 0.);
+    TemperatureNP[TEMPERATURE_EXTERNAL].fill("TEMPERATURE_ETX", "External (c)", "%.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", ENVIRONMENT_TAB,
                        IP_RO, 0, IPS_IDLE);
 
     // Current Speed
-    IUFillNumber(&SpeedN[0], "SPEED", "steps/s", "%.f", 0, 7000., 1, 0);
-    IUFillNumberVector(&SpeedNP, SpeedN, 1, getDeviceName(), "FOCUS_SPEED", "Motor Speed", MAIN_CONTROL_TAB, IP_RO, 0,
+    SpeedNP[0].fill("SPEED", "steps/s", "%.f", 0, 7000., 1, 0);
+    SpeedNP.fill(getDeviceName(), "FOCUS_SPEED", "Motor Speed", MAIN_CONTROL_TAB, IP_RO, 0,
                        IPS_IDLE);
 
     // Focuser calibration
-    IUFillText(&CalibrationMessageT[0], "CALIBRATION", "Calibration stage", "Press START to begin the Calibration.");
-    IUFillTextVector(&CalibrationMessageTP, CalibrationMessageT, 1, getDeviceName(), "CALIBRATION_MESSAGE", "Calibration",
+    CalibrationMessageTP[0].fill("CALIBRATION", "Calibration stage", "Press START to begin the Calibration.");
+    CalibrationMessageTP.fill(getDeviceName(), "CALIBRATION_MESSAGE", "Calibration",
                      MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Calibration
-    IUFillSwitch(&CalibrationS[CALIBRATION_START], "CALIBRATION_START", "Start", ISS_OFF);
-    IUFillSwitch(&CalibrationS[CALIBRATION_NEXT], "CALIBRATION_NEXT", "Next", ISS_OFF);
-    IUFillSwitchVector(&CalibrationSP, CalibrationS, 2, getDeviceName(), "FOCUS_CALIBRATION", "Calibration", MAIN_CONTROL_TAB,
+    CalibrationSP[CALIBRATION_START].fill("CALIBRATION_START", "Start", ISS_OFF);
+    CalibrationSP[CALIBRATION_NEXT].fill("CALIBRATION_NEXT", "Next", ISS_OFF);
+    CalibrationSP.fill(getDeviceName(), "FOCUS_CALIBRATION", "Calibration", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Speed Moves
-    IUFillSwitch(&FastMoveS[FASTMOVE_IN], "FASTMOVE_IN", "Move In", ISS_OFF);
-    IUFillSwitch(&FastMoveS[FASTMOVE_OUT], "FASTMOVE_OUT", "Move out", ISS_OFF);
-    IUFillSwitch(&FastMoveS[FASTMOVE_STOP], "FASTMOVE_STOP", "Stop", ISS_OFF);
-    IUFillSwitchVector(&FastMoveSP, FastMoveS, 3, getDeviceName(), "FAST_MOVE", "Calibration Move", MAIN_CONTROL_TAB, IP_RW,
+    FastMoveSP[FASTMOVE_IN].fill("FASTMOVE_IN", "Move In", ISS_OFF);
+    FastMoveSP[FASTMOVE_OUT].fill("FASTMOVE_OUT", "Move out", ISS_OFF);
+    FastMoveSP[FASTMOVE_STOP].fill("FASTMOVE_STOP", "Stop", ISS_OFF);
+    FastMoveSP.fill(getDeviceName(), "FAST_MOVE", "Calibration Move", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
     // Hold state
-    IUFillSwitch(&MotorHoldS[MOTOR_HOLD_ON], "HOLD_ON", "Hold On", ISS_OFF);
-    IUFillSwitch(&MotorHoldS[MOTOR_HOLD_OFF], "HOLD_OFF", "Hold Off", ISS_OFF);
-    IUFillSwitchVector(&MotorHoldSP, MotorHoldS, 2, getDeviceName(), "MOTOR_HOLD", "Motor Hold", MAIN_CONTROL_TAB,
+    MotorHoldSP[MOTOR_HOLD_ON].fill("HOLD_ON", "Hold On", ISS_OFF);
+    MotorHoldSP[MOTOR_HOLD_OFF].fill("HOLD_OFF", "Hold Off", ISS_OFF);
+    MotorHoldSP.fill(getDeviceName(), "MOTOR_HOLD", "Motor Hold", MAIN_CONTROL_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Override the default Max. Position to make it Read-Only
-    IUFillNumberVector(&FocusMaxPosNP, FocusMaxPosN, 1, getDeviceName(), "FOCUS_MAX", "Max. Position", MAIN_CONTROL_TAB, IP_RO,
+    FocusMaxPosNP.fill(getDeviceName(), "FOCUS_MAX", "Max. Position", MAIN_CONTROL_TAB, IP_RO,
                        0, IPS_IDLE);
 
     // Home Position
-    IUFillSwitch(&HomeS[0], "FOCUS_HOME_GO", "Go", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 1, getDeviceName(), "FOCUS_HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
+    HomeSP[0].fill("FOCUS_HOME_GO", "Go", ISS_OFF);
+    HomeSP.fill(getDeviceName(), "FOCUS_HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_IDLE);
 
     // Motor rate
-    IUFillNumber(&MotorRateN[MOTOR_RATE_ACC], "ACC", "Acceleration", "%.f", 1, 10, 1, 1);
-    IUFillNumber(&MotorRateN[MOTOR_RATE_RUN], "RUN", "Run Speed", "%.f", 1, 10, 1, 2);
-    IUFillNumber(&MotorRateN[MOTOR_RATE_DEC], "DEC", "Deceleration", "%.f", 1, 10, 1, 1);
-    IUFillNumberVector(&MotorRateNP, MotorRateN, 3, getDeviceName(), "MOTOR_RATE", "Motor Rate", MOTOR_TAB, IP_RW, 0,
+    MotorRateNP[MOTOR_RATE_ACC].fill("ACC", "Acceleration", "%.f", 1, 10, 1, 1);
+    MotorRateNP[MOTOR_RATE_RUN].fill("RUN", "Run Speed", "%.f", 1, 10, 1, 2);
+    MotorRateNP[MOTOR_RATE_DEC].fill("DEC", "Deceleration", "%.f", 1, 10, 1, 1);
+    MotorRateNP.fill(getDeviceName(), "MOTOR_RATE", "Motor Rate", MOTOR_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // Motor current
-    IUFillNumber(&MotorCurrentN[MOTOR_CURR_ACC], "CURR_ACC", "Acceleration", "%.f", 1, 10, 1, 7);
-    IUFillNumber(&MotorCurrentN[MOTOR_CURR_RUN], "CURR_RUN", "Run", "%.f", 1, 10, 1, 7);
-    IUFillNumber(&MotorCurrentN[MOTOR_CURR_DEC], "CURR_DEC", "Deceleration", "%.f", 1, 10, 1, 7);
-    IUFillNumber(&MotorCurrentN[MOTOR_CURR_HOLD], "CURR_HOLD", "Hold", "%.f", 0, 5, 1, 3);
-    IUFillNumberVector(&MotorCurrentNP, MotorCurrentN, 4, getDeviceName(), "MOTOR_CURRENT", "Current", MOTOR_TAB, IP_RW, 0,
+    MotorCurrentNP[MOTOR_CURR_ACC].fill("CURR_ACC", "Acceleration", "%.f", 1, 10, 1, 7);
+    MotorCurrentNP[MOTOR_CURR_RUN].fill("CURR_RUN", "Run", "%.f", 1, 10, 1, 7);
+    MotorCurrentNP[MOTOR_CURR_DEC].fill("CURR_DEC", "Deceleration", "%.f", 1, 10, 1, 7);
+    MotorCurrentNP[MOTOR_CURR_HOLD].fill("CURR_HOLD", "Hold", "%.f", 0, 5, 1, 3);
+    MotorCurrentNP.fill(getDeviceName(), "MOTOR_CURRENT", "Current", MOTOR_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // Load motor preset
-    IUFillSwitch(&MotorApplyPresetS[MOTOR_APPLY_LIGHT], "MOTOR_APPLY_LIGHT", "Light", ISS_OFF);
-    IUFillSwitch(&MotorApplyPresetS[MOTOR_APPLY_MEDIUM], "MOTOR_APPLY_MEDIUM", "Medium", ISS_OFF);
-    IUFillSwitch(&MotorApplyPresetS[MOTOR_APPLY_HEAVY], "MOTOR_APPLY_HEAVY", "Heavy", ISS_OFF);
-    IUFillSwitchVector(&MotorApplyPresetSP, MotorApplyPresetS, 3, getDeviceName(), "MOTOR_APPLY_PRESET", "Apply Preset",
+    MotorApplyPresetSP[MOTOR_APPLY_LIGHT].fill("MOTOR_APPLY_LIGHT", "Light", ISS_OFF);
+    MotorApplyPresetSP[MOTOR_APPLY_MEDIUM].fill("MOTOR_APPLY_MEDIUM", "Medium", ISS_OFF);
+    MotorApplyPresetSP[MOTOR_APPLY_HEAVY].fill("MOTOR_APPLY_HEAVY", "Heavy", ISS_OFF);
+    MotorApplyPresetSP.fill(getDeviceName(), "MOTOR_APPLY_PRESET", "Apply Preset",
                        MOTOR_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Load user preset
-    IUFillSwitch(&MotorApplyUserPresetS[MOTOR_APPLY_USER1], "MOTOR_APPLY_USER1", "User 1", ISS_OFF);
-    IUFillSwitch(&MotorApplyUserPresetS[MOTOR_APPLY_USER2], "MOTOR_APPLY_USER2", "User 2", ISS_OFF);
-    IUFillSwitch(&MotorApplyUserPresetS[MOTOR_APPLY_USER3], "MOTOR_APPLY_USER3", "User 3", ISS_OFF);
-    IUFillSwitchVector(&MotorApplyUserPresetSP, MotorApplyUserPresetS, 3, getDeviceName(), "MOTOR_APPLY_USER_PRESET",
+    MotorApplyUserPresetSP[MOTOR_APPLY_USER1].fill("MOTOR_APPLY_USER1", "User 1", ISS_OFF);
+    MotorApplyUserPresetSP[MOTOR_APPLY_USER2].fill("MOTOR_APPLY_USER2", "User 2", ISS_OFF);
+    MotorApplyUserPresetSP[MOTOR_APPLY_USER3].fill("MOTOR_APPLY_USER3", "User 3", ISS_OFF);
+    MotorApplyUserPresetSP.fill(getDeviceName(), "MOTOR_APPLY_USER_PRESET",
                        "Apply Custom", MOTOR_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Save user preset
-    IUFillSwitch(&MotorSaveUserPresetS[MOTOR_SAVE_USER1], "MOTOR_SAVE_USER1", "User 1", ISS_OFF);
-    IUFillSwitch(&MotorSaveUserPresetS[MOTOR_SAVE_USER2], "MOTOR_SAVE_USER2", "User 2", ISS_OFF);
-    IUFillSwitch(&MotorSaveUserPresetS[MOTOR_SAVE_USER3], "MOTOR_SAVE_USER3", "User 3", ISS_OFF);
-    IUFillSwitchVector(&MotorSaveUserPresetSP, MotorSaveUserPresetS, 3, getDeviceName(), "MOTOR_SAVE_USER_PRESET",
+    MotorSaveUserPresetSP[MOTOR_SAVE_USER1].fill("MOTOR_SAVE_USER1", "User 1", ISS_OFF);
+    MotorSaveUserPresetSP[MOTOR_SAVE_USER2].fill("MOTOR_SAVE_USER2", "User 2", ISS_OFF);
+    MotorSaveUserPresetSP[MOTOR_SAVE_USER3].fill("MOTOR_SAVE_USER3", "User 3", ISS_OFF);
+    MotorSaveUserPresetSP.fill(getDeviceName(), "MOTOR_SAVE_USER_PRESET",
                        "Save Custom", MOTOR_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Relative and absolute movement
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 50000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 200000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(200000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
-    FocusMaxPosN[0].value = 2097152;
-    PresetN[0].max = FocusMaxPosN[0].value;
-    PresetN[1].max = FocusMaxPosN[0].value;
-    PresetN[2].max = FocusMaxPosN[0].value;
+    FocusMaxPosNP[0].setValue(2097152);
+    PresetNP[0].setMax(FocusMaxPosNP[0].value);
+    PresetNP[1].setMax(FocusMaxPosNP[0].value);
+    PresetNP[2].setMax(FocusMaxPosNP[0].value);
 
     addAuxControls();
 
@@ -232,24 +232,24 @@ bool SestoSenso2::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&SpeedNP);
-        defineProperty(&CalibrationMessageTP);
-        defineProperty(&CalibrationSP);
-        defineProperty(&HomeSP);
-        defineProperty(&MotorRateNP);
-        defineProperty(&MotorCurrentNP);
-        defineProperty(&MotorHoldSP);
-        defineProperty(&MotorApplyPresetSP);
-        defineProperty(&MotorApplyUserPresetSP);
-        defineProperty(&MotorSaveUserPresetSP);
+        defineProperty(SpeedNP);
+        defineProperty(CalibrationMessageTP);
+        defineProperty(CalibrationSP);
+        defineProperty(HomeSP);
+        defineProperty(MotorRateNP);
+        defineProperty(MotorCurrentNP);
+        defineProperty(MotorHoldSP);
+        defineProperty(MotorApplyPresetSP);
+        defineProperty(MotorApplyUserPresetSP);
+        defineProperty(MotorSaveUserPresetSP);
 
-        defineProperty(&FirmwareTP);
+        defineProperty(FirmwareTP);
 
         if (updateTemperature())
-            defineProperty(&TemperatureNP);
+            defineProperty(TemperatureNP);
 
         if (updateVoltageIn())
-            defineProperty(&VoltageInNP);
+            defineProperty(VoltageInNP);
 
         if (getStartupValues())
             LOG_INFO("Parameters updated, focuser ready for use.");
@@ -258,20 +258,20 @@ bool SestoSenso2::updateProperties()
     }
     else
     {
-        if (TemperatureNP.s == IPS_OK)
-            deleteProperty(TemperatureNP.name);
-        deleteProperty(FirmwareTP.name);
-        deleteProperty(VoltageInNP.name);
-        deleteProperty(CalibrationMessageTP.name);
-        deleteProperty(CalibrationSP.name);
-        deleteProperty(SpeedNP.name);
-        deleteProperty(HomeSP.name);
-        deleteProperty(MotorRateNP.name);
-        deleteProperty(MotorCurrentNP.name);
-        deleteProperty(MotorHoldSP.name);
-        deleteProperty(MotorApplyPresetSP.name);
-        deleteProperty(MotorApplyUserPresetSP.name);
-        deleteProperty(MotorSaveUserPresetSP.name);
+        if (TemperatureNP.getState() == IPS_OK)
+            deleteProperty(TemperatureNP.getName());
+        deleteProperty(FirmwareTP.getName());
+        deleteProperty(VoltageInNP.getName());
+        deleteProperty(CalibrationMessageTP.getName());
+        deleteProperty(CalibrationSP.getName());
+        deleteProperty(SpeedNP.getName());
+        deleteProperty(HomeSP.getName());
+        deleteProperty(MotorRateNP.getName());
+        deleteProperty(MotorCurrentNP.getName());
+        deleteProperty(MotorHoldSP.getName());
+        deleteProperty(MotorApplyPresetSP.getName());
+        deleteProperty(MotorApplyUserPresetSP.getName());
+        deleteProperty(MotorSaveUserPresetSP.getName());
     }
 
     return true;
@@ -325,13 +325,13 @@ bool SestoSenso2::updateTemperature()
     if (temperature > 90)
         return false;
 
-    TemperatureN[TEMPERATURE_MOTOR].value = temperature;
-    TemperatureNP.s = IPS_OK;
+    TemperatureNP[TEMPERATURE_MOTOR].setValue(temperature);
+    TemperatureNP.setState(IPS_OK);
 
     // External temperature - Optional
     if (command->getExternalTemp(res))
     {
-        TemperatureN[TEMPERATURE_EXTERNAL].value = -273.15;
+        TemperatureNP[TEMPERATURE_EXTERNAL].setValue(-273.15);
         try
         {
             temperature = std::stod(res);
@@ -342,7 +342,7 @@ bool SestoSenso2::updateTemperature()
         }
 
         if (temperature < 90)
-            TemperatureN[TEMPERATURE_EXTERNAL].value = temperature;
+            TemperatureNP[TEMPERATURE_EXTERNAL].setValue(temperature);
     }
 
     return true;
@@ -365,34 +365,34 @@ bool SestoSenso2::updateMaxLimit()
 
     if (maxLimit > 0)
     {
-        FocusMaxPosN[0].max = maxLimit;
-        if (FocusMaxPosN[0].value > maxLimit)
-            FocusMaxPosN[0].value = maxLimit;
+        FocusMaxPosNP[0].setMax(maxLimit);
+        if (FocusMaxPosNP[0].value > maxLimit)
+            FocusMaxPosNP[0].setValue(maxLimit);
 
-        FocusAbsPosN[0].min   = 0;
-        FocusAbsPosN[0].max   = maxLimit;
-        FocusAbsPosN[0].value = 0;
-        FocusAbsPosN[0].step  = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
+        FocusAbsPosNP[0].setMin(0);
+        FocusAbsPosNP[0].setMax(maxLimit);
+        FocusAbsPosNP[0].setValue(0);
+        FocusAbsPosNP[0].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
 
-        FocusRelPosN[0].min   = 0.;
-        FocusRelPosN[0].max   = FocusAbsPosN[0].step * 10;
-        FocusRelPosN[0].value = 0;
-        FocusRelPosN[0].step  = FocusAbsPosN[0].step;
+        FocusRelPosNP[0].setMin(0.);
+        FocusRelPosNP[0].setMax(FocusAbsPosNP[0].step * 10);
+        FocusRelPosNP[0].setValue(0);
+        FocusRelPosNP[0].setStep(FocusAbsPosNP[0].step);
 
-        PresetN[0].max = maxLimit;
-        PresetN[0].step = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
-        PresetN[1].max = maxLimit;
-        PresetN[1].step = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
-        PresetN[2].max = maxLimit;
-        PresetN[2].step = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
+        PresetNP[0].setMax(maxLimit);
+        PresetNP[0].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
+        PresetNP[1].setMax(maxLimit);
+        PresetNP[1].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
+        PresetNP[2].setMax(maxLimit);
+        PresetNP[2].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
 
 
-        FocusMaxPosNP.s = IPS_OK;
+        FocusMaxPosNP.setState(IPS_OK);
         return true;
     }
 
 
-    FocusMaxPosNP.s = IPS_ALERT;
+    FocusMaxPosNP.setState(IPS_ALERT);
     return false;
 }
 
@@ -400,20 +400,20 @@ bool SestoSenso2::updatePosition()
 {
     char res[SESTO_LEN] = {0};
     if (isSimulation())
-        snprintf(res, SESTO_LEN, "%u", static_cast<uint32_t>(FocusAbsPosN[0].value));
+        snprintf(res, SESTO_LEN, "%u", static_cast<uint32_t>(FocusAbsPosNP[0].value));
     else if (command->getAbsolutePosition(res) == false)
         return false;
 
     try
     {
-        FocusAbsPosN[0].value = std::stoi(res);
-        FocusAbsPosNP.s = IPS_OK;
+        FocusAbsPosNP[0].setValue(std::stoi(res));
+        FocusAbsPosNP.setState(IPS_OK);
         return true;
     }
     catch(...)
     {
         LOGF_WARN("Failed to process position response: %s (%d bytes)", res, strlen(res));
-        FocusAbsPosNP.s = IPS_ALERT;
+        FocusAbsPosNP.setState(IPS_ALERT);
         return false;
     }
 }
@@ -441,8 +441,8 @@ bool SestoSenso2::updateVoltageIn()
     if (voltageIn > 24)
         return false;
 
-    VoltageInN[0].value = voltageIn;
-    VoltageInNP.s = (voltageIn >= 11.0) ? IPS_OK : IPS_ALERT;
+    VoltageInNP[0].setValue(voltageIn);
+    VoltageInNP.setState((voltageIn >= 11.0) ? IPS_OK : IPS_ALERT);
 
     return true;
 }
@@ -468,36 +468,36 @@ bool SestoSenso2::fetchMotorSettings()
     {
         if (!command->getMotorSettings(ms, mc, motorHoldActive))
         {
-            MotorRateNP.s = IPS_IDLE;
-            MotorCurrentNP.s = IPS_IDLE;
-            MotorHoldSP.s = IPS_IDLE;
+            MotorRateNP.setState(IPS_IDLE);
+            MotorCurrentNP.setState(IPS_IDLE);
+            MotorHoldSP.setState(IPS_IDLE);
             return false;
         }
     }
 
-    MotorRateN[MOTOR_RATE_ACC].value = ms.accRate;
-    MotorRateN[MOTOR_RATE_RUN].value = ms.runSpeed;
-    MotorRateN[MOTOR_RATE_DEC].value = ms.decRate;
-    MotorRateNP.s = IPS_OK;
-    IDSetNumber(&MotorRateNP, nullptr);
+    MotorRateNP[MOTOR_RATE_ACC].setValue(ms.accRate);
+    MotorRateNP[MOTOR_RATE_RUN].setValue(ms.runSpeed);
+    MotorRateNP[MOTOR_RATE_DEC].setValue(ms.decRate);
+    MotorRateNP.setState(IPS_OK);
+    MotorRateNP.apply();
 
-    MotorCurrentN[MOTOR_CURR_ACC].value = mc.accCurrent;
-    MotorCurrentN[MOTOR_CURR_RUN].value = mc.runCurrent;
-    MotorCurrentN[MOTOR_CURR_DEC].value = mc.decCurrent;
-    MotorCurrentN[MOTOR_CURR_HOLD].value = mc.holdCurrent;
-    MotorCurrentNP.s = IPS_OK;
-    IDSetNumber(&MotorCurrentNP, nullptr);
+    MotorCurrentNP[MOTOR_CURR_ACC].setValue(mc.accCurrent);
+    MotorCurrentNP[MOTOR_CURR_RUN].setValue(mc.runCurrent);
+    MotorCurrentNP[MOTOR_CURR_DEC].setValue(mc.decCurrent);
+    MotorCurrentNP[MOTOR_CURR_HOLD].setValue(mc.holdCurrent);
+    MotorCurrentNP.setState(IPS_OK);
+    MotorCurrentNP.apply();
 
     // Also update motor hold switch
     const char *activeSwitchID = motorHoldActive ? "HOLD_ON" : "HOLD_OFF";
-    ISwitch *sp = IUFindSwitch(&MotorHoldSP, activeSwitchID);
+    ISwitch *sp = MotorHoldSP.findWidgetByName(activeSwitchID);
     assert(sp != nullptr && "Motor hold switch not found");
     if (sp)
     {
-        IUResetSwitch(&MotorHoldSP);
+        MotorHoldSP.reset();
         sp->s = ISS_ON;
-        MotorHoldSP.s = motorHoldActive ? IPS_OK : IPS_ALERT;
-        IDSetSwitch(&MotorHoldSP, nullptr);
+        MotorHoldSP.setState(motorHoldActive ? IPS_OK : IPS_ALERT);
+        MotorHoldSP.apply();
     }
 
     if (motorHoldActive && mc.holdCurrent == 0)
@@ -515,9 +515,9 @@ bool SestoSenso2::applyMotorRates()
 
     // Send INDI state to driver
     MotorRates mr;
-    mr.accRate = static_cast<uint32_t>(MotorRateN[MOTOR_RATE_ACC].value);
-    mr.runSpeed = static_cast<uint32_t>(MotorRateN[MOTOR_RATE_RUN].value);
-    mr.decRate = static_cast<uint32_t>(MotorRateN[MOTOR_RATE_DEC].value);
+    mr.accRate = static_cast<uint32_t>(MotorRateNP[MOTOR_RATE_ACC].value);
+    mr.runSpeed = static_cast<uint32_t>(MotorRateNP[MOTOR_RATE_RUN].value);
+    mr.decRate = static_cast<uint32_t>(MotorRateNP[MOTOR_RATE_DEC].value);
 
     if (!command->setMotorRates(mr))
     {
@@ -537,10 +537,10 @@ bool SestoSenso2::applyMotorCurrents()
 
     // Send INDI state to driver
     MotorCurrents mc;
-    mc.accCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_ACC].value);
-    mc.runCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_RUN].value);
-    mc.decCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_DEC].value);
-    mc.holdCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_HOLD].value);
+    mc.accCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_ACC].value);
+    mc.runCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_RUN].value);
+    mc.decCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_DEC].value);
+    mc.holdCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_HOLD].value);
 
     if (!command->setMotorCurrents(mc))
     {
@@ -560,7 +560,7 @@ bool SestoSenso2::isMotionComplete()
 
     if (isSimulation())
     {
-        int32_t nextPos = FocusAbsPosN[0].value;
+        int32_t nextPos = FocusAbsPosNP[0].getValue();
         int32_t targPos = static_cast<int32_t>(targetPos);
 
         if (targPos > nextPos)
@@ -572,8 +572,8 @@ bool SestoSenso2::isMotionComplete()
             nextPos = targetPos;
         else if (nextPos < 0)
             nextPos = 0;
-        else if (nextPos > FocusAbsPosN[0].max)
-            nextPos = FocusAbsPosN[0].max;
+        else if (nextPos > FocusAbsPosNP[0].max)
+            nextPos = FocusAbsPosNP[0].getMax();
 
         snprintf(res, SESTO_LEN, "%d", nextPos);
     }
@@ -584,8 +584,8 @@ bool SestoSenso2::isMotionComplete()
             try
             {
                 uint32_t newSpeed = std::stoi(res);
-                SpeedN[0].value = newSpeed;
-                SpeedNP.s = IPS_OK;
+                SpeedNP[0].setValue(newSpeed);
+                SpeedNP.setState(IPS_OK);
             }
             catch (...)
             {
@@ -601,7 +601,7 @@ bool SestoSenso2::isMotionComplete()
                 try
                 {
                     uint32_t newPos = std::stoi(res);
-                    FocusAbsPosN[0].value = newPos;
+                    FocusAbsPosNP[0].setValue(newPos);
                 }
                 catch (...)
                 {
@@ -620,17 +620,17 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Calibrate focuser
-        if (!strcmp(name, CalibrationSP.name))
+        if (CalibrationSP.isNameMatch(name))
         {
             int current_switch = 0;
 
-            CalibrationSP.s = IPS_BUSY;
-            //IDSetSwitch(&CalibrationSP, nullptr);
-            IUUpdateSwitch(&CalibrationSP, states, names, n);
+            CalibrationSP.setState(IPS_BUSY);
+            //CalibrationSP.apply();
+            CalibrationSP.update(states, names, n);
 
-            current_switch = IUFindOnSwitchIndex(&CalibrationSP);
-            CalibrationS[current_switch].s = ISS_ON;
-            IDSetSwitch(&CalibrationSP, nullptr);
+            current_switch = CalibrationSP.findOnSwitchIndex();
+            CalibrationSP[current_switch].setState(ISS_ON);
+            CalibrationSP.apply();
 
             if (current_switch == CALIBRATION_START)
             {
@@ -638,8 +638,8 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                 {
                     // Start the calibration process
                     LOG_INFO("Start Calibration");
-                    CalibrationSP.s = IPS_BUSY;
-                    IDSetSwitch(&CalibrationSP, nullptr);
+                    CalibrationSP.setState(IPS_BUSY);
+                    CalibrationSP.apply();
 
                     //
                     // Init
@@ -647,8 +647,8 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                     if (m_IsSestoSenso2 && command->initCalibration() == false)
                         return false;
 
-                    IUSaveText(&CalibrationMessageT[0], "Set focus in MIN position and then press NEXT.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Set focus in MIN position and then press NEXT.");
+                    CalibrationMessageTP.apply();
 
                     // Motor hold disabled during calibration init, so fetch new hold state
                     fetchMotorSettings();
@@ -659,22 +659,22 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                 else
                 {
                     LOG_INFO("Already started calibration. Proceed to next step.");
-                    IUSaveText(&CalibrationMessageT[0], "Already started. Proceed to NEXT.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Already started. Proceed to NEXT.");
+                    CalibrationMessageTP.apply();
                 }
             }
             else if (current_switch == CALIBRATION_NEXT)
             {
                 if (cStage == GoToMiddle)
                 {
-                    defineProperty(&FastMoveSP);
+                    defineProperty(FastMoveSP);
                     if (m_IsSestoSenso2)
                     {
                         if (command->storeAsMinPosition() == false)
                             return false;
 
-                        IUSaveText(&CalibrationMessageT[0], "Press MOVE OUT to move focuser out (CAUTION!)");
-                        IDSetText(&CalibrationMessageTP, nullptr);
+                        CalibrationMessageTP[0].setText("Press MOVE OUT to move focuser out (CAUTION!)");
+                        CalibrationMessageTP.apply();
                         cStage = GoMinimum;
                     }
                     // For Esatto, start moving out immediately
@@ -683,8 +683,8 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                         cStage = GoMaximum;
 
                         ISState fs[1] = { ISS_ON };
-                        const char *fn[1] =  { FastMoveS[FASTMOVE_OUT].name };
-                        ISNewSwitch(getDeviceName(), FastMoveSP.name, fs, const_cast<char **>(fn), 1);
+                        const char *fn[1] =  { FastMoveSP[FASTMOVE_OUT].getName() };
+                        ISNewSwitch(getDeviceName(), FastMoveSP.getName(), fs, const_cast<char **>(fn), 1);
                     }
                 }
                 else if (cStage == GoMinimum)
@@ -693,8 +693,8 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                     if (m_IsSestoSenso2 && command->storeAsMaxPosition(res) == false)
                         return false;
 
-                    IUSaveText(&CalibrationMessageT[0], "Press NEXT to finish.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Press NEXT to finish.");
+                    CalibrationMessageTP.apply();
                     cStage = GoMaximum;
                 }
                 else if (cStage == GoMaximum)
@@ -708,61 +708,61 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                     sscanf(res, "%d", &maxLimit);
                     LOGF_INFO("MAX setting is %d", maxLimit);
 
-                    FocusMaxPosN[0].max = maxLimit;
-                    FocusMaxPosN[0].value = maxLimit;
+                    FocusMaxPosNP[0].setMax(maxLimit);
+                    FocusMaxPosNP[0].setValue(maxLimit);
 
-                    FocusAbsPosN[0].min   = 0;
-                    FocusAbsPosN[0].max   = maxLimit;
-                    FocusAbsPosN[0].value = maxLimit;
-                    FocusAbsPosN[0].step  = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
+                    FocusAbsPosNP[0].setMin(0);
+                    FocusAbsPosNP[0].setMax(maxLimit);
+                    FocusAbsPosNP[0].setValue(maxLimit);
+                    FocusAbsPosNP[0].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
 
-                    FocusRelPosN[0].min   = 0.;
-                    FocusRelPosN[0].max   = FocusAbsPosN[0].step * 10;
-                    FocusRelPosN[0].value = 0;
-                    FocusRelPosN[0].step  = FocusAbsPosN[0].step;
+                    FocusRelPosNP[0].setMin(0.);
+                    FocusRelPosNP[0].setMax(FocusAbsPosNP[0].step * 10);
+                    FocusRelPosNP[0].setValue(0);
+                    FocusRelPosNP[0].setStep(FocusAbsPosNP[0].step);
 
-                    PresetN[0].max = maxLimit;
-                    PresetN[0].step = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
-                    PresetN[1].max = maxLimit;
-                    PresetN[1].step = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
-                    PresetN[2].max = maxLimit;
-                    PresetN[2].step = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 50.0;
+                    PresetNP[0].setMax(maxLimit);
+                    PresetNP[0].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
+                    PresetNP[1].setMax(maxLimit);
+                    PresetNP[1].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
+                    PresetNP[2].setMax(maxLimit);
+                    PresetNP[2].setStep((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 50.0);
 
-                    FocusMaxPosNP.s = IPS_OK;
-                    IUUpdateMinMax(&FocusAbsPosNP);
-                    IUUpdateMinMax(&FocusRelPosNP);
-                    IUUpdateMinMax(&PresetNP);
-                    IUUpdateMinMax(&FocusMaxPosNP);
+                    FocusMaxPosNP.setState(IPS_OK);
+                    FocusAbsPosNP.updateMinMax();
+                    FocusRelPosNP.updateMinMax();
+                    PresetNP.updateMinMax();
+                    FocusMaxPosNP.updateMinMax();
 
-                    IUSaveText(&CalibrationMessageT[0], "Calibration Completed.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Calibration Completed.");
+                    CalibrationMessageTP.apply();
 
-                    deleteProperty(FastMoveSP.name);
+                    deleteProperty(FastMoveSP.getName());
                     cStage = Complete;
 
                     LOG_INFO("Calibration completed");
-                    CalibrationSP.s = IPS_OK;
-                    IDSetSwitch(&CalibrationSP, nullptr);
-                    CalibrationS[current_switch].s = ISS_OFF;
-                    IDSetSwitch(&CalibrationSP, nullptr);
+                    CalibrationSP.setState(IPS_OK);
+                    CalibrationSP.apply();
+                    CalibrationSP[current_switch].setState(ISS_OFF);
+                    CalibrationSP.apply();
 
                     // Double check motor hold state after calibration
                     fetchMotorSettings();
                 }
                 else
                 {
-                    IUSaveText(&CalibrationMessageT[0], "Calibration not in progress.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Calibration not in progress.");
+                    CalibrationMessageTP.apply();
                 }
 
             }
             return true;
         }
         // Fast motion
-        else if (!strcmp(name, FastMoveSP.name))
+        else if (FastMoveSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FastMoveSP, states, names, n);
-            int current_switch = IUFindOnSwitchIndex(&FastMoveSP);
+            FastMoveSP.update(states, names, n);
+            int current_switch = FastMoveSP.findOnSwitchIndex();
             char res[SESTO_LEN] = {0};
 
             switch (current_switch)
@@ -780,7 +780,7 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                         {
                             return false;
                         }
-                        IUSaveText(&CalibrationMessageT[0], "Press STOP focuser almost at MAX position.");
+                        CalibrationMessageTP[0].setText("Press STOP focuser almost at MAX position.");
 
                         // GoOutToFindMaxPos should cause motor hold to be reactivated
                         fetchMotorSettings();
@@ -789,39 +789,39 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                     {
                         if (command->fastMoveOut(res))
                         {
-                            IUSaveText(&CalibrationMessageT[0], "Focusing out to detect hall sensor.");
+                            CalibrationMessageTP[0].setText("Focusing out to detect hall sensor.");
 
                             if (m_MotionProgressTimerID > 0)
                                 IERmTimer(m_MotionProgressTimerID);
                             m_MotionProgressTimerID = IEAddTimer(500, &SestoSenso2::checkMotionProgressHelper, this);
                         }
                     }
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP.apply();
                     break;
                 case FASTMOVE_STOP:
                     if (command->stop() == false)
                     {
                         return false;
                     }
-                    IUSaveText(&CalibrationMessageT[0], "Press NEXT to store max limit.");
-                    IDSetText(&CalibrationMessageTP, nullptr);
+                    CalibrationMessageTP[0].setText("Press NEXT to store max limit.");
+                    CalibrationMessageTP.apply();
                     break;
                 default:
                     break;
             }
 
-            FastMoveSP.s = IPS_BUSY;
-            IDSetSwitch(&FastMoveSP, nullptr);
+            FastMoveSP.setState(IPS_BUSY);
+            FastMoveSP.apply();
             return true;
         }
         // Homing
-        else if (!strcmp(HomeSP.name, name))
+        else if (HomeSP.isNameMatch(name))
         {
             char res[SESTO_LEN] = {0};
             if (command->goHome(res))
             {
-                HomeS[0].s = ISS_ON;
-                HomeSP.s = IPS_BUSY;
+                HomeSP[0].setState(ISS_ON);
+                HomeSP.setState(IPS_BUSY);
 
                 if (m_MotionProgressTimerID > 0)
                     IERmTimer(m_MotionProgressTimerID);
@@ -829,44 +829,44 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
             }
             else
             {
-                HomeS[0].s = ISS_OFF;
-                HomeSP.s = IPS_ALERT;
+                HomeSP[0].setState(ISS_OFF);
+                HomeSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&HomeSP, nullptr);
+            HomeSP.apply();
             return true;
         }
-        else if (!strcmp(name, MotorHoldSP.name))
+        else if (MotorHoldSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MotorHoldSP, states, names, n);
-            ISwitch *sp = IUFindOnSwitch(&MotorHoldSP);
+            MotorHoldSP.update(states, names, n);
+            ISwitch *sp = MotorHoldSP.findOnSwitch();
             assert(sp != nullptr);
 
             // NOTE: Default to HOLD_ON as a safety feature
             if (!strcmp(sp->name, "HOLD_OFF"))
             {
                 command->setMotorHold(false);
-                MotorHoldSP.s = IPS_ALERT;
+                MotorHoldSP.setState(IPS_ALERT);
                 LOG_INFO("Motor hold OFF. You may now manually adjust the focuser. Remember to enable motor hold once done.");
             }
             else
             {
                 command->setMotorHold(true);
-                MotorHoldSP.s = IPS_OK;
+                MotorHoldSP.setState(IPS_OK);
                 LOG_INFO("Motor hold ON. Do NOT attempt to manually adjust the focuser!");
-                if (MotorCurrentN[MOTOR_CURR_HOLD].value < 2.0)
+                if (MotorCurrentNP[MOTOR_CURR_HOLD].value < 2.0)
                 {
-                    LOGF_WARN("Motor hold current set to %.1f: This may be insufficent to hold focus", MotorCurrentN[MOTOR_CURR_HOLD].value);
+                    LOGF_WARN("Motor hold current set to %.1f: This may be insufficent to hold focus", MotorCurrentNP[MOTOR_CURR_HOLD].getValue());
                 }
             }
 
-            IDSetSwitch(&MotorHoldSP, nullptr);
+            MotorHoldSP.apply();
             return true;
         }
-        else if (!strcmp(name, MotorApplyPresetSP.name))
+        else if (MotorApplyPresetSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MotorApplyPresetSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&MotorApplyPresetSP);
+            MotorApplyPresetSP.update(states, names, n);
+            int index = MotorApplyPresetSP.findOnSwitchIndex();
             assert(index >= 0 && index < 3);
 
             const char* presetName = MOTOR_PRESET_NAMES[index];
@@ -874,75 +874,75 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
             if (command->applyMotorPreset(presetName))
             {
                 LOGF_INFO("Loaded motor preset: %s", presetName);
-                MotorApplyPresetSP.s = IPS_IDLE;
+                MotorApplyPresetSP.setState(IPS_IDLE);
             }
             else
             {
                 LOGF_ERROR("Failed to load motor preset: %s", presetName);
-                MotorApplyPresetSP.s = IPS_ALERT;
+                MotorApplyPresetSP.setState(IPS_ALERT);
             }
 
-            MotorApplyPresetS[index].s = ISS_OFF;
-            IDSetSwitch(&MotorApplyPresetSP, nullptr);
+            MotorApplyPresetSP[index].setState(ISS_OFF);
+            MotorApplyPresetSP.apply();
 
             fetchMotorSettings();
             return true;
         }
-        else if (!strcmp(name, MotorApplyUserPresetSP.name))
+        else if (MotorApplyUserPresetSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MotorApplyUserPresetSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&MotorApplyUserPresetSP);
+            MotorApplyUserPresetSP.update(states, names, n);
+            int index = MotorApplyUserPresetSP.findOnSwitchIndex();
             assert(index >= 0 && index < 3);
             uint32_t userIndex = index + 1;
 
             if (command->applyMotorUserPreset(userIndex))
             {
                 LOGF_INFO("Loaded motor user preset: %u", userIndex);
-                MotorApplyUserPresetSP.s = IPS_IDLE;
+                MotorApplyUserPresetSP.setState(IPS_IDLE);
             }
             else
             {
                 LOGF_ERROR("Failed to load motor user preset: %u", userIndex);
-                MotorApplyUserPresetSP.s = IPS_ALERT;
+                MotorApplyUserPresetSP.setState(IPS_ALERT);
             }
 
-            MotorApplyUserPresetS[index].s = ISS_OFF;
-            IDSetSwitch(&MotorApplyUserPresetSP, nullptr);
+            MotorApplyUserPresetSP[index].setState(ISS_OFF);
+            MotorApplyUserPresetSP.apply();
 
             fetchMotorSettings();
             return true;
         }
-        else if (!strcmp(name, MotorSaveUserPresetSP.name))
+        else if (MotorSaveUserPresetSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MotorSaveUserPresetSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&MotorSaveUserPresetSP);
+            MotorSaveUserPresetSP.update(states, names, n);
+            int index = MotorSaveUserPresetSP.findOnSwitchIndex();
             assert(index >= 0 && index < 3);
             uint32_t userIndex = index + 1;
 
             MotorRates mr;
-            mr.accRate = static_cast<uint32_t>(MotorRateN[MOTOR_RATE_ACC].value);
-            mr.runSpeed = static_cast<uint32_t>(MotorRateN[MOTOR_RATE_RUN].value);
-            mr.decRate = static_cast<uint32_t>(MotorRateN[MOTOR_RATE_DEC].value);
+            mr.accRate = static_cast<uint32_t>(MotorRateNP[MOTOR_RATE_ACC].value);
+            mr.runSpeed = static_cast<uint32_t>(MotorRateNP[MOTOR_RATE_RUN].value);
+            mr.decRate = static_cast<uint32_t>(MotorRateNP[MOTOR_RATE_DEC].value);
 
             MotorCurrents mc;
-            mc.accCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_ACC].value);
-            mc.runCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_RUN].value);
-            mc.decCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_DEC].value);
-            mc.holdCurrent = static_cast<uint32_t>(MotorCurrentN[MOTOR_CURR_HOLD].value);
+            mc.accCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_ACC].value);
+            mc.runCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_RUN].value);
+            mc.decCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_DEC].value);
+            mc.holdCurrent = static_cast<uint32_t>(MotorCurrentNP[MOTOR_CURR_HOLD].value);
 
             if (command->saveMotorUserPreset(userIndex, mr, mc))
             {
                 LOGF_INFO("Saved motor user preset %u to firmware", userIndex);
-                MotorSaveUserPresetSP.s = IPS_IDLE;
+                MotorSaveUserPresetSP.setState(IPS_IDLE);
             }
             else
             {
                 LOGF_ERROR("Failed to save motor user preset %u to firmware", userIndex);
-                MotorSaveUserPresetSP.s = IPS_ALERT;
+                MotorSaveUserPresetSP.setState(IPS_ALERT);
             }
 
-            MotorSaveUserPresetS[index].s = ISS_OFF;
-            IDSetSwitch(&MotorSaveUserPresetSP, nullptr);
+            MotorSaveUserPresetSP[index].setState(ISS_OFF);
+            MotorSaveUserPresetSP.apply();
             return true;
         }
     }
@@ -954,20 +954,20 @@ bool SestoSenso2::ISNewNumber(const char *dev, const char *name, double values[]
     if (dev == nullptr || strcmp(dev, getDeviceName()) != 0)
         return INDI::Focuser::ISNewNumber(dev, name, values, names, n);
 
-    if (!strcmp(name, MotorRateNP.name))
+    if (MotorRateNP.isNameMatch(name))
     {
-        IUUpdateNumber(&MotorRateNP, values, names, n);
-        MotorRateNP.s = IPS_OK;
+        MotorRateNP.update(values, names, n);
+        MotorRateNP.setState(IPS_OK);
         applyMotorRates();
-        IDSetNumber(&MotorRateNP, nullptr);
+        MotorRateNP.apply();
         return true;
     }
-    else if (!strcmp(name, MotorCurrentNP.name))
+    else if (MotorCurrentNP.isNameMatch(name))
     {
-        IUUpdateNumber(&MotorCurrentNP, values, names, n);
-        MotorCurrentNP.s = IPS_OK;
+        MotorCurrentNP.update(values, names, n);
+        MotorCurrentNP.setState(IPS_OK);
         applyMotorCurrents();
-        IDSetNumber(&MotorCurrentNP, nullptr);
+        MotorCurrentNP.apply();
         return true;
     }
 
@@ -993,9 +993,9 @@ IPState SestoSenso2::MoveAbsFocuser(uint32_t targetTicks)
 
 IPState SestoSenso2::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
-    int reversed = (IUFindOnSwitchIndex(&FocusReverseSP) == INDI_ENABLED) ? -1 : 1;
+    int reversed = (FocusReverseSP.findOnSwitchIndex() == INDI_ENABLED) ? -1 : 1;
     int relativeTicks =  ((dir == FOCUS_INWARD) ? -ticks : ticks) * reversed;
-    double newPosition = FocusAbsPosN[0].value + relativeTicks;
+    double newPosition = FocusAbsPosNP[0].getValue() + relativeTicks;
 
     bool rc = MoveAbsFocuser(newPosition);
 
@@ -1015,11 +1015,11 @@ bool SestoSenso2::AbortFocuser()
 
     bool rc = command->abort();
 
-    if (rc && HomeSP.s == IPS_BUSY)
+    if (rc && HomeSP.getState() == IPS_BUSY)
     {
-        HomeS[0].s = ISS_OFF;
-        HomeSP.s = IPS_IDLE;
-        IDSetSwitch(&HomeSP, nullptr);
+        HomeSP[0].setState(ISS_OFF);
+        HomeSP.setState(IPS_IDLE);
+        HomeSP.apply();
     }
 
     return rc;
@@ -1044,30 +1044,30 @@ void SestoSenso2::checkMotionProgressCallback()
 {
     if (isMotionComplete())
     {
-        FocusAbsPosNP.s = IPS_OK;
-        FocusRelPosNP.s = IPS_OK;
-        SpeedNP.s = IPS_OK;
-        SpeedN[0].value = 0;
-        IDSetNumber(&SpeedNP, nullptr);
+        FocusAbsPosNP.setState(IPS_OK);
+        FocusRelPosNP.setState(IPS_OK);
+        SpeedNP.setState(IPS_OK);
+        SpeedNP[0].setValue(0);
+        SpeedNP.apply();
 
-        IDSetNumber(&FocusRelPosNP, nullptr);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusRelPosNP.apply();
+        FocusAbsPosNP.apply();
 
 
-        lastPos = FocusAbsPosN[0].value;
+        lastPos = FocusAbsPosNP[0].getValue();
 
-        if (HomeSP.s == IPS_BUSY)
+        if (HomeSP.getState() == IPS_BUSY)
         {
             LOG_INFO("Focuser at home position.");
-            HomeS[0].s = ISS_OFF;
-            HomeSP.s = IPS_OK;
-            IDSetSwitch(&HomeSP, nullptr);
+            HomeSP[0].setState(ISS_OFF);
+            HomeSP.setState(IPS_OK);
+            HomeSP.apply();
         }
-        else if (CalibrationSP.s == IPS_BUSY)
+        else if (CalibrationSP.getState() == IPS_BUSY)
         {
             ISState states[2] = { ISS_OFF, ISS_ON };
-            const char * names[2] = { CalibrationS[CALIBRATION_START].name, CalibrationS[CALIBRATION_NEXT].name };
-            ISNewSwitch(getDeviceName(), CalibrationSP.name, states, const_cast<char **>(names), CalibrationSP.nsp);
+            const char * names[2] = { CalibrationSP[CALIBRATION_START].getName(), CalibrationSP[CALIBRATION_NEXT].getName() };
+            ISNewSwitch(getDeviceName(), CalibrationSP.getName(), states, const_cast<char **>(names), CalibrationSP.size());
         }
         else
             LOG_INFO("Focuser reached requested position.");
@@ -1075,13 +1075,13 @@ void SestoSenso2::checkMotionProgressCallback()
     }
     else
     {
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
     }
 
-    SpeedNP.s = IPS_BUSY;
-    IDSetNumber(&SpeedNP, nullptr);
+    SpeedNP.setState(IPS_BUSY);
+    SpeedNP.apply();
 
-    lastPos = FocusAbsPosN[0].value;
+    lastPos = FocusAbsPosNP[0].getValue();
 
     IERmTimer(m_MotionProgressTimerID);
     m_MotionProgressTimerID = IEAddTimer(500, &SestoSenso2::checkMotionProgressHelper, this);
@@ -1098,8 +1098,8 @@ void SestoSenso2::checkHallSensorCallback()
             if (detected == 1)
             {
                 ISState states[2] = { ISS_OFF, ISS_ON };
-                const char * names[2] = { CalibrationS[CALIBRATION_START].name, CalibrationS[CALIBRATION_NEXT].name };
-                ISNewSwitch(getDeviceName(), CalibrationSP.name, states, const_cast<char **>(names), CalibrationSP.nsp);
+                const char * names[2] = { CalibrationSP[CALIBRATION_START].getName(), CalibrationSP[CALIBRATION_NEXT].getName() };
+                ISNewSwitch(getDeviceName(), CalibrationSP.getName(), states, const_cast<char **>(names), CalibrationSP.size());
                 return;
             }
         }
@@ -1110,8 +1110,8 @@ void SestoSenso2::checkHallSensorCallback()
 
 void SestoSenso2::TimerHit()
 {
-    if (!isConnected() || FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY || (m_IsSestoSenso2
-            && CalibrationSP.s == IPS_BUSY))
+    if (!isConnected() || FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY || (m_IsSestoSenso2
+            && CalibrationSP.getState() == IPS_BUSY))
     {
         SetTimer(getCurrentPollingPeriod());
         return;
@@ -1120,10 +1120,10 @@ void SestoSenso2::TimerHit()
     bool rc = updatePosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 0)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 0)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
@@ -1132,10 +1132,10 @@ void SestoSenso2::TimerHit()
         rc = updateTemperature();
         if (rc)
         {
-            if (fabs(lastTemperature - TemperatureN[0].value) >= 0.1)
+            if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.1)
             {
-                IDSetNumber(&TemperatureNP, nullptr);
-                lastTemperature = TemperatureN[0].value;
+                TemperatureNP.apply();
+                lastTemperature = TemperatureNP[0].getValue();
             }
         }
 
@@ -1143,12 +1143,12 @@ void SestoSenso2::TimerHit()
         rc = updateVoltageIn();
         if (rc)
         {
-            if (fabs(lastVoltageIn - VoltageInN[0].value) >= 0.1)
+            if (fabs(lastVoltageIn - VoltageInNP[0].getValue()) >= 0.1)
             {
-                IDSetNumber(&VoltageInNP, nullptr);
-                lastVoltageIn = VoltageInN[0].value;
+                VoltageInNP.apply();
+                lastVoltageIn = VoltageInNP[0].getValue();
 
-                if (VoltageInN[0].value < 11.0)
+                if (VoltageInNP[0].value < 11.0)
                 {
                     LOG_WARN("Please check 12v DC power supply is connected.");
                 }
@@ -1166,7 +1166,7 @@ bool SestoSenso2::getStartupValues()
     bool rc = updatePosition();
     if (rc)
     {
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
     }
 
     rc &= fetchMotorSettings();
@@ -1206,12 +1206,12 @@ bool SestoSenso2::Ack()
     }
 
     m_IsSestoSenso2 = !strstr(res, "ESATTO");
-    IUSaveText(&FirmwareT[FIRMWARE_SN], res);
+    FirmwareTP[FIRMWARE_SN].setText(res);
 
     if (command->getFirmwareVersion(res))
     {
         LOGF_INFO("Firmware version: %s", res);
-        IUSaveText(&FirmwareT[FIRMWARE_VERSION], res);
+        FirmwareTP[FIRMWARE_VERSION].setText(res);
     }
     else
     {
@@ -1252,8 +1252,8 @@ bool SestoSenso2::saveConfigItems(FILE *fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &MotorRateNP);
-    IUSaveConfigNumber(fp, &MotorCurrentNP);
+    MotorRateNP.save(fp);
+    MotorCurrentNP.save(fp);
     return true;
 }
 

--- a/drivers/focuser/sestosenso2.h
+++ b/drivers/focuser/sestosenso2.h
@@ -22,6 +22,11 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class CommandSet
 {
 
@@ -139,39 +144,31 @@ class SestoSenso2 : public INDI::Focuser
         double lastVoltageIn { 0 };
         double lastTemperature { 0 };
         uint16_t m_TemperatureCounter { 0 };
-
-        INumberVectorProperty TemperatureNP;
-        INumber TemperatureN[2];
+        INDI::PropertyNumber TemperatureNP {2};
         enum
         {
             TEMPERATURE_MOTOR,
             TEMPERATURE_EXTERNAL,
         };
 
-        INumber SpeedN[1];
-        INumberVectorProperty SpeedNP;
-
-        ITextVectorProperty FirmwareTP;
-        IText FirmwareT[2];
+        INDI::PropertyNumber SpeedNP {1};
+        INDI::PropertyText FirmwareTP {2};
         enum
         {
             FIRMWARE_SN,
             FIRMWARE_VERSION,
         };
 
-        INumber VoltageInN[1] {};
-        INumberVectorProperty VoltageInNP;
+        INDI::PropertyNumber VoltageInNP {1};
 
-        ISwitch CalibrationS[2];
-        ISwitchVectorProperty CalibrationSP;
+        INDI::PropertySwitch CalibrationSP {2};
         enum
         {
             CALIBRATION_START,
             CALIBRATION_NEXT
         };
 
-        ISwitch FastMoveS[3];
-        ISwitchVectorProperty FastMoveSP;
+        INDI::PropertySwitch FastMoveSP {3};
         enum
         {
             FASTMOVE_IN,
@@ -184,18 +181,14 @@ class SestoSenso2 : public INDI::Focuser
             CMD_OK = true,
             CMD_FALSE = false
         };
-
-        INumberVectorProperty MotorRateNP;
-        INumber MotorRateN[3];
+        INDI::PropertyNumber MotorRateNP {3};
         enum
         {
             MOTOR_RATE_ACC,
             MOTOR_RATE_RUN,
             MOTOR_RATE_DEC
         };
-
-        INumberVectorProperty MotorCurrentNP;
-        INumber MotorCurrentN[4];
+        INDI::PropertyNumber MotorCurrentNP {4};
         enum
         {
             MOTOR_CURR_ACC,
@@ -203,47 +196,36 @@ class SestoSenso2 : public INDI::Focuser
             MOTOR_CURR_DEC,
             MOTOR_CURR_HOLD
         };
-
-        ISwitchVectorProperty MotorHoldSP;
-        ISwitch MotorHoldS[2];
+        INDI::PropertySwitch MotorHoldSP {2};
         enum
         {
             MOTOR_HOLD_ON,
             MOTOR_HOLD_OFF
         };
-
-        ISwitchVectorProperty MotorApplyPresetSP;
-        ISwitch MotorApplyPresetS[3];
+        INDI::PropertySwitch MotorApplyPresetSP {3};
         enum
         {
             MOTOR_APPLY_LIGHT,
             MOTOR_APPLY_MEDIUM,
             MOTOR_APPLY_HEAVY,
         };
-
-        ISwitchVectorProperty MotorApplyUserPresetSP;
-        ISwitch MotorApplyUserPresetS[3];
+        INDI::PropertySwitch MotorApplyUserPresetSP {3};
         enum
         {
             MOTOR_APPLY_USER1,
             MOTOR_APPLY_USER2,
             MOTOR_APPLY_USER3
         };
-
-        ISwitchVectorProperty MotorSaveUserPresetSP;
-        ISwitch MotorSaveUserPresetS[3];
+        INDI::PropertySwitch MotorSaveUserPresetSP {3};
         enum
         {
             MOTOR_SAVE_USER1,
             MOTOR_SAVE_USER2,
             MOTOR_SAVE_USER3
         };
+        INDI::PropertySwitch HomeSP {1};
 
-        ISwitchVectorProperty HomeSP;
-        ISwitch HomeS[1];
-
-        IText CalibrationMessageT[1] {};
-        ITextVectorProperty CalibrationMessageTP;
+        INDI::PropertyText CalibrationMessageTP {1};
 
         typedef enum { Idle, GoToMiddle, GoMinimum, GoDupa, GoMaximum, Complete } CalibrationStage;
         CalibrationStage cStage { Idle };

--- a/drivers/focuser/si_efs.cpp
+++ b/drivers/focuser/si_efs.cpp
@@ -116,19 +116,19 @@ bool SIEFS::Connect()
         bool rc = getMaxPosition(&maximumPosition);
         if (rc)
         {
-            FocusMaxPosN[0].value = maximumPosition;
+            FocusMaxPosNP[0].setValue(maximumPosition);
 
-            FocusAbsPosN[0].min = 0;
-            FocusAbsPosN[0].max = FocusMaxPosN[0].value;
-            FocusAbsPosN[0].step = FocusMaxPosN[0].value / 50.0;
+            FocusAbsPosNP[0].setMin(0);
+            FocusAbsPosNP[0].setMax(FocusMaxPosNP[0].value);
+            FocusAbsPosNP[0].setStep(FocusMaxPosNP[0].value / 50.0);
 
-            FocusSyncN[0].min = 0;
-            FocusSyncN[0].max = FocusMaxPosN[0].value;
-            FocusSyncN[0].step = FocusMaxPosN[0].value / 50.0;
+            FocusSyncNP[0].setMin(0);
+            FocusSyncNP[0].setMax(FocusMaxPosNP[0].value);
+            FocusSyncNP[0].setStep(FocusMaxPosNP[0].value / 50.0);
 
-            FocusRelPosN[0].max  = FocusMaxPosN[0].value / 2;
-            FocusRelPosN[0].step = FocusMaxPosN[0].value / 100.0;
-            FocusRelPosN[0].min  = 0;
+            FocusRelPosNP[0].setMax(FocusMaxPosNP[0].value / 2);
+            FocusRelPosNP[0].setStep(FocusMaxPosNP[0].value / 100.0);
+            FocusRelPosNP[0].setMin(0);
         }
 
         SetTimer(getCurrentPollingPeriod());
@@ -172,43 +172,43 @@ void SIEFS::TimerHit()
     bool rc = getAbsPosition(&currentTicks);
 
     if (rc)
-        FocusAbsPosN[0].value = currentTicks;
+        FocusAbsPosNP[0].setValue(currentTicks);
 
     getStatus();
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (isSimulation())
         {
-            if (FocusAbsPosN[0].value < targetPosition)
+            if (FocusAbsPosNP[0].value < targetPosition)
                 simPosition += 500;
             else
                 simPosition -= 500;
 
             if (std::abs(simPosition - static_cast<int32_t>(targetPosition)) < 500)
             {
-                FocusAbsPosN[0].value = targetPosition;
-                simPosition = FocusAbsPosN[0].value;
+                FocusAbsPosNP[0].setValue(targetPosition);
+                simPosition = FocusAbsPosNP[0].getValue();
                 m_Motor = SI_NOT_MOVING;
             }
 
-            FocusAbsPosN[0].value = simPosition;
+            FocusAbsPosNP[0].setValue(simPosition);
         }
 
-        if (m_Motor == SI_NOT_MOVING && targetPosition == FocusAbsPosN[0].value)
+        if (m_Motor == SI_NOT_MOVING && targetPosition == FocusAbsPosNP[0].getValue())
         {
-            if (FocusRelPosNP.s == IPS_BUSY)
+            if (FocusRelPosNP.getState() == IPS_BUSY)
             {
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusRelPosNP, nullptr);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusRelPosNP.apply();
             }
 
-            FocusAbsPosNP.s = IPS_OK;
+            FocusAbsPosNP.setState(IPS_OK);
             LOG_DEBUG("Focuser reached target position.");
         }
     }
 
-    IDSetNumber(&FocusAbsPosNP, nullptr);
+    FocusAbsPosNP.apply();
 
     SetTimer(getCurrentPollingPeriod());
 }
@@ -227,7 +227,7 @@ IPState SIEFS::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -235,13 +235,13 @@ IPState SIEFS::MoveAbsFocuser(uint32_t targetTicks)
 IPState SIEFS::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
     int direction = (dir == FOCUS_INWARD) ? -1 : 1;
-    int reversed = (FocusReverseS[INDI_ENABLED].s == ISS_ON) ? -1 : 1;
+    int reversed = (FocusReverseSP[INDI_ENABLED].getState() == ISS_ON) ? -1 : 1;
     int relative = static_cast<int>(ticks);
 
-    int targetAbsPosition = FocusAbsPosN[0].value + (relative * direction * reversed);
+    int targetAbsPosition = FocusAbsPosNP[0].getValue() + (relative * direction * reversed);
 
-    targetAbsPosition = std::min(static_cast<uint32_t>(FocusMaxPosN[0].value)
-                                 , static_cast<uint32_t>(std::max(static_cast<int>(FocusAbsPosN[0].min), targetAbsPosition)));
+    targetAbsPosition = std::min(static_cast<uint32_t>(FocusMaxPosNP[0].value)
+                                 , static_cast<uint32_t>(std::max(static_cast<int>(FocusAbsPosNP[0].min), targetAbsPosition)));
 
     return MoveAbsFocuser(targetAbsPosition);
 }

--- a/drivers/focuser/smartfocus.h
+++ b/drivers/focuser/smartfocus.h
@@ -20,6 +20,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertylight.h"
+
 class SmartFocus : public INDI::Focuser
 {
   public:
@@ -88,8 +92,6 @@ class SmartFocus : public INDI::Focuser
     State state { Idle };
     int timer_id { 0 };
 
-    ILight FlagsL[5];
-    ILightVectorProperty FlagsLP;
-    INumber MotionErrorN[1];
-    INumberVectorProperty MotionErrorNP;
+    INDI::PropertyLight FlagsLP {5};
+    INDI::PropertyNumber MotionErrorNP {1};
 };

--- a/drivers/focuser/steeldrive.cpp
+++ b/drivers/focuser/steeldrive.cpp
@@ -88,26 +88,26 @@ bool SteelDrive::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    FocusSpeedN[0].min   = 350;
-    FocusSpeedN[0].max   = 1000;
-    FocusSpeedN[0].value = 500;
-    FocusSpeedN[0].step  = 50;
+    FocusSpeedNP[0].setMin(350);
+    FocusSpeedNP[0].setMax(1000);
+    FocusSpeedNP[0].setValue(500);
+    FocusSpeedNP[0].setStep(50);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Temperature Settings
-    IUFillNumber(&TemperatureSettingN[FOCUS_T_COEFF], "Coefficient", "", "%.3f", 0, 0.999, 0.1, 0.1);
-    IUFillNumber(&TemperatureSettingN[FOCUS_T_SAMPLES], "# of Samples", "", "%3.0f", 16, 128, 16, 16);
-    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 2, getDeviceName(), "Temperature Settings", "",
+    TemperatureSettingNP[FOCUS_T_COEFF].fill("Coefficient", "", "%.3f", 0, 0.999, 0.1, 0.1);
+    TemperatureSettingNP[FOCUS_T_SAMPLES].fill("# of Samples", "", "%3.0f", 16, 128, 16, 16);
+    TemperatureSettingNP.fill(getDeviceName(), "Temperature Settings", "",
                        FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureCompensateS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "Temperature Compensate",
+    TemperatureCompensateSP[0].fill("Enable", "", ISS_OFF);
+    TemperatureCompensateSP[1].fill("Disable", "", ISS_ON);
+    TemperatureCompensateSP.fill(getDeviceName(), "Temperature Compensate",
                        "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Focuser Models
@@ -130,19 +130,19 @@ bool SteelDrive::initProperties()
                        IPS_IDLE);
 
     // Custom Settings
-    IUFillNumber(&CustomSettingN[FOCUS_MAX_TRIP], "Max Trip (mm)", "", "%6.2f", 20, 150, 0, 30);
-    IUFillNumber(&CustomSettingN[FOCUS_GEAR_RATIO], "Gear Ratio", "", "%.5f", 0.1, 1, 0, .25040);
-    IUFillNumberVector(&CustomSettingNP, CustomSettingN, 2, getDeviceName(), "Custom Settings", "", FOCUS_SETTINGS_TAB,
+    CustomSettingNP[FOCUS_MAX_TRIP].fill("Max Trip (mm)", "", "%6.2f", 20, 150, 0, 30);
+    CustomSettingNP[FOCUS_GEAR_RATIO].fill("Gear Ratio", "", "%.5f", 0.1, 1, 0, .25040);
+    CustomSettingNP.fill(getDeviceName(), "Custom Settings", "", FOCUS_SETTINGS_TAB,
                        IP_RW, 0, IPS_IDLE);
 
     // Focuser Accleration
-    IUFillNumber(&AccelerationN[0], "Ramp", "", "%3.0f", 1500., 3000., 100., 2000.);
-    IUFillNumberVector(&AccelerationNP, AccelerationN, 1, getDeviceName(), "FOCUS_ACCELERATION", "Acceleration",
+    AccelerationNP[0].fill("Ramp", "", "%3.0f", 1500., 3000., 100., 2000.);
+    AccelerationNP.fill(getDeviceName(), "FOCUS_ACCELERATION", "Acceleration",
                        FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Focus Sync
-    IUFillNumber(&SyncN[0], "Position (steps)", "", "%3.0f", 0., 200000., 100., 0.);
-    IUFillNumberVector(&SyncNP, SyncN, 1, getDeviceName(), "FOCUS_SYNC", "Sync", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
+    SyncNP[0].fill("Position (steps)", "", "%3.0f", 0., 200000., 100., 0.);
+    SyncNP.fill(getDeviceName(), "FOCUS_SYNC", "Sync", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     // Version
     IUFillText(&VersionT[0], "HW Rev.", "", nullptr);
@@ -150,9 +150,9 @@ bool SteelDrive::initProperties()
     IUFillTextVector(&VersionTP, VersionT, 2, getDeviceName(), "FOCUS_VERSION", "Version", MAIN_CONTROL_TAB, IP_RO, 0,
                      IPS_IDLE);
 
-    FocusRelPosN[0].value = 0;
-    FocusAbsPosN[0].value = 0;
-    simPosition           = FocusAbsPosN[0].value;
+    FocusRelPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setValue(0);
+    simPosition           = FocusAbsPosNP[0].getValue();
 
     updateFocusMaxRange(fSettings[4].maxTrip, fSettings[4].gearRatio);
 
@@ -169,14 +169,14 @@ bool SteelDrive::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
-        defineProperty(&TemperatureSettingNP);
-        defineProperty(&TemperatureCompensateSP);
+        defineProperty(TemperatureNP);
+        defineProperty(TemperatureSettingNP);
+        defineProperty(TemperatureCompensateSP);
 
         defineProperty(&ModelSP);
-        defineProperty(&CustomSettingNP);
-        defineProperty(&AccelerationNP);
-        defineProperty(&SyncNP);
+        defineProperty(CustomSettingNP);
+        defineProperty(AccelerationNP);
+        defineProperty(SyncNP);
 
         defineProperty(&VersionTP);
 
@@ -188,14 +188,14 @@ bool SteelDrive::updateProperties()
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(TemperatureSettingNP.name);
-        deleteProperty(TemperatureCompensateSP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(TemperatureSettingNP.getName());
+        deleteProperty(TemperatureCompensateSP.getName());
 
         deleteProperty(ModelSP.name);
-        deleteProperty(CustomSettingNP.name);
-        deleteProperty(AccelerationNP.name);
-        deleteProperty(SyncNP.name);
+        deleteProperty(CustomSettingNP.getName());
+        deleteProperty(AccelerationNP.getName());
+        deleteProperty(SyncNP.getName());
 
         deleteProperty(VersionTP.name);
     }
@@ -426,8 +426,8 @@ bool SteelDrive::updateTemperature()
 
     if (rc > 0)
     {
-        TemperatureN[0].value = ((double)temperature) / 100.0;
-        TemperatureNP.s       = IPS_OK;
+        TemperatureNP[0].setValue(((double)temperature) / 100.0);
+        TemperatureNP.setState(IPS_OK);
     }
     else
     {
@@ -435,13 +435,13 @@ bool SteelDrive::updateTemperature()
         rc = sscanf(resp, ":F5%s#", junk);
         if (rc > 0)
         {
-            TemperatureN[0].value = 0;
+            TemperatureNP[0].setValue(0);
             LOG_DEBUG("Temperature probe is not connected.");
         }
         else
             LOGF_ERROR("Unknown error: focuser temperature value (%s)", resp);
 
-        TemperatureNP.s = IPS_ALERT;
+        TemperatureNP.setState(IPS_ALERT);
         return false;
     }
 
@@ -503,7 +503,7 @@ bool SteelDrive::updatePosition()
 
     if (rc > 0)
     {
-        FocusAbsPosN[0].value = pos;
+        FocusAbsPosNP[0].setValue(pos);
     }
     else
     {
@@ -555,7 +555,7 @@ bool SteelDrive::updateSpeed()
 
     if (rc > 0)
     {
-        FocusSpeedN[0].value = speed;
+        FocusSpeedNP[0].setValue(speed);
     }
     else
     {
@@ -607,7 +607,7 @@ bool SteelDrive::updateAcceleration()
 
     if (rc > 0)
     {
-        AccelerationN[0].value = accel;
+        AccelerationNP[0].setValue(accel);
     }
     else
     {
@@ -663,13 +663,13 @@ bool SteelDrive::updateTemperatureSettings()
         strncpy(enabled, tResp + 3, 1);
         strncpy(selectedFocuser, tResp + 4, 1);
 
-        TemperatureSettingN[FOCUS_T_COEFF].value = atof(coeff) / 1000.0;
+        TemperatureSettingNP[FOCUS_T_COEFF].setValue(atof(coeff) / 1000.0);
 
-        IUResetSwitch(&TemperatureCompensateSP);
+        TemperatureCompensateSP.reset();
         if (enabled[0] == '0')
-            TemperatureCompensateS[1].s = ISS_ON;
+            TemperatureCompensateSP[1].setState(ISS_ON);
         else
-            TemperatureCompensateS[0].s = ISS_ON;
+            TemperatureCompensateSP[0].setState(ISS_ON);
     }
     else
     {
@@ -776,8 +776,8 @@ bool SteelDrive::updateCustomSettings()
         fSettings[sFocuser].maxTrip   = (atof(maxTrip) * gearRatio) / 100.0;
         fSettings[sFocuser].gearRatio = gearRatio;
 
-        CustomSettingN[FOCUS_MAX_TRIP].value   = fSettings[sFocuser].maxTrip;
-        CustomSettingN[FOCUS_GEAR_RATIO].value = fSettings[sFocuser].gearRatio;
+        CustomSettingNP[FOCUS_MAX_TRIP].setValue(fSettings[sFocuser].maxTrip);
+        CustomSettingNP[FOCUS_GEAR_RATIO].setValue(fSettings[sFocuser].gearRatio);
 
         LOGF_DEBUG("Updated max trip: %g gear ratio: %g", fSettings[sFocuser].maxTrip,
                    fSettings[sFocuser].gearRatio);
@@ -800,7 +800,7 @@ bool SteelDrive::setTemperatureSamples(unsigned int targetSamples, unsigned int 
     char errstr[MAXRBUF];
     char cmd[STEELDRIVE_MAXBUF];
 
-    int maxSample = TemperatureSettingN[FOCUS_T_SAMPLES].max;
+    int maxSample = TemperatureSettingNP[FOCUS_T_SAMPLES].getMax();
     int sample    = 0;
 
     for (int i = maxSample; i > 0;)
@@ -837,7 +837,7 @@ bool SteelDrive::setTemperatureSamples(unsigned int targetSamples, unsigned int 
         return false;
     }
 
-    TemperatureSettingN[FOCUS_T_SAMPLES].value = sample;
+    TemperatureSettingNP[FOCUS_T_SAMPLES].setValue(sample);
     *finalSample                               = sample;
 
     return true;
@@ -852,8 +852,8 @@ bool SteelDrive::setTemperatureCompensation()
     char errstr[MAXRBUF];
     char cmd[STEELDRIVE_MAXBUF];
 
-    double coeff      = TemperatureSettingN[FOCUS_T_COEFF].value;
-    bool enable       = TemperatureCompensateS[0].s == ISS_ON;
+    double coeff      = TemperatureSettingNP[FOCUS_T_COEFF].getValue();
+    bool enable       = TemperatureCompensateSP[0].getState() == ISS_ON;
     int selectedFocus = IUFindOnSwitchIndex(&ModelSP);
 
     snprintf(cmd, STEELDRIVE_CMD + 1, ":F%02d%03d%d#", selectedFocus, (int)(coeff * 1000), enable ? 2 : 0);
@@ -948,13 +948,13 @@ bool SteelDrive::moveFocuser(unsigned int position)
     char errstr[MAXRBUF];
     char cmd[STEELDRIVE_MAXBUF];
 
-    if (position < FocusAbsPosN[0].min || position > FocusAbsPosN[0].max)
+    if (position < FocusAbsPosNP[0].min || position > FocusAbsPosNP[0].max)
     {
         LOGF_ERROR("Requested position value out of bound: %d", position);
         return false;
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY)
         AbortFocuser();
 
     snprintf(cmd, STEELDRIVE_CMD_LONG + 1, ":F9%07d#", position);
@@ -1062,24 +1062,24 @@ bool SteelDrive::ISNewSwitch(const char *dev, const char *name, ISState *states,
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int last_index = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
+            int last_index = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
 
             bool rc = setTemperatureCompensation();
 
             if (!rc)
             {
-                TemperatureCompensateSP.s = IPS_ALERT;
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateS[last_index].s = ISS_ON;
-                IDSetSwitch(&TemperatureCompensateSP, nullptr);
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP[last_index].setState(ISS_ON);
+                TemperatureCompensateSP.apply();
                 return false;
             }
 
-            TemperatureCompensateSP.s = IPS_OK;
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.setState(IPS_OK);
+            TemperatureCompensateSP.apply();
             return true;
         }
 
@@ -1090,13 +1090,13 @@ bool SteelDrive::ISNewSwitch(const char *dev, const char *name, ISState *states,
             int i = IUFindOnSwitchIndex(&ModelSP);
 
             double focusMaxPos  = floor(fSettings[i].maxTrip / fSettings[i].gearRatio) * 100;
-            FocusAbsPosN[0].max = focusMaxPos;
-            IUUpdateMinMax(&FocusAbsPosNP);
+            FocusAbsPosNP[0].setMax(focusMaxPos);
+            FocusAbsPosNP.updateMinMax();
 
-            CustomSettingN[FOCUS_MAX_TRIP].value   = fSettings[i].maxTrip;
-            CustomSettingN[FOCUS_GEAR_RATIO].value = fSettings[i].gearRatio;
+            CustomSettingNP[FOCUS_MAX_TRIP].setValue(fSettings[i].maxTrip);
+            CustomSettingNP[FOCUS_GEAR_RATIO].setValue(fSettings[i].gearRatio);
 
-            IDSetNumber(&CustomSettingNP, nullptr);
+            CustomSettingNP.apply();
 
             ModelSP.s = IPS_OK;
             IDSetSwitch(&ModelSP, nullptr);
@@ -1116,30 +1116,30 @@ bool SteelDrive::ISNewNumber(const char *dev, const char *name, double values[],
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Set Accelration
-        if (strcmp(name, AccelerationNP.name) == 0)
+        if (AccelerationNP.isNameMatch(name))
         {
             if (setAcceleration((int)values[0]))
             {
-                IUUpdateNumber(&AccelerationNP, values, names, n);
-                AccelerationNP.s = IPS_OK;
-                IDSetNumber(&AccelerationNP, nullptr);
+                AccelerationNP.update(values, names, n);
+                AccelerationNP.setState(IPS_OK);
+                AccelerationNP.apply();
                 return true;
             }
             else
             {
-                AccelerationNP.s = IPS_ALERT;
-                IDSetNumber(&AccelerationNP, nullptr);
+                AccelerationNP.setState(IPS_ALERT);
+                AccelerationNP.apply();
                 return false;
             }
         }
 
         // Set Temperature Settings
-        if (strcmp(name, TemperatureSettingNP.name) == 0)
+        if (TemperatureSettingNP.isNameMatch(name))
         {
             // Coeff is only needed when we enable or disable the temperature compensation. Here we only set the # of samples
             unsigned int targetSamples;
 
-            if (strcmp(names[0], TemperatureSettingN[FOCUS_T_SAMPLES].name) == 0)
+            if (strcmp(names[0], TemperatureSettingNP[FOCUS_T_SAMPLES].getName()) == 0)
                 targetSamples = (int)values[0];
             else
                 targetSamples = (int)values[1];
@@ -1148,41 +1148,41 @@ bool SteelDrive::ISNewNumber(const char *dev, const char *name, double values[],
 
             if (setTemperatureSamples(targetSamples, &finalSample))
             {
-                IUUpdateNumber(&TemperatureSettingNP, values, names, n);
-                TemperatureSettingN[FOCUS_T_SAMPLES].value = finalSample;
+                TemperatureSettingNP.update(values, names, n);
+                TemperatureSettingNP[FOCUS_T_SAMPLES].setValue(finalSample);
 
-                if (TemperatureSettingN[FOCUS_T_COEFF].value > TemperatureSettingN[FOCUS_T_COEFF].max)
-                    TemperatureSettingN[FOCUS_T_COEFF].value = TemperatureSettingN[FOCUS_T_COEFF].max;
+                if (TemperatureSettingNP[FOCUS_T_COEFF].value > TemperatureSettingNP[FOCUS_T_COEFF].max)
+                    TemperatureSettingNP[FOCUS_T_COEFF].setValue(TemperatureSettingNP[FOCUS_T_COEFF].max);
 
-                TemperatureSettingNP.s = IPS_OK;
-                IDSetNumber(&TemperatureSettingNP, nullptr);
+                TemperatureSettingNP.setState(IPS_OK);
+                TemperatureSettingNP.apply();
                 return true;
             }
             else
             {
-                TemperatureSettingNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureSettingNP, nullptr);
+                TemperatureSettingNP.setState(IPS_ALERT);
+                TemperatureSettingNP.apply();
                 return true;
             }
         }
 
         // Set Custom Settings
-        if (strcmp(name, CustomSettingNP.name) == 0)
+        if (CustomSettingNP.isNameMatch(name))
         {
             int i = IUFindOnSwitchIndex(&ModelSP);
 
             // If the model is NOT set to custom, then the values cannot be updated
             if (i != 4)
             {
-                CustomSettingNP.s = IPS_IDLE;
+                CustomSettingNP.setState(IPS_IDLE);
                 LOG_WARN("You can not set custom values for a non-custom focuser.");
-                IDSetNumber(&CustomSettingNP, nullptr);
+                CustomSettingNP.apply();
                 return false;
             }
 
             double maxTrip, gearRatio;
 
-            if (strcmp(names[0], CustomSettingN[FOCUS_MAX_TRIP].name) == 0)
+            if (strcmp(names[0], CustomSettingNP[FOCUS_MAX_TRIP].getName()) == 0)
             {
                 maxTrip   = values[0];
                 gearRatio = values[1];
@@ -1195,39 +1195,39 @@ bool SteelDrive::ISNewNumber(const char *dev, const char *name, double values[],
 
             if (setCustomSettings(maxTrip, gearRatio))
             {
-                IUUpdateNumber(&CustomSettingNP, values, names, n);
-                CustomSettingNP.s = IPS_OK;
-                IDSetNumber(&CustomSettingNP, nullptr);
+                CustomSettingNP.update(values, names, n);
+                CustomSettingNP.setState(IPS_OK);
+                CustomSettingNP.apply();
 
                 updateFocusMaxRange(maxTrip, gearRatio);
-                IUUpdateMinMax(&FocusAbsPosNP);
-                IUUpdateMinMax(&FocusRelPosNP);
+                FocusAbsPosNP.updateMinMax();
+                FocusRelPosNP.updateMinMax();
             }
             else
             {
-                CustomSettingNP.s = IPS_ALERT;
-                IDSetNumber(&CustomSettingNP, nullptr);
+                CustomSettingNP.setState(IPS_ALERT);
+                CustomSettingNP.apply();
             }
         }
 
         // Set Sync Position
-        if (strcmp(name, SyncNP.name) == 0)
+        if (SyncNP.isNameMatch(name))
         {
             if (Sync((unsigned int)values[0]))
             {
-                IUUpdateNumber(&SyncNP, values, names, n);
-                SyncNP.s = IPS_OK;
-                IDSetNumber(&SyncNP, nullptr);
+                SyncNP.update(values, names, n);
+                SyncNP.setState(IPS_OK);
+                SyncNP.apply();
 
                 if (updatePosition())
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
+                    FocusAbsPosNP.apply();
 
                 return true;
             }
             else
             {
-                SyncNP.s = IPS_ALERT;
-                IDSetNumber(&SyncNP, nullptr);
+                SyncNP.setState(IPS_ALERT);
+                SyncNP.apply();
 
                 return false;
             }
@@ -1246,23 +1246,23 @@ void SteelDrive::GetFocusParams()
         IDSetText(&VersionTP, nullptr);
 
     if (updateTemperature())
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 
     if (updateTemperatureSettings())
-        IDSetNumber(&TemperatureSettingNP, nullptr);
+        TemperatureSettingNP.apply();
 
     if (updatePosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (updateSpeed())
-        IDSetNumber(&FocusSpeedNP, nullptr);
+        FocusSpeedNP.apply();
 
     if (updateAcceleration())
-        IDSetNumber(&AccelerationNP, nullptr);
+        AccelerationNP.apply();
 
     if (updateCustomSettings())
     {
-        IDSetNumber(&CustomSettingNP, nullptr);
+        CustomSettingNP.apply();
         IDSetSwitch(&ModelSP, nullptr);
     }
 }
@@ -1278,8 +1278,8 @@ bool SteelDrive::SetFocuserSpeed(int speed)
 
     currentSpeed = speed;
 
-    FocusSpeedNP.s = IPS_OK;
-    IDSetNumber(&FocusSpeedNP, nullptr);
+    FocusSpeedNP.setState(IPS_OK);
+    FocusSpeedNP.apply();
 
     return true;
 }
@@ -1320,7 +1320,7 @@ IPState SteelDrive::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -1331,18 +1331,18 @@ IPState SteelDrive::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     bool rc            = false;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     rc = moveFocuser(newPosition);
 
     if (!rc)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
-    FocusAbsPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -1355,10 +1355,10 @@ void SteelDrive::TimerHit()
     bool rc = updatePosition();
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > STEELDIVE_POSITION_THRESHOLD)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > STEELDIVE_POSITION_THRESHOLD)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
@@ -1368,84 +1368,84 @@ void SteelDrive::TimerHit()
         rc                       = updateTemperature();
         if (rc)
         {
-            if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
-                lastTemperature = TemperatureN[0].value;
+            if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
+                lastTemperature = TemperatureNP[0].getValue();
         }
 
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
     }
 
-    if (FocusTimerNP.s == IPS_BUSY)
+    if (FocusTimerNP.getState() == IPS_BUSY)
     {
         float remaining = CalcTimeLeft(focusMoveStart, focusMoveRequest);
 
         if (sim)
         {
-            if (FocusMotionS[FOCUS_INWARD].s == ISS_ON)
+            if (FocusMotionSP[FOCUS_INWARD].getState() == ISS_ON)
             {
-                FocusAbsPosN[0].value -= FocusSpeedN[0].value;
-                if (FocusAbsPosN[0].value <= 0)
-                    FocusAbsPosN[0].value = 0;
-                simPosition = FocusAbsPosN[0].value;
+                FocusAbsPosNP[0].value -= FocusSpeedNP[0].getValue();
+                if (FocusAbsPosNP[0].value <= 0)
+                    FocusAbsPosNP[0].setValue(0);
+                simPosition = FocusAbsPosNP[0].getValue();
             }
             else
             {
-                FocusAbsPosN[0].value += FocusSpeedN[0].value;
-                if (FocusAbsPosN[0].value >= FocusAbsPosN[0].max)
-                    FocusAbsPosN[0].value = FocusAbsPosN[0].max;
-                simPosition = FocusAbsPosN[0].value;
+                FocusAbsPosNP[0].value += FocusSpeedNP[0].getValue();
+                if (FocusAbsPosNP[0].value >= FocusAbsPosNP[0].max)
+                    FocusAbsPosNP[0].setValue(FocusAbsPosNP[0].max);
+                simPosition = FocusAbsPosNP[0].getValue();
             }
         }
 
         // If we exceed focus abs values, stop timer and motion
-        if (FocusAbsPosN[0].value <= 0 || FocusAbsPosN[0].value >= FocusAbsPosN[0].max)
+        if (FocusAbsPosNP[0].value <= 0 || FocusAbsPosNP[0].getValue() >= FocusAbsPosNP[0].max)
         {
             AbortFocuser();
 
-            if (FocusAbsPosN[0].value <= 0)
-                FocusAbsPosN[0].value = 0;
+            if (FocusAbsPosNP[0].value <= 0)
+                FocusAbsPosNP[0].setValue(0);
             else
-                FocusAbsPosN[0].value = FocusAbsPosN[0].max;
+                FocusAbsPosNP[0].setValue(FocusAbsPosNP[0].max);
 
-            FocusTimerN[0].value = 0;
-            FocusTimerNP.s       = IPS_IDLE;
+            FocusTimerNP[0].setValue(0);
+            FocusTimerNP.setState(IPS_IDLE);
         }
         else if (remaining <= 0)
         {
-            FocusTimerNP.s       = IPS_OK;
-            FocusTimerN[0].value = 0;
+            FocusTimerNP.setState(IPS_OK);
+            FocusTimerNP[0].setValue(0);
             AbortFocuser();
         }
         else
-            FocusTimerN[0].value = remaining * 1000.0;
+            FocusTimerNP[0].setValue(remaining * 1000.0);
 
-        IDSetNumber(&FocusTimerNP, nullptr);
+        FocusTimerNP.apply();
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (sim)
         {
-            if (FocusAbsPosN[0].value < targetPos)
+            if (FocusAbsPosNP[0].value < targetPos)
                 simPosition += 100;
             else
                 simPosition -= 100;
 
             if (fabs(simPosition - targetPos) < 100)
             {
-                FocusAbsPosN[0].value = targetPos;
-                simPosition           = FocusAbsPosN[0].value;
+                FocusAbsPosNP[0].setValue(targetPos);
+                simPosition           = FocusAbsPosNP[0].getValue();
             }
         }
 
         // Set it OK to within 5 steps
-        if (fabs(targetPos - FocusAbsPosN[0].value) < 5)
+        if (fabs(targetPos - FocusAbsPosNP[0].getValue()) < 5)
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
             LOG_INFO("Focuser reached requested position.");
         }
     }
@@ -1472,16 +1472,16 @@ bool SteelDrive::AbortFocuser()
         return false;
     }
 
-    if (FocusRelPosNP.s == IPS_BUSY)
+    if (FocusRelPosNP.getState() == IPS_BUSY)
     {
-        FocusRelPosNP.s = IPS_IDLE;
-        IDSetNumber(&FocusRelPosNP, nullptr);
+        FocusRelPosNP.setState(IPS_IDLE);
+        FocusRelPosNP.apply();
     }
 
-    FocusTimerNP.s = IPS_IDLE;
-    FocusAbsPosNP.s = IPS_IDLE;
-    IDSetNumber(&FocusTimerNP, nullptr);
-    IDSetNumber(&FocusAbsPosNP, nullptr);
+    FocusTimerNP.setState(IPS_IDLE);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusTimerNP.apply();
+    FocusAbsPosNP.apply();
 
     return true;
 }
@@ -1513,11 +1513,11 @@ bool SteelDrive::saveConfigItems(FILE *fp)
 {
     INDI::Focuser::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &TemperatureSettingNP);
-    IUSaveConfigSwitch(fp, &TemperatureCompensateSP);
-    IUSaveConfigNumber(fp, &FocusSpeedNP);
-    IUSaveConfigNumber(fp, &AccelerationNP);
-    IUSaveConfigNumber(fp, &CustomSettingNP);
+    TemperatureSettingNP.save(fp);
+    TemperatureCompensateSP.save(fp);
+    FocusSpeedNP.save(fp);
+    AccelerationNP.save(fp);
+    CustomSettingNP.save(fp);
     IUSaveConfigSwitch(fp, &ModelSP);
 
     return saveFocuserConfig();
@@ -1561,11 +1561,11 @@ void SteelDrive::updateFocusMaxRange(double maxTrip, double gearRatio)
     double maxSteps = floor(maxTrip / gearRatio * 100.0);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min  = 0;
-    FocusRelPosN[0].max  = floor(maxSteps / 2.0);
-    FocusRelPosN[0].step = 100;
+    FocusRelPosNP[0].setMin(0);
+    FocusRelPosNP[0].setMax(floor(maxSteps / 2.0));
+    FocusRelPosNP[0].setStep(100);
 
-    FocusAbsPosN[0].min  = 0;
-    FocusAbsPosN[0].max  = maxSteps;
-    FocusAbsPosN[0].step = 1000;
+    FocusAbsPosNP[0].setMin(0);
+    FocusAbsPosNP[0].setMax(maxSteps);
+    FocusAbsPosNP[0].setStep(1000);
 }

--- a/drivers/focuser/steeldrive.h
+++ b/drivers/focuser/steeldrive.h
@@ -22,6 +22,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class SteelDrive : public INDI::Focuser
 {
   public:
@@ -107,26 +111,20 @@ class SteelDrive : public INDI::Focuser
     struct timeval focusMoveStart { 0, 0 };
     float focusMoveRequest { 0 };
 
-    INumber TemperatureN[1];
-    INumberVectorProperty TemperatureNP;
+    INDI::PropertyNumber TemperatureNP {1};
 
-    INumber AccelerationN[1];
-    INumberVectorProperty AccelerationNP;
+    INDI::PropertyNumber AccelerationNP {1};
 
-    INumber TemperatureSettingN[2];
-    INumberVectorProperty TemperatureSettingNP;
+    INDI::PropertyNumber TemperatureSettingNP {2};
 
-    ISwitch TemperatureCompensateS[2];
-    ISwitchVectorProperty TemperatureCompensateSP;
+    INDI::PropertySwitch TemperatureCompensateSP {2};
 
     ISwitch ModelS[5];
     ISwitchVectorProperty ModelSP;
 
-    INumber CustomSettingN[2];
-    INumberVectorProperty CustomSettingNP;
+    INDI::PropertyNumber CustomSettingNP {2};
 
-    INumber SyncN[1];
-    INumberVectorProperty SyncNP;
+    INDI::PropertyNumber SyncNP {1};
 
     IText VersionT[2] {};
     ITextVectorProperty VersionTP;

--- a/drivers/focuser/steeldrive2.cpp
+++ b/drivers/focuser/steeldrive2.cpp
@@ -90,44 +90,42 @@ bool SteelDriveII::initProperties()
     INDI::Focuser::initProperties();
 
     // Focuser Information
-    IUFillText(&InfoT[INFO_NAME], "INFO_NAME", "Name", "NA");
-    IUFillText(&InfoT[INFO_VERSION], "INFO_VERSION", "Version", "NA");
-    IUFillTextVector(&InfoTP, InfoT, 2, getDeviceName(), "INFO", "Info", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
+    InfoTP[INFO_NAME].fill("INFO_NAME", "Name", "NA");
+    InfoTP[INFO_VERSION].fill("INFO_VERSION", "Version", "NA");
+    InfoTP.fill(getDeviceName(), "INFO", "Info", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     // Focuser Device Operation
-    IUFillSwitch(&OperationS[OPERATION_REBOOT], "OPERATION_REBOOT", "Reboot", ISS_OFF);
-    IUFillSwitch(&OperationS[OPERATION_RESET], "OPERATION_RESET", "Factory Reset", ISS_OFF);
-    IUFillSwitch(&OperationS[OPERATION_ZEROING], "OPERATION_ZEROING", "Zero Home", ISS_OFF);
-    IUFillSwitchVector(&OperationSP, OperationS, 3, getDeviceName(), "OPERATION", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
+    OperationSP[OPERATION_REBOOT].fill("OPERATION_REBOOT", "Reboot", ISS_OFF);
+    OperationSP[OPERATION_RESET].fill("OPERATION_RESET", "Factory Reset", ISS_OFF);
+    OperationSP[OPERATION_ZEROING].fill("OPERATION_ZEROING", "Zero Home", ISS_OFF);
+    OperationSP.fill(getDeviceName(), "OPERATION", "Device", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Temperature Compensation
-    IUFillSwitch(&TemperatureCompensationS[TC_ENABLED], "TC_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensationS[TC_DISABLED], "TC_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensationSP, TemperatureCompensationS, 2, getDeviceName(), "TC_COMPENSATE", "Compensation", COMPENSATION_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    TemperatureCompensationSP[TC_ENABLED].fill("TC_ENABLED", "Enabled", ISS_OFF);
+    TemperatureCompensationSP[TC_DISABLED].fill("TC_DISABLED", "Disabled", ISS_ON);
+    TemperatureCompensationSP.fill(getDeviceName(), "TC_COMPENSATE", "Compensation", COMPENSATION_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // TC State
-    IUFillSwitch(&TemperatureStateS[TC_ENABLED], "TC_ACTIVE", "Active", ISS_OFF);
-    IUFillSwitch(&TemperatureStateS[TC_DISABLED], "TC_PAUSED", "Paused", ISS_ON);
-    IUFillSwitchVector(&TemperatureStateSP, TemperatureStateS, 2, getDeviceName(), "TC_State", "State", COMPENSATION_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    TemperatureStateSP[TC_ENABLED].fill("TC_ACTIVE", "Active", ISS_OFF);
+    TemperatureStateSP[TC_DISABLED].fill("TC_PAUSED", "Paused", ISS_ON);
+    TemperatureStateSP.fill(getDeviceName(), "TC_State", "State", COMPENSATION_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Temperature Compensation Settings
-    IUFillNumber(&TemperatureSettingsN[TC_FACTOR], "TC_FACTOR", "Factor", "%.2f", 0, 1, 0.1, 0);
-    IUFillNumber(&TemperatureSettingsN[TC_PERIOD], "TC_PERIOD", "Period (ms)", "%.f", 10, 600000, 1000, 0);
-    IUFillNumber(&TemperatureSettingsN[TC_DELTA], "TC_DELTA", "Delta (C)", "%.2f", 0, 10, 0.1, 0);
-    IUFillNumberVector(&TemperatureSettingsNP, TemperatureSettingsN, 3, getDeviceName(), "TC_SETTINGS", "Settings", COMPENSATION_TAB, IP_RW, 60, IPS_IDLE);
+    TemperatureSettingsNP[TC_FACTOR].fill("TC_FACTOR", "Factor", "%.2f", 0, 1, 0.1, 0);
+    TemperatureSettingsNP[TC_PERIOD].fill("TC_PERIOD", "Period (ms)", "%.f", 10, 600000, 1000, 0);
+    TemperatureSettingsNP[TC_DELTA].fill("TC_DELTA", "Delta (C)", "%.2f", 0, 10, 0.1, 0);
+    TemperatureSettingsNP.fill(getDeviceName(), "TC_SETTINGS", "Settings", COMPENSATION_TAB, IP_RW, 60, IPS_IDLE);
 
     // Temperature Sensors
-    IUFillNumber(&TemperatureSensorN[TEMP_0], "TEMP_0", "Motor (C)", "%.2f", -60, 60, 0, 0);
-    IUFillNumber(&TemperatureSensorN[TEMP_1], "TEMP_1", "Controller (C)", "%.f", -60, 60, 0, 0);
-    IUFillNumber(&TemperatureSensorN[TEMP_AVG], "TEMP_AVG", "Average (C)", "%.2f", -60, 60, 0, 0);
-    IUFillNumberVector(&TemperatureSensorNP, TemperatureSensorN, 3, getDeviceName(), "TC_SENSOR", "Sensor", COMPENSATION_TAB, IP_RO, 60, IPS_IDLE);
+    TemperatureSensorNP[TEMP_0].fill("TEMP_0", "Motor (C)", "%.2f", -60, 60, 0, 0);
+    TemperatureSensorNP[TEMP_1].fill("TEMP_1", "Controller (C)", "%.f", -60, 60, 0, 0);
+    TemperatureSensorNP[TEMP_AVG].fill("TEMP_AVG", "Average (C)", "%.2f", -60, 60, 0, 0);
+    TemperatureSensorNP.fill(getDeviceName(), "TC_SENSOR", "Sensor", COMPENSATION_TAB, IP_RO, 60, IPS_IDLE);
 
     // Stepper Drive
-    IUFillNumber(&StepperDriveN[CURRENT_MOVE], "STEPPER_DRIVE_CURRENT_MOVE", "Inverse Current Move", "%.f", 0, 127, 1, 25);
-    IUFillNumber(&StepperDriveN[CURRENT_HOLD], "STEPPER_DRIVE_CURRENT_HOLD", "Inverse Current Hold", "%.f", 0, 127, 1, 100);
-    IUFillNumberVector(
-        &StepperDriveNP, StepperDriveN, NARRAY(StepperDriveN),
-        getDeviceName(), "STEPPER_DRIVE", "Stepper Drive", OPTIONS_TAB, IP_RW, 60, IPS_IDLE
+    StepperDriveNP[CURRENT_MOVE].fill("STEPPER_DRIVE_CURRENT_MOVE", "Inverse Current Move", "%.f", 0, 127, 1, 25);
+    StepperDriveNP[CURRENT_HOLD].fill("STEPPER_DRIVE_CURRENT_HOLD", "Inverse Current Hold", "%.f", 0, 127, 1, 100);
+    StepperDriveNP.fill(getDeviceName(), "STEPPER_DRIVE", "Stepper Drive", OPTIONS_TAB, IP_RW, 60, IPS_IDLE
     );
 
     addAuxControls();
@@ -148,25 +146,25 @@ bool SteelDriveII::updateProperties()
     {
         getStartupValues();
 
-        defineProperty(&InfoTP);
-        defineProperty(&OperationSP);
+        defineProperty(InfoTP);
+        defineProperty(OperationSP);
 
-        defineProperty(&TemperatureCompensationSP);
-        defineProperty(&TemperatureStateSP);
-        defineProperty(&TemperatureSettingsNP);
-        defineProperty(&TemperatureSensorNP);
-        defineProperty(&StepperDriveNP);
+        defineProperty(TemperatureCompensationSP);
+        defineProperty(TemperatureStateSP);
+        defineProperty(TemperatureSettingsNP);
+        defineProperty(TemperatureSensorNP);
+        defineProperty(StepperDriveNP);
     }
     else
     {
-        deleteProperty(InfoTP.name);
-        deleteProperty(OperationSP.name);
+        deleteProperty(InfoTP.getName());
+        deleteProperty(OperationSP.getName());
 
-        deleteProperty(TemperatureCompensationSP.name);
-        deleteProperty(TemperatureStateSP.name);
-        deleteProperty(TemperatureSettingsNP.name);
-        deleteProperty(TemperatureSensorNP.name);
-        deleteProperty(StepperDriveNP.name);
+        deleteProperty(TemperatureCompensationSP.getName());
+        deleteProperty(TemperatureStateSP.getName());
+        deleteProperty(TemperatureSettingsNP.getName());
+        deleteProperty(TemperatureSensorNP.getName());
+        deleteProperty(StepperDriveNP.getName());
     }
 
     return true;
@@ -203,59 +201,59 @@ bool SteelDriveII::ISNewSwitch(const char *dev, const char *name, ISState *state
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Compensation
-        if (!strcmp(TemperatureCompensationSP.name, name))
+        if (TemperatureCompensationSP.isNameMatch(name))
         {
-            bool enabled = !strcmp(IUFindOnSwitchName(states, names, n), TemperatureCompensationS[TC_ENABLED].name);
+            bool enabled = !strcmp(IUFindOnSwitchName(states, names, n), TemperatureCompensationSP[TC_ENABLED].getName());
             bool rc = setParameter("TCOMP", enabled ? "1" : "0");
 
             if (rc)
             {
-                IUUpdateSwitch(&TemperatureCompensationSP, states, names, n);
-                TemperatureCompensationSP.s = IPS_OK;
+                TemperatureCompensationSP.update(states, names, n);
+                TemperatureCompensationSP.setState(IPS_OK);
                 LOGF_INFO("Temperature compensation is %s.", enabled ? "enabled" : "disabled");
             }
             else
             {
-                TemperatureCompensationSP.s = IPS_ALERT;
+                TemperatureCompensationSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&TemperatureCompensationSP, nullptr);
+            TemperatureCompensationSP.apply();
             return true;
         }
 
         // Temperature State (Paused or Active)
-        if (!strcmp(TemperatureStateSP.name, name))
+        if (TemperatureStateSP.isNameMatch(name))
         {
-            bool active = !strcmp(IUFindOnSwitchName(states, names, n), TemperatureStateS[TC_ACTIVE].name);
+            bool active = !strcmp(IUFindOnSwitchName(states, names, n), TemperatureStateSP[TC_ACTIVE].getName());
             bool rc = setParameter("TCOMP_PAUSE", active ? "0" : "1");
 
             if (rc)
             {
-                IUUpdateSwitch(&TemperatureStateSP, states, names, n);
-                TemperatureStateSP.s = IPS_OK;
+                TemperatureStateSP.update(states, names, n);
+                TemperatureStateSP.setState(IPS_OK);
                 LOGF_INFO("Temperature compensation is %s.", active ? "active" : "paused");
             }
             else
             {
-                TemperatureStateSP.s = IPS_ALERT;
+                TemperatureStateSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&TemperatureStateSP, nullptr);
+            TemperatureStateSP.apply();
             return true;
         }
 
         // Operations
-        if (!strcmp(OperationSP.name, name))
+        if (OperationSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&OperationSP, states, names, n);
-            if (OperationS[OPERATION_RESET].s == ISS_ON)
+            OperationSP.update(states, names, n);
+            if (OperationSP[OPERATION_RESET].getState() == ISS_ON)
             {
-                IUResetSwitch(&OperationSP);
+                OperationSP.reset();
                 if (m_ConfirmFactoryReset == false)
                 {
                     LOG_WARN("Click button again to confirm factory reset.");
-                    OperationSP.s = IPS_IDLE;
-                    IDSetSwitch(&OperationSP, nullptr);
+                    OperationSP.setState(IPS_IDLE);
+                    OperationSP.apply();
                     return true;
                 }
                 else
@@ -263,32 +261,32 @@ bool SteelDriveII::ISNewSwitch(const char *dev, const char *name, ISState *state
                     m_ConfirmFactoryReset = false;
                     if (!sendCommandOK("RESET"))
                     {
-                        OperationSP.s = IPS_ALERT;
+                        OperationSP.setState(IPS_ALERT);
                         LOG_ERROR("Failed to reset to factory settings.");
-                        IDSetSwitch(&OperationSP, nullptr);
+                        OperationSP.apply();
                         return true;
                     }
                 }
             }
 
-            if (OperationS[OPERATION_REBOOT].s == ISS_ON)
+            if (OperationSP[OPERATION_REBOOT].getState() == ISS_ON)
             {
-                IUResetSwitch(&OperationSP);
+                OperationSP.reset();
                 if (!sendCommand("REBOOT"))
                 {
-                    OperationSP.s = IPS_ALERT;
+                    OperationSP.setState(IPS_ALERT);
                     LOG_ERROR("Failed to reboot device.");
-                    IDSetSwitch(&OperationSP, nullptr);
+                    OperationSP.apply();
                     return true;
                 }
 
                 LOG_INFO("Device is rebooting...");
-                OperationSP.s = IPS_OK;
-                IDSetSwitch(&OperationSP, nullptr);
+                OperationSP.setState(IPS_OK);
+                OperationSP.apply();
                 return true;
             }
 
-            if (OperationS[OPERATION_ZEROING].s == ISS_ON)
+            if (OperationSP[OPERATION_ZEROING].getState() == ISS_ON)
             {
                 if (!sendCommandOK("SET USE_ENDSTOP:1"))
                 {
@@ -297,17 +295,17 @@ bool SteelDriveII::ISNewSwitch(const char *dev, const char *name, ISState *state
 
                 if (!sendCommandOK("ZEROING"))
                 {
-                    IUResetSwitch(&OperationSP);
+                    OperationSP.reset();
                     LOG_ERROR("Failed to zero to home position.");
-                    OperationSP.s = IPS_ALERT;
+                    OperationSP.setState(IPS_ALERT);
                 }
                 else
                 {
-                    OperationSP.s = IPS_BUSY;
+                    OperationSP.setState(IPS_BUSY);
                     LOG_INFO("Zeroing to home position in progress...");
                 }
 
-                IDSetSwitch(&OperationSP, nullptr);
+                OperationSP.apply();
                 return true;
             }
         }
@@ -324,47 +322,47 @@ bool SteelDriveII::ISNewNumber(const char *dev, const char *name, double values[
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(TemperatureSettingsNP.name, name))
+        if (TemperatureSettingsNP.isNameMatch(name))
         {
-            double factor = TemperatureSettingsN[TC_FACTOR].value;
-            double period = TemperatureSettingsN[TC_PERIOD].value;
-            double delta  = TemperatureSettingsN[TC_DELTA].value;
+            double factor = TemperatureSettingsNP[TC_FACTOR].getValue();
+            double period = TemperatureSettingsNP[TC_PERIOD].getValue();
+            double delta  = TemperatureSettingsNP[TC_DELTA].getValue();
             bool rc1 = true, rc2 = true, rc3 = true;
-            IUUpdateNumber(&TemperatureSettingsNP, values, names, n);
+            TemperatureSettingsNP.update(values, names, n);
 
-            if (factor != TemperatureSettingsN[TC_FACTOR].value)
+            if (factor != TemperatureSettingsNP[TC_FACTOR].getValue())
                 rc1 = setParameter("TCOMP_FACTOR", to_string(factor));
-            if (period != TemperatureSettingsN[TC_PERIOD].value)
+            if (period != TemperatureSettingsNP[TC_PERIOD].getValue())
                 rc2 = setParameter("TCOMP_PERIOD", to_string(period));
-            if (delta != TemperatureSettingsN[TC_DELTA].value)
+            if (delta != TemperatureSettingsNP[TC_DELTA].getValue())
                 rc3 = setParameter("TCOMP_DELTA", to_string(delta));
 
-            TemperatureSettingsNP.s = (rc1 && rc2 && rc3) ? IPS_OK : IPS_ALERT;
-            IDSetNumber(&TemperatureSettingsNP, nullptr);
+            TemperatureSettingsNP.setState((rc1 && rc2 && rc3) ? IPS_OK : IPS_ALERT);
+            TemperatureSettingsNP.apply();
             return true;
         }
 
-        if (!strcmp(StepperDriveNP.name, name))
+        if (StepperDriveNP.isNameMatch(name))
         {
-            StepperDriveNP.s = IPS_OK;
+            StepperDriveNP.setState(IPS_OK);
 
-            if (StepperDriveN[CURRENT_MOVE].value != values[CURRENT_MOVE])
+            if (StepperDriveNP[CURRENT_MOVE].value != values[CURRENT_MOVE])
             {
                 if (setParameter("CURRENT_MOVE", to_string(values[CURRENT_MOVE], 0)))
-                    StepperDriveN[CURRENT_MOVE].value = values[CURRENT_MOVE];
+                    StepperDriveNP[CURRENT_MOVE].setValue(values[CURRENT_MOVE]);
                 else
-                    StepperDriveNP.s = IPS_ALERT;
+                    StepperDriveNP.setState(IPS_ALERT);
             }
 
-            if (StepperDriveN[CURRENT_HOLD].value != values[CURRENT_HOLD])
+            if (StepperDriveNP[CURRENT_HOLD].value != values[CURRENT_HOLD])
             {
                 if (setParameter("CURRENT_HOLD", to_string(values[CURRENT_HOLD], 0)))
-                    StepperDriveN[CURRENT_HOLD].value = values[CURRENT_HOLD];
+                    StepperDriveNP[CURRENT_HOLD].setValue(values[CURRENT_HOLD]);
                 else
-                    StepperDriveNP.s = IPS_ALERT;
+                    StepperDriveNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&StepperDriveNP, nullptr);
+            StepperDriveNP.apply();
             return true;
         }
 
@@ -409,11 +407,11 @@ IPState SteelDriveII::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     uint32_t limit = std::stoul(m_Summary[LIMIT]);
 
     int direction = (dir == FOCUS_INWARD) ? -1 : 1;
-    int reversed = (FocusReverseS[INDI_ENABLED].s == ISS_ON) ? -1 : 1;
+    int reversed = (FocusReverseSP[INDI_ENABLED].getState() == ISS_ON) ? -1 : 1;
     int relative = static_cast<int>(ticks);
-    int targetAbsPosition = FocusAbsPosN[0].value + (relative * direction * reversed);
+    int targetAbsPosition = FocusAbsPosNP[0].getValue() + (relative * direction * reversed);
 
-    targetAbsPosition = std::min(limit, static_cast<uint32_t>(std::max(static_cast<int>(FocusAbsPosN[0].min), targetAbsPosition)));
+    targetAbsPosition = std::min(limit, static_cast<uint32_t>(std::max(static_cast<int>(FocusAbsPosNP[0].min), targetAbsPosition)));
 
     return MoveAbsFocuser(targetAbsPosition);
 }
@@ -431,70 +429,70 @@ void SteelDriveII::TimerHit()
     uint32_t summaryPosition = std::max(0, std::stoi(m_Summary[POSITION]));
 
     // Check if we're idle but the focuser is in motion
-    if (FocusAbsPosNP.s != IPS_BUSY && (m_State == GOING_UP || m_State == GOING_DOWN))
+    if (FocusAbsPosNP.getState() != IPS_BUSY && (m_State == GOING_UP || m_State == GOING_DOWN))
     {
-        IUResetSwitch(&FocusMotionSP);
-        FocusMotionS[FOCUS_INWARD].s = (m_State == GOING_DOWN) ? ISS_ON : ISS_OFF;
-        FocusMotionS[FOCUS_OUTWARD].s = (m_State == GOING_DOWN) ? ISS_OFF : ISS_ON;
-        FocusMotionSP.s = IPS_BUSY;
-        FocusAbsPosNP.s = IPS_BUSY;
-        FocusRelPosNP.s = IPS_BUSY;
-        FocusAbsPosN[0].value = summaryPosition;
+        FocusMotionSP.reset();
+        FocusMotionSP[FOCUS_INWARD].setState((m_State == GOING_DOWN) ? ISS_ON : ISS_OFF);
+        FocusMotionSP[FOCUS_OUTWARD].setState((m_State == GOING_DOWN) ? ISS_OFF : ISS_ON);
+        FocusMotionSP.setState(IPS_BUSY);
+        FocusAbsPosNP.setState(IPS_BUSY);
+        FocusRelPosNP.setState(IPS_BUSY);
+        FocusAbsPosNP[0].setValue(summaryPosition);
 
-        IDSetSwitch(&FocusMotionSP, nullptr);
-        IDSetNumber(&FocusRelPosNP, nullptr);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusMotionSP.apply();
+        FocusRelPosNP.apply();
+        FocusAbsPosNP.apply();
     }
-    else if (FocusAbsPosNP.s == IPS_BUSY && (m_State == STOPPED || m_State == ZEROED))
+    else if (FocusAbsPosNP.getState() == IPS_BUSY && (m_State == STOPPED || m_State == ZEROED))
     {
-        if (OperationSP.s == IPS_BUSY)
+        if (OperationSP.getState() == IPS_BUSY)
         {
-            IUResetSwitch(&OperationSP);
+            OperationSP.reset();
             LOG_INFO("Homing is complete");
-            OperationSP.s = IPS_OK;
-            IDSetSwitch(&OperationSP, nullptr);
+            OperationSP.setState(IPS_OK);
+            OperationSP.apply();
         }
 
-        FocusAbsPosNP.s = IPS_OK;
-        FocusAbsPosN[0].value = summaryPosition;
-        if (FocusRelPosNP.s == IPS_BUSY)
+        FocusAbsPosNP.setState(IPS_OK);
+        FocusAbsPosNP[0].setValue(summaryPosition);
+        if (FocusRelPosNP.getState() == IPS_BUSY)
         {
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusRelPosNP.apply();
         }
-        if (FocusMotionSP.s == IPS_BUSY)
+        if (FocusMotionSP.getState() == IPS_BUSY)
         {
-            FocusMotionSP.s = IPS_IDLE;
-            IDSetSwitch(&FocusMotionSP, nullptr);
+            FocusMotionSP.setState(IPS_IDLE);
+            FocusMotionSP.apply();
         }
 
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
     }
-    else if (std::fabs(FocusAbsPosN[0].value - summaryPosition) > 0)
+    else if (std::fabs(FocusAbsPosNP[0].value - summaryPosition) > 0)
     {
-        FocusAbsPosN[0].value = summaryPosition;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setValue(summaryPosition);
+        FocusAbsPosNP.apply();
     }
 
-    if (std::fabs(FocusMaxPosN[0].value - std::stoul(m_Summary[LIMIT])) > 0)
+    if (std::fabs(FocusMaxPosNP[0].value - std::stoul(m_Summary[LIMIT])) > 0)
     {
-        FocusMaxPosN[0].value = std::stoul(m_Summary[LIMIT]);
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP[0].setValue(std::stoul(m_Summary[LIMIT]));
+        FocusMaxPosNP.apply();
     }
 
     double temp0 = std::stod(m_Summary[TEMP0]);
     double temp1 = std::stod(m_Summary[TEMP1]);
     double tempa = std::stod(m_Summary[TEMPAVG]);
 
-    if (temp0 != TemperatureSensorN[TEMP_0].value ||
-            temp1 != TemperatureSensorN[TEMP_1].value ||
-            tempa != TemperatureSensorN[TEMP_AVG].value)
+    if (temp0 != TemperatureSensorNP[TEMP_0].value ||
+            temp1 != TemperatureSensorNP[TEMP_1].value ||
+            tempa != TemperatureSensorNP[TEMP_AVG].getValue())
     {
-        TemperatureSensorN[TEMP_0].value = temp0;
-        TemperatureSensorN[TEMP_1].value = temp1;
-        TemperatureSensorN[TEMP_AVG].value = tempa;
-        TemperatureSensorNP.s = IPS_OK;
-        IDSetNumber(&TemperatureSensorNP, nullptr);
+        TemperatureSensorNP[TEMP_0].setValue(temp0);
+        TemperatureSensorNP[TEMP_1].setValue(temp1);
+        TemperatureSensorNP[TEMP_AVG].setValue(tempa);
+        TemperatureSensorNP.setState(IPS_OK);
+        TemperatureSensorNP.apply();
     }
 
     SetTimer(getCurrentPollingPeriod());
@@ -544,57 +542,57 @@ void SteelDriveII::getStartupValues()
     std::string value;
 
     if (getParameter("NAME", value))
-        IUSaveText(&InfoT[INFO_NAME], value.c_str());
+        InfoTP[INFO_NAME].setText(value);
 
     if (getParameter("VERSION", value))
-        IUSaveText(&InfoT[INFO_VERSION], value.c_str());
+        InfoTP[INFO_VERSION].setText(value);
 
     if (getParameter("TCOMP", value))
     {
-        TemperatureCompensationS[TC_ENABLED].s = (value == "1") ? ISS_ON : ISS_OFF;
-        TemperatureCompensationS[TC_DISABLED].s = (value == "1") ? ISS_OFF : ISS_ON;
+        TemperatureCompensationSP[TC_ENABLED].setState((value == "1") ? ISS_ON : ISS_OFF);
+        TemperatureCompensationSP[TC_DISABLED].setState((value == "1") ? ISS_OFF : ISS_ON);
     }
 
     if (getParameter("TCOMP_FACTOR", value))
     {
-        TemperatureSettingsN[TC_FACTOR].value = std::stod(value);
+        TemperatureSettingsNP[TC_FACTOR].setValue(std::stod(value));
     }
 
     if (getParameter("TCOMP_PERIOD", value))
     {
-        TemperatureSettingsN[TC_PERIOD].value = std::stod(value);
+        TemperatureSettingsNP[TC_PERIOD].setValue(std::stod(value));
     }
 
     if (getParameter("TCOMP_DELTA", value))
     {
-        TemperatureSettingsN[TC_DELTA].value = std::stod(value);
+        TemperatureSettingsNP[TC_DELTA].setValue(std::stod(value));
     }
 
     if (getParameter("TCOMP_PAUSE", value))
     {
-        TemperatureStateS[TC_ACTIVE].s = (value == "0") ? ISS_ON : ISS_OFF;
-        TemperatureStateS[TC_PAUSED].s = (value == "0") ? ISS_OFF : ISS_ON;
+        TemperatureStateSP[TC_ACTIVE].setState((value == "0") ? ISS_ON : ISS_OFF);
+        TemperatureStateSP[TC_PAUSED].setState((value == "0") ? ISS_OFF : ISS_ON);
     }
 
-    StepperDriveNP.s = IPS_OK;
+    StepperDriveNP.setState(IPS_OK);
     if (getParameter("CURRENT_MOVE", value))
-        StepperDriveN[CURRENT_MOVE].value = std::stod(value);
+        StepperDriveNP[CURRENT_MOVE].setValue(std::stod(value));
     else
-        StepperDriveNP.s = IPS_ALERT;
+        StepperDriveNP.setState(IPS_ALERT);
 
     if (getParameter("CURRENT_HOLD", value))
-        StepperDriveN[CURRENT_HOLD].value = std::stod(value);
+        StepperDriveNP[CURRENT_HOLD].setValue(std::stod(value));
     else
-        StepperDriveNP.s = IPS_ALERT;
+        StepperDriveNP.setState(IPS_ALERT);
 
     getSummary();
 
-    FocusMaxPosN[0].value = std::stoul(m_Summary[LIMIT]);
-    IDSetNumber(&FocusMaxPosNP, nullptr);
+    FocusMaxPosNP[0].setValue(std::stoul(m_Summary[LIMIT]));
+    FocusMaxPosNP.apply();
 
-    TemperatureSensorN[TEMP_0].value = std::stod(m_Summary[TEMP0]);
-    TemperatureSensorN[TEMP_1].value = std::stod(m_Summary[TEMP1]);
-    TemperatureSensorN[TEMP_AVG].value = std::stod(m_Summary[TEMPAVG]);
+    TemperatureSensorNP[TEMP_0].setValue(std::stod(m_Summary[TEMP0]));
+    TemperatureSensorNP[TEMP_1].setValue(std::stod(m_Summary[TEMP1]));
+    TemperatureSensorNP[TEMP_AVG].setValue(std::stod(m_Summary[TEMPAVG]));
 
 }
 

--- a/drivers/focuser/steeldrive2.h
+++ b/drivers/focuser/steeldrive2.h
@@ -25,6 +25,11 @@
 
 #include <map>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class SteelDriveII : public INDI::Focuser
 {
     public:
@@ -83,8 +88,7 @@ class SteelDriveII : public INDI::Focuser
         ///////////////////////////////////////////////////////////////////////////////////
 
         // Focuser Informatin
-        ITextVectorProperty InfoTP;
-        IText InfoT[2] {};
+        INDI::PropertyText InfoTP {2};
         enum
         {
             INFO_NAME,
@@ -92,8 +96,7 @@ class SteelDriveII : public INDI::Focuser
         };
 
         // Focuser Operations
-        ISwitchVectorProperty OperationSP;
-        ISwitch OperationS[3];
+        INDI::PropertySwitch OperationSP {3};
         enum
         {
             OPERATION_REBOOT,
@@ -102,8 +105,7 @@ class SteelDriveII : public INDI::Focuser
         };
 
         // Temperature Compensation
-        ISwitchVectorProperty TemperatureCompensationSP;
-        ISwitch TemperatureCompensationS[2];
+        INDI::PropertySwitch TemperatureCompensationSP {2};
         enum
         {
             TC_ENABLED,
@@ -111,8 +113,7 @@ class SteelDriveII : public INDI::Focuser
         };
 
         // TC State
-        ISwitchVectorProperty TemperatureStateSP;
-        ISwitch TemperatureStateS[2];
+        INDI::PropertySwitch TemperatureStateSP {2};
         enum
         {
             TC_ACTIVE,
@@ -120,8 +121,7 @@ class SteelDriveII : public INDI::Focuser
         };
 
         // Temperature Compensation Settings
-        INumberVectorProperty TemperatureSettingsNP;
-        INumber TemperatureSettingsN[3];
+        INDI::PropertyNumber TemperatureSettingsNP {3};
         enum
         {
             TC_FACTOR,
@@ -130,8 +130,7 @@ class SteelDriveII : public INDI::Focuser
         };
 
         // Temperature Sensors
-        INumberVectorProperty TemperatureSensorNP;
-        INumber TemperatureSensorN[3];
+        INDI::PropertyNumber TemperatureSensorNP {3};
         enum
         {
             TEMP_0,
@@ -140,8 +139,7 @@ class SteelDriveII : public INDI::Focuser
         };
 
         // Stepper Drive
-        INumberVectorProperty StepperDriveNP;
-        INumber StepperDriveN[2];
+        INDI::PropertyNumber StepperDriveNP {2};
         enum
         {
             CURRENT_MOVE,

--- a/drivers/focuser/tcfs.cpp
+++ b/drivers/focuser/tcfs.cpp
@@ -30,7 +30,7 @@
 #include <termios.h>
 
 #define mydev           "Optec TCF-S"
-#define currentPosition FocusAbsPosN[0].value
+#define currentPosition FocusAbsPosNP[0].value
 
 // We declare an auto pointer to TCFS.
 static std::unique_ptr<TCFS> tcfs(new TCFS());
@@ -98,66 +98,66 @@ bool TCFS::initProperties()
     {
         isTCFS3 = true;
 
-        FocusMaxPosN[0].max   = 9999;
-        FocusAbsPosN[0].max   = 9999;
-        FocusRelPosN[0].max   = 2000;
-        FocusRelPosN[0].step  = 100;
-        FocusAbsPosN[0].step  = 100;
-        FocusRelPosN[0].value = 0;
+        FocusMaxPosNP[0].setMax(9999);
+        FocusAbsPosNP[0].setMax(9999);
+        FocusRelPosNP[0].setMax(2000);
+        FocusRelPosNP[0].setStep(100);
+        FocusAbsPosNP[0].setStep(100);
+        FocusRelPosNP[0].setValue(0);
         LOG_DEBUG("TCF-S3 detected. Updating maximum position value to 9999.");
     }
     else
     {
         isTCFS3 = false;
 
-        FocusMaxPosN[0].max   = 7000;
-        FocusAbsPosN[0].max   = 7000;
-        FocusRelPosN[0].max   = 2000;
-        FocusRelPosN[0].step  = 100;
-        FocusAbsPosN[0].step  = 100;
-        FocusRelPosN[0].value = 0;
+        FocusMaxPosNP[0].setMax(7000);
+        FocusAbsPosNP[0].setMax(7000);
+        FocusRelPosNP[0].setMax(2000);
+        FocusRelPosNP[0].setStep(100);
+        FocusAbsPosNP[0].setStep(100);
+        FocusRelPosNP[0].setValue(0);
         LOG_DEBUG("TCF-S detected. Updating maximum position value to 7000.");
     }
 
-    IUFillSwitch(&FocusModeS[0], "Manual", "", ISS_ON);
-    IUFillSwitch(&FocusModeS[1], "Auto A", "", ISS_OFF);
-    IUFillSwitch(&FocusModeS[2], "Auto B", "", ISS_OFF);
-    IUFillSwitchVector(&FocusModeSP, FocusModeS, 3, getDeviceName(), "FOCUS_MODE", "Mode", "Main Control", IP_RW,
+    FocusModeSP[0].fill("Manual", "", ISS_ON);
+    FocusModeSP[1].fill("Auto A", "", ISS_OFF);
+    FocusModeSP[2].fill("Auto B", "", ISS_OFF);
+    FocusModeSP.fill(getDeviceName(), "FOCUS_MODE", "Mode", "Main Control", IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&FocusPowerS[0], "FOCUS_SLEEP", "Sleep", ISS_OFF);
-    IUFillSwitch(&FocusPowerS[1], "FOCUS_WAKEUP", "Wake up", ISS_OFF);
-    IUFillSwitchVector(&FocusPowerSP, FocusPowerS, 2, getDeviceName(), "FOCUS_POWER", "Power", "Operation", IP_RW,
+    FocusPowerSP[0].fill("FOCUS_SLEEP", "Sleep", ISS_OFF);
+    FocusPowerSP[1].fill("FOCUS_WAKEUP", "Wake up", ISS_OFF);
+    FocusPowerSP.fill(getDeviceName(), "FOCUS_POWER", "Power", "Operation", IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&FocusGotoS[0], "FOCUS_MIN", "Min", ISS_OFF);
-    IUFillSwitch(&FocusGotoS[1], "FOCUS_CENTER", "Center", ISS_OFF);
-    IUFillSwitch(&FocusGotoS[2], "FOCUS_MAX", "Max", ISS_OFF);
-    IUFillSwitch(&FocusGotoS[3], "FOCUS_HOME", "Home", ISS_OFF);
-    IUFillSwitchVector(&FocusGotoSP, FocusGotoS, 4, getDeviceName(), "FOCUS_GOTO", "Go to", "Main Control", IP_RW,
+    FocusGotoSP[0].fill("FOCUS_MIN", "Min", ISS_OFF);
+    FocusGotoSP[1].fill("FOCUS_CENTER", "Center", ISS_OFF);
+    FocusGotoSP[2].fill("FOCUS_MAX", "Max", ISS_OFF);
+    FocusGotoSP[3].fill("FOCUS_HOME", "Home", ISS_OFF);
+    FocusGotoSP.fill(getDeviceName(), "FOCUS_GOTO", "Go to", "Main Control", IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillNumber(&FocusTemperatureN[0], "FOCUS_TEMPERATURE_VALUE", "Temperature (c)", "%.3f", -50.0, 80, 0, 0);
-    IUFillNumberVector(&FocusTemperatureNP, FocusTemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Probe", "Operation", IP_RO, 0, IPS_IDLE);
+    FocusTemperatureNP[0].fill("FOCUS_TEMPERATURE_VALUE", "Temperature (c)", "%.3f", -50.0, 80, 0, 0);
+    FocusTemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Probe", "Operation", IP_RO, 0, IPS_IDLE);
 
-    IUFillSwitch(&FocusTelemetryS[0], "FOCUS_TELEMETRY_ON", "Enable", ISS_ON);
-    IUFillSwitch(&FocusTelemetryS[1], "FOCUS_TELEMETRY_OFF", "Disable", ISS_OFF);
-    IUFillSwitchVector(&FocusTelemetrySP, FocusTelemetryS, 2, getDeviceName(), "FOCUS_TELEMETRY", "Telemetry", "Operation", IP_RW,
+    FocusTelemetrySP[0].fill("FOCUS_TELEMETRY_ON", "Enable", ISS_ON);
+    FocusTelemetrySP[1].fill("FOCUS_TELEMETRY_OFF", "Disable", ISS_OFF);
+    FocusTelemetrySP.fill(getDeviceName(), "FOCUS_TELEMETRY", "Telemetry", "Operation", IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Mode parameters
-    IUFillNumber(&FocusModeAN[0], "FOCUS_SLOPE_A", "Slope A", "%.0f", -999, 999, 10, 0);
-    IUFillNumber(&FocusModeAN[1], "FOCUS_INTERCEPT_A", "Intercept A", "%.0f", 0, FocusAbsPosN[0].max, 10, 0);
-    IUFillNumber(&FocusModeAN[2], "FOCUS_DELAY_A", "Delay A", "%.2f", 0.00, 9.99, 1.0, 0);
-    IUFillNumberVector(&FocusModeANP, FocusModeAN, 3, getDeviceName(), "FOCUS_MODE_A", "Mode A", "Presets", IP_RW, 0, IPS_IDLE);
-    IUFillNumber(&FocusModeBN[0], "FOCUS_SLOPE_B", "Slope B", "%.0f", -999, 999, 10, 0);
-    IUFillNumber(&FocusModeBN[1], "FOCUS_INTERCEPT_B", "Intercept B", "%.0f", 0, FocusAbsPosN[0].max, 10, 0);
-    IUFillNumber(&FocusModeBN[2], "FOCUS_DELAY_B", "Delay B", "%.2f", 0.00, 9.99, 1.0, 0);
-    IUFillNumberVector(&FocusModeBNP, FocusModeBN, 3, getDeviceName(), "FOCUS_MODE_B", "Mode B", "Presets", IP_RW, 0, IPS_IDLE);
+    FocusModeANP[0].fill("FOCUS_SLOPE_A", "Slope A", "%.0f", -999, 999, 10, 0);
+    FocusModeANP[1].fill("FOCUS_INTERCEPT_A", "Intercept A", "%.0f", 0, FocusAbsPosNP[0].max, 10, 0);
+    FocusModeANP[2].fill("FOCUS_DELAY_A", "Delay A", "%.2f", 0.00, 9.99, 1.0, 0);
+    FocusModeANP.fill(getDeviceName(), "FOCUS_MODE_A", "Mode A", "Presets", IP_RW, 0, IPS_IDLE);
+    FocusModeBNP[0].fill("FOCUS_SLOPE_B", "Slope B", "%.0f", -999, 999, 10, 0);
+    FocusModeBNP[1].fill("FOCUS_INTERCEPT_B", "Intercept B", "%.0f", 0, FocusAbsPosNP[0].max, 10, 0);
+    FocusModeBNP[2].fill("FOCUS_DELAY_B", "Delay B", "%.2f", 0.00, 9.99, 1.0, 0);
+    FocusModeBNP.fill(getDeviceName(), "FOCUS_MODE_B", "Mode B", "Presets", IP_RW, 0, IPS_IDLE);
 
-    IUFillSwitch(&FocusStartModeS[0], "FOCUS_START_ON", "Enable", ISS_OFF);
-    IUFillSwitch(&FocusStartModeS[1], "FOCUS_START_OFF", "Disable", ISS_ON);
-    IUFillSwitchVector(&FocusStartModeSP, FocusStartModeS, 2, getDeviceName(), "FOCUS_START_MODE", "Startup Mode", "Presets", IP_RW,
+    FocusStartModeSP[0].fill("FOCUS_START_ON", "Enable", ISS_OFF);
+    FocusStartModeSP[1].fill("FOCUS_START_OFF", "Disable", ISS_ON);
+    FocusStartModeSP.fill(getDeviceName(), "FOCUS_START_MODE", "Startup Mode", "Presets", IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Default to 19200
@@ -181,26 +181,26 @@ bool TCFS::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&FocusGotoSP);
-        defineProperty(&FocusTemperatureNP);
-        defineProperty(&FocusPowerSP);
-        defineProperty(&FocusModeSP);
-        defineProperty(&FocusTelemetrySP);
-        defineProperty(&FocusStartModeSP);
-        defineProperty(&FocusModeANP);
-        defineProperty(&FocusModeBNP);;
+        defineProperty(FocusGotoSP);
+        defineProperty(FocusTemperatureNP);
+        defineProperty(FocusPowerSP);
+        defineProperty(FocusModeSP);
+        defineProperty(FocusTelemetrySP);
+        defineProperty(FocusStartModeSP);
+        defineProperty(FocusModeANP);
+        defineProperty(FocusModeBNP);;
         GetFocusParams();
     }
     else
     {
-        deleteProperty(FocusGotoSP.name);
-        deleteProperty(FocusTemperatureNP.name);
-        deleteProperty(FocusPowerSP.name);
-        deleteProperty(FocusModeSP.name);
-        deleteProperty(FocusTelemetrySP.name);
-        deleteProperty(FocusStartModeSP.name);
-        deleteProperty(FocusModeANP.name);
-        deleteProperty(FocusModeBNP.name);;
+        deleteProperty(FocusGotoSP.getName());
+        deleteProperty(FocusTemperatureNP.getName());
+        deleteProperty(FocusPowerSP.getName());
+        deleteProperty(FocusModeSP.getName());
+        deleteProperty(FocusTelemetrySP.getName());
+        deleteProperty(FocusStartModeSP.getName());
+        deleteProperty(FocusModeANP.getName());
+        deleteProperty(FocusModeBNP.getName());;
     }
 
     return true;
@@ -214,9 +214,9 @@ bool TCFS::saveConfigItems(FILE *fp)
 {
     INDI::Focuser::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &FocusModeANP);
-    IUSaveConfigNumber(fp, &FocusModeBNP);
-    IUSaveConfigSwitch(fp, &FocusStartModeSP);
+    FocusModeANP.save(fp);
+    FocusModeBNP.save(fp);
+    FocusStartModeSP.save(fp);
 
     // Add more properties to config file here
     //        IUSaveConfigSwitch(fp, &SwitchSP);
@@ -232,7 +232,7 @@ bool TCFS::saveConfigItems(FILE *fp)
 *****************************************************************/
 void TCFS::GetFocusParams()
 {
-    LOGF_DEBUG("A slope=%.0f", FocusModeANP.np[0].value);//, FocusModeAN[0].value);
+    LOGF_DEBUG("A slope=%.0f", FocusModeANP[0].getValue());//, FocusModeANP[0].getValue());
     /*
         char response[TCFS_MAX_CMD] = { 0 };
         int slope;
@@ -253,8 +253,8 @@ void TCFS::GetFocusParams()
             return;
         }
 
-        FocusModeANP.np[0].value = slope * (is_negative==1?-1:1);
-        IDSetNumber(&FocusModeANP, nullptr);
+        FocusModeANP[0].setValue(slope * (is_negative==1?-1:1));
+        FocusModeANP.apply();
 
         response[0] = '\0';
         dispatch_command(FRSLOP, 0, MODE_B);
@@ -274,8 +274,8 @@ void TCFS::GetFocusParams()
             return;
         }
 
-        FocusModeBNP.np[0].value = slope * (is_negative==1?-1:1);
-        IDSetNumber(&FocusModeBNP, nullptr);
+        FocusModeBNP[0].setValue(slope * (is_negative==1?-1:1));
+        FocusModeBNP.apply();
     */
 }
 
@@ -306,7 +306,7 @@ bool TCFS::Handshake()
         LOG_INFO("Successfully connected to TCF-S Focuser in Manual Mode.");
 
         // Enable temperature readout
-        FocusTemperatureNP.s = IPS_OK;
+        FocusTemperatureNP.setState(IPS_OK);
 
         return true;
     }
@@ -342,8 +342,8 @@ bool TCFS::SetManualMode()
 *****************************************************************/
 bool TCFS::Disconnect()
 {
-    FocusTemperatureNP.s = IPS_IDLE;
-    IDSetNumber(&FocusTemperatureNP, nullptr);
+    FocusTemperatureNP.setState(IPS_IDLE);
+    FocusTemperatureNP.apply();
 
     dispatch_command(FFMODE);
 
@@ -365,66 +365,66 @@ bool TCFS::ISNewNumber(const char *dev, const char *name, double values[], char 
         // In Sleep mode only FWAKUP can be accepted
         // While focuser is moving don't allow actions other than FMMODE
 
-        if (!strcmp(name, FocusModeANP.name))
+        if (FocusModeANP.isNameMatch(name))
         {
-            IUUpdateNumber(&FocusModeANP, values, names, n);
+            FocusModeANP.update(values, names, n);
 
-            dispatch_command(FLSLOP, FocusModeAN[0].value, MODE_A);
+            dispatch_command(FLSLOP, FocusModeANP[0].getValue(), MODE_A);
             if (read_tcfs(response) == false)
             {
-                FocusModeANP.s = IPS_ALERT;
-                IDSetNumber(&FocusModeANP, "Error reading TCF-S reply.");
+                FocusModeANP.setState(IPS_ALERT);
+                FocusModeANP.apply("Error reading TCF-S reply.");
                 return true;
             }
-            dispatch_command(FLSIGN, FocusModeAN[0].value, MODE_A);
+            dispatch_command(FLSIGN, FocusModeANP[0].getValue(), MODE_A);
             if (read_tcfs(response) == false)
             {
-                FocusModeANP.s = IPS_ALERT;
-                IDSetNumber(&FocusModeANP, "Error reading TCF-S reply.");
-                return true;
-            }
-            //saveConfig();
-            dispatch_command(FDELAY, FocusModeAN[2].value * 100, MODE_A);
-            if (read_tcfs(response) == false)
-            {
-                FocusModeANP.s = IPS_ALERT;
-                IDSetNumber(&FocusModeANP, "Error reading TCF-S reply.");
+                FocusModeANP.setState(IPS_ALERT);
+                FocusModeANP.apply("Error reading TCF-S reply.");
                 return true;
             }
             //saveConfig();
-            FocusModeANP.s = IPS_OK;
-            IDSetNumber(&FocusModeANP, nullptr);
+            dispatch_command(FDELAY, FocusModeANP[2].value * 100, MODE_A);
+            if (read_tcfs(response) == false)
+            {
+                FocusModeANP.setState(IPS_ALERT);
+                FocusModeANP.apply("Error reading TCF-S reply.");
+                return true;
+            }
+            //saveConfig();
+            FocusModeANP.setState(IPS_OK);
+            FocusModeANP.apply();
 
             return true;
         }
-        if (!strcmp(name, FocusModeBNP.name))
+        if (FocusModeBNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FocusModeBNP, values, names, n);
+            FocusModeBNP.update(values, names, n);
 
-            dispatch_command(FLSLOP, FocusModeBN[0].value, MODE_B);
+            dispatch_command(FLSLOP, FocusModeBNP[0].getValue(), MODE_B);
             if (read_tcfs(response) == false)
             {
-                FocusModeBNP.s = IPS_ALERT;
-                IDSetNumber(&FocusModeBNP, "Error reading TCF-S reply.");
+                FocusModeBNP.setState(IPS_ALERT);
+                FocusModeBNP.apply("Error reading TCF-S reply.");
                 return true;
             }
-            dispatch_command(FLSIGN, FocusModeBN[0].value, MODE_B);
+            dispatch_command(FLSIGN, FocusModeBNP[0].getValue(), MODE_B);
             if (read_tcfs(response) == false)
             {
-                FocusModeBNP.s = IPS_ALERT;
-                IDSetNumber(&FocusModeBNP, "Error reading TCF-S reply.");
+                FocusModeBNP.setState(IPS_ALERT);
+                FocusModeBNP.apply("Error reading TCF-S reply.");
                 return true;
             }
-            dispatch_command(FDELAY, FocusModeBN[2].value * 100, MODE_B);
+            dispatch_command(FDELAY, FocusModeBNP[2].value * 100, MODE_B);
             if (read_tcfs(response) == false)
             {
-                FocusModeBNP.s = IPS_ALERT;
-                IDSetNumber(&FocusModeBNP, "Error reading TCF-S reply.");
+                FocusModeBNP.setState(IPS_ALERT);
+                FocusModeBNP.apply("Error reading TCF-S reply.");
                 return true;
             }
             //saveConfig();
-            FocusModeBNP.s = IPS_OK;
-            IDSetNumber(&FocusModeBNP, nullptr);
+            FocusModeBNP.setState(IPS_OK);
+            FocusModeBNP.apply();
 
             return true;
         }
@@ -446,25 +446,25 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
         // In Auto mode only FMMODE can be accepted
         // In Sleep mode only FWAKUP can be accepted
         // While focuser is moving don't allow actions other than FMMODE
-        if (!strcmp(FocusMotionSP.name, name))
+        if (FocusMotionSP.isNameMatch(name))
         {
-            if (FocusModeSP.sp[0].s != ISS_ON)
+            if (FocusModeSP[0].s != ISS_ON)
             {
                 LOG_WARN("The focuser can only be moved in Manual mode.");
                 return true;
             }
         }
-        if (FocusRelPosNP.s == IPS_BUSY)
+        if (FocusRelPosNP.getState() == IPS_BUSY)
         {
             LOG_WARN("The focuser is in motion. Wait until it has stopped");
             return true;
         }
-        if (!strcmp(FocusPowerSP.name, name))
+        if (FocusPowerSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FocusPowerSP, states, names, n);
+            FocusPowerSP.update(states, names, n);
             bool sleep = false;
 
-            ISwitch *sp = IUFindOnSwitch(&FocusPowerSP);
+            ISwitch *sp = FocusPowerSP.findOnSwitch();
 
             // Sleep
             if (!strcmp(sp->name, "FOCUS_SLEEP"))
@@ -478,9 +478,9 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
 
             if (read_tcfs(response) == false)
             {
-                IUResetSwitch(&FocusPowerSP);
-                FocusPowerSP.s = IPS_ALERT;
-                IDSetSwitch(&FocusPowerSP, "Error reading TCF-S reply.");
+                FocusPowerSP.reset();
+                FocusPowerSP.setState(IPS_ALERT);
+                FocusPowerSP.apply("Error reading TCF-S reply.");
                 return true;
             }
 
@@ -491,22 +491,22 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
 
                 if (strcmp(response, "ZZZ") == 0)
                 {
-                    FocusPowerSP.s = IPS_OK;
-                    IDSetSwitch(&FocusPowerSP, "Focuser is set into sleep mode.");
-                    FocusAbsPosNP.s = IPS_IDLE;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
+                    FocusPowerSP.setState(IPS_OK);
+                    FocusPowerSP.apply("Focuser is set into sleep mode.");
+                    FocusAbsPosNP.setState(IPS_IDLE);
+                    FocusAbsPosNP.apply();
                     //                    if (FocusTemperatureNP)
                     {
-                        FocusTemperatureNP.s = IPS_IDLE;
-                        IDSetNumber(&FocusTemperatureNP, nullptr);
+                        FocusTemperatureNP.setState(IPS_IDLE);
+                        FocusTemperatureNP.apply();
                     }
 
                     return true;
                 }
                 else
                 {
-                    FocusPowerSP.s = IPS_ALERT;
-                    IDSetSwitch(&FocusPowerSP, "Focuser sleep mode operation failed. Response: %s.", response);
+                    FocusPowerSP.setState(IPS_ALERT);
+                    FocusPowerSP.apply("Focuser sleep mode operation failed. Response: %s.", response);
                     return true;
                 }
             }
@@ -517,29 +517,29 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
 
                 if (strcmp(response, "WAKE") == 0)
                 {
-                    FocusPowerSP.s = IPS_OK;
-                    IDSetSwitch(&FocusPowerSP, "Focuser is awake.");
-                    FocusAbsPosNP.s = IPS_OK;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
+                    FocusPowerSP.setState(IPS_OK);
+                    FocusPowerSP.apply("Focuser is awake.");
+                    FocusAbsPosNP.setState(IPS_OK);
+                    FocusAbsPosNP.apply();
                     //                    if (FocusTemperatureNP)
                     {
-                        FocusTemperatureNP.s = IPS_OK;
-                        IDSetNumber(&FocusTemperatureNP, nullptr);
+                        FocusTemperatureNP.setState(IPS_OK);
+                        FocusTemperatureNP.apply();
                     }
 
                     return true;
                 }
                 else
                 {
-                    FocusPowerSP.s = IPS_ALERT;
-                    IDSetSwitch(&FocusPowerSP, "Focuser wake up operation failed. Response: %s", response);
+                    FocusPowerSP.setState(IPS_ALERT);
+                    FocusPowerSP.apply("Focuser wake up operation failed. Response: %s", response);
                     return true;
                 }
             }
         }
 
         // Do not process any command if focuser is asleep
-        if (isConnected() && FocusPowerSP.sp[0].s == ISS_ON)
+        if (isConnected() && FocusPowerSP[0].s == ISS_ON)
         {
             ISwitchVectorProperty *svp = getSwitch(name);
             if (svp)
@@ -551,20 +551,20 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
             return true;
         }
 
-        if (!strcmp(FocusModeSP.name, name))
+        if (FocusModeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FocusModeSP, states, names, n);
-            FocusModeSP.s = IPS_OK;
+            FocusModeSP.update(states, names, n);
+            FocusModeSP.setState(IPS_OK);
 
-            ISwitch *sp = IUFindOnSwitch(&FocusModeSP);
+            ISwitch *sp = FocusModeSP.findOnSwitch();
 
             if (!strcmp(sp->name, "Manual"))
             {
                 if (!isSimulation() && !SetManualMode())
                 {
-                    IUResetSwitch(&FocusModeSP);
-                    FocusModeSP.s = IPS_ALERT;
-                    IDSetSwitch(&FocusModeSP, "Error switching to manual mode. No reply from TCF-S. Try again.");
+                    FocusModeSP.reset();
+                    FocusModeSP.setState(IPS_ALERT);
+                    FocusModeSP.apply("Error switching to manual mode. No reply from TCF-S. Try again.");
                     return true;
                 }
                 LOG_INFO("Entered Manual Mode");
@@ -572,15 +572,15 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
             }
             else if (!strcmp(sp->name, "Auto A"))
             {
-                if(FocusStartModeSP.sp[0].s == ISS_ON)
+                if(FocusStartModeSP[0].s == ISS_ON)
                 {
-                    FocusModeSP.s = IPS_BUSY;
-                    uint32_t startPos = -FocusTemperatureN[0].value * FocusModeAN[0].value
-                                        + FocusModeAN[1].value;
+                    FocusModeSP.setState(IPS_BUSY);
+                    uint32_t startPos = -FocusTemperatureNP[0].value * FocusModeANP[0].getValue()
+                                        + FocusModeANP[1].value;
                     LOGF_DEBUG("Autocomp A T=%.1f; m=%f; i=%f; p0=%d;",
-                               FocusTemperatureN[0].value,
-                               FocusModeAN[0].value,
-                               FocusModeAN[1].value,
+                               FocusTemperatureNP[0].getValue(),
+                               FocusModeANP[0].getValue(),
+                               FocusModeANP[1].getValue(),
                                startPos);
                     MoveAbsFocuser(startPos);
                 }
@@ -590,9 +590,9 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
                     read_tcfs(response);
                     if (!isSimulation() && strcmp(response, "A") != 0)
                     {
-                        IUResetSwitch(&FocusModeSP);
-                        FocusModeSP.s = IPS_ALERT;
-                        IDSetSwitch(&FocusModeSP, "Error switching to Auto Mode A, No reply from TCF-S. Try again.");
+                        FocusModeSP.reset();
+                        FocusModeSP.setState(IPS_ALERT);
+                        FocusModeSP.apply("Error switching to Auto Mode A, No reply from TCF-S. Try again.");
                     }
                     LOG_INFO("Entered Auto Mode A");
                     currentMode = MODE_A;
@@ -600,15 +600,15 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
             }
             else
             {
-                if(FocusStartModeSP.sp[0].s == ISS_ON)
+                if(FocusStartModeSP[0].s == ISS_ON)
                 {
-                    FocusModeSP.s = IPS_BUSY;
-                    uint32_t startPos = -FocusTemperatureN[0].value * FocusModeBN[0].value
-                                        + FocusModeBN[1].value;
+                    FocusModeSP.setState(IPS_BUSY);
+                    uint32_t startPos = -FocusTemperatureNP[0].value * FocusModeBNP[0].getValue()
+                                        + FocusModeBNP[1].value;
                     LOGF_DEBUG("Autocomp B T=%.1f; m=%f; i=%f; p0=%d;",
-                               FocusTemperatureN[0].value,
-                               FocusModeBN[0].value,
-                               FocusModeBN[1].value,
+                               FocusTemperatureNP[0].getValue(),
+                               FocusModeBNP[0].getValue(),
+                               FocusModeBNP[1].getValue(),
                                startPos);
                     MoveAbsFocuser(startPos);
                 }
@@ -618,20 +618,20 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
                     read_tcfs(response);
                     if (!isSimulation() && strcmp(response, "B") != 0)
                     {
-                        IUResetSwitch(&FocusModeSP);
-                        FocusModeSP.s = IPS_ALERT;
-                        IDSetSwitch(&FocusModeSP, "Error switching to Auto Mode B, No reply from TCF-S. Try again.");
+                        FocusModeSP.reset();
+                        FocusModeSP.setState(IPS_ALERT);
+                        FocusModeSP.apply("Error switching to Auto Mode B, No reply from TCF-S. Try again.");
                     }
                     LOG_INFO("Entered Auto Mode B");
                     currentMode = MODE_B;
                 }
             }
 
-            IDSetSwitch(&FocusModeSP, nullptr);
+            FocusModeSP.apply();
             return true;
         }
         // Do not process any other command if focuser is in auto mode
-        if (isConnected() && FocusModeSP.sp[0].s != ISS_ON)
+        if (isConnected() && FocusModeSP[0].s != ISS_ON)
         {
             ISwitchVectorProperty *svp = getSwitch(name);
             if (svp)
@@ -643,56 +643,56 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
             return true;
         }
 
-        if (!strcmp(FocusStartModeSP.name, name))
+        if (FocusStartModeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FocusStartModeSP, states, names, n);
-            FocusStartModeSP.s = IPS_OK;
-            //            ISwitch *sp = IUFindOnSwitch(&FocusStartModeSP);
-            IDSetSwitch(&FocusStartModeSP, nullptr);
-            LOGF_DEBUG("Start Mode %d", FocusStartModeSP.sp[0].s );
+            FocusStartModeSP.update(states, names, n);
+            FocusStartModeSP.setState(IPS_OK);
+            //            ISwitch *sp = FocusStartModeSP.findOnSwitch();
+            FocusStartModeSP.apply();
+            LOGF_DEBUG("Start Mode %d", FocusStartModeSP[0].s );
             return true;
         }
 
-        if (!strcmp(FocusGotoSP.name, name))
+        if (FocusGotoSP.isNameMatch(name))
         {
-            if (FocusModeSP.sp[0].s != ISS_ON)
+            if (FocusModeSP[0].s != ISS_ON)
             {
-                FocusGotoSP.s = IPS_IDLE;
-                IDSetSwitch(&FocusGotoSP, nullptr);
+                FocusGotoSP.setState(IPS_IDLE);
+                FocusGotoSP.apply();
                 LOG_WARN("The focuser can only be moved in Manual mode.");
                 return false;
             }
 
-            IUUpdateSwitch(&FocusGotoSP, states, names, n);
-            FocusGotoSP.s = IPS_BUSY;
+            FocusGotoSP.update(states, names, n);
+            FocusGotoSP.setState(IPS_BUSY);
 
-            ISwitch *sp = IUFindOnSwitch(&FocusGotoSP);
+            ISwitch *sp = FocusGotoSP.findOnSwitch();
 
             // Min
             if (!strcmp(sp->name, "FOCUS_MIN"))
             {
                 targetTicks = currentPosition;
                 MoveRelFocuser(FOCUS_INWARD, currentPosition);
-                IDSetSwitch(&FocusGotoSP, "Moving focuser to minimum position...");
+                FocusGotoSP.apply("Moving focuser to minimum position...");
             }
             // Center
             else if (!strcmp(sp->name, "FOCUS_CENTER"))
             {
                 dispatch_command(FCENTR);
-                FocusAbsPosNP.s = IPS_BUSY;
-                FocusRelPosNP.s = IPS_BUSY;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
-                IDSetNumber(&FocusRelPosNP, nullptr);
-                IDSetSwitch(&FocusGotoSP, "Moving focuser to center position %d...", isTCFS3 ? 5000 : 3500);
+                FocusAbsPosNP.setState(IPS_BUSY);
+                FocusRelPosNP.setState(IPS_BUSY);
+                FocusAbsPosNP.apply();
+                FocusRelPosNP.apply();
+                FocusGotoSP.apply("Moving focuser to center position %d...", isTCFS3 ? 5000 : 3500);
                 return true;
             }
             // Max
             else if (!strcmp(sp->name, "FOCUS_MAX"))
             {
                 unsigned int delta = 0;
-                delta              = FocusAbsPosN[0].max - currentPosition;
+                delta              = FocusAbsPosNP[0].max - currentPosition;
                 MoveRelFocuser(FOCUS_OUTWARD, delta);
-                IDSetSwitch(&FocusGotoSP, "Moving focuser to maximum position %g...", FocusAbsPosN[0].max);
+                FocusGotoSP.apply("Moving focuser to maximum position %g...", FocusAbsPosNP[0].max);
             }
             // Home
             else if (!strcmp(sp->name, "FOCUS_HOME"))
@@ -705,32 +705,32 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
 
                 if (strcmp(response, "DONE") == 0)
                 {
-                    IUResetSwitch(&FocusGotoSP);
-                    FocusGotoSP.s = IPS_OK;
-                    IDSetSwitch(&FocusGotoSP, "Moving focuser to new calculated position based on temperature...");
+                    FocusGotoSP.reset();
+                    FocusGotoSP.setState(IPS_OK);
+                    FocusGotoSP.apply("Moving focuser to new calculated position based on temperature...");
                     return true;
                 }
                 else
                 {
-                    IUResetSwitch(&FocusGotoSP);
-                    FocusGotoSP.s = IPS_ALERT;
-                    IDSetSwitch(&FocusGotoSP, "Failed to move focuser to home position!");
+                    FocusGotoSP.reset();
+                    FocusGotoSP.setState(IPS_ALERT);
+                    FocusGotoSP.apply("Failed to move focuser to home position!");
                     return true;
                 }
             }
 
-            IDSetSwitch(&FocusGotoSP, nullptr);
+            FocusGotoSP.apply();
             return true;
         }
         // handle quiet mode on/off
-        if (!strcmp(FocusTelemetrySP.name, name))
+        if (FocusTelemetrySP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FocusTelemetrySP, states, names, n);
+            FocusTelemetrySP.update(states, names, n);
 
 
             bool quiet = false;
 
-            ISwitch *sp = IUFindOnSwitch(&FocusTelemetrySP);
+            ISwitch *sp = FocusTelemetrySP.findOnSwitch();
 
             // Telemetry off
             if (!strcmp(sp->name, "FOCUS_TELEMETRY_OFF"))
@@ -744,9 +744,9 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
 
             if (read_tcfs(response) == false)
             {
-                IUResetSwitch(&FocusTelemetrySP);
-                FocusTelemetrySP.s = IPS_ALERT;
-                IDSetSwitch(&FocusTelemetrySP, "Error reading TCF-S reply.");
+                FocusTelemetrySP.reset();
+                FocusTelemetrySP.setState(IPS_ALERT);
+                FocusTelemetrySP.apply("Error reading TCF-S reply.");
                 return true;
             }
 
@@ -755,20 +755,19 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
 
             if (strcmp(response, "DONE") == 0)
             {
-                FocusTelemetrySP.s = IPS_OK;
-                IDSetSwitch(&FocusTelemetrySP,
-                            quiet ? "Focuser Telemetry is off." : "Focuser Telemetry is on.");
+                FocusTelemetrySP.setState(IPS_OK);
+                FocusTelemetrySP.apply(quiet ? "Focuser Telemetry is off." : "Focuser Telemetry is on.");
                 //                if (FocusTemperatureNP)
                 {
-                    FocusTemperatureNP.s = quiet ? IPS_IDLE : IPS_OK;
-                    IDSetNumber(&FocusTemperatureNP, nullptr);
+                    FocusTemperatureNP.setState(quiet ? IPS_IDLE : IPS_OK);
+                    FocusTemperatureNP.apply();
                 }
                 return true;
             }
             else
             {
-                FocusTelemetrySP.s = IPS_ALERT;
-                IDSetSwitch(&FocusTelemetrySP, "Focuser telemetry mode failed. Response: %s.", response);
+                FocusTelemetrySP.setState(IPS_ALERT);
+                FocusTelemetrySP.apply("Focuser telemetry mode failed. Response: %s.", response);
                 return true;
             }
         }
@@ -785,7 +784,7 @@ IPState TCFS::MoveAbsFocuser(uint32_t targetTicks)
 
 IPState TCFS::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
-    //    if (FocusModeSP.sp[0].s != ISS_ON)
+    //    if (FocusModeSP[0].s != ISS_ON)
     //    {
     //        LOG_WARN("The focuser can only be moved in Manual mode.");
     //        return IPS_ALERT;
@@ -819,25 +818,25 @@ IPState TCFS::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
         LOGF_DEBUG("Moving outward by %d steps to position %d", targetTicks, targetPosition);
     }
 
-    FocusAbsPosNP.s = IPS_BUSY;
-    FocusRelPosNP.s = IPS_BUSY;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
+    FocusAbsPosNP.setState(IPS_BUSY);
+    FocusRelPosNP.setState(IPS_BUSY);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
 
     simulated_position = targetPosition;
     if(prevMode != MANUAL)
     {
-        IUResetSwitch(&FocusModeSP);
+        FocusModeSP.reset();
         if (prevMode == MODE_A)
         {
-            FocusModeSP.sp[1].s = ISS_ON;
+            FocusModeSP[1].setState(ISS_ON);
         }
         else
         {
-            FocusModeSP.sp[2].s = ISS_ON;
+            FocusModeSP[2].setState(ISS_ON);
         }
-        FocusModeSP.s = IPS_BUSY;
-        IDSetSwitch(&FocusModeSP, nullptr);
+        FocusModeSP.setState(IPS_BUSY);
+        FocusModeSP.apply();
     }
 
     return IPS_BUSY;
@@ -970,7 +969,7 @@ void TCFS::TimerHit()
     char response[TCFS_MAX_CMD] = { 0 };
     // If focuser is moving wait until "*" is received
     // Then set moving indicator to OK
-    if (FocusRelPosNP.s == IPS_BUSY)
+    if (FocusRelPosNP.getState() == IPS_BUSY)
     {
         LOGF_DEBUG("%s Motion in Progress...", __FUNCTION__);
         if (read_tcfs(response, true) == false)
@@ -981,32 +980,32 @@ void TCFS::TimerHit()
         LOGF_DEBUG("%s READY %s", __FUNCTION__, response );
         if(strcmp(response, "*") == 0)
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
 
             // If the focuser has stopped moving and auto mode is requested then
             // it is ok to set it now
-            if(FocusModeSP.s == IPS_BUSY &&  // Had to move before going Auto
-                    (FocusModeSP.sp[1].s == ISS_ON || FocusModeSP.sp[2].s == ISS_ON))
+            if(FocusModeSP.getState() == IPS_BUSY &&  // Had to move before going Auto
+                    (FocusModeSP[1].s == ISS_ON || FocusModeSP[2].s == ISS_ON))
             {
-                const char* mode = (FocusModeSP.sp[1].s == ISS_ON) ? "A" : "B";
+                const char* mode = (FocusModeSP[1].s == ISS_ON) ? "A" : "B";
                 dispatch_command(
-                    (FocusModeSP.sp[1].s == ISS_ON) ? FAMODE : FBMODE);
+                    (FocusModeSP[1].s == ISS_ON) ? FAMODE : FBMODE);
                 read_tcfs(response);
                 if (!isSimulation() && strcmp(response, mode) != 0)
                 {
-                    IUResetSwitch(&FocusModeSP);
-                    FocusModeSP.s = IPS_ALERT;
-                    IDSetSwitch(&FocusModeSP, "Error switching to Auto Mode %s. No reply from TCF-S. Try again.", mode);
+                    FocusModeSP.reset();
+                    FocusModeSP.setState(IPS_ALERT);
+                    FocusModeSP.apply("Error switching to Auto Mode %s. No reply from TCF-S. Try again.", mode);
                     SetTimer(getCurrentPollingPeriod());
                     return;
                 }
-                FocusModeSP.s = IPS_OK;
+                FocusModeSP.setState(IPS_OK);
                 LOGF_INFO("Entered Auto Mode %s", mode);
-                currentMode = (FocusModeSP.sp[1].s == ISS_ON) ? MODE_A : MODE_B;
-                IDSetSwitch(&FocusModeSP, nullptr);
+                currentMode = (FocusModeSP[1].s == ISS_ON) ? MODE_A : MODE_B;
+                FocusModeSP.apply();
             }
             SetTimer(getCurrentPollingPeriod());
             return;
@@ -1018,7 +1017,7 @@ void TCFS::TimerHit()
 
     if(!isSimulation() && currentMode != MANUAL)
     {
-        if (FocusTelemetrySP.sp[1].s == ISS_ON)
+        if (FocusTelemetrySP[1].s == ISS_ON)
         {
             LOGF_DEBUG("%s %s", __FUNCTION__, "Telemetry is off");
             SetTimer(getCurrentPollingPeriod());
@@ -1038,17 +1037,17 @@ void TCFS::TimerHit()
                 if (lastPosition != currentPosition)
                 {
                     lastPosition = currentPosition;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
+                    FocusAbsPosNP.apply();
                 }
             }
             else if(sscanf(response, "T=%f", &f_temperature) == 1)
             {
-                FocusTemperatureNP.np[0].value = f_temperature;
+                FocusTemperatureNP[0].setValue(f_temperature);
 
-                if (lastTemperature != FocusTemperatureNP.np[0].value)
+                if (lastTemperature != FocusTemperatureNP[0].getValue())
                 {
-                    lastTemperature = FocusTemperatureNP.np[0].value;
-                    IDSetNumber(&FocusTemperatureNP, nullptr);
+                    lastTemperature = FocusTemperatureNP[0].getValue();
+                    FocusTemperatureNP.apply();
                 }
             }
         }
@@ -1056,9 +1055,9 @@ void TCFS::TimerHit()
         return;
     }
 
-    if (FocusGotoSP.s == IPS_BUSY)
+    if (FocusGotoSP.getState() == IPS_BUSY)
     {
-        ISwitch *sp = IUFindOnSwitch(&FocusGotoSP);
+        ISwitch *sp = FocusGotoSP.findOnSwitch();
 
         if (sp != nullptr && strcmp(sp->name, "FOCUS_CENTER") == 0)
         {
@@ -1075,22 +1074,22 @@ void TCFS::TimerHit()
 
             if (strcmp(response, "CENTER") == 0)
             {
-                IUResetSwitch(&FocusGotoSP);
-                FocusGotoSP.s  = IPS_OK;
-                FocusAbsPosNP.s = IPS_OK;
+                FocusGotoSP.reset();
+                FocusGotoSP.setState(IPS_OK);
+                FocusAbsPosNP.setState(IPS_OK);
 
-                IDSetSwitch(&FocusGotoSP, nullptr);
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusGotoSP.apply();
+                FocusAbsPosNP.apply();
 
                 LOG_INFO("Focuser moved to center position.");
             }
         }
     }
 
-    switch (FocusAbsPosNP.s)
+    switch (FocusAbsPosNP.getState())
     {
         case IPS_OK:
-            if (FocusModeSP.sp[0].s == ISS_ON)
+            if (FocusModeSP[0].s == ISS_ON)
                 dispatch_command(FPOSRO);
 
             if (read_tcfs(response) == false)
@@ -1108,7 +1107,7 @@ void TCFS::TimerHit()
             if (lastPosition != currentPosition)
             {
                 lastPosition = currentPosition;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusAbsPosNP.apply();
             }
             break;
 
@@ -1133,18 +1132,18 @@ void TCFS::TimerHit()
             if (strcmp(response, "*") == 0)
             {
                 LOGF_DEBUG("Moving focuser %d steps to position %d.", targetTicks, targetPosition);
-                FocusAbsPosNP.s = IPS_OK;
-                FocusRelPosNP.s = IPS_OK;
-                FocusGotoSP.s  = IPS_OK;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
-                IDSetNumber(&FocusRelPosNP, nullptr);
-                IDSetSwitch(&FocusGotoSP, nullptr);
+                FocusAbsPosNP.setState(IPS_OK);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusGotoSP.setState(IPS_OK);
+                FocusAbsPosNP.apply();
+                FocusRelPosNP.apply();
+                FocusGotoSP.apply();
             }
             else
             {
-                FocusAbsPosNP.s = IPS_ALERT;
+                FocusAbsPosNP.setState(IPS_ALERT);
                 LOGF_ERROR("Unable to read response from focuser #%s#.", response);
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusAbsPosNP.apply();
             }
             break;
 
@@ -1152,17 +1151,17 @@ void TCFS::TimerHit()
             break;
     }
 
-    if (FocusTemperatureNP.s == IPS_OK || FocusTemperatureNP.s == IPS_BUSY)
+    if (FocusTemperatureNP.getState() == IPS_OK || FocusTemperatureNP.getState() == IPS_BUSY)
     {
         // Read Temperature
         // Manual Mode
-        if (FocusModeSP.sp[0].s == ISS_ON)
+        if (FocusModeSP[0].s == ISS_ON)
             dispatch_command(FTMPRO);
 
         if (read_tcfs(response) == false)
         {
-            FocusTemperatureNP.s = IPS_ALERT;
-            IDSetNumber(&FocusTemperatureNP, nullptr);
+            FocusTemperatureNP.setState(IPS_ALERT);
+            FocusTemperatureNP.apply();
             LOG_ERROR("Failed to read temperature. Is sensor connected?");
 
             SetTimer(getCurrentPollingPeriod());
@@ -1176,19 +1175,19 @@ void TCFS::TimerHit()
 
         if (rc == 1)
         {
-            FocusTemperatureNP.np[0].value = f_temperature;
+            FocusTemperatureNP[0].setValue(f_temperature);
 
-            if (fabs(lastTemperature - FocusTemperatureNP.np[0].value) > 0.01)
+            if (fabs(lastTemperature - FocusTemperatureNP[0].getValue()) > 0.01)
             {
-                lastTemperature = FocusTemperatureNP.np[0].value;
-                IDSetNumber(&FocusTemperatureNP, nullptr);
+                lastTemperature = FocusTemperatureNP[0].getValue();
+                FocusTemperatureNP.apply();
             }
         }
         else
         {
-            FocusTemperatureNP.s = IPS_ALERT;
+            FocusTemperatureNP.setState(IPS_ALERT);
             LOGF_ERROR("Failed to read temperature: %s", response);
-            IDSetNumber(&FocusTemperatureNP, nullptr);
+            FocusTemperatureNP.apply();
         }
     }
 

--- a/drivers/focuser/tcfs.h
+++ b/drivers/focuser/tcfs.h
@@ -25,6 +25,10 @@
 
 #include <string>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 #define TCFS_MAX_CMD      16
 #define TCFS_ERROR_BUFFER 1024
 
@@ -93,22 +97,14 @@ class TCFS : public INDI::Focuser
     bool read_tcfs(char *response, bool silent = false);
     bool dispatch_command(TCFSCommand command_type, int val=0, TCFSMode m=MANUAL);
 
-    INumber FocusModeAN[3];
-    INumberVectorProperty FocusModeANP;
-    INumber FocusModeBN[3];
-    INumberVectorProperty FocusModeBNP;
-    ISwitch FocusTelemetryS[2];
-    ISwitchVectorProperty FocusTelemetrySP;
-    ISwitch FocusModeS[3];
-    ISwitchVectorProperty FocusModeSP;
-    ISwitch FocusPowerS[2];
-    ISwitchVectorProperty FocusPowerSP;
-    ISwitch FocusGotoS[4];
-    ISwitchVectorProperty FocusGotoSP;
-    INumber FocusTemperatureN[1];
-    INumberVectorProperty FocusTemperatureNP;
-    ISwitch FocusStartModeS[3];
-    ISwitchVectorProperty FocusStartModeSP;
+    INDI::PropertyNumber FocusModeANP {3};
+    INDI::PropertyNumber FocusModeBNP {3};
+    INDI::PropertySwitch FocusTelemetrySP {2};
+    INDI::PropertySwitch FocusModeSP {3};
+    INDI::PropertySwitch FocusPowerSP {2};
+    INDI::PropertySwitch FocusGotoSP {4};
+    INDI::PropertyNumber FocusTemperatureNP {1};
+    INDI::PropertySwitch FocusStartModeSP {3};
 
     unsigned int simulated_position { 3000 };
     float simulated_temperature { 25.4 };

--- a/drivers/focuser/usbfocusv3.cpp
+++ b/drivers/focuser/usbfocusv3.cpp
@@ -100,86 +100,86 @@ bool USBFocusV3::initProperties()
 
     /*** init driver parameters ***/
 
-    FocusSpeedN[0].min   = 1;
-    FocusSpeedN[0].max   = 3;
-    FocusSpeedN[0].value = 2;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(3);
+    FocusSpeedNP[0].setValue(2);
 
     // Step Mode
-    IUFillSwitch(&StepModeS[UFOPHSTEPS], "HALF", "Half Step", ISS_ON);
-    IUFillSwitch(&StepModeS[UFOPFSTEPS], "FULL", "Full Step", ISS_OFF);
-    IUFillSwitchVector(&StepModeSP, StepModeS, 2, getDeviceName(), "STEP_MODE", "Step Mode", OPTIONS_TAB, IP_RW,
+    StepModeSP[UFOPHSTEPS].fill("HALF", "Half Step", ISS_ON);
+    StepModeSP[UFOPFSTEPS].fill("FULL", "Full Step", ISS_OFF);
+    StepModeSP.fill(getDeviceName(), "STEP_MODE", "Step Mode", OPTIONS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Direction
-    IUFillSwitch(&RotDirS[UFOPSDIR], "STANDARD", "Standard rotation", ISS_ON);
-    IUFillSwitch(&RotDirS[UFOPRDIR], "REVERSE", "Reverse rotation", ISS_OFF);
-    IUFillSwitchVector(&RotDirSP, RotDirS, 2, getDeviceName(), "ROTATION_MODE", "Rotation Mode", OPTIONS_TAB, IP_RW,
+    RotDirSP[UFOPSDIR].fill("STANDARD", "Standard rotation", ISS_ON);
+    RotDirSP[UFOPRDIR].fill("REVERSE", "Reverse rotation", ISS_OFF);
+    RotDirSP.fill(getDeviceName(), "ROTATION_MODE", "Rotation Mode", OPTIONS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Focuser temperature
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50., 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Maximum Position
-    IUFillNumber(&MaxPositionN[0], "MAXPOSITION", "Maximum position", "%5.0f", 1., 65535., 0., 65535.);
-    IUFillNumberVector(&MaxPositionNP, MaxPositionN, 1, getDeviceName(), "FOCUS_MAXPOSITION", "Max. Position",
+    MaxPositionNP[0].fill("MAXPOSITION", "Maximum position", "%5.0f", 1., 65535., 0., 65535.);
+    MaxPositionNP.fill(getDeviceName(), "FOCUS_MAXPOSITION", "Max. Position",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Temperature Settings
-    IUFillNumber(&TemperatureSettingN[0], "COEFFICIENT", "Coefficient", "%3.0f", 0., 999., 1., 15.);
-    IUFillNumber(&TemperatureSettingN[1], "THRESHOLD", "Threshold", "%3.0f", 0., 999., 1., 10.);
-    IUFillNumberVector(&TemperatureSettingNP, TemperatureSettingN, 2, getDeviceName(), "TEMPERATURE_SETTINGS",
+    TemperatureSettingNP[0].fill("COEFFICIENT", "Coefficient", "%3.0f", 0., 999., 1., 15.);
+    TemperatureSettingNP[1].fill("THRESHOLD", "Threshold", "%3.0f", 0., 999., 1., 10.);
+    TemperatureSettingNP.fill(getDeviceName(), "TEMPERATURE_SETTINGS",
                        "Temp. Settings", OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Temperature Compensation Sign
-    IUFillSwitch(&TempCompSignS[UFOPNSIGN], "NEGATIVE", "Negative", ISS_OFF);
-    IUFillSwitch(&TempCompSignS[UFOPPSIGN], "POSITIVE", "Positive", ISS_ON);
-    IUFillSwitchVector(&TempCompSignSP, TempCompSignS, 2, getDeviceName(), "TCOMP_SIGN", "TComp. Sign", OPTIONS_TAB,
+    TempCompSignSP[UFOPNSIGN].fill("NEGATIVE", "Negative", ISS_OFF);
+    TempCompSignSP[UFOPPSIGN].fill("POSITIVE", "Positive", ISS_ON);
+    TempCompSignSP.fill(getDeviceName(), "TCOMP_SIGN", "TComp. Sign", OPTIONS_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Compensate for temperature
-    IUFillSwitch(&TemperatureCompensateS[0], "ENABLE", "Enable", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[1], "DISABLE", "Disable", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "TEMP_COMPENSATION",
+    TemperatureCompensateSP[0].fill("ENABLE", "Enable", ISS_OFF);
+    TemperatureCompensateSP[1].fill("DISABLE", "Disable", ISS_ON);
+    TemperatureCompensateSP.fill(getDeviceName(), "TEMP_COMPENSATION",
                        "Temp. Comp.", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Compensate for temperature
-    //    IUFillSwitch(&BacklashDirectionS[BACKLASH_IN], "IN", "In", ISS_OFF);
-    //    IUFillSwitch(&BacklashDirectionS[BACKLASH_OUT], "OUT", "Out", ISS_ON);
-    //    IUFillSwitchVector(&BacklashDirectionSP, BacklashDirectionS, 2, getDeviceName(), "BACKLASH_DIRECTION",
+    //    BacklashDirectionSP[BACKLASH_IN].fill("IN", "In", ISS_OFF);
+    //    BacklashDirectionSP[BACKLASH_OUT].fill("OUT", "Out", ISS_ON);
+    //    BacklashDirectionSP.fill(getDeviceName(), "BACKLASH_DIRECTION",
     //                       "Backlash direction", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     //    // Backlash compensation steps
-    //    IUFillNumber(&BacklashSettingN[0], "FOCUS_BACKLASH_VALUE", "Steps", "%5.0f", 0., 65535., 1., 0.);
-    //    IUFillNumberVector(&BacklashSettingNP, BacklashSettingN, 1, getDeviceName(), "FOCUS_BACKLASH_STEPS", "Backlash steps",
+    //    BacklashSettingNP[0].fill("FOCUS_BACKLASH_VALUE", "Steps", "%5.0f", 0., 65535., 1., 0.);
+    //    BacklashSettingNP.fill(getDeviceName(), "FOCUS_BACKLASH_STEPS", "Backlash steps",
     //                       OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
-    FocusBacklashN[0].min = -65535.;
-    FocusBacklashN[0].max = 65535.;
-    FocusBacklashN[0].step = 1000.;
-    FocusBacklashN[0].value = 0.;
+    FocusBacklashNP[0].setMin(-65535.);
+    FocusBacklashNP[0].setMax(65535.);
+    FocusBacklashNP[0].setStep(1000.);
+    FocusBacklashNP[0].setValue(0.);
 
     // Reset
-    IUFillSwitch(&ResetS[0], "RESET", "Reset", ISS_OFF);
-    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "RESET", "Reset", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
+    ResetSP[0].fill("RESET", "Reset", ISS_OFF);
+    ResetSP.fill(getDeviceName(), "RESET", "Reset", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Firmware version
-    IUFillNumber(&FWversionN[0], "FIRMWARE", "Firmware Version", "%5.0f", 0., 65535., 1., 0.);
-    IUFillNumberVector(&FWversionNP, FWversionN, 1, getDeviceName(), "FW_VERSION", "Firmware", OPTIONS_TAB, IP_RO, 0,
+    FWversionNP[0].fill("FIRMWARE", "Firmware Version", "%5.0f", 0., 65535., 1., 0.);
+    FWversionNP.fill(getDeviceName(), "FW_VERSION", "Firmware", OPTIONS_TAB, IP_RO, 0,
                        IPS_IDLE);
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = float(maxpos);
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(float(maxpos));
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1);
 
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = float(maxpos);
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(float(maxpos));
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1);
 
     addDebugControl();
 
@@ -194,18 +194,18 @@ bool USBFocusV3::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&TemperatureNP);
-        defineProperty(&MaxPositionNP);
-        defineProperty(&StepModeSP);
-        defineProperty(&RotDirSP);
-        defineProperty(&MaxPositionNP);
-        defineProperty(&TemperatureSettingNP);
-        defineProperty(&TempCompSignSP);
-        defineProperty(&TemperatureCompensateSP);
-        //        defineProperty(&BacklashDirectionSP);
-        //        defineProperty(&BacklashSettingNP);
-        defineProperty(&ResetSP);
-        defineProperty(&FWversionNP);
+        defineProperty(TemperatureNP);
+        defineProperty(MaxPositionNP);
+        defineProperty(StepModeSP);
+        defineProperty(RotDirSP);
+        defineProperty(MaxPositionNP);
+        defineProperty(TemperatureSettingNP);
+        defineProperty(TempCompSignSP);
+        defineProperty(TemperatureCompensateSP);
+        //        defineProperty(BacklashDirectionSP);
+        //        defineProperty(BacklashSettingNP);
+        defineProperty(ResetSP);
+        defineProperty(FWversionNP);
 
         GetFocusParams();
 
@@ -215,17 +215,17 @@ bool USBFocusV3::updateProperties()
     }
     else
     {
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(MaxPositionNP.name);
-        deleteProperty(StepModeSP.name);
-        deleteProperty(RotDirSP.name);
-        deleteProperty(TemperatureSettingNP.name);
-        deleteProperty(TempCompSignSP.name);
-        deleteProperty(TemperatureCompensateSP.name);
-        //        deleteProperty(BacklashDirectionSP.name);
-        //        deleteProperty(BacklashSettingNP.name);
-        deleteProperty(ResetSP.name);
-        deleteProperty(FWversionNP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(MaxPositionNP.getName());
+        deleteProperty(StepModeSP.getName());
+        deleteProperty(RotDirSP.getName());
+        deleteProperty(TemperatureSettingNP.getName());
+        deleteProperty(TempCompSignSP.getName());
+        deleteProperty(TemperatureCompensateSP.getName());
+        //        deleteProperty(BacklashDirectionSP.getName());
+        //        deleteProperty(BacklashSettingNP.getName());
+        deleteProperty(ResetSP.getName());
+        deleteProperty(FWversionNP.getName());
     }
 
     return true;
@@ -413,12 +413,12 @@ bool USBFocusV3::getControllerStatus()
 
 bool USBFocusV3::updateStepMode()
 {
-    IUResetSwitch(&StepModeSP);
+    StepModeSP.reset();
 
     if (stepmode == UFOPHSTEPS)
-        StepModeS[UFOPHSTEPS].s = ISS_ON;
+        StepModeSP[UFOPHSTEPS].setState(ISS_ON);
     else if (stepmode == UFOPFSTEPS)
-        StepModeS[UFOPFSTEPS].s = ISS_ON;
+        StepModeSP[UFOPFSTEPS].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: focuser step value (%d)", stepmode);
@@ -430,12 +430,12 @@ bool USBFocusV3::updateStepMode()
 
 bool USBFocusV3::updateRotDir()
 {
-    IUResetSwitch(&RotDirSP);
+    RotDirSP.reset();
 
     if (direction == UFOPSDIR)
-        RotDirS[UFOPSDIR].s = ISS_ON;
+        RotDirSP[UFOPSDIR].setState(ISS_ON);
     else if (direction == UFOPRDIR)
-        RotDirS[UFOPRDIR].s = ISS_ON;
+        RotDirSP[UFOPRDIR].setState(ISS_ON);
     else
     {
         LOGF_ERROR("Unknown error: rotation direction  (%d)", direction);
@@ -463,7 +463,7 @@ bool USBFocusV3::updateTemperature()
 
             if (rc > 0)
             {
-                TemperatureN[0].value = temp;
+                TemperatureNP[0].setValue(temp);
                 break;
             }
             else
@@ -484,7 +484,7 @@ bool USBFocusV3::updateTemperature()
 
 bool USBFocusV3::updateFWversion()
 {
-    FWversionN[0].value = firmware;
+    FWversionNP[0].setValue(firmware);
     return true;
 }
 
@@ -506,7 +506,7 @@ bool USBFocusV3::updatePosition()
 
             if (rc > 0)
             {
-                FocusAbsPosN[0].value = pos;
+                FocusAbsPosNP[0].setValue(pos);
                 break;
             }
             else
@@ -527,15 +527,15 @@ bool USBFocusV3::updatePosition()
 
 bool USBFocusV3::updateMaxPos()
 {
-    MaxPositionN[0].value = maxpos;
-    FocusAbsPosN[0].max   = maxpos;
+    MaxPositionNP[0].setValue(maxpos);
+    FocusAbsPosNP[0].setMax(maxpos);
     return true;
 }
 
 bool USBFocusV3::updateTempCompSettings()
 {
-    TemperatureSettingN[0].value = stepsdeg;
-    TemperatureSettingN[1].value = tcomp_thr;
+    TemperatureSettingNP[0].setValue(stepsdeg);
+    TemperatureSettingNP[1].setValue(tcomp_thr);
     return true;
 }
 
@@ -553,12 +553,12 @@ bool USBFocusV3::updateTempCompSign()
 
     if (rc > 0)
     {
-        IUResetSwitch(&TempCompSignSP);
+        TempCompSignSP.reset();
 
         if (sign == UFOPNSIGN)
-            TempCompSignS[UFOPNSIGN].s = ISS_ON;
+            TempCompSignSP[UFOPNSIGN].setState(ISS_ON);
         else if (sign == UFOPPSIGN)
-            TempCompSignS[UFOPPSIGN].s = ISS_ON;
+            TempCompSignSP[UFOPPSIGN].setState(ISS_ON);
         else
         {
             LOGF_ERROR("Unknown error: temp. comp. sign  (%d)", sign);
@@ -597,7 +597,7 @@ bool USBFocusV3::updateSpeed()
     if (drvspeed != 0)
     {
         currentSpeed         = drvspeed;
-        FocusSpeedN[0].value = drvspeed;
+        FocusSpeedNP[0].setValue(drvspeed);
     }
     else
     {
@@ -665,14 +665,14 @@ bool USBFocusV3::MoveFocuserUF(FocusDirection dir, unsigned int rticks)
 
     unsigned int ticks;
 
-    if ((dir == FOCUS_INWARD) && (rticks > FocusAbsPosN[0].value))
+    if ((dir == FOCUS_INWARD) && (rticks > FocusAbsPosNP[0].getValue()))
     {
-        ticks = FocusAbsPosN[0].value;
+        ticks = FocusAbsPosNP[0].getValue();
         LOGF_WARN("Requested %u ticks but inward movement has been limited to %u ticks", rticks, ticks);
     }
-    else if ((dir == FOCUS_OUTWARD) && ((FocusAbsPosN[0].value + rticks) > MaxPositionN[0].value))
+    else if ((dir == FOCUS_OUTWARD) && ((FocusAbsPosNP[0].value + rticks) > MaxPositionNP[0].getValue()))
     {
-        ticks = MaxPositionN[0].value - FocusAbsPosN[0].value;
+        ticks = MaxPositionNP[0].getValue() - FocusAbsPosNP[0].getValue();
         LOGF_WARN("Requested %u ticks but outward movement has been limited to %u ticks", rticks, ticks);
     }
     else
@@ -759,7 +759,7 @@ bool USBFocusV3::setMaxPos(unsigned int maxp)
     if (strncmp(resp, UFORSDONE, strlen(UFORSDONE)) == 0)
     {
         maxpos              = maxp;
-        FocusAbsPosN[0].max = maxpos;
+        FocusAbsPosNP[0].setMax(maxpos);
         return true;
     }
 
@@ -855,16 +855,16 @@ bool USBFocusV3::ISNewSwitch(const char *dev, const char *name, ISState *states,
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(StepModeSP.name, name) == 0)
+        if (StepModeSP.isNameMatch(name))
         {
             bool rc          = false;
-            int current_mode = IUFindOnSwitchIndex(&StepModeSP);
-            IUUpdateSwitch(&StepModeSP, states, names, n);
-            int target_mode = IUFindOnSwitchIndex(&StepModeSP);
+            int current_mode = StepModeSP.findOnSwitchIndex();
+            StepModeSP.update(states, names, n);
+            int target_mode = StepModeSP.findOnSwitchIndex();
             if (current_mode == target_mode)
             {
-                StepModeSP.s = IPS_OK;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.setState(IPS_OK);
+                StepModeSP.apply();
                 return true;
             }
 
@@ -875,115 +875,115 @@ bool USBFocusV3::ISNewSwitch(const char *dev, const char *name, ISState *states,
 
             if (!rc)
             {
-                IUResetSwitch(&StepModeSP);
-                StepModeS[current_mode].s = ISS_ON;
-                StepModeSP.s              = IPS_ALERT;
-                IDSetSwitch(&StepModeSP, nullptr);
+                StepModeSP.reset();
+                StepModeSP[current_mode].setState(ISS_ON);
+                StepModeSP.setState(IPS_ALERT);
+                StepModeSP.apply();
                 return false;
             }
 
-            StepModeSP.s = IPS_OK;
-            IDSetSwitch(&StepModeSP, nullptr);
+            StepModeSP.setState(IPS_OK);
+            StepModeSP.apply();
             return true;
         }
 
-        if (strcmp(RotDirSP.name, name) == 0)
+        if (RotDirSP.isNameMatch(name))
         {
             bool rc          = false;
-            int current_mode = IUFindOnSwitchIndex(&RotDirSP);
-            IUUpdateSwitch(&RotDirSP, states, names, n);
-            int target_mode = IUFindOnSwitchIndex(&RotDirSP);
+            int current_mode = RotDirSP.findOnSwitchIndex();
+            RotDirSP.update(states, names, n);
+            int target_mode = RotDirSP.findOnSwitchIndex();
             if (current_mode == target_mode)
             {
-                RotDirSP.s = IPS_OK;
-                IDSetSwitch(&RotDirSP, nullptr);
+                RotDirSP.setState(IPS_OK);
+                RotDirSP.apply();
                 return true;
             }
 
             rc = setRotDir(target_mode);
             if (!rc)
             {
-                IUResetSwitch(&RotDirSP);
-                RotDirS[current_mode].s = ISS_ON;
-                RotDirSP.s              = IPS_ALERT;
-                IDSetSwitch(&RotDirSP, nullptr);
+                RotDirSP.reset();
+                RotDirSP[current_mode].setState(ISS_ON);
+                RotDirSP.setState(IPS_ALERT);
+                RotDirSP.apply();
                 return false;
             }
 
-            RotDirSP.s = IPS_OK;
-            IDSetSwitch(&RotDirSP, nullptr);
+            RotDirSP.setState(IPS_OK);
+            RotDirSP.apply();
             return true;
         }
 
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int last_index = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
+            int last_index = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
 
-            bool rc = setTemperatureCompensation((TemperatureCompensateS[0].s == ISS_ON));
+            bool rc = setTemperatureCompensation((TemperatureCompensateSP[0].getState() == ISS_ON));
 
             if (!rc)
             {
-                TemperatureCompensateSP.s = IPS_ALERT;
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateS[last_index].s = ISS_ON;
-                IDSetSwitch(&TemperatureCompensateSP, nullptr);
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP[last_index].setState(ISS_ON);
+                TemperatureCompensateSP.apply();
                 return false;
             }
 
-            TemperatureCompensateSP.s = IPS_OK;
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.setState(IPS_OK);
+            TemperatureCompensateSP.apply();
             return true;
         }
 
-        if (strcmp(TempCompSignSP.name, name) == 0)
+        if (TempCompSignSP.isNameMatch(name))
         {
             bool rc          = false;
-            int current_mode = IUFindOnSwitchIndex(&TempCompSignSP);
-            IUUpdateSwitch(&TempCompSignSP, states, names, n);
-            int target_mode = IUFindOnSwitchIndex(&TempCompSignSP);
+            int current_mode = TempCompSignSP.findOnSwitchIndex();
+            TempCompSignSP.update(states, names, n);
+            int target_mode = TempCompSignSP.findOnSwitchIndex();
             if (current_mode == target_mode)
             {
-                TempCompSignSP.s = IPS_OK;
-                IDSetSwitch(&TempCompSignSP, nullptr);
+                TempCompSignSP.setState(IPS_OK);
+                TempCompSignSP.apply();
                 return true;
             }
 
             rc = setTempCompSign(target_mode);
             if (!rc)
             {
-                IUResetSwitch(&TempCompSignSP);
-                TempCompSignS[current_mode].s = ISS_ON;
-                TempCompSignSP.s              = IPS_ALERT;
-                IDSetSwitch(&TempCompSignSP, nullptr);
+                TempCompSignSP.reset();
+                TempCompSignSP[current_mode].setState(ISS_ON);
+                TempCompSignSP.setState(IPS_ALERT);
+                TempCompSignSP.apply();
                 return false;
             }
 
-            TempCompSignSP.s = IPS_OK;
-            IDSetSwitch(&TempCompSignSP, nullptr);
+            TempCompSignSP.setState(IPS_OK);
+            TempCompSignSP.apply();
             return true;
         }
 
-        //        if (strcmp(BacklashDirectionSP.name, name) == 0)
+        //        if (BacklashDirectionSP.isNameMatch(name))
         //        {
-        //            IUUpdateSwitch(&BacklashDirectionSP, states, names, n);
-        //            int target_direction  = IUFindOnSwitchIndex(&BacklashDirectionSP);
+        //            BacklashDirectionSP.update(states, names, n);
+        //            int target_direction  = BacklashDirectionSP.findOnSwitchIndex();
         //            backlashIn            = (target_direction == BACKLASH_IN);
-        //            BacklashDirectionSP.s = IPS_OK;
-        //            IDSetSwitch(&BacklashDirectionSP, nullptr);
+        //            BacklashDirectionSP.setState(IPS_OK);
+        //            BacklashDirectionSP.apply();
         //            return true;
         //        }
 
-        if (strcmp(ResetSP.name, name) == 0)
+        if (ResetSP.isNameMatch(name))
         {
-            IUResetSwitch(&ResetSP);
+            ResetSP.reset();
 
             if (reset())
-                ResetSP.s = IPS_OK;
+                ResetSP.setState(IPS_OK);
             else
-                ResetSP.s = IPS_ALERT;
+                ResetSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&ResetSP, nullptr);
+            ResetSP.apply();
             return true;
         }
     }
@@ -995,50 +995,50 @@ bool USBFocusV3::ISNewNumber(const char *dev, const char *name, double values[],
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, MaxPositionNP.name) == 0)
+        if (MaxPositionNP.isNameMatch(name))
         {
-            IUUpdateNumber(&MaxPositionNP, values, names, n);
-            if (!setMaxPos(MaxPositionN[0].value))
+            MaxPositionNP.update(values, names, n);
+            if (!setMaxPos(MaxPositionNP[0].value))
             {
-                MaxPositionNP.s = IPS_ALERT;
-                IDSetNumber(&MaxPositionNP, nullptr);
+                MaxPositionNP.setState(IPS_ALERT);
+                MaxPositionNP.apply();
                 return false;
             }
-            MaxPositionNP.s = IPS_OK;
-            IDSetNumber(&MaxPositionNP, nullptr);
+            MaxPositionNP.setState(IPS_OK);
+            MaxPositionNP.apply();
             return true;
         }
 
-        if (strcmp(name, TemperatureSettingNP.name) == 0)
+        if (TemperatureSettingNP.isNameMatch(name))
         {
-            IUUpdateNumber(&TemperatureSettingNP, values, names, n);
-            if (!setAutoTempCompThreshold(TemperatureSettingN[1].value) ||
-                    !setTemperatureCoefficient(TemperatureSettingN[UFOPNSIGN].value))
+            TemperatureSettingNP.update(values, names, n);
+            if (!setAutoTempCompThreshold(TemperatureSettingNP[1].value) ||
+                    !setTemperatureCoefficient(TemperatureSettingNP[UFOPNSIGN].value))
             {
-                TemperatureSettingNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureSettingNP, nullptr);
+                TemperatureSettingNP.setState(IPS_ALERT);
+                TemperatureSettingNP.apply();
                 return false;
             }
 
-            TemperatureSettingNP.s = IPS_OK;
-            IDSetNumber(&TemperatureSettingNP, nullptr);
+            TemperatureSettingNP.setState(IPS_OK);
+            TemperatureSettingNP.apply();
             return true;
         }
 
-        //        if (strcmp(name, BacklashSettingNP.name) == 0)
+        //        if (BacklashSettingNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&BacklashSettingNP, values, names, n);
-        //            backlashSteps       = std::round(BacklashSettingN[0].value);
-        //            BacklashSettingNP.s = IPS_OK;
-        //            IDSetNumber(&BacklashSettingNP, nullptr);
+        //            BacklashSettingNP.update(values, names, n);
+        //            backlashSteps       = std::round(BacklashSettingNP[0].value);
+        //            BacklashSettingNP.setState(IPS_OK);
+        //            BacklashSettingNP.apply();
         //            return true;
         //        }
 
-        if (strcmp(name, FWversionNP.name) == 0)
+        if (FWversionNP.isNameMatch(name))
         {
-            IUUpdateNumber(&FWversionNP, values, names, n);
-            FWversionNP.s = IPS_OK;
-            IDSetNumber(&FWversionNP, nullptr);
+            FWversionNP.update(values, names, n);
+            FWversionNP.setState(IPS_OK);
+            FWversionNP.apply();
             return true;
         }
     }
@@ -1051,34 +1051,34 @@ void USBFocusV3::GetFocusParams()
     getControllerStatus();
 
     if (updatePosition())
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     if (updateMaxPos())
     {
-        IDSetNumber(&MaxPositionNP, nullptr);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        MaxPositionNP.apply();
+        FocusAbsPosNP.apply();
     }
 
     if (updateTemperature())
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP.apply();
 
     if (updateTempCompSettings())
-        IDSetNumber(&TemperatureSettingNP, nullptr);
+        TemperatureSettingNP.apply();
 
     if (updateTempCompSign())
-        IDSetSwitch(&TempCompSignSP, nullptr);
+        TempCompSignSP.apply();
 
     if (updateSpeed())
-        IDSetNumber(&FocusSpeedNP, nullptr);
+        FocusSpeedNP.apply();
 
     if (updateStepMode())
-        IDSetSwitch(&StepModeSP, nullptr);
+        StepModeSP.apply();
 
     if (updateRotDir())
-        IDSetSwitch(&RotDirSP, nullptr);
+        RotDirSP.apply();
 
     if (updateFWversion())
-        IDSetNumber(&FWversionNP, nullptr);
+        FWversionNP.apply();
 }
 
 bool USBFocusV3::SetFocuserSpeed(int speed)
@@ -1092,8 +1092,8 @@ bool USBFocusV3::SetFocuserSpeed(int speed)
 
     currentSpeed = speed;
 
-    FocusSpeedNP.s = IPS_OK;
-    IDSetNumber(&FocusSpeedNP, nullptr);
+    FocusSpeedNP.setState(IPS_OK);
+    FocusSpeedNP.apply();
 
     return true;
 }
@@ -1104,7 +1104,7 @@ IPState USBFocusV3::MoveAbsFocuser(uint32_t targetTicks)
 
     targetPos = targetTicks;
 
-    ticks = targetPos - FocusAbsPosN[0].value;
+    ticks = targetPos - FocusAbsPosNP[0].getValue();
 
     bool rc = false;
 
@@ -1116,7 +1116,7 @@ IPState USBFocusV3::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -1126,16 +1126,16 @@ IPState USBFocusV3::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     bool rc = false;
     uint32_t aticks;
 
-    if ((dir == FOCUS_INWARD) && (ticks > FocusAbsPosN[0].value))
+    if ((dir == FOCUS_INWARD) && (ticks > FocusAbsPosNP[0].getValue()))
     {
-        aticks = FocusAbsPosN[0].value;
+        aticks = FocusAbsPosNP[0].getValue();
         DEBUGF(INDI::Logger::DBG_WARNING,
                "Requested %u ticks but relative inward movement has been limited to %u ticks", ticks, aticks);
         ticks = aticks;
     }
-    else if ((dir == FOCUS_OUTWARD) && ((FocusAbsPosN[0].value + ticks) > MaxPositionN[0].value))
+    else if ((dir == FOCUS_OUTWARD) && ((FocusAbsPosNP[0].value + ticks) > MaxPositionNP[0].getValue()))
     {
-        aticks = MaxPositionN[0].value - FocusAbsPosN[0].value;
+        aticks = MaxPositionNP[0].getValue() - FocusAbsPosNP[0].getValue();
         DEBUGF(INDI::Logger::DBG_WARNING,
                "Requested %u ticks but relative outward movement has been limited to %u ticks", ticks, aticks);
         ticks = aticks;
@@ -1146,8 +1146,8 @@ IPState USBFocusV3::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s       = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -1163,10 +1163,10 @@ void USBFocusV3::TimerHit()
 
     if (rc)
     {
-        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        if (fabs(lastPos - FocusAbsPosNP[0].getValue()) > 5)
         {
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            lastPos = FocusAbsPosN[0].value;
+            FocusAbsPosNP.apply();
+            lastPos = FocusAbsPosNP[0].getValue();
         }
     }
 
@@ -1174,32 +1174,32 @@ void USBFocusV3::TimerHit()
 
     if (rc)
     {
-        if (fabs(lastTemperature - TemperatureN[0].value) >= 0.5)
+        if (fabs(lastTemperature - TemperatureNP[0].getValue()) >= 0.5)
         {
-            IDSetNumber(&TemperatureNP, nullptr);
-            lastTemperature = TemperatureN[0].value;
+            TemperatureNP.apply();
+            lastTemperature = TemperatureNP[0].getValue();
         }
     }
 
-    if (FocusTimerNP.s == IPS_BUSY)
+    if (FocusTimerNP.getState() == IPS_BUSY)
     {
         float remaining = CalcTimeLeft(focusMoveStart, focusMoveRequest);
 
         if (remaining <= 0)
         {
-            FocusTimerNP.s       = IPS_OK;
-            FocusTimerN[0].value = 0;
+            FocusTimerNP.setState(IPS_OK);
+            FocusTimerNP[0].setValue(0);
             AbortFocuser();
         }
         else
-            FocusTimerN[0].value = remaining * 1000.0;
+            FocusTimerNP[0].setValue(remaining * 1000.0);
 
-        IDSetNumber(&FocusTimerNP, nullptr);
+        FocusTimerNP.apply();
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
-        if (backlashMove && (fabs(backlashTargetPos - FocusAbsPosN[0].value) < 1))
+        if (backlashMove && (fabs(backlashTargetPos - FocusAbsPosNP[0].getValue()) < 1))
         {
             // Backlash target reached, now go to real target
             MoveAbsFocuser(targetPos);
@@ -1207,13 +1207,13 @@ void USBFocusV3::TimerHit()
         }
         else
         {
-            if (fabs(targetPos - FocusAbsPosN[0].value) < 1)
+            if (fabs(targetPos - FocusAbsPosNP[0].getValue()) < 1)
             {
-                FocusAbsPosNP.s = IPS_OK;
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
-                IDSetNumber(&FocusRelPosNP, nullptr);
-                lastPos = FocusAbsPosN[0].value;
+                FocusAbsPosNP.setState(IPS_OK);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusAbsPosNP.apply();
+                FocusRelPosNP.apply();
+                lastPos = FocusAbsPosNP[0].getValue();
                 LOG_INFO("Focuser reached requested position.");
             }
         }
@@ -1228,10 +1228,10 @@ bool USBFocusV3::AbortFocuser()
     if (!sendCommand(UFOCABORT, resp))
         return false;
 
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocusRelPosNP.s = IPS_IDLE;
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetNumber(&FocusRelPosNP, nullptr);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocusRelPosNP.setState(IPS_IDLE);
+    FocusAbsPosNP.apply();
+    FocusRelPosNP.apply();
     backlashMove = false;
     moving       = false;
     return true;
@@ -1266,7 +1266,7 @@ bool USBFocusV3::SetFocuserBacklash(int32_t steps)
 //{
 //    INDI::Focuser::saveConfigItems(fp);
 
-//    IUSaveConfigNumber(fp, &BacklashSettingNP);
-//    IUSaveConfigSwitch(fp, &BacklashDirectionSP);
+//    BacklashSettingNP.save(fp);
+//    BacklashDirectionSP.save(fp);
 //    return true;
 //}

--- a/drivers/focuser/usbfocusv3.h
+++ b/drivers/focuser/usbfocusv3.h
@@ -23,6 +23,10 @@
 
 #include "indifocuser.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /***************************** USB Focus V3 Commands **************************/
 
 #define UFOCREADPARAM "SGETAL"
@@ -158,29 +162,22 @@ class USBFocusV3 : public INDI::Focuser
         };
         float focusMoveRequest{ 0 };
 
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
-        ISwitch StepModeS[2];
-        ISwitchVectorProperty StepModeSP;
+        INDI::PropertySwitch StepModeSP {2};
 
-        ISwitch RotDirS[2];
-        ISwitchVectorProperty RotDirSP;
+        INDI::PropertySwitch RotDirSP {2};
 
-        INumber MaxPositionN[1];
-        INumberVectorProperty MaxPositionNP;
+        INDI::PropertyNumber MaxPositionNP {1};
 
-        INumber TemperatureSettingN[2];
-        INumberVectorProperty TemperatureSettingNP;
+        INDI::PropertyNumber TemperatureSettingNP {2};
 
-        ISwitch TempCompSignS[2];
-        ISwitchVectorProperty TempCompSignSP;
+        INDI::PropertySwitch TempCompSignSP {2};
 
-        ISwitch TemperatureCompensateS[2];
-        ISwitchVectorProperty TemperatureCompensateSP;
+        INDI::PropertySwitch TemperatureCompensateSP {2};
 
-        //    INumber BacklashSettingN[1];
-        //    INumberVectorProperty BacklashSettingNP;
+        //    INDI::PropertyNumber BacklashSettingNP {1};
+        //
 
         typedef enum
         {
@@ -188,12 +185,10 @@ class USBFocusV3 : public INDI::Focuser
             BACKLASH_OUT = 1
         } BacklashDirection;
 
-        //    ISwitch BacklashDirectionS[2];
-        //    ISwitchVectorProperty BacklashDirectionSP;
+        //    INDI::PropertySwitch BacklashDirectionSP {2};
+        //
 
-        ISwitch ResetS[1];
-        ISwitchVectorProperty ResetSP;
+        INDI::PropertySwitch ResetSP {1};
 
-        INumber FWversionN[1];
-        INumberVectorProperty FWversionNP;
+        INDI::PropertyNumber FWversionNP {1};
 };

--- a/drivers/rotator/gemini.cpp
+++ b/drivers/rotator/gemini.cpp
@@ -126,119 +126,119 @@ bool Gemini::initProperties()
     // Focuser Properties
     ///////////////////////////////////////////////////////////
 
-    IUFillNumber(&TemperatureN[0], "TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("TEMPERATURE", "Celsius", "%6.2f", -50, 70., 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // Enable/Disable temperature compensation
-    IUFillSwitch(&TemperatureCompensateS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateSP, TemperatureCompensateS, 2, getDeviceName(), "T. Compensation", "",
+    TemperatureCompensateSP[0].fill("Enable", "", ISS_OFF);
+    TemperatureCompensateSP[1].fill("Disable", "", ISS_ON);
+    TemperatureCompensateSP.fill(getDeviceName(), "T. Compensation", "",
                        FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Enable/Disable temperature compensation on start
-    IUFillSwitch(&TemperatureCompensateOnStartS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateOnStartS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&TemperatureCompensateOnStartSP, TemperatureCompensateOnStartS, 2, getDeviceName(),
+    TemperatureCompensateOnStartSP[0].fill("Enable", "", ISS_OFF);
+    TemperatureCompensateOnStartSP[1].fill("Disable", "", ISS_ON);
+    TemperatureCompensateOnStartSP.fill(getDeviceName(),
                        "T. Compensation @Start", "", FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Temperature Coefficient
-    IUFillNumber(&TemperatureCoeffN[0], "A", "", "%.f", -9999, 9999, 100., 0.);
-    IUFillNumber(&TemperatureCoeffN[1], "B", "", "%.f", -9999, 9999, 100., 0.);
-    IUFillNumber(&TemperatureCoeffN[2], "C", "", "%.f", -9999, 9999, 100., 0.);
-    IUFillNumber(&TemperatureCoeffN[3], "D", "", "%.f", -9999, 9999, 100., 0.);
-    IUFillNumber(&TemperatureCoeffN[4], "E", "", "%.f", -9999, 9999, 100., 0.);
-    IUFillNumberVector(&TemperatureCoeffNP, TemperatureCoeffN, 5, getDeviceName(), "T. Coeff", "", FOCUS_SETTINGS_TAB,
+    TemperatureCoeffNP[0].fill("A", "", "%.f", -9999, 9999, 100., 0.);
+    TemperatureCoeffNP[1].fill("B", "", "%.f", -9999, 9999, 100., 0.);
+    TemperatureCoeffNP[2].fill("C", "", "%.f", -9999, 9999, 100., 0.);
+    TemperatureCoeffNP[3].fill("D", "", "%.f", -9999, 9999, 100., 0.);
+    TemperatureCoeffNP[4].fill("E", "", "%.f", -9999, 9999, 100., 0.);
+    TemperatureCoeffNP.fill(getDeviceName(), "T. Coeff", "", FOCUS_SETTINGS_TAB,
                        IP_RW, 0, IPS_IDLE);
 
     // Enable/Disable Home on Start
-    IUFillSwitch(&FocuserHomeOnStartS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&FocuserHomeOnStartS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&FocuserHomeOnStartSP, FocuserHomeOnStartS, 2, getDeviceName(), "FOCUSER_HOME_ON_START", "Home on Start",
+    FocuserHomeOnStartSP[0].fill("Enable", "", ISS_OFF);
+    FocuserHomeOnStartSP[1].fill("Disable", "", ISS_ON);
+    FocuserHomeOnStartSP.fill(getDeviceName(), "FOCUSER_HOME_ON_START", "Home on Start",
                        FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Enable/Disable temperature Mode
-    IUFillSwitch(&TemperatureCompensateModeS[0], "A", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[1], "B", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[2], "C", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[3], "D", "", ISS_OFF);
-    IUFillSwitch(&TemperatureCompensateModeS[4], "E", "", ISS_OFF);
-    IUFillSwitchVector(&TemperatureCompensateModeSP, TemperatureCompensateModeS, 5, getDeviceName(), "Compensate Mode",
+    TemperatureCompensateModeSP[0].fill("A", "", ISS_OFF);
+    TemperatureCompensateModeSP[1].fill("B", "", ISS_OFF);
+    TemperatureCompensateModeSP[2].fill("C", "", ISS_OFF);
+    TemperatureCompensateModeSP[3].fill("D", "", ISS_OFF);
+    TemperatureCompensateModeSP[4].fill("E", "", ISS_OFF);
+    TemperatureCompensateModeSP.fill(getDeviceName(), "Compensate Mode",
                        "", FOCUS_SETTINGS_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     //    // Enable/Disable backlash
-    //    IUFillSwitch(&FocusBacklashS[0], "Enable", "", ISS_OFF);
-    //    IUFillSwitch(&FocusBacklashS[1], "Disable", "", ISS_ON);
-    //    IUFillSwitchVector(&FocusBacklashSP, FocusBacklashS, 2, getDeviceName(), "FOCUSER_BACKLASH_COMPENSATION", "Backlash Compensation",
+    //    FocusBacklashSP[0].fill("Enable", "", ISS_OFF);
+    //    FocusBacklashSP[1].fill("Disable", "", ISS_ON);
+    //    FocusBacklashSP.fill(getDeviceName(), "FOCUSER_BACKLASH_COMPENSATION", "Backlash Compensation",
     //                       FOCUS_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     //    // Backlash Value
-    //    IUFillNumber(&FocusBacklashN[0], "Value", "", "%.f", 0, 99, 5., 0.);
-    //    IUFillNumberVector(&FocusBacklashNP, FocusBacklashN, 1, getDeviceName(), "FOCUSER_BACKLASH", "Backlash", FOCUS_SETTINGS_TAB, IP_RW, 0,
+    //    FocusBacklashNP[0].fill("Value", "", "%.f", 0, 99, 5., 0.);
+    //    FocusBacklashNP.fill(getDeviceName(), "FOCUSER_BACKLASH", "Backlash", FOCUS_SETTINGS_TAB, IP_RW, 0,
     //                       IPS_IDLE);
 
     // Go to home/center
-    IUFillSwitch(&FocuserGotoS[GOTO_CENTER], "Center", "", ISS_OFF);
-    IUFillSwitch(&FocuserGotoS[GOTO_HOME], "Home", "", ISS_OFF);
-    IUFillSwitchVector(&FocuserGotoSP, FocuserGotoS, 2, getDeviceName(), "FOCUSER_GOTO", "Goto", MAIN_CONTROL_TAB, IP_RW,
+    FocuserGotoSP[GOTO_CENTER].fill("Center", "", ISS_OFF);
+    FocuserGotoSP[GOTO_HOME].fill("Home", "", ISS_OFF);
+    FocuserGotoSP.fill(getDeviceName(), "FOCUSER_GOTO", "Goto", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Focus Status indicators
-    IUFillLight(&FocuserStatusL[STATUS_MOVING], "Is Moving", "", IPS_IDLE);
-    IUFillLight(&FocuserStatusL[STATUS_HOMING], "Is Homing", "", IPS_IDLE);
-    IUFillLight(&FocuserStatusL[STATUS_HOMED], "Is Homed", "", IPS_IDLE);
-    IUFillLight(&FocuserStatusL[STATUS_FFDETECT], "FF Detect", "", IPS_IDLE);
-    IUFillLight(&FocuserStatusL[STATUS_TMPPROBE], "Tmp Probe", "", IPS_IDLE);
-    IUFillLight(&FocuserStatusL[STATUS_REMOTEIO], "Remote IO", "", IPS_IDLE);
-    IUFillLight(&FocuserStatusL[STATUS_HNDCTRL], "Hnd Ctrl", "", IPS_IDLE);
-    IUFillLight(&FocuserStatusL[STATUS_REVERSE], "Reverse", "", IPS_IDLE);
-    IUFillLightVector(&FocuserStatusLP, FocuserStatusL, 8, getDeviceName(), "FOCUSER_STATUS", "Focuser", STATUS_TAB, IPS_IDLE);
+    FocuserStatusLP[STATUS_MOVING].fill("Is Moving", "", IPS_IDLE);
+    FocuserStatusLP[STATUS_HOMING].fill("Is Homing", "", IPS_IDLE);
+    FocuserStatusLP[STATUS_HOMED].fill("Is Homed", "", IPS_IDLE);
+    FocuserStatusLP[STATUS_FFDETECT].fill("FF Detect", "", IPS_IDLE);
+    FocuserStatusLP[STATUS_TMPPROBE].fill("Tmp Probe", "", IPS_IDLE);
+    FocuserStatusLP[STATUS_REMOTEIO].fill("Remote IO", "", IPS_IDLE);
+    FocuserStatusLP[STATUS_HNDCTRL].fill("Hnd Ctrl", "", IPS_IDLE);
+    FocuserStatusLP[STATUS_REVERSE].fill("Reverse", "", IPS_IDLE);
+    FocuserStatusLP.fill(getDeviceName(), "FOCUSER_STATUS", "Focuser", STATUS_TAB, IPS_IDLE);
 
     ////////////////////////////////////////////////////////////
     // Rotator Properties
     ///////////////////////////////////////////////////////////
 
     // Enable/Disable Home on Start
-    IUFillSwitch(&RotatorHomeOnStartS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&RotatorHomeOnStartS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&RotatorHomeOnStartSP, RotatorHomeOnStartS, 2, getDeviceName(), "ROTATOR_HOME_ON_START", "Home on Start",
+    RotatorHomeOnStartSP[0].fill("Enable", "", ISS_OFF);
+    RotatorHomeOnStartSP[1].fill("Disable", "", ISS_ON);
+    RotatorHomeOnStartSP.fill(getDeviceName(), "ROTATOR_HOME_ON_START", "Home on Start",
                        ROTATOR_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Rotator Status indicators
-    IUFillLight(&RotatorStatusL[STATUS_MOVING], "Is Moving", "", IPS_IDLE);
-    IUFillLight(&RotatorStatusL[STATUS_HOMING], "Is Homing", "", IPS_IDLE);
-    IUFillLight(&RotatorStatusL[STATUS_HOMED], "Is Homed", "", IPS_IDLE);
-    IUFillLight(&RotatorStatusL[STATUS_FFDETECT], "FF Detect", "", IPS_IDLE);
-    IUFillLight(&RotatorStatusL[STATUS_TMPPROBE], "Tmp Probe", "", IPS_IDLE);
-    IUFillLight(&RotatorStatusL[STATUS_REMOTEIO], "Remote IO", "", IPS_IDLE);
-    IUFillLight(&RotatorStatusL[STATUS_HNDCTRL], "Hnd Ctrl", "", IPS_IDLE);
-    IUFillLight(&RotatorStatusL[STATUS_REVERSE], "Reverse", "", IPS_IDLE);
-    IUFillLightVector(&RotatorStatusLP, RotatorStatusL, 8, getDeviceName(), "ROTATOR_STATUS", "Rotator", STATUS_TAB, IPS_IDLE);
+    RotatorStatusLP[STATUS_MOVING].fill("Is Moving", "", IPS_IDLE);
+    RotatorStatusLP[STATUS_HOMING].fill("Is Homing", "", IPS_IDLE);
+    RotatorStatusLP[STATUS_HOMED].fill("Is Homed", "", IPS_IDLE);
+    RotatorStatusLP[STATUS_FFDETECT].fill("FF Detect", "", IPS_IDLE);
+    RotatorStatusLP[STATUS_TMPPROBE].fill("Tmp Probe", "", IPS_IDLE);
+    RotatorStatusLP[STATUS_REMOTEIO].fill("Remote IO", "", IPS_IDLE);
+    RotatorStatusLP[STATUS_HNDCTRL].fill("Hnd Ctrl", "", IPS_IDLE);
+    RotatorStatusLP[STATUS_REVERSE].fill("Reverse", "", IPS_IDLE);
+    RotatorStatusLP.fill(getDeviceName(), "ROTATOR_STATUS", "Rotator", STATUS_TAB, IPS_IDLE);
 
     INDI::RotatorInterface::initProperties(ROTATOR_TAB);
 
     // Rotator Ticks
-    IUFillNumber(&RotatorAbsPosN[0], "ROTATOR_ABSOLUTE_POSITION", "Ticks", "%.f", 0., 0., 0., 0.);
-    IUFillNumberVector(&RotatorAbsPosNP, RotatorAbsPosN, 1, getDeviceName(), "ABS_ROTATOR_POSITION", "Goto", ROTATOR_TAB, IP_RW,
+    RotatorAbsPosNP[0].fill("ROTATOR_ABSOLUTE_POSITION", "Ticks", "%.f", 0., 0., 0., 0.);
+    RotatorAbsPosNP.fill(getDeviceName(), "ABS_ROTATOR_POSITION", "Goto", ROTATOR_TAB, IP_RW,
                        0, IPS_IDLE );
 #if 0
 
 
     // Rotator Degree
-    IUFillNumber(&RotatorAbsAngleN[0], "ANGLE", "Degrees", "%.2f", 0, 360., 10., 0.);
-    IUFillNumberVector(&RotatorAbsAngleNP, RotatorAbsAngleN, 1, getDeviceName(), "ABS_ROTATOR_ANGLE", "Angle", ROTATOR_TAB,
+    RotatorAbsAngleNP[0].fill("ANGLE", "Degrees", "%.2f", 0, 360., 10., 0.);
+    RotatorAbsAngleNP.fill(getDeviceName(), "ABS_ROTATOR_ANGLE", "Angle", ROTATOR_TAB,
                        IP_RW, 0, IPS_IDLE );
 
     // Abort Rotator
-    IUFillSwitch(&AbortRotatorS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&AbortRotatorSP, AbortRotatorS, 1, getDeviceName(), "ROTATOR_ABORT_MOTION", "Abort Motion", ROTATOR_TAB,
+    AbortRotatorSP[0].fill("ABORT", "Abort", ISS_OFF);
+    AbortRotatorSP.fill(getDeviceName(), "ROTATOR_ABORT_MOTION", "Abort Motion", ROTATOR_TAB,
                        IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Rotator Go to home/center
-    IUFillSwitch(&RotatorGotoS[GOTO_CENTER], "Center", "", ISS_OFF);
-    IUFillSwitch(&RotatorGotoS[GOTO_HOME], "Home", "", ISS_OFF);
-    IUFillSwitchVector(&RotatorGotoSP, RotatorGotoS, 2, getDeviceName(), "ROTATOR_GOTO", "Goto", ROTATOR_TAB, IP_RW,
+    RotatorGotoSP[GOTO_CENTER].fill("Center", "", ISS_OFF);
+    RotatorGotoSP[GOTO_HOME].fill("Home", "", ISS_OFF);
+    RotatorGotoSP.fill(getDeviceName(), "ROTATOR_GOTO", "Goto", ROTATOR_TAB, IP_RW,
                        ISR_1OFMANY, 0,
                        IPS_IDLE);
 #endif
@@ -248,18 +248,18 @@ bool Gemini::initProperties()
     ///////////////////////////////////////////////////////////
 
     // Focus name configure in the HUB
-    IUFillText(&HFocusNameT[DEVICE_FOCUSER], "FocusName", "Focuser name", "");
-    IUFillText(&HFocusNameT[DEVICE_ROTATOR], "RotatorName", "Rotator name", "");
-    IUFillTextVector(&HFocusNameTP, HFocusNameT, 2, getDeviceName(), "HUBNAMES", "HUB", HUB_TAB, IP_RW, 0,
+    HFocusNameTP[DEVICE_FOCUSER].fill("FocusName", "Focuser name", "");
+    HFocusNameTP[DEVICE_ROTATOR].fill("RotatorName", "Rotator name", "");
+    HFocusNameTP.fill(getDeviceName(), "HUBNAMES", "HUB", HUB_TAB, IP_RW, 0,
                      IPS_IDLE);
 
     // Led intensity value
-    IUFillNumber(&LedN[0], "Intensity", "", "%.f", 0, 100, 5., 0.);
-    IUFillNumberVector(&LedNP, LedN, 1, getDeviceName(), "Led", "", HUB_TAB, IP_RW, 0, IPS_IDLE);
+    LedNP[0].fill("Intensity", "", "%.f", 0, 100, 5., 0.);
+    LedNP.fill(getDeviceName(), "Led", "", HUB_TAB, IP_RW, 0, IPS_IDLE);
 
     // Reset to Factory setting
-    IUFillSwitch(&ResetS[0], "Factory", "", ISS_OFF);
-    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "Reset", "", HUB_TAB, IP_RW, ISR_ATMOST1, 0,
+    ResetSP[0].fill("Factory", "", ISS_OFF);
+    ResetSP.fill(getDeviceName(), "Reset", "", HUB_TAB, IP_RW, ISR_ATMOST1, 0,
                        IPS_IDLE);
 
     addAuxControls();
@@ -281,34 +281,34 @@ bool Gemini::updateProperties()
     if (isConnected())
     {
         // Focuser Properties
-        defineProperty(&TemperatureNP);
-        defineProperty(&TemperatureCoeffNP);
-        defineProperty(&TemperatureCompensateModeSP);
-        defineProperty(&TemperatureCompensateSP);
-        defineProperty(&TemperatureCompensateOnStartSP);
-        //        defineProperty(&FocusBacklashSP);
-        //        defineProperty(&FocusBacklashNP);
-        defineProperty(&FocuserHomeOnStartSP);
-        defineProperty(&FocuserGotoSP);
-        defineProperty(&FocuserStatusLP);
+        defineProperty(TemperatureNP);
+        defineProperty(TemperatureCoeffNP);
+        defineProperty(TemperatureCompensateModeSP);
+        defineProperty(TemperatureCompensateSP);
+        defineProperty(TemperatureCompensateOnStartSP);
+        //        defineProperty(FocusBacklashSP);
+        //        defineProperty(FocusBacklashNP);
+        defineProperty(FocuserHomeOnStartSP);
+        defineProperty(FocuserGotoSP);
+        defineProperty(FocuserStatusLP);
 
         // Rotator Properties
         INDI::RotatorInterface::updateProperties();
         /*
 
-        defineProperty(&RotatorAbsAngleNP);
-        defineProperty(&AbortRotatorSP);
-        defineProperty(&RotatorGotoSP);
-        defineProperty(&ReverseRotatorSP);
+        defineProperty(RotatorAbsAngleNP);
+        defineProperty(AbortRotatorSP);
+        defineProperty(RotatorGotoSP);
+        defineProperty(ReverseRotatorSP);
         */
-        defineProperty(&RotatorAbsPosNP);
-        defineProperty(&RotatorHomeOnStartSP);
-        defineProperty(&RotatorStatusLP);
+        defineProperty(RotatorAbsPosNP);
+        defineProperty(RotatorHomeOnStartSP);
+        defineProperty(RotatorStatusLP);
 
         // Hub Properties
-        defineProperty(&HFocusNameTP);
-        defineProperty(&ResetSP);
-        defineProperty(&LedNP);
+        defineProperty(HFocusNameTP);
+        defineProperty(ResetSP);
+        defineProperty(LedNP);
 
         if (getFocusConfig() && getRotatorConfig())
             LOG_INFO("Gemini parameters updated, rotating focuser ready for use.");
@@ -321,35 +321,35 @@ bool Gemini::updateProperties()
     else
     {
         // Focuser Properties
-        deleteProperty(TemperatureNP.name);
-        deleteProperty(TemperatureCoeffNP.name);
-        deleteProperty(TemperatureCompensateModeSP.name);
-        deleteProperty(TemperatureCompensateSP.name);
-        deleteProperty(TemperatureCompensateOnStartSP.name);
-        //        deleteProperty(FocusBacklashSP.name);
-        //        deleteProperty(FocusBacklashNP.name);
-        deleteProperty(FocuserGotoSP.name);
-        deleteProperty(FocuserHomeOnStartSP.name);
-        deleteProperty(FocuserStatusLP.name);
+        deleteProperty(TemperatureNP.getName());
+        deleteProperty(TemperatureCoeffNP.getName());
+        deleteProperty(TemperatureCompensateModeSP.getName());
+        deleteProperty(TemperatureCompensateSP.getName());
+        deleteProperty(TemperatureCompensateOnStartSP.getName());
+        //        deleteProperty(FocusBacklashSP.getName());
+        //        deleteProperty(FocusBacklashNP.getName());
+        deleteProperty(FocuserGotoSP.getName());
+        deleteProperty(FocuserHomeOnStartSP.getName());
+        deleteProperty(FocuserStatusLP.getName());
 
         // Rotator Properties
         INDI::RotatorInterface::updateProperties();
         /*
-        deleteProperty(RotatorAbsAngleNP.name);
-        deleteProperty(AbortRotatorSP.name);
-        deleteProperty(RotatorGotoSP.name);
-        deleteProperty(ReverseRotatorSP.name);
+        deleteProperty(RotatorAbsAngleNP.getName());
+        deleteProperty(AbortRotatorSP.getName());
+        deleteProperty(RotatorGotoSP.getName());
+        deleteProperty(ReverseRotatorSP.getName());
         */
 
-        deleteProperty(RotatorAbsPosNP.name);
-        deleteProperty(RotatorHomeOnStartSP.name);
+        deleteProperty(RotatorAbsPosNP.getName());
+        deleteProperty(RotatorHomeOnStartSP.getName());
 
-        deleteProperty(RotatorStatusLP.name);
+        deleteProperty(RotatorStatusLP.getName());
 
         // Hub Properties
-        deleteProperty(HFocusNameTP.name);
-        deleteProperty(LedNP.name);
-        deleteProperty(ResetSP.name);
+        deleteProperty(HFocusNameTP.getName());
+        deleteProperty(LedNP.getName());
+        deleteProperty(ResetSP.getName());
     }
 
     return true;
@@ -388,171 +388,171 @@ bool Gemini::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Compensation
-        if (strcmp(TemperatureCompensateSP.name, name) == 0)
+        if (TemperatureCompensateSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&TemperatureCompensateSP);
-            IUUpdateSwitch(&TemperatureCompensateSP, states, names, n);
-            if (setTemperatureCompensation(TemperatureCompensateS[0].s == ISS_ON))
+            int prevIndex = TemperatureCompensateSP.findOnSwitchIndex();
+            TemperatureCompensateSP.update(states, names, n);
+            if (setTemperatureCompensation(TemperatureCompensateSP[0].getState() == ISS_ON))
             {
-                TemperatureCompensateSP.s = IPS_OK;
+                TemperatureCompensateSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&TemperatureCompensateSP);
-                TemperatureCompensateSP.s           = IPS_ALERT;
-                TemperatureCompensateS[prevIndex].s = ISS_ON;
+                TemperatureCompensateSP.reset();
+                TemperatureCompensateSP.setState(IPS_ALERT);
+                TemperatureCompensateSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&TemperatureCompensateSP, nullptr);
+            TemperatureCompensateSP.apply();
             return true;
         }
 
         // Temperature Compensation on Start
-        if (!strcmp(TemperatureCompensateOnStartSP.name, name))
+        if (TemperatureCompensateOnStartSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&TemperatureCompensateOnStartSP);
-            IUUpdateSwitch(&TemperatureCompensateOnStartSP, states, names, n);
-            if (setTemperatureCompensationOnStart(TemperatureCompensateOnStartS[0].s == ISS_ON))
+            int prevIndex = TemperatureCompensateOnStartSP.findOnSwitchIndex();
+            TemperatureCompensateOnStartSP.update(states, names, n);
+            if (setTemperatureCompensationOnStart(TemperatureCompensateOnStartSP[0].getState() == ISS_ON))
             {
-                TemperatureCompensateOnStartSP.s = IPS_OK;
+                TemperatureCompensateOnStartSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&TemperatureCompensateOnStartSP);
-                TemperatureCompensateOnStartSP.s           = IPS_ALERT;
-                TemperatureCompensateOnStartS[prevIndex].s = ISS_ON;
+                TemperatureCompensateOnStartSP.reset();
+                TemperatureCompensateOnStartSP.setState(IPS_ALERT);
+                TemperatureCompensateOnStartSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&TemperatureCompensateOnStartSP, nullptr);
+            TemperatureCompensateOnStartSP.apply();
             return true;
         }
 
         // Temperature Compensation Mode
-        if (!strcmp(TemperatureCompensateModeSP.name, name))
+        if (TemperatureCompensateModeSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&TemperatureCompensateModeSP);
-            IUUpdateSwitch(&TemperatureCompensateModeSP, states, names, n);
-            char mode = IUFindOnSwitchIndex(&TemperatureCompensateModeSP) + 'A';
+            int prevIndex = TemperatureCompensateModeSP.findOnSwitchIndex();
+            TemperatureCompensateModeSP.update(states, names, n);
+            char mode = TemperatureCompensateModeSP.findOnSwitchIndex() + 'A';
             if (setTemperatureCompensationMode(mode))
             {
-                TemperatureCompensateModeSP.s = IPS_OK;
+                TemperatureCompensateModeSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&TemperatureCompensateModeSP);
-                TemperatureCompensateModeSP.s           = IPS_ALERT;
-                TemperatureCompensateModeS[prevIndex].s = ISS_ON;
+                TemperatureCompensateModeSP.reset();
+                TemperatureCompensateModeSP.setState(IPS_ALERT);
+                TemperatureCompensateModeSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&TemperatureCompensateModeSP, nullptr);
+            TemperatureCompensateModeSP.apply();
             return true;
         }
 
         // Focuser Home on Start Enable/Disable
-        if (!strcmp(FocuserHomeOnStartSP.name, name))
+        if (FocuserHomeOnStartSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&FocuserHomeOnStartSP);
-            IUUpdateSwitch(&FocuserHomeOnStartSP, states, names, n);
-            if (homeOnStart(DEVICE_FOCUSER, FocuserHomeOnStartS[0].s == ISS_ON))
+            int prevIndex = FocuserHomeOnStartSP.findOnSwitchIndex();
+            FocuserHomeOnStartSP.update(states, names, n);
+            if (homeOnStart(DEVICE_FOCUSER, FocuserHomeOnStartSP[0].getState() == ISS_ON))
             {
-                FocuserHomeOnStartSP.s = IPS_OK;
+                FocuserHomeOnStartSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&FocuserHomeOnStartSP);
-                FocuserHomeOnStartSP.s           = IPS_ALERT;
-                FocuserHomeOnStartS[prevIndex].s = ISS_ON;
+                FocuserHomeOnStartSP.reset();
+                FocuserHomeOnStartSP.setState(IPS_ALERT);
+                FocuserHomeOnStartSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&FocuserHomeOnStartSP, nullptr);
+            FocuserHomeOnStartSP.apply();
             return true;
         }
 
         // Rotator Home on Start Enable/Disable
-        if (!strcmp(RotatorHomeOnStartSP.name, name))
+        if (RotatorHomeOnStartSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&RotatorHomeOnStartSP);
-            IUUpdateSwitch(&RotatorHomeOnStartSP, states, names, n);
-            if (homeOnStart(DEVICE_ROTATOR, RotatorHomeOnStartS[0].s == ISS_ON))
+            int prevIndex = RotatorHomeOnStartSP.findOnSwitchIndex();
+            RotatorHomeOnStartSP.update(states, names, n);
+            if (homeOnStart(DEVICE_ROTATOR, RotatorHomeOnStartSP[0].getState() == ISS_ON))
             {
-                RotatorHomeOnStartSP.s = IPS_OK;
+                RotatorHomeOnStartSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&RotatorHomeOnStartSP);
-                RotatorHomeOnStartSP.s           = IPS_ALERT;
-                RotatorHomeOnStartS[prevIndex].s = ISS_ON;
+                RotatorHomeOnStartSP.reset();
+                RotatorHomeOnStartSP.setState(IPS_ALERT);
+                RotatorHomeOnStartSP[prevIndex].setState(ISS_ON);
             }
 
-            IDSetSwitch(&RotatorHomeOnStartSP, nullptr);
+            RotatorHomeOnStartSP.apply();
             return true;
         }
 
         // Focuser Backlash enable/disable
-        //        if (!strcmp(FocusBacklashSP.name, name))
+        //        if (FocusBacklashSP.isNameMatch(name))
         //        {
-        //            int prevIndex = IUFindOnSwitchIndex(&FocusBacklashSP);
-        //            IUUpdateSwitch(&FocusBacklashSP, states, names, n);
-        //            if (setBacklashCompensation(DEVICE_FOCUSER, FocusBacklashS[0].s == ISS_ON))
+        //            int prevIndex = FocusBacklashSP.findOnSwitchIndex();
+        //            FocusBacklashSP.update(states, names, n);
+        //            if (setBacklashCompensation(DEVICE_FOCUSER, FocusBacklashSP[0].getState() == ISS_ON))
         //            {
-        //                FocusBacklashSP.s = IPS_OK;
+        //                FocusBacklashSP.setState(IPS_OK);
         //            }
         //            else
         //            {
-        //                IUResetSwitch(&FocusBacklashSP);
-        //                FocusBacklashSP.s           = IPS_ALERT;
-        //                FocusBacklashS[prevIndex].s = ISS_ON;
+        //                FocusBacklashSP.reset();
+        //                FocusBacklashSP.setState(IPS_ALERT);
+        //                FocusBacklashSP[prevIndex].setState(ISS_ON);
         //            }
 
-        //            IDSetSwitch(&FocusBacklashSP, nullptr);
+        //            FocusBacklashSP.apply();
         //            return true;
         //        }
 
         // Reset to Factory setting
-        if (strcmp(ResetSP.name, name) == 0)
+        if (ResetSP.isNameMatch(name))
         {
-            IUResetSwitch(&ResetSP);
+            ResetSP.reset();
             if (resetFactory())
-                ResetSP.s = IPS_OK;
+                ResetSP.setState(IPS_OK);
             else
-                ResetSP.s = IPS_ALERT;
+                ResetSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&ResetSP, nullptr);
+            ResetSP.apply();
             return true;
         }
 
         // Focser Go to home/center
-        if (!strcmp(FocuserGotoSP.name, name))
+        if (FocuserGotoSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FocuserGotoSP, states, names, n);
+            FocuserGotoSP.update(states, names, n);
 
-            if (FocuserGotoS[GOTO_HOME].s == ISS_ON)
+            if (FocuserGotoSP[GOTO_HOME].getState() == ISS_ON)
             {
                 if (home(DEVICE_FOCUSER))
                 {
-                    FocuserGotoSP.s = IPS_BUSY;
-                    FocusAbsPosNP.s = IPS_BUSY;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
+                    FocuserGotoSP.setState(IPS_BUSY);
+                    FocusAbsPosNP.setState(IPS_BUSY);
+                    FocusAbsPosNP.apply();
                     isFocuserHoming = true;
                     LOG_INFO("Focuser moving to home position...");
                 }
                 else
-                    FocuserGotoSP.s = IPS_ALERT;
+                    FocuserGotoSP.setState(IPS_ALERT);
             }
             else
             {
                 if (center(DEVICE_FOCUSER))
                 {
-                    FocuserGotoSP.s = IPS_BUSY;
+                    FocuserGotoSP.setState(IPS_BUSY);
                     LOG_INFO("Focuser moving to center position...");
-                    FocusAbsPosNP.s = IPS_BUSY;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
+                    FocusAbsPosNP.setState(IPS_BUSY);
+                    FocusAbsPosNP.apply();
                 }
                 else
-                    FocuserGotoSP.s = IPS_ALERT;
+                    FocuserGotoSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&FocuserGotoSP, nullptr);
+            FocuserGotoSP.apply();
             return true;
         }
 
@@ -565,71 +565,71 @@ bool Gemini::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
 
         // Rotator Go to home/center
 #if 0
-        if (!strcmp(RotatorGotoSP.name, name))
+        if (RotatorGotoSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&RotatorGotoSP, states, names, n);
+            RotatorGotoSP.update(states, names, n);
 
-            if (RotatorGotoS[GOTO_HOME].s == ISS_ON)
+            if (RotatorGotoSP[GOTO_HOME].getState() == ISS_ON)
             {
                 if (home(DEVICE_ROTATOR))
                 {
-                    RotatorGotoSP.s = IPS_BUSY;
-                    RotatorAbsPosNP.s = IPS_BUSY;
-                    IDSetNumber(&RotatorAbsPosNP, nullptr);
+                    RotatorGotoSP.setState(IPS_BUSY);
+                    RotatorAbsPosNP.setState(IPS_BUSY);
+                    RotatorAbsPosNP.apply();
                     isRotatorHoming = true;
                     LOG_INFO("Rotator moving to home position...");
                 }
                 else
-                    RotatorGotoSP.s = IPS_ALERT;
+                    RotatorGotoSP.setState(IPS_ALERT);
             }
             else
             {
                 if (center(DEVICE_ROTATOR))
                 {
-                    RotatorGotoSP.s = IPS_BUSY;
+                    RotatorGotoSP.setState(IPS_BUSY);
                     LOG_INFO("Rotator moving to center position...");
-                    RotatorAbsPosNP.s = IPS_BUSY;
-                    IDSetNumber(&RotatorAbsPosNP, nullptr);
+                    RotatorAbsPosNP.setState(IPS_BUSY);
+                    RotatorAbsPosNP.apply();
                 }
                 else
-                    RotatorGotoSP.s = IPS_ALERT;
+                    RotatorGotoSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&RotatorGotoSP, nullptr);
+            RotatorGotoSP.apply();
             return true;
         }
 
         // Reverse Direction
-        if (!strcmp(ReverseRotatorSP.name, name))
+        if (ReverseRotatorSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ReverseRotatorSP, states, names, n);
+            ReverseRotatorSP.update(states, names, n);
 
-            if (reverseRotator(ReverseRotatorS[0].s == ISS_ON))
-                ReverseRotatorSP.s = IPS_OK;
+            if (reverseRotator(ReverseRotatorSP[0].getState() == ISS_ON))
+                ReverseRotatorSP.setState(IPS_OK);
             else
-                ReverseRotatorSP.s = IPS_ALERT;
+                ReverseRotatorSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&ReverseRotatorSP, nullptr);
+            ReverseRotatorSP.apply();
             return true;
         }
 
         // Halt Rotator
-        if (!strcmp(AbortRotatorSP.name, name))
+        if (AbortRotatorSP.isNameMatch(name))
         {
             if (halt(DEVICE_ROTATOR))
             {
-                RotatorAbsPosNP.s = RotatorAbsAngleNP.s = RotatorGotoSP.s = IPS_IDLE;
-                IDSetNumber(&RotatorAbsPosNP, nullptr);
-                IDSetNumber(&RotatorAbsAngleNP, nullptr);
-                IUResetSwitch(&RotatorGotoSP);
-                IDSetSwitch(&RotatorGotoSP, nullptr);
+                RotatorAbsPosNP.setState(RotatorAbsAngleNP.setState(RotatorGotoSP.setState(IPS_IDLE)));
+                RotatorAbsPosNP.apply();
+                RotatorAbsAngleNP.apply();
+                RotatorGotoSP.reset();
+                RotatorGotoSP.apply();
 
-                AbortRotatorSP.s = IPS_OK;
+                AbortRotatorSP.setState(IPS_OK);
             }
             else
-                AbortRotatorSP.s = IPS_ALERT;
+                AbortRotatorSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&AbortRotatorSP, nullptr);
+            AbortRotatorSP.apply();
             return true;
         }
 #endif
@@ -646,15 +646,15 @@ bool Gemini::ISNewText(const char *dev, const char *name, char *texts[], char *n
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Set device nickname to the HUB itself
-        if (!strcmp(name, HFocusNameTP.name))
+        if (HFocusNameTP.isNameMatch(name))
         {
-            IUUpdateText(&HFocusNameTP, texts, names, n);
-            if (setNickname(DEVICE_FOCUSER, HFocusNameT[DEVICE_FOCUSER].text)
-                    && setNickname(DEVICE_ROTATOR, HFocusNameT[DEVICE_ROTATOR].text))
-                HFocusNameTP.s = IPS_OK;
+            HFocusNameTP.update(texts, names, n);
+            if (setNickname(DEVICE_FOCUSER, HFocusNameTP[DEVICE_FOCUSER].getText())
+                    && setNickname(DEVICE_ROTATOR, HFocusNameTP[DEVICE_ROTATOR].getText()))
+                HFocusNameTP.setState(IPS_OK);
             else
-                HFocusNameTP.s = IPS_ALERT;
-            IDSetText(&HFocusNameTP, nullptr);
+                HFocusNameTP.setState(IPS_ALERT);
+            HFocusNameTP.apply();
             return true;
         }
     }
@@ -669,78 +669,78 @@ bool Gemini::ISNewNumber(const char *dev, const char *name, double values[], cha
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Temperature Coefficient
-        if (!strcmp(TemperatureCoeffNP.name, name))
+        if (TemperatureCoeffNP.isNameMatch(name))
         {
-            IUUpdateNumber(&TemperatureCoeffNP, values, names, n);
+            TemperatureCoeffNP.update(values, names, n);
             for (int i = 0; i < n; i++)
             {
-                if (setTemperatureCompensationCoeff('A' + i, TemperatureCoeffN[i].value) == false)
+                if (setTemperatureCompensationCoeff('A' + i, TemperatureCoeffNP[i].getValue()) == false)
                 {
                     LOG_ERROR("Failed to set temperature coefficients.");
-                    TemperatureCoeffNP.s = IPS_ALERT;
-                    IDSetNumber(&TemperatureCoeffNP, nullptr);
+                    TemperatureCoeffNP.setState(IPS_ALERT);
+                    TemperatureCoeffNP.apply();
                     return false;
                 }
             }
 
-            TemperatureCoeffNP.s = IPS_OK;
-            IDSetNumber(&TemperatureCoeffNP, nullptr);
+            TemperatureCoeffNP.setState(IPS_OK);
+            TemperatureCoeffNP.apply();
             return true;
         }
 
         // Focuser Backlash Value
-        //        if (!strcmp(FocusBacklashNP.name, name))
+        //        if (FocusBacklashNP.isNameMatch(name))
         //        {
-        //            IUUpdateNumber(&FocusBacklashNP, values, names, n);
-        //            if (setBacklashCompensationSteps(DEVICE_FOCUSER, FocusBacklashN[0].value) == false)
+        //            FocusBacklashNP.update(values, names, n);
+        //            if (setBacklashCompensationSteps(DEVICE_FOCUSER, FocusBacklashNP[0].getValue()) == false)
         //            {
         //                LOG_ERROR("Failed to set focuser backlash value.");
-        //                FocusBacklashNP.s = IPS_ALERT;
-        //                IDSetNumber(&FocusBacklashNP, nullptr);
+        //                FocusBacklashNP.setState(IPS_ALERT);
+        //                FocusBacklashNP.apply();
         //                return false;
         //            }
 
-        //            FocusBacklashNP.s = IPS_OK;
-        //            IDSetNumber(&FocusBacklashNP, nullptr);
+        //            FocusBacklashNP.setState(IPS_OK);
+        //            FocusBacklashNP.apply();
         //            return true;
         //        }
 
         // Rotator Backlash Value
-        if (!strcmp(RotatorBacklashNP.name, name))
+        if (RotatorBacklashNP.isNameMatch(name))
         {
-            IUUpdateNumber(&RotatorBacklashNP, values, names, n);
-            if (setBacklashCompensationSteps(DEVICE_ROTATOR, RotatorBacklashN[0].value) == false)
+            RotatorBacklashNP.update(values, names, n);
+            if (setBacklashCompensationSteps(DEVICE_ROTATOR, RotatorBacklashNP[0].getValue()) == false)
             {
                 LOG_ERROR("Failed to set rotator backlash value.");
-                RotatorBacklashNP.s = IPS_ALERT;
-                IDSetNumber(&RotatorBacklashNP, nullptr);
+                RotatorBacklashNP.setState(IPS_ALERT);
+                RotatorBacklashNP.apply();
                 return false;
             }
 
-            RotatorBacklashNP.s = IPS_OK;
-            IDSetNumber(&RotatorBacklashNP, nullptr);
+            RotatorBacklashNP.setState(IPS_OK);
+            RotatorBacklashNP.apply();
             return true;
         }
 
         // Set LED intensity to the HUB itself via function setLedLevel()
-        if (!strcmp(LedNP.name, name))
+        if (LedNP.isNameMatch(name))
         {
-            IUUpdateNumber(&LedNP, values, names, n);
-            if (setLedLevel(LedN[0].value))
-                LedNP.s = IPS_OK;
+            LedNP.update(values, names, n);
+            if (setLedLevel(LedNP[0].value))
+                LedNP.setState(IPS_OK);
             else
-                LedNP.s = IPS_ALERT;
-            LOGF_INFO("Focuser LED level intensity : %f", LedN[0].value);
-            IDSetNumber(&LedNP, nullptr);
+                LedNP.setState(IPS_ALERT);
+            LOGF_INFO("Focuser LED level intensity : %f", LedNP[0].getValue());
+            LedNP.apply();
             return true;
         }
 
         // Set Rotator Absolute Steps
-        if (!strcmp(RotatorAbsPosNP.name, name))
+        if (RotatorAbsPosNP.isNameMatch(name))
         {
-            IUUpdateNumber(&RotatorAbsPosNP, values, names, n);
-            RotatorAbsPosNP.s = MoveAbsRotatorTicks(static_cast<uint32_t>(RotatorAbsPosN[0].value));
-            IDSetNumber(&RotatorAbsPosNP, nullptr);
+            RotatorAbsPosNP.update(values, names, n);
+            RotatorAbsPosNP.setState(MoveAbsRotatorTicks(static_cast<uint32_t>(RotatorAbsPosNP[0].value)));
+            RotatorAbsPosNP.apply();
             return true;
         }
 
@@ -752,20 +752,20 @@ bool Gemini::ISNewNumber(const char *dev, const char *name, double values[], cha
 
 #if 0
         // Set Rotator Absolute Steps
-        if (!strcmp(RotatorAbsPosNP.name, name))
+        if (RotatorAbsPosNP.isNameMatch(name))
         {
-            IUUpdateNumber(&RotatorAbsPosNP, values, names, n);
-            RotatorAbsPosNP.s = MoveAbsRotatorTicks(static_cast<uint32_t>(RotatorAbsPosN[0].value));
-            IDSetNumber(&RotatorAbsPosNP, nullptr);
+            RotatorAbsPosNP.update(values, names, n);
+            RotatorAbsPosNP.setState(MoveAbsRotatorTicks(static_cast<uint32_t>(RotatorAbsPosNP[0].value)));
+            RotatorAbsPosNP.apply();
             return true;
         }
 
         // Set Rotator Absolute Angle
-        if (!strcmp(RotatorAbsAngleNP.name, name))
+        if (RotatorAbsAngleNP.isNameMatch(name))
         {
-            IUUpdateNumber(&RotatorAbsAngleNP, values, names, n);
-            RotatorAbsAngleNP.s = MoveAbsRotatorAngle(RotatorAbsAngleN[0].value);
-            IDSetNumber(&RotatorAbsAngleNP, nullptr);
+            RotatorAbsAngleNP.update(values, names, n);
+            RotatorAbsAngleNP.setState(MoveAbsRotatorAngle(RotatorAbsAngleNP[0].value));
+            RotatorAbsAngleNP.apply();
             return true;
         }
 #endif
@@ -910,11 +910,11 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUSaveText(&HFocusNameT[0], nickname);
-    IDSetText(&HFocusNameTP, nullptr);
+    HFocusNameTP[0].setText(nickname);
+    HFocusNameTP.apply();
 
-    HFocusNameTP.s = IPS_OK;
-    IDSetText(&HFocusNameTP, nullptr);
+    HFocusNameTP.setState(IPS_OK);
+    HFocusNameTP.apply();
 
     memset(response, 0, sizeof(response));
 
@@ -937,16 +937,16 @@ bool Gemini::getFocusConfig()
     rc = sscanf(response, "%16[^=]=%d", key, &maxPos);
     if (rc == 2)
     {
-        FocusAbsPosN[0].max = maxPos;
-        FocusAbsPosN[0].step = maxPos / 50.0;
-        FocusAbsPosN[0].min = 0;
+        FocusAbsPosNP[0].setMax(maxPos);
+        FocusAbsPosNP[0].setStep(maxPos / 50.0);
+        FocusAbsPosNP[0].setMin(0);
 
-        FocusRelPosN[0].max  = maxPos / 2;
-        FocusRelPosN[0].step = maxPos / 100.0;
-        FocusRelPosN[0].min  = 0;
+        FocusRelPosNP[0].setMax(maxPos / 2);
+        FocusRelPosNP[0].setStep(maxPos / 100.0);
+        FocusRelPosNP[0].setMin(0);
 
-        IUUpdateMinMax(&FocusAbsPosNP);
-        IUUpdateMinMax(&FocusRelPosNP);
+        FocusAbsPosNP.updateMinMax();
+        FocusRelPosNP.updateMinMax();
 
         maxControllerTicks = maxPos;
     }
@@ -976,7 +976,7 @@ bool Gemini::getFocusConfig()
     // Temperature Compensation On?
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "TComp ON = %d\n", TemperatureCompensateS[0].s == ISS_ON ? 1 : 0);
+        snprintf(response, sizeof(response), "TComp ON = %d\n", TemperatureCompensateSP[0].getState() == ISS_ON ? 1 : 0);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -993,18 +993,18 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&TemperatureCompensateSP);
-    TemperatureCompensateS[0].s = TCompOn ? ISS_ON : ISS_OFF;
-    TemperatureCompensateS[0].s = TCompOn ? ISS_OFF : ISS_ON;
-    TemperatureCompensateSP.s   = IPS_OK;
-    IDSetSwitch(&TemperatureCompensateSP, nullptr);
+    TemperatureCompensateSP.reset();
+    TemperatureCompensateSP[0].setState(TCompOn ? ISS_ON : ISS_OFF);
+    TemperatureCompensateSP[0].setState(TCompOn ? ISS_OFF : ISS_ON);
+    TemperatureCompensateSP.setState(IPS_OK);
+    TemperatureCompensateSP.apply();
 
     memset(response, 0, sizeof(response));
 
     // Temperature Coeff A
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "TempCo A = %d\n", (int)TemperatureCoeffN[FOCUS_A_COEFF].value);
+        snprintf(response, sizeof(response), "TempCo A = %d\n", (int)TemperatureCoeffNP[FOCUS_A_COEFF].getValue());
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1021,14 +1021,14 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    TemperatureCoeffN[FOCUS_A_COEFF].value = TCoeffA;
+    TemperatureCoeffNP[FOCUS_A_COEFF].setValue(TCoeffA);
 
     memset(response, 0, sizeof(response));
 
     // Temperature Coeff B
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "TempCo B = %d\n", (int)TemperatureCoeffN[FOCUS_B_COEFF].value);
+        snprintf(response, sizeof(response), "TempCo B = %d\n", (int)TemperatureCoeffNP[FOCUS_B_COEFF].getValue());
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1045,14 +1045,14 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    TemperatureCoeffN[FOCUS_B_COEFF].value = TCoeffB;
+    TemperatureCoeffNP[FOCUS_B_COEFF].setValue(TCoeffB);
 
     memset(response, 0, sizeof(response));
 
     // Temperature Coeff C
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "TempCo C = %d\n", (int)TemperatureCoeffN[FOCUS_C_COEFF].value);
+        snprintf(response, sizeof(response), "TempCo C = %d\n", (int)TemperatureCoeffNP[FOCUS_C_COEFF].getValue());
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1069,14 +1069,14 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    TemperatureCoeffN[FOCUS_C_COEFF].value = TCoeffC;
+    TemperatureCoeffNP[FOCUS_C_COEFF].setValue(TCoeffC);
 
     memset(response, 0, sizeof(response));
 
     // Temperature Coeff D
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "TempCo D = %d\n", (int)TemperatureCoeffN[FOCUS_D_COEFF].value);
+        snprintf(response, sizeof(response), "TempCo D = %d\n", (int)TemperatureCoeffNP[FOCUS_D_COEFF].getValue());
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1093,14 +1093,14 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    TemperatureCoeffN[FOCUS_D_COEFF].value = TCoeffD;
+    TemperatureCoeffNP[FOCUS_D_COEFF].setValue(TCoeffD);
 
     memset(response, 0, sizeof(response));
 
     // Temperature Coeff E
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "TempCo E = %d\n", (int)TemperatureCoeffN[FOCUS_E_COEFF].value);
+        snprintf(response, sizeof(response), "TempCo E = %d\n", (int)TemperatureCoeffNP[FOCUS_E_COEFF].getValue());
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1117,10 +1117,10 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    TemperatureCoeffN[FOCUS_E_COEFF].value = TCoeffE;
+    TemperatureCoeffNP[FOCUS_E_COEFF].setValue(TCoeffE);
 
-    TemperatureCoeffNP.s = IPS_OK;
-    IDSetNumber(&TemperatureCoeffNP, nullptr);
+    TemperatureCoeffNP.setState(IPS_OK);
+    TemperatureCoeffNP.apply();
 
     memset(response, 0, sizeof(response));
 
@@ -1144,26 +1144,26 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&TemperatureCompensateModeSP);
+    TemperatureCompensateModeSP.reset();
     int index = compensateMode - 'A';
     if (index >= 0 && index <= 5)
     {
-        TemperatureCompensateModeS[index].s = ISS_ON;
-        TemperatureCompensateModeSP.s       = IPS_OK;
+        TemperatureCompensateModeSP[index].setState(ISS_ON);
+        TemperatureCompensateModeSP.setState(IPS_OK);
     }
     else
     {
         LOGF_ERROR("Invalid index %d for compensation mode.", index);
-        TemperatureCompensateModeSP.s = IPS_ALERT;
+        TemperatureCompensateModeSP.setState(IPS_ALERT);
     }
 
-    IDSetSwitch(&TemperatureCompensateModeSP, nullptr);
+    TemperatureCompensateModeSP.apply();
 
     // Backlash Compensation
     memset(response, 0, sizeof(response));
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "BLC En = %d\n", FocusBacklashS[INDI_ENABLED].s == ISS_ON ? 1 : 0);
+        snprintf(response, sizeof(response), "BLC En = %d\n", FocusBacklashSP[INDI_ENABLED].getState() == ISS_ON ? 1 : 0);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1180,11 +1180,11 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&FocusBacklashSP);
-    FocusBacklashS[INDI_ENABLED].s = BLCCompensate ? ISS_ON : ISS_OFF;
-    FocusBacklashS[INDI_DISABLED].s = BLCCompensate ? ISS_OFF : ISS_ON;
-    FocusBacklashSP.s   = IPS_OK;
-    IDSetSwitch(&FocusBacklashSP, nullptr);
+    FocusBacklashSP.reset();
+    FocusBacklashSP[INDI_ENABLED].setState(BLCCompensate ? ISS_ON : ISS_OFF);
+    FocusBacklashSP[INDI_DISABLED].setState(BLCCompensate ? ISS_OFF : ISS_ON);
+    FocusBacklashSP.setState(IPS_OK);
+    FocusBacklashSP.apply();
 
     // Backlash Value
     memset(response, 0, sizeof(response));
@@ -1207,15 +1207,15 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    FocusBacklashN[0].value = BLCValue;
-    FocusBacklashNP.s       = IPS_OK;
-    IDSetNumber(&FocusBacklashNP, nullptr);
+    FocusBacklashNP[0].setValue(BLCValue);
+    FocusBacklashNP.setState(IPS_OK);
+    FocusBacklashNP.apply();
 
     // Temperature Compensation on Start
     memset(response, 0, sizeof(response));
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "TC Start = %d\n", TemperatureCompensateOnStartS[0].s == ISS_ON ? 1 : 0);
+        snprintf(response, sizeof(response), "TC Start = %d\n", TemperatureCompensateOnStartSP[0].getState() == ISS_ON ? 1 : 0);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1232,11 +1232,11 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&TemperatureCompensateOnStartSP);
-    TemperatureCompensateOnStartS[0].s = TCOnStart ? ISS_ON : ISS_OFF;
-    TemperatureCompensateOnStartS[1].s = TCOnStart ? ISS_OFF : ISS_ON;
-    TemperatureCompensateOnStartSP.s   = IPS_OK;
-    IDSetSwitch(&TemperatureCompensateOnStartSP, nullptr);
+    TemperatureCompensateOnStartSP.reset();
+    TemperatureCompensateOnStartSP[0].setState(TCOnStart ? ISS_ON : ISS_OFF);
+    TemperatureCompensateOnStartSP[1].setState(TCOnStart ? ISS_OFF : ISS_ON);
+    TemperatureCompensateOnStartSP.setState(IPS_OK);
+    TemperatureCompensateOnStartSP.apply();
 
     // Get Status Parameters
     memset(response, 0, sizeof(response));
@@ -1244,7 +1244,7 @@ bool Gemini::getFocusConfig()
     // Home on start on?
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "HOnStart = %d\n", FocuserHomeOnStartS[0].s == ISS_ON ? 1 : 0);
+        snprintf(response, sizeof(response), "HOnStart = %d\n", FocuserHomeOnStartSP[0].getState() == ISS_ON ? 1 : 0);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1261,11 +1261,11 @@ bool Gemini::getFocusConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&FocuserHomeOnStartSP);
-    FocuserHomeOnStartS[0].s = StartOnHome ? ISS_ON : ISS_OFF;
-    FocuserHomeOnStartS[1].s = StartOnHome ? ISS_OFF : ISS_ON;
-    FocuserHomeOnStartSP.s   = IPS_OK;
-    IDSetSwitch(&FocuserHomeOnStartSP, nullptr);
+    FocuserHomeOnStartSP.reset();
+    FocuserHomeOnStartSP[0].setState(StartOnHome ? ISS_ON : ISS_OFF);
+    FocuserHomeOnStartSP[1].setState(StartOnHome ? ISS_OFF : ISS_ON);
+    FocuserHomeOnStartSP.setState(IPS_OK);
+    FocuserHomeOnStartSP.apply();
 
     // Added By Philippe Besson the 28th of June for 'END' evalution
     // END is reached
@@ -1368,10 +1368,10 @@ bool Gemini::getRotatorStatus()
     if (rc == 2)
     {
         // Do not spam unless there is an actual change
-        if (RotatorAbsPosN[0].value != currPos)
+        if (RotatorAbsPosNP[0].value != currPos)
         {
-            RotatorAbsPosN[0].value = currPos;
-            IDSetNumber(&RotatorAbsPosNP, nullptr);
+            RotatorAbsPosNP[0].setValue(currPos);
+            RotatorAbsPosNP.apply();
         }
     }
     else
@@ -1418,11 +1418,11 @@ bool Gemini::getRotatorStatus()
     if (rc == 2)
     {
         // Only send when above a threshold
-        double diffPA = fabs(GotoRotatorN[0].value - currPA / 1000.0);
+        double diffPA = fabs(GotoRotatorNP[0].value - currPA / 1000.0);
         if (diffPA >= 0.01)
         {
-            GotoRotatorN[0].value = currPA / 1000.0;
-            IDSetNumber(&GotoRotatorNP, nullptr);
+            GotoRotatorNP[0].setValue(currPA / 1000.0);
+            GotoRotatorNP.apply();
         }
     }
     else
@@ -1471,7 +1471,7 @@ bool Gemini::getRotatorStatus()
     if (rc != 2)
         return false;
 
-    RotatorStatusL[STATUS_MOVING].s = isMoving ? IPS_BUSY : IPS_IDLE;
+    RotatorStatusLP[STATUS_MOVING].setState(isMoving ? IPS_BUSY : IPS_IDLE);
 
     ///////////////////////////////////////
     // #6 is Homing?
@@ -1496,10 +1496,10 @@ bool Gemini::getRotatorStatus()
     if (rc != 2)
         return false;
 
-    RotatorStatusL[STATUS_HOMING].s = _isHoming ? IPS_BUSY : IPS_IDLE;
+    RotatorStatusLP[STATUS_HOMING].setState(_isHoming ? IPS_BUSY : IPS_IDLE);
 
     // We set that isHoming in process, but we don't set it to false here it must be reset in TimerHit
-    if (RotatorStatusL[STATUS_HOMING].s == IPS_BUSY)
+    if (RotatorStatusLP[STATUS_HOMING].getState() == IPS_BUSY)
         isRotatorHoming = true;
 
     ///////////////////////////////////////
@@ -1525,8 +1525,8 @@ bool Gemini::getRotatorStatus()
     if (rc != 2)
         return false;
 
-    RotatorStatusL[STATUS_HOMED].s = isHomed ? IPS_OK : IPS_IDLE;
-    IDSetLight(&RotatorStatusLP, nullptr);
+    RotatorStatusLP[STATUS_HOMED].setState(isHomed ? IPS_OK : IPS_IDLE);
+    RotatorStatusLP.apply();
 
     // Added By Philippe Besson the 28th of June for 'END' evalution
     // END is reached
@@ -1641,9 +1641,9 @@ bool Gemini::getRotatorConfig()
     if (rc != 2)
         return false;
 
-    IUSaveText(&HFocusNameT[DEVICE_ROTATOR], nickname);
-    HFocusNameTP.s = IPS_OK;
-    IDSetText(&HFocusNameTP, nullptr);
+    HFocusNameTP[DEVICE_ROTATOR].setText(nickname);
+    HFocusNameTP.setState(IPS_OK);
+    HFocusNameTP.apply();
 
     memset(response, 0, sizeof(response));
 
@@ -1668,10 +1668,10 @@ bool Gemini::getRotatorConfig()
     rc = sscanf(response, "%16[^=]=%d", key, &maxPos);
     if (rc == 2)
     {
-        RotatorAbsPosN[0].min = 0;
-        RotatorAbsPosN[0].max = maxPos;
-        RotatorAbsPosN[0].step = maxPos / 50.0;
-        IUUpdateMinMax(&RotatorAbsPosNP);
+        RotatorAbsPosNP[0].setMin(0);
+        RotatorAbsPosNP[0].setMax(maxPos);
+        RotatorAbsPosNP[0].setStep(maxPos / 50.0);
+        RotatorAbsPosNP.updateMinMax();
     }
     else
         return false;
@@ -1704,7 +1704,7 @@ bool Gemini::getRotatorConfig()
     memset(response, 0, sizeof(response));
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "BLCSteps = %d\n", RotatorBacklashS[INDI_ENABLED].s == ISS_ON ? 1 : 0);
+        snprintf(response, sizeof(response), "BLCSteps = %d\n", RotatorBacklashSP[INDI_ENABLED].getState() == ISS_ON ? 1 : 0);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1721,11 +1721,11 @@ bool Gemini::getRotatorConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&RotatorBacklashSP);
-    RotatorBacklashS[INDI_ENABLED].s = BLCCompensate ? ISS_ON : ISS_OFF;
-    RotatorBacklashS[INDI_DISABLED].s = BLCCompensate ? ISS_OFF : ISS_ON;
-    RotatorBacklashSP.s   = IPS_OK;
-    IDSetSwitch(&RotatorBacklashSP, nullptr);
+    RotatorBacklashSP.reset();
+    RotatorBacklashSP[INDI_ENABLED].setState(BLCCompensate ? ISS_ON : ISS_OFF);
+    RotatorBacklashSP[INDI_DISABLED].setState(BLCCompensate ? ISS_OFF : ISS_ON);
+    RotatorBacklashSP.setState(IPS_OK);
+    RotatorBacklashSP.apply();
 
     ////////////////////////////////////////////////////////////
     // Backlash Value
@@ -1750,9 +1750,9 @@ bool Gemini::getRotatorConfig()
     if (rc != 2)
         return false;
 
-    RotatorBacklashN[0].value = BLCValue;
-    RotatorBacklashNP.s       = IPS_OK;
-    IDSetNumber(&RotatorBacklashNP, nullptr);
+    RotatorBacklashNP[0].setValue(BLCValue);
+    RotatorBacklashNP.setState(IPS_OK);
+    RotatorBacklashNP.apply();
 
     ////////////////////////////////////////////////////////////
     // Home on start on?
@@ -1760,7 +1760,7 @@ bool Gemini::getRotatorConfig()
     memset(response, 0, sizeof(response));
     if (isSimulation())
     {
-        snprintf(response, sizeof(response), "HOnStart = %d\n", RotatorHomeOnStartS[0].s == ISS_ON ? 1 : 0);
+        snprintf(response, sizeof(response), "HOnStart = %d\n", RotatorHomeOnStartSP[0].getState() == ISS_ON ? 1 : 0);
         nbytes_read = strlen(response);
     }
     else if ((errcode = tty_read_section(PortFD, response, 0xA, GEMINI_TIMEOUT, &nbytes_read)) != TTY_OK)
@@ -1777,11 +1777,11 @@ bool Gemini::getRotatorConfig()
     if (rc != 2)
         return false;
 
-    IUResetSwitch(&RotatorHomeOnStartSP);
-    RotatorHomeOnStartS[0].s = StartOnHome ? ISS_ON : ISS_OFF;
-    RotatorHomeOnStartS[1].s = StartOnHome ? ISS_OFF : ISS_ON;
-    RotatorHomeOnStartSP.s   = IPS_OK;
-    IDSetSwitch(&RotatorHomeOnStartSP, nullptr);
+    RotatorHomeOnStartSP.reset();
+    RotatorHomeOnStartSP[0].setState(StartOnHome ? ISS_ON : ISS_OFF);
+    RotatorHomeOnStartSP[1].setState(StartOnHome ? ISS_OFF : ISS_ON);
+    RotatorHomeOnStartSP.setState(IPS_OK);
+    RotatorHomeOnStartSP.apply();
 
     ////////////////////////////////////////////////////////////
     // Reverse?
@@ -1806,20 +1806,20 @@ bool Gemini::getRotatorConfig()
     if (rc != 2)
         return false;
 
-    RotatorStatusL[STATUS_REVERSE].s = reverse ? IPS_OK : IPS_IDLE;
+    RotatorStatusLP[STATUS_REVERSE].setState(reverse ? IPS_OK : IPS_IDLE);
 
     // If reverse is enable and switch shows disabled, let's change that
     // same thing is reverse is disabled but switch is enabled
-    if ((reverse && ReverseRotatorS[1].s == ISS_ON) || (!reverse && ReverseRotatorS[0].s == ISS_ON))
+    if ((reverse && ReverseRotatorSP[1].s == ISS_ON) || (!reverse && ReverseRotatorSP[0].s == ISS_ON))
     {
-        IUResetSwitch(&ReverseRotatorSP);
-        ReverseRotatorS[0].s = (reverse == 1) ? ISS_ON : ISS_OFF;
-        ReverseRotatorS[1].s = (reverse == 0) ? ISS_ON : ISS_OFF;
-        IDSetSwitch(&ReverseRotatorSP, nullptr);
+        ReverseRotatorSP.reset();
+        ReverseRotatorSP[0].setState((reverse == 1) ? ISS_ON : ISS_OFF);
+        ReverseRotatorSP[1].setState((reverse == 0) ? ISS_ON : ISS_OFF);
+        ReverseRotatorSP.apply();
     }
 
-    RotatorStatusLP.s = IPS_OK;
-    IDSetLight(&RotatorStatusLP, nullptr);
+    RotatorStatusLP.setState(IPS_OK);
+    RotatorStatusLP.apply();
 
     ////////////////////////////////////////////////////////////
     // Max Speed - Not used
@@ -1941,8 +1941,8 @@ bool Gemini::getFocusStatus()
     int rc = sscanf(response, "%16[^=]=%f", key, &temperature);
     if (rc == 2)
     {
-        TemperatureN[0].value = temperature;
-        IDSetNumber(&TemperatureNP, nullptr);
+        TemperatureNP[0].setValue(temperature);
+        TemperatureNP.apply();
     }
     else
     {
@@ -1951,10 +1951,10 @@ bool Gemini::getFocusStatus()
 
         if (rc != 2 || strcmp(np, "NP"))
         {
-            if (TemperatureNP.s != IPS_ALERT)
+            if (TemperatureNP.getState() != IPS_ALERT)
             {
-                TemperatureNP.s = IPS_ALERT;
-                IDSetNumber(&TemperatureNP, nullptr);
+                TemperatureNP.setState(IPS_ALERT);
+                TemperatureNP.apply();
             }
             return false;
         }
@@ -1982,8 +1982,8 @@ bool Gemini::getFocusStatus()
     rc = sscanf(response, "%16[^=]=%d", key, &currPos);
     if (rc == 2)
     {
-        FocusAbsPosN[0].value = currPos;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setValue(currPos);
+        FocusAbsPosNP.apply();
     }
     else
         return false;
@@ -2031,7 +2031,7 @@ bool Gemini::getFocusStatus()
     if (rc != 2)
         return false;
 
-    FocuserStatusL[STATUS_MOVING].s = isMoving ? IPS_BUSY : IPS_IDLE;
+    FocuserStatusLP[STATUS_MOVING].setState(isMoving ? IPS_BUSY : IPS_IDLE);
 
     ///////////////////////////////////////
     // #4 is Homing?
@@ -2056,13 +2056,13 @@ bool Gemini::getFocusStatus()
     if (rc != 2)
         return false;
 
-    FocuserStatusL[STATUS_HOMING].s = _isHoming ? IPS_BUSY : IPS_IDLE;
+    FocuserStatusLP[STATUS_HOMING].setState(_isHoming ? IPS_BUSY : IPS_IDLE);
     // For relative focusers home is not applicable.
     if (isFocuserAbsolute == false)
-        FocuserStatusL[STATUS_HOMING].s = IPS_IDLE;
+        FocuserStatusLP[STATUS_HOMING].setState(IPS_IDLE);
 
     // We set that isHoming in process, but we don't set it to false here it must be reset in TimerHit
-    if (FocuserStatusL[STATUS_HOMING].s == IPS_BUSY)
+    if (FocuserStatusLP[STATUS_HOMING].getState() == IPS_BUSY)
         isFocuserHoming = true;
 
     ///////////////////////////////////////
@@ -2088,10 +2088,10 @@ bool Gemini::getFocusStatus()
     if (rc != 2)
         return false;
 
-    FocuserStatusL[STATUS_HOMED].s = isHomed ? IPS_OK : IPS_IDLE;
+    FocuserStatusLP[STATUS_HOMED].setState(isHomed ? IPS_OK : IPS_IDLE);
     // For relative focusers home is not applicable.
     if (isFocuserAbsolute == false)
-        FocuserStatusL[STATUS_HOMED].s = IPS_IDLE;
+        FocuserStatusLP[STATUS_HOMED].setState(IPS_IDLE);
 
     ///////////////////////////////////////
     // #7 Temperature probe?
@@ -2116,7 +2116,7 @@ bool Gemini::getFocusStatus()
     if (rc != 2)
         return false;
 
-    FocuserStatusL[STATUS_TMPPROBE].s = TmpProbe ? IPS_OK : IPS_IDLE;
+    FocuserStatusLP[STATUS_TMPPROBE].setState(TmpProbe ? IPS_OK : IPS_IDLE);
 
     ///////////////////////////////////////
     // #8 Remote IO?
@@ -2141,7 +2141,7 @@ bool Gemini::getFocusStatus()
     if (rc != 2)
         return false;
 
-    FocuserStatusL[STATUS_REMOTEIO].s = RemoteIO ? IPS_OK : IPS_IDLE;
+    FocuserStatusLP[STATUS_REMOTEIO].setState(RemoteIO ? IPS_OK : IPS_IDLE);
 
     ///////////////////////////////////////
     // #9 Hand controller?
@@ -2166,10 +2166,10 @@ bool Gemini::getFocusStatus()
     if (rc != 2)
         return false;
 
-    FocuserStatusL[STATUS_HNDCTRL].s = HndCtlr ? IPS_OK : IPS_IDLE;
+    FocuserStatusLP[STATUS_HNDCTRL].setState(HndCtlr ? IPS_OK : IPS_IDLE);
 
-    FocuserStatusLP.s = IPS_OK;
-    IDSetLight(&FocuserStatusLP, nullptr);
+    FocuserStatusLP.setState(IPS_OK);
+    FocuserStatusLP.apply();
 
     // Added By Philippe Besson the 28th of June for 'END' evalution
     // END is reached
@@ -2461,7 +2461,7 @@ bool Gemini::homeOnStart(DeviceType type, bool enable)
 bool Gemini::center(DeviceType type)
 {
     if (type == DEVICE_ROTATOR)
-        return MoveAbsRotatorTicks(RotatorAbsPosN[0].max / 2);
+        return MoveAbsRotatorTicks(RotatorAbsPosNP[0].getMax() / 2);
 
     const char * cmd = "<F100CENTER>";
     int errcode = 0;
@@ -2479,12 +2479,12 @@ bool Gemini::center(DeviceType type)
         if (type == DEVICE_FOCUSER)
         {
             focuserSimStatus[STATUS_MOVING] = ISS_ON;
-            targetFocuserPosition = FocusAbsPosN[0].max / 2;
+            targetFocuserPosition = FocusAbsPosNP[0].getMax() / 2;
         }
         else
         {
             rotatorSimStatus[STATUS_MOVING] = ISS_ON;
-            targetRotatorPosition = RotatorAbsPosN[0].max / 2;
+            targetRotatorPosition = RotatorAbsPosNP[0].getMax() / 2;
         }
 
     }
@@ -2994,7 +2994,7 @@ IPState Gemini::MoveAbsFocuser(uint32_t targetTicks)
             return IPS_ALERT;
     }
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     tcflush(PortFD, TCIFLUSH);
 
@@ -3009,9 +3009,9 @@ IPState Gemini::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     uint32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     return MoveAbsFocuser(newPosition);
 }
@@ -3046,11 +3046,11 @@ void Gemini::TimerHit()
         return;
     }
 
-    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if (isSimulation())
         {
-            if (FocusAbsPosN[0].value < targetFocuserPosition)
+            if (FocusAbsPosNP[0].value < targetFocuserPosition)
                 focuserSimPosition += 100;
             else
                 focuserSimPosition -= 100;
@@ -3059,48 +3059,48 @@ void Gemini::TimerHit()
 
             if (std::abs((int64_t)focuserSimPosition - (int64_t)targetFocuserPosition) < 100)
             {
-                FocusAbsPosN[0].value    = targetFocuserPosition;
-                focuserSimPosition              = FocusAbsPosN[0].value;
+                FocusAbsPosNP[0].setValue(targetFocuserPosition);
+                focuserSimPosition              = FocusAbsPosNP[0].getValue();
                 focuserSimStatus[STATUS_MOVING] = ISS_OFF;
-                FocuserStatusL[STATUS_MOVING].s = IPS_IDLE;
+                FocuserStatusLP[STATUS_MOVING].setState(IPS_IDLE);
                 if (focuserSimStatus[STATUS_HOMING] == ISS_ON)
                 {
-                    FocuserStatusL[STATUS_HOMED].s = IPS_OK;
+                    FocuserStatusLP[STATUS_HOMED].setState(IPS_OK);
                     focuserSimStatus[STATUS_HOMING] = ISS_OFF;
                 }
             }
         }
 
-        if (isFocuserHoming && FocuserStatusL[STATUS_HOMED].s == IPS_OK)
+        if (isFocuserHoming && FocuserStatusLP[STATUS_HOMED].s == IPS_OK)
         {
             isFocuserHoming = false;
-            FocuserGotoSP.s = IPS_OK;
-            IUResetSwitch(&FocuserGotoSP);
-            FocuserGotoS[GOTO_HOME].s = ISS_ON;
-            IDSetSwitch(&FocuserGotoSP, nullptr);
-            FocusAbsPosNP.s = IPS_OK;
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocuserGotoSP.setState(IPS_OK);
+            FocuserGotoSP.reset();
+            FocuserGotoSP[GOTO_HOME].setState(ISS_ON);
+            FocuserGotoSP.apply();
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.apply();
             LOG_INFO("Focuser reached home position.");
         }
-        else if (FocuserStatusL[STATUS_MOVING].s == IPS_IDLE)
+        else if (FocuserStatusLP[STATUS_MOVING].getState() == IPS_IDLE)
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            if (FocuserGotoSP.s == IPS_BUSY)
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
+            FocusRelPosNP.apply();
+            if (FocuserGotoSP.getState() == IPS_BUSY)
             {
-                IUResetSwitch(&FocuserGotoSP);
-                FocuserGotoSP.s = IPS_OK;
-                IDSetSwitch(&FocuserGotoSP, nullptr);
+                FocuserGotoSP.reset();
+                FocuserGotoSP.setState(IPS_OK);
+                FocuserGotoSP.apply();
             }
             LOG_INFO("Focuser reached requested position.");
         }
     }
-    if (FocuserStatusL[STATUS_HOMING].s == IPS_BUSY && FocuserGotoSP.s != IPS_BUSY)
+    if (FocuserStatusLP[STATUS_HOMING].getState() == IPS_BUSY && FocuserGotoSP.getState() != IPS_BUSY)
     {
-        FocuserGotoSP.s = IPS_BUSY;
-        IDSetSwitch(&FocuserGotoSP, nullptr);
+        FocuserGotoSP.setState(IPS_BUSY);
+        FocuserGotoSP.apply();
     }
 
     // Rotator Status
@@ -3119,11 +3119,11 @@ void Gemini::TimerHit()
         return;
     }
 
-    if (RotatorAbsPosNP.s == IPS_BUSY || GotoRotatorNP.s == IPS_BUSY)
+    if (RotatorAbsPosNP.getState() == IPS_BUSY || GotoRotatorNP.getState() == IPS_BUSY)
     {
         /*if (isSimulation())
         {
-            if (RotatorAbsPosN[0].value < targetRotatorPosition)
+            if (RotatorAbsPosNP[0].value < targetRotatorPosition)
                 RotatorSimPosition += 100;
             else
                 RotatorSimPosition -= 100;
@@ -3132,49 +3132,49 @@ void Gemini::TimerHit()
 
             if (std::abs((int64_t)RotatorSimPosition - (int64_t)targetRotatorPosition) < 100)
             {
-                RotatorAbsPosN[0].value    = targetRotatorPosition;
-                RotatorSimPosition              = RotatorAbsPosN[0].value;
+                RotatorAbsPosNP[0].setValue(targetRotatorPosition);
+                RotatorSimPosition              = RotatorAbsPosNP[0].getValue();
                 RotatorSimStatus[STATUS_MOVING] = ISS_OFF;
-                RotatorStatusL[STATUS_MOVING].s = IPS_IDLE;
+                RotatorStatusLP[STATUS_MOVING].setState(IPS_IDLE);
                 if (RotatorSimStatus[STATUS_HOMING] == ISS_ON)
                 {
-                    RotatorStatusL[STATUS_HOMED].s = IPS_OK;
+                    RotatorStatusLP[STATUS_HOMED].setState(IPS_OK);
                     RotatorSimStatus[STATUS_HOMING] = ISS_OFF;
                 }
             }
         }*/
 
-        if (isRotatorHoming && RotatorStatusL[STATUS_HOMED].s == IPS_OK)
+        if (isRotatorHoming && RotatorStatusLP[STATUS_HOMED].s == IPS_OK)
         {
             isRotatorHoming = false;
-            HomeRotatorSP.s = IPS_OK;
-            IUResetSwitch(&HomeRotatorSP);
-            IDSetSwitch(&HomeRotatorSP, nullptr);
-            RotatorAbsPosNP.s = IPS_OK;
-            IDSetNumber(&RotatorAbsPosNP, nullptr);
-            GotoRotatorNP.s = IPS_OK;
-            IDSetNumber(&GotoRotatorNP, nullptr);
+            HomeRotatorSP.setState(IPS_OK);
+            HomeRotatorSP.reset();
+            HomeRotatorSP.apply();
+            RotatorAbsPosNP.setState(IPS_OK);
+            RotatorAbsPosNP.apply();
+            GotoRotatorNP.setState(IPS_OK);
+            GotoRotatorNP.apply();
             LOG_INFO("Rotator reached home position.");
         }
-        else if (RotatorStatusL[STATUS_MOVING].s == IPS_IDLE)
+        else if (RotatorStatusLP[STATUS_MOVING].getState() == IPS_IDLE)
         {
-            RotatorAbsPosNP.s = IPS_OK;
-            IDSetNumber(&RotatorAbsPosNP, nullptr);
-            GotoRotatorNP.s = IPS_OK;
-            IDSetNumber(&GotoRotatorNP, nullptr);
-            if (HomeRotatorSP.s == IPS_BUSY)
+            RotatorAbsPosNP.setState(IPS_OK);
+            RotatorAbsPosNP.apply();
+            GotoRotatorNP.setState(IPS_OK);
+            GotoRotatorNP.apply();
+            if (HomeRotatorSP.getState() == IPS_BUSY)
             {
-                IUResetSwitch(&HomeRotatorSP);
-                HomeRotatorSP.s = IPS_OK;
-                IDSetSwitch(&HomeRotatorSP, nullptr);
+                HomeRotatorSP.reset();
+                HomeRotatorSP.setState(IPS_OK);
+                HomeRotatorSP.apply();
             }
             LOG_INFO("Rotator reached requested position.");
         }
     }
-    if (RotatorStatusL[STATUS_HOMING].s == IPS_BUSY && HomeRotatorSP.s != IPS_BUSY)
+    if (RotatorStatusLP[STATUS_HOMING].getState() == IPS_BUSY && HomeRotatorSP.getState() != IPS_BUSY)
     {
-        HomeRotatorSP.s = IPS_BUSY;
-        IDSetSwitch(&HomeRotatorSP, nullptr);
+        HomeRotatorSP.setState(IPS_BUSY);
+        HomeRotatorSP.apply();
     }
 
     SetTimer(getCurrentPollingPeriod());
@@ -3219,18 +3219,18 @@ bool Gemini::AbortFocuser()
     }
 
 
-    if (FocusRelPosNP.s == IPS_BUSY)
+    if (FocusRelPosNP.getState() == IPS_BUSY)
     {
-        FocusRelPosNP.s = IPS_IDLE;
-        IDSetNumber(&FocusRelPosNP, nullptr);
+        FocusRelPosNP.setState(IPS_IDLE);
+        FocusRelPosNP.apply();
     }
 
-    FocusTimerNP.s = IPS_IDLE;
-    FocusAbsPosNP.s = IPS_IDLE;
-    FocuserGotoSP.s = IPS_IDLE;
-    IUResetSwitch(&FocuserGotoSP);
-    IDSetNumber(&FocusAbsPosNP, nullptr);
-    IDSetSwitch(&FocuserGotoSP, nullptr);
+    FocusTimerNP.setState(IPS_IDLE);
+    FocusAbsPosNP.setState(IPS_IDLE);
+    FocuserGotoSP.setState(IPS_IDLE);
+    FocuserGotoSP.reset();
+    FocusAbsPosNP.apply();
+    FocuserGotoSP.apply();
 
     tcflush(PortFD, TCIFLUSH);
 
@@ -3291,7 +3291,7 @@ IPState Gemini::MoveAbsRotatorTicks(uint32_t targetTicks)
             return IPS_ALERT;
     }
 
-    RotatorAbsPosNP.s = IPS_BUSY;
+    RotatorAbsPosNP.setState(IPS_BUSY);
 
     tcflush(PortFD, TCIFLUSH);
 
@@ -3332,7 +3332,7 @@ IPState Gemini::MoveAbsRotatorAngle(double angle)
             return IPS_ALERT;
     }
 
-    GotoRotatorNP.s = IPS_BUSY;
+    GotoRotatorNP.setState(IPS_BUSY);
 
     tcflush(PortFD, TCIFLUSH);
 
@@ -3349,12 +3349,12 @@ bool Gemini::saveConfigItems(FILE *fp)
     // Rotator Configs
     RI::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &TemperatureCompensateSP);
-    IUSaveConfigSwitch(fp, &TemperatureCompensateOnStartSP);
-    IUSaveConfigNumber(fp, &TemperatureCoeffNP);
-    IUSaveConfigSwitch(fp, &TemperatureCompensateModeSP);
-    IUSaveConfigSwitch(fp, &FocuserHomeOnStartSP);
-    IUSaveConfigSwitch(fp, &RotatorHomeOnStartSP);
+    TemperatureCompensateSP.save(fp);
+    TemperatureCompensateOnStartSP.save(fp);
+    TemperatureCoeffNP.save(fp);
+    TemperatureCompensateModeSP.save(fp);
+    FocuserHomeOnStartSP.save(fp);
+    RotatorHomeOnStartSP.save(fp);
 
     return true;
 }
@@ -3365,8 +3365,8 @@ bool Gemini::saveConfigItems(FILE *fp)
 IPState Gemini::MoveRotator(double angle)
 {
     IPState state = MoveAbsRotatorAngle(angle);
-    RotatorAbsPosNP.s = state;
-    IDSetNumber(&RotatorAbsPosNP, nullptr);
+    RotatorAbsPosNP.setState(state);
+    RotatorAbsPosNP.apply();
 
     return state;
 }

--- a/drivers/rotator/gemini.h
+++ b/drivers/rotator/gemini.h
@@ -25,6 +25,12 @@
 
 #include <map>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
+
 class Gemini : public INDI::Focuser, public INDI::RotatorInterface
 {
     public:
@@ -155,44 +161,36 @@ class Gemini : public INDI::Focuser, public INDI::RotatorInterface
         ///////////////////////////////////////////////////////////
 
         // Set/Get Temperature
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Enable/Disable temperature compnesation
-        ISwitch TemperatureCompensateS[2];
-        ISwitchVectorProperty TemperatureCompensateSP;
+        INDI::PropertySwitch TemperatureCompensateSP {2};
 
         // Enable/Disable temperature compnesation on start
-        ISwitch TemperatureCompensateOnStartS[2];
-        ISwitchVectorProperty TemperatureCompensateOnStartSP;
+        INDI::PropertySwitch TemperatureCompensateOnStartSP {2};
 
         // Temperature Coefficient
-        INumber TemperatureCoeffN[5];
-        INumberVectorProperty TemperatureCoeffNP;
+        INDI::PropertyNumber TemperatureCoeffNP {5};
 
         // Temperature Coefficient Mode
-        ISwitch TemperatureCompensateModeS[5];
-        ISwitchVectorProperty TemperatureCompensateModeSP;
+        INDI::PropertySwitch TemperatureCompensateModeSP {5};
 
         // Enable/Disable backlash
-        //    ISwitch FocuserBacklashCompensationS[2];
+        //    INDI::PropertySwitch FocuserBacklashCompensationSP {2};
         //    ISwitchVectorProperty FocuserFocusBacklashSP;
 
         // Backlash Value
-        //    INumber FocusBacklashN[1];
-        //    INumberVectorProperty FocusBacklashNP;
+        //    INDI::PropertyNumber FocusBacklashNP {1};
+        //
 
         // Home On Start
-        ISwitch FocuserHomeOnStartS[2];
-        ISwitchVectorProperty FocuserHomeOnStartSP;
+        INDI::PropertySwitch FocuserHomeOnStartSP {2};
 
         // Go to home/center
-        ISwitch FocuserGotoS[2];
-        ISwitchVectorProperty FocuserGotoSP;
+        INDI::PropertySwitch FocuserGotoSP {2};
 
         // Status indicators
-        ILight FocuserStatusL[8];
-        ILightVectorProperty FocuserStatusLP;
+        INDI::PropertyLight FocuserStatusLP {8};
 
         bool isFocuserAbsolute;
         bool isFocuserHoming;
@@ -214,36 +212,29 @@ class Gemini : public INDI::Focuser, public INDI::RotatorInterface
         ///////////////////////////////////////////////////////////
 
         // Status
-        ILight RotatorStatusL[8];
-        ILightVectorProperty RotatorStatusLP;
+        INDI::PropertyLight RotatorStatusLP {8};
 
         // Rotator Steps
-        INumber RotatorAbsPosN[1];
-        INumberVectorProperty RotatorAbsPosNP;
+        INDI::PropertyNumber RotatorAbsPosNP {1};
 
 #if 0
         // Reverse Direction
-        ISwitch RotatorReverseS[2];
-        ISwitchVectorProperty RotatorReverseSP;
+        INDI::PropertySwitch RotatorReverseSP {2};
 
 
 
         // Rotator Degrees or PA (Position Angle)
-        INumber RotatorAbsAngleN[1];
-        INumberVectorProperty RotatorAbsAngleNP;
+        INDI::PropertyNumber RotatorAbsAngleNP {1};
 
         // Abort
-        ISwitch AbortRotatorS[1];
-        ISwitchVectorProperty AbortRotatorSP;
+        INDI::PropertySwitch AbortRotatorSP {1};
 
         // Go to home/center
-        ISwitch RotatorGotoS[2];
-        ISwitchVectorProperty RotatorGotoSP;
+        INDI::PropertySwitch RotatorGotoSP {2};
 #endif
 
         // Home On Start
-        ISwitch RotatorHomeOnStartS[2];
-        ISwitchVectorProperty RotatorHomeOnStartSP;
+        INDI::PropertySwitch RotatorHomeOnStartSP {2};
 
         bool isRotatorHoming;
 
@@ -266,16 +257,13 @@ class Gemini : public INDI::Focuser, public INDI::RotatorInterface
         ///////////////////////////////////////////////////////////
 
         // Reset to Factory setting
-        ISwitch ResetS[1];
-        ISwitchVectorProperty ResetSP;
+        INDI::PropertySwitch ResetSP {1};
 
         // Focus and rotator name configure in the HUB
-        IText HFocusNameT[2] {};
-        ITextVectorProperty HFocusNameTP;
+        INDI::PropertyText HFocusNameTP {2};
 
         // Led Intensity Value
-        INumber LedN[1];
-        INumberVectorProperty LedNP;
+        INDI::PropertyNumber LedNP {1};
 
         uint32_t DBG_FOCUS;
 };

--- a/drivers/rotator/integra.cpp
+++ b/drivers/rotator/integra.cpp
@@ -129,46 +129,46 @@ bool Integra::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    IUFillNumber(&MaxPositionN[0], "FOCUSER", "Focuser", "%.f",
+    MaxPositionNP[0].fill("FOCUSER", "Focuser", "%.f",
                  0, wellKnownIntegra85FocusMax, 0., wellKnownIntegra85FocusMax);
-    IUFillNumber(&MaxPositionN[1], "ROTATOR", "Rotator", "%.f",
+    MaxPositionNP[1].fill("ROTATOR", "Rotator", "%.f",
                  0, wellKnownIntegra85RotateMax, 0., wellKnownIntegra85RotateMax);
-    IUFillNumberVector(&MaxPositionNP, MaxPositionN, 2, getDeviceName(), "MAX_POSITION", "Max position",
+    MaxPositionNP.fill(getDeviceName(), "MAX_POSITION", "Max position",
                        SETTINGS_TAB, IP_RO, 0, IPS_IDLE);
 
-    FocusSpeedN[0].min = 1;
-    FocusSpeedN[0].max = 1;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(1);
+    FocusSpeedNP[0].setValue(1);
 
     // Temperature Sensor
-    IUFillNumber(&SensorN[SENSOR_TEMPERATURE], "TEMPERATURE", "Temperature (C)", "%.2f", -100, 100., 1., 0.);
-    IUFillNumberVector(&SensorNP, SensorN, 1, getDeviceName(), "SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE );
+    SensorNP[SENSOR_TEMPERATURE].fill("TEMPERATURE", "Temperature (C)", "%.2f", -100, 100., 1., 0.);
+    SensorNP.fill(getDeviceName(), "SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE );
 
     // Home Find
-    IUFillSwitch(&FindHomeS[HOMING_IDLE], "HOMING_IDLE", "Idle", ISS_ON);
-    IUFillSwitch(&FindHomeS[HOMING_START], "HOMING_START", "Start", ISS_OFF);
-    IUFillSwitch(&FindHomeS[HOMING_ABORT], "HOMING_ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&FindHomeSP, FindHomeS, HOMING_COUNT, getDeviceName(), "HOMING", "Home at Center", SETTINGS_TAB, IP_RW,
+    FindHomeSP[HOMING_IDLE].fill("HOMING_IDLE", "Idle", ISS_ON);
+    FindHomeSP[HOMING_START].fill("HOMING_START", "Start", ISS_OFF);
+    FindHomeSP[HOMING_ABORT].fill("HOMING_ABORT", "Abort", ISS_OFF);
+    FindHomeSP.fill(getDeviceName(), "HOMING", "Home at Center", SETTINGS_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
     // Relative and absolute movement
-    FocusAbsPosN[0].min   = 0;
-    FocusAbsPosN[0].max   = MaxPositionN[0].value;
-    FocusAbsPosN[0].step  = MaxPositionN[0].value / 50.0;
-    FocusAbsPosN[0].value = 0;
+    FocusAbsPosNP[0].setMin(0);
+    FocusAbsPosNP[0].setMax(MaxPositionNP[0].getValue());
+    FocusAbsPosNP[0].setStep(MaxPositionNP[0].value / 50.0);
+    FocusAbsPosNP[0].setValue(0);
 
-    FocusRelPosN[0].min   = 0;
-    FocusRelPosN[0].max   = (FocusAbsPosN[0].max - FocusAbsPosN[0].min) / 2;
-    FocusRelPosN[0].step  = FocusRelPosN[0].max / 100.0;
-    FocusRelPosN[0].value = 100;
+    FocusRelPosNP[0].setMin(0);
+    FocusRelPosNP[0].setMax((FocusAbsPosNP[0].max - FocusAbsPosNP[0].min) / 2);
+    FocusRelPosNP[0].setStep(FocusRelPosNP[0].getMax() / 100.0);
+    FocusRelPosNP[0].setValue(100);
 
     RI::initProperties(ROTATOR_TAB);
 
     // Rotator Ticks
-    IUFillNumber(&RotatorAbsPosN[0], "ROTATOR_ABSOLUTE_POSITION", "Ticks", "%.f", 0., 61802., 1., 0.);
-    IUFillNumberVector(&RotatorAbsPosNP, RotatorAbsPosN, 1, getDeviceName(), "ABS_ROTATOR_POSITION", "Goto", ROTATOR_TAB, IP_RW,
+    RotatorAbsPosNP[0].fill("ROTATOR_ABSOLUTE_POSITION", "Ticks", "%.f", 0., 61802., 1., 0.);
+    RotatorAbsPosNP.fill(getDeviceName(), "ABS_ROTATOR_POSITION", "Goto", ROTATOR_TAB, IP_RW,
                        0, IPS_IDLE );
-    RotatorAbsPosN[0].min = 0;
+    RotatorAbsPosNP[0].setMin(0);
 
     addDebugControl();
 
@@ -189,26 +189,26 @@ bool Integra::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&MaxPositionNP);
+        defineProperty(MaxPositionNP);
         // Focus
-        defineProperty(&SensorNP);
-        defineProperty(&FindHomeSP);
+        defineProperty(SensorNP);
+        defineProperty(FindHomeSP);
 
         // Rotator
         RI::updateProperties();
-        defineProperty(&RotatorAbsPosNP);
+        defineProperty(RotatorAbsPosNP);
     }
     else
     {
-        deleteProperty(MaxPositionNP.name);
+        deleteProperty(MaxPositionNP.getName());
 
         // Focus
-        deleteProperty(SensorNP.name);
-        deleteProperty(FindHomeSP.name);
+        deleteProperty(SensorNP.getName());
+        deleteProperty(FindHomeSP.getName());
 
         // Rotator
         RI::updateProperties();
-        deleteProperty(RotatorAbsPosNP.name);
+        deleteProperty(RotatorAbsPosNP.getName());
     }
 
     return true;
@@ -290,8 +290,8 @@ bool Integra::getFirmware()
 // Called from our ::Handshake
 bool Integra::getFocuserType()
 {
-    int focus_max = int(FocusAbsPosN[0].max);
-    int rotator_max = int(RotatorAbsPosN[0].max);
+    int focus_max = int(FocusAbsPosNP[0].max);
+    int rotator_max = int(RotatorAbsPosNP[0].max);
     if (focus_max != wellKnownIntegra85FocusMax)
     {
         LOGF_ERROR("This is no Integra85 because focus max position %d != %d, trying to continue still", focus_max,
@@ -309,9 +309,9 @@ bool Integra::getFocuserType()
     LOGF_INFO("Focuser Type %s", resp);
     if (strcmp(resp, "Integra85") == 0)
     {
-        // RotatorAbsPosN[0].max is already set by getMaxPosition
-        rotatorTicksPerDegree = RotatorAbsPosN[0].max / 360.0;
-        rotatorDegreesPerTick = 360.0 / RotatorAbsPosN[0].max;
+        // RotatorAbsPosNP[0].max is already set by getMaxPosition
+        rotatorTicksPerDegree = RotatorAbsPosNP[0].getMax() / 360.0;
+        rotatorDegreesPerTick = 360.0 / RotatorAbsPosNP[0].getMax();
     }
 
     return true;
@@ -331,11 +331,11 @@ bool Integra::relativeGotoMotor(MotorType type, int32_t relativePosition)
     {
         if (relativePosition > 0)
         {
-            if (lastFocuserPosition + relativePosition > MaxPositionN[MOTOR_FOCUS].value)
+            if (lastFocuserPosition + relativePosition > MaxPositionNP[MOTOR_FOCUS].getValue())
             {
-                int newRelativePosition = (int32_t)floor(MaxPositionN[MOTOR_FOCUS].value) - lastFocuserPosition;
+                int newRelativePosition = (int32_t)floor(MaxPositionNP[MOTOR_FOCUS].value) - lastFocuserPosition;
                 LOGF_INFO("Focus position change %d clipped to %d to stay at MAX %d",
-                          relativePosition, newRelativePosition, MaxPositionN[MOTOR_FOCUS].value);
+                          relativePosition, newRelativePosition, MaxPositionNP[MOTOR_FOCUS].getValue());
                 relativePosition = newRelativePosition;
             }
         }
@@ -354,21 +354,21 @@ bool Integra::relativeGotoMotor(MotorType type, int32_t relativePosition)
     {
         if (relativePosition > 0)
         {
-            if (lastRotatorPosition + relativePosition > MaxPositionN[MOTOR_ROTATOR].value)
+            if (lastRotatorPosition + relativePosition > MaxPositionNP[MOTOR_ROTATOR].getValue())
             {
-                int newRelativePosition = (int32_t)floor(MaxPositionN[MOTOR_ROTATOR].value) - lastRotatorPosition;
+                int newRelativePosition = (int32_t)floor(MaxPositionNP[MOTOR_ROTATOR].value) - lastRotatorPosition;
                 LOGF_INFO("Rotator position change %d clipped to %d to stay at MAX %d",
-                          relativePosition, newRelativePosition, MaxPositionN[MOTOR_ROTATOR].value);
+                          relativePosition, newRelativePosition, MaxPositionNP[MOTOR_ROTATOR].getValue());
                 relativePosition = newRelativePosition;
             }
         }
         else
         {
-            if (lastRotatorPosition + relativePosition < - MaxPositionN[MOTOR_ROTATOR].value)
+            if (lastRotatorPosition + relativePosition < - MaxPositionNP[MOTOR_ROTATOR].getValue())
             {
-                int newRelativePosition = - (int32_t)floor(MaxPositionN[MOTOR_ROTATOR].value) - lastRotatorPosition;
+                int newRelativePosition = - (int32_t)floor(MaxPositionNP[MOTOR_ROTATOR].value) - lastRotatorPosition;
                 LOGF_INFO("Rotator position change %d clipped to %d to stay at MIN %d",
-                          relativePosition, newRelativePosition, - MaxPositionN[MOTOR_ROTATOR].value);
+                          relativePosition, newRelativePosition, - MaxPositionNP[MOTOR_ROTATOR].getValue());
                 relativePosition = newRelativePosition;
             }
         }
@@ -408,9 +408,9 @@ bool Integra::getPosition(MotorType type)
     {
         if (type == MOTOR_FOCUS)
         {
-            if (FocusAbsPosN[0].value != position)
+            if (FocusAbsPosNP[0].value != position)
             {
-                auto position_from = (int) FocusAbsPosN[0].value;
+                auto position_from = (int) FocusAbsPosNP[0].getValue();
                 int position_to = position;
                 if (haveReadFocusPositionAtLeastOnce)
                 {
@@ -420,14 +420,14 @@ bool Integra::getPosition(MotorType type)
                 {
                     LOGF_DEBUG("Focus position is %d", position_to);
                 }
-                FocusAbsPosN[0].value = position;
+                FocusAbsPosNP[0].setValue(position);
             }
         }
         else if (type == MOTOR_ROTATOR)
         {
-            if (RotatorAbsPosN[0].value != position)
+            if (RotatorAbsPosNP[0].value != position)
             {
-                auto position_from = (int) RotatorAbsPosN[0].value;
+                auto position_from = (int) RotatorAbsPosNP[0].getValue();
                 int position_to = position;
                 if (haveReadRotatorPositionAtLeastOnce)
                 {
@@ -439,7 +439,7 @@ bool Integra::getPosition(MotorType type)
                     LOGF_DEBUG("Rotator angle is %.2f, position is %d",
                                rotatorTicksToDegrees(position_to), position_to);
                 }
-                RotatorAbsPosN[0].value = position;
+                RotatorAbsPosNP[0].setValue(position);
             }
         }
         else
@@ -458,52 +458,52 @@ bool Integra::ISNewSwitch (const char * dev, const char * name, ISState * states
 {
     if(strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, FindHomeSP.name) == 0)
+        if (FindHomeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&FindHomeSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&FindHomeSP);
+            FindHomeSP.update(states, names, n);
+            int index = FindHomeSP.findOnSwitchIndex();
             switch (index)
             {
                 case HOMING_IDLE:
                     LOG_INFO("Homing state is IDLE");
-                    FindHomeS[HOMING_IDLE].s = ISS_ON;
-                    FindHomeSP.s = IPS_OK;
+                    FindHomeSP[HOMING_IDLE].setState(ISS_ON);
+                    FindHomeSP.setState(IPS_OK);
                     break;
                 case HOMING_START:
                     if (findHome())
                     {
-                        FindHomeSP.s = IPS_BUSY;
-                        FindHomeS[HOMING_START].s = ISS_ON;
+                        FindHomeSP.setState(IPS_BUSY);
+                        FindHomeSP[HOMING_START].setState(ISS_ON);
                         DEBUG(INDI::Logger::DBG_WARNING,
                               "Homing process can take up to 2 minutes. You cannot control the unit until the process is fully complete.");
                     }
                     else
                     {
-                        FindHomeSP.s = IPS_ALERT;
-                        FindHomeS[HOMING_START].s = ISS_OFF;
+                        FindHomeSP.setState(IPS_ALERT);
+                        FindHomeSP[HOMING_START].setState(ISS_OFF);
                         LOG_ERROR("Failed to start homing process.");
                     }
                     break;
                 case HOMING_ABORT:
                     if (abortHome())
                     {
-                        FindHomeSP.s = IPS_IDLE;
-                        FindHomeS[HOMING_ABORT].s = ISS_ON;
+                        FindHomeSP.setState(IPS_IDLE);
+                        FindHomeSP[HOMING_ABORT].setState(ISS_ON);
                         LOG_WARN("Homing aborted");
                     }
                     else
                     {
-                        FindHomeSP.s = IPS_ALERT;
-                        FindHomeS[HOMING_ABORT].s = ISS_OFF;
+                        FindHomeSP.setState(IPS_ALERT);
+                        FindHomeSP[HOMING_ABORT].setState(ISS_OFF);
                         LOG_ERROR("Failed to abort homing process.");
                     }
                     break;
                 default:
-                    FindHomeSP.s = IPS_ALERT;
-                    IDSetSwitch(&FindHomeSP, "Unknown homing index %d", index);
+                    FindHomeSP.setState(IPS_ALERT);
+                    FindHomeSP.apply("Unknown homing index %d", index);
                     return false;
             }
-            IDSetSwitch(&FindHomeSP, nullptr);
+            FindHomeSP.apply();
             return true;
         }
         else if (strstr(name, "ROTATOR"))
@@ -520,11 +520,11 @@ bool Integra::ISNewNumber (const char * dev, const char * name, double values[],
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, RotatorAbsPosNP.name) == 0)
+        if (RotatorAbsPosNP.isNameMatch(name))
         {
-            RotatorAbsPosNP.s = (gotoMotor(MOTOR_ROTATOR, static_cast<int32_t>(values[0])) ? IPS_BUSY : IPS_ALERT);
-            IDSetNumber(&RotatorAbsPosNP, nullptr);
-            if (RotatorAbsPosNP.s == IPS_BUSY)
+            RotatorAbsPosNP.setState((gotoMotor(MOTOR_ROTATOR, static_cast<int32_t>(values[0])) ? IPS_BUSY : IPS_ALERT));
+            RotatorAbsPosNP.apply();
+            if (RotatorAbsPosNP.getState() == IPS_BUSY)
                 LOGF_DEBUG("Rotator moving from %d to %.f ticks...", lastRotatorPosition, values[0]);
             return true;
         }
@@ -548,7 +548,7 @@ IPState Integra::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -560,16 +560,16 @@ IPState Integra::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     LOGF_DEBUG("Focuser will move in direction %d relative %d ticks...", dir, ticks);
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     rc = gotoMotor(MOTOR_FOCUS, newPosition);
     if (!rc)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -586,21 +586,21 @@ void Integra::TimerHit()
     bool savePositionsToEEPROM = false;
 
     // sanity check warning ...
-    if (int(FocusAbsPosN[0].max) != wellKnownIntegra85FocusMax || int(RotatorAbsPosN[0].max) != wellKnownIntegra85RotateMax)
+    if (int(FocusAbsPosNP[0].max) != wellKnownIntegra85FocusMax || int(RotatorAbsPosNP[0].max) != wellKnownIntegra85RotateMax)
     {
         LOGF_WARN("Warning: Focus motor max position %d should be %d and Rotator motor max position %d should be %d",
-                  int(FocusAbsPosN[0].max), wellKnownIntegra85FocusMax,
-                  int(RotatorAbsPosN[0].max), wellKnownIntegra85RotateMax);
+                  int(FocusAbsPosNP[0].max), wellKnownIntegra85FocusMax,
+                  int(RotatorAbsPosNP[0].max), wellKnownIntegra85RotateMax);
     }
 
     // #1 If we're homing, we check if homing is complete as we cannot check for anything else
-    if (FindHomeSP.s == IPS_BUSY)
+    if (FindHomeSP.getState() == IPS_BUSY)
     {
         if (isHomingComplete())
         {
-            FindHomeS[0].s = ISS_OFF;
-            FindHomeSP.s = IPS_OK;
-            IDSetSwitch(&FindHomeSP, nullptr);
+            FindHomeSP[0].setState(ISS_OFF);
+            FindHomeSP.setState(IPS_OK);
+            FindHomeSP.apply();
 
             LOG_INFO("Homing is complete");
             // Next read positions and save to EEPROM :
@@ -617,8 +617,8 @@ void Integra::TimerHit()
     }
 
     // #2 Get Temperature, only read this when no motors are active, and about once per minute
-    if (FocusAbsPosNP.s != IPS_BUSY && FocusRelPosNP.s != IPS_BUSY
-            && RotatorAbsPosNP.s != IPS_BUSY
+    if (FocusAbsPosNP.getState() != IPS_BUSY && FocusRelPosNP.getState() != IPS_BUSY
+            && RotatorAbsPosNP.getState() != IPS_BUSY
             && timeToReadTemperature <= 0)
     {
         rc = getTemperature();
@@ -627,10 +627,10 @@ void Integra::TimerHit()
         if (rc)
         {
             timeToReadTemperature = INTEGRA_TEMPERATURE_LOOP_SKIPS;
-            if (fabs(SensorN[SENSOR_TEMPERATURE].value - lastTemperature) > INTEGRA_TEMPERATURE_TRESHOLD_IN_C)
+            if (fabs(SensorNP[SENSOR_TEMPERATURE].value - lastTemperature) > INTEGRA_TEMPERATURE_TRESHOLD_IN_C)
             {
-                lastTemperature = SensorN[SENSOR_TEMPERATURE].value;
-                IDSetNumber(&SensorNP, nullptr);
+                lastTemperature = SensorNP[SENSOR_TEMPERATURE].getValue();
+                SensorNP.apply();
             }
         }
     }
@@ -643,21 +643,21 @@ void Integra::TimerHit()
     // #4 is not used on Integra85
 
     // #5 Focus Position & Status
-    if (!haveReadFocusPositionAtLeastOnce || FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    if (!haveReadFocusPositionAtLeastOnce || FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
     {
         if ( ! isMotorMoving(MOTOR_FOCUS))
         {
             LOG_DEBUG("Focuser stopped");
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.setState(IPS_OK);
             rc = getPosition(MOTOR_FOCUS);
             if (rc)
             {
-                if (FocusAbsPosN[0].value != lastFocuserPosition)
+                if (FocusAbsPosNP[0].value != lastFocuserPosition)
                 {
-                    lastFocuserPosition = FocusAbsPosN[0].value;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
-                    IDSetNumber(&FocusRelPosNP, nullptr);
+                    lastFocuserPosition = FocusAbsPosNP[0].getValue();
+                    FocusAbsPosNP.apply();
+                    FocusRelPosNP.apply();
                     if (haveReadFocusPositionAtLeastOnce)
                     {
                         LOGF_INFO("Focuser reached requested position %d", lastFocuserPosition);
@@ -678,23 +678,23 @@ void Integra::TimerHit()
     }
 
     // #6 Rotator Position & Status
-    if (!haveReadRotatorPositionAtLeastOnce  || RotatorAbsPosNP.s == IPS_BUSY)
+    if (!haveReadRotatorPositionAtLeastOnce  || RotatorAbsPosNP.getState() == IPS_BUSY)
     {
         if ( ! isMotorMoving(MOTOR_ROTATOR))
         {
             LOG_DEBUG("Rotator stopped");
-            RotatorAbsPosNP.s = IPS_OK;
-            GotoRotatorNP.s = IPS_OK;
+            RotatorAbsPosNP.setState(IPS_OK);
+            GotoRotatorNP.setState(IPS_OK);
             rc = getPosition(MOTOR_ROTATOR);
             if (rc)
             {
-                if (RotatorAbsPosN[0].value != lastRotatorPosition)
+                if (RotatorAbsPosNP[0].value != lastRotatorPosition)
                 {
-                    lastRotatorPosition = RotatorAbsPosN[0].value;
-                    GotoRotatorN[0].value = rotatorTicksToDegrees(
-                                                lastRotatorPosition); //range360(RotatorAbsPosN[0].value / rotatorTicksPerDegree);
-                    IDSetNumber(&RotatorAbsPosNP, nullptr);
-                    IDSetNumber(&GotoRotatorNP, nullptr);
+                    lastRotatorPosition = RotatorAbsPosNP[0].getValue();
+                    GotoRotatorNP[0].setValue(rotatorTicksToDegrees(
+                                                lastRotatorPosition)); //range360(RotatorAbsPosNP[0].value / rotatorTicksPerDegree);
+                    RotatorAbsPosNP.apply();
+                    GotoRotatorNP.apply();
                     if (haveReadRotatorPositionAtLeastOnce)
                         LOGF_INFO("Rotator reached requested angle %.2f, position %d",
                                   rotatorTicksToDegrees(lastRotatorPosition), lastRotatorPosition);
@@ -793,22 +793,22 @@ bool Integra::getMaxPosition(MotorType type)
         return false;
     }
     int position = atoi(res);
-    if (MaxPositionN[type].value == position)
+    if (MaxPositionNP[type].value == position)
     {
         LOGF_INFO("%s motor max position is %d", (type == MOTOR_FOCUS) ? "Focuser" : "Rotator", position);
     }
     else
     {
         LOGF_WARN("Updated %s motor max position from %d to %d",
-                  (type == MOTOR_FOCUS) ? "Focuser" : "Rotator", MaxPositionN[type].value, position);
-        MaxPositionN[type].value = position;
+                  (type == MOTOR_FOCUS) ? "Focuser" : "Rotator", MaxPositionNP[type].getValue(), position);
+        MaxPositionNP[type].setValue(position);
         if (type == MOTOR_FOCUS)
         {
-            FocusAbsPosN[0].max = MaxPositionN[type].value;
+            FocusAbsPosNP[0].setMax(MaxPositionNP[type].getValue());
         }
         else if (type == MOTOR_ROTATOR)
         {
-            RotatorAbsPosN[0].max = MaxPositionN[type].value;
+            RotatorAbsPosNP[0].setMax(MaxPositionNP[type].getValue());
         }
         else
         {
@@ -828,7 +828,7 @@ bool Integra::getTemperature()
     char res[16] = {0};
     if (integraGetCommand(__FUNCTION__, get_temperature, res ) )
     {
-        SensorN[SENSOR_TEMPERATURE].value = strtod(res, nullptr);
+        SensorNP[SENSOR_TEMPERATURE].setValue(strtod(res, nullptr));
         return true;
     }
     return false;
@@ -874,8 +874,8 @@ IPState Integra::MoveRotator(double angle)
     bool rc = relativeGotoMotor(MOTOR_ROTATOR, p2 - p1);
     if (rc)
     {
-        RotatorAbsPosNP.s = IPS_BUSY;
-        IDSetNumber(&RotatorAbsPosNP, nullptr);
+        RotatorAbsPosNP.setState(IPS_BUSY);
+        RotatorAbsPosNP.apply();
         return IPS_BUSY;
     }
 
@@ -885,10 +885,10 @@ IPState Integra::MoveRotator(double angle)
 bool Integra::AbortRotator()
 {
     bool rc = stopMotor(MOTOR_ROTATOR);
-    if (rc && RotatorAbsPosNP.s != IPS_OK)
+    if (rc && RotatorAbsPosNP.getState() != IPS_OK)
     {
-        RotatorAbsPosNP.s = IPS_OK;
-        IDSetNumber(&RotatorAbsPosNP, nullptr);
+        RotatorAbsPosNP.setState(IPS_OK);
+        RotatorAbsPosNP.apply();
     }
 
     return rc;

--- a/drivers/rotator/integra.h
+++ b/drivers/rotator/integra.h
@@ -22,6 +22,10 @@
 #include "indifocuser.h"
 #include "indirotatorinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class Integra : public INDI::Focuser, public INDI::RotatorInterface
 {
     public:
@@ -90,18 +94,14 @@ class Integra : public INDI::Focuser, public INDI::RotatorInterface
         uint32_t rotatorDegreesToTicks(double angle);
         double rotatorTicksToDegrees(uint32_t ticks);
 
-        INumber MaxPositionN[2];
-        INumberVectorProperty MaxPositionNP;
+        INDI::PropertyNumber MaxPositionNP {2};
 
-        INumber SensorN[2];
-        INumberVectorProperty SensorNP;
+        INDI::PropertyNumber SensorNP {2};
         enum { SENSOR_TEMPERATURE };
 
-        ISwitch FindHomeS[HOMING_COUNT];
-        ISwitchVectorProperty FindHomeSP;
+        INDI::PropertySwitch FindHomeSP {HOMING_COUNT};
 
-        INumber RotatorAbsPosN[1];
-        INumberVectorProperty RotatorAbsPosNP;
+        INDI::PropertyNumber RotatorAbsPosNP {1};
 
         double lastTemperature { 0 };
         int timeToReadTemperature = 0;

--- a/drivers/rotator/nightcrawler.cpp
+++ b/drivers/rotator/nightcrawler.cpp
@@ -93,59 +93,59 @@ bool NightCrawler::initProperties()
 {
     INDI::Focuser::initProperties();
 
-    FocusSpeedN[0].min = 1;
-    FocusSpeedN[0].max = 1;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(1);
+    FocusSpeedNP[0].setValue(1);
 
     // Focus Sync
-    IUFillNumber(&SyncFocusN[0], "FOCUS_SYNC_OFFSET", "Ticks", "%.f", 0, 100000., 0., 0.);
-    IUFillNumberVector(&SyncFocusNP, SyncFocusN, 1, getDeviceName(), "FOCUS_SYNC", "Sync", MAIN_CONTROL_TAB, IP_RW, 0,
+    SyncFocusNP[0].fill("FOCUS_SYNC_OFFSET", "Ticks", "%.f", 0, 100000., 0., 0.);
+    SyncFocusNP.fill(getDeviceName(), "FOCUS_SYNC", "Sync", MAIN_CONTROL_TAB, IP_RW, 0,
                        IPS_IDLE );
 
     // Temperature + Voltage Sensors
-    IUFillNumber(&SensorN[SENSOR_TEMPERATURE], "TEMPERATURE", "Temperature (C)", "%.2f", -100, 100., 1., 0.);
-    IUFillNumber(&SensorN[SENSOR_VOLTAGE], "VOLTAGE", "Voltage (V)", "%.2f", 0, 20., 1., 0.);
-    IUFillNumberVector(&SensorNP, SensorN, 2, getDeviceName(), "SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE );
+    SensorNP[SENSOR_TEMPERATURE].fill("TEMPERATURE", "Temperature (C)", "%.2f", -100, 100., 1., 0.);
+    SensorNP[SENSOR_VOLTAGE].fill("VOLTAGE", "Voltage (V)", "%.2f", 0, 20., 1., 0.);
+    SensorNP.fill(getDeviceName(), "SENSORS", "Sensors", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE );
 
     // Temperature offset
-    IUFillNumber(&TemperatureOffsetN[0], "OFFSET", "Offset", "%.2f", -15, 15., 1., 0.);
-    IUFillNumberVector(&TemperatureOffsetNP, TemperatureOffsetN, 1, getDeviceName(), "TEMPERATURE_OFFSET", "Temperature",
+    TemperatureOffsetNP[0].fill("OFFSET", "Offset", "%.2f", -15, 15., 1., 0.);
+    TemperatureOffsetNP.fill(getDeviceName(), "TEMPERATURE_OFFSET", "Temperature",
                        MAIN_CONTROL_TAB, IP_WO, 0, IPS_IDLE );
 
     // Motor Step Delay
-    IUFillNumber(&FocusStepDelayN[0], "FOCUS_STEP", "Value", "%.f", 7, 100., 1., 7.);
-    IUFillNumberVector(&FocusStepDelayNP, FocusStepDelayN, 1, getDeviceName(), "FOCUS_STEP_DELAY", "Step Rate", SETTINGS_TAB,
+    FocusStepDelayNP[0].fill("FOCUS_STEP", "Value", "%.f", 7, 100., 1., 7.);
+    FocusStepDelayNP.fill(getDeviceName(), "FOCUS_STEP_DELAY", "Step Rate", SETTINGS_TAB,
                        IP_RW, 0, IPS_IDLE );
 
     // Limit Switch
-    IUFillLight(&LimitSwitchL[ROTATION_SWITCH], "ROTATION_SWITCH", "Rotation Home", IPS_OK);
-    IUFillLight(&LimitSwitchL[OUT_SWITCH], "OUT_SWITCH", "Focus Out Limit", IPS_OK);
-    IUFillLight(&LimitSwitchL[IN_SWITCH], "IN_SWITCH", "Focus In Limit", IPS_OK);
-    IUFillLightVector(&LimitSwitchLP, LimitSwitchL, 3, getDeviceName(), "LIMIT_SWITCHES", "Limit Switch", SETTINGS_TAB,
+    LimitSwitchLP[ROTATION_SWITCH].fill("ROTATION_SWITCH", "Rotation Home", IPS_OK);
+    LimitSwitchLP[OUT_SWITCH].fill("OUT_SWITCH", "Focus Out Limit", IPS_OK);
+    LimitSwitchLP[IN_SWITCH].fill("IN_SWITCH", "Focus In Limit", IPS_OK);
+    LimitSwitchLP.fill(getDeviceName(), "LIMIT_SWITCHES", "Limit Switch", SETTINGS_TAB,
                       IPS_IDLE);
 
     // Home selection
-    IUFillSwitch(&HomeSelectionS[MOTOR_FOCUS], "FOCUS", "Focuser", ISS_ON);
-    IUFillSwitch(&HomeSelectionS[MOTOR_ROTATOR], "ROTATOR", "Rotator", ISS_ON);
-    IUFillSwitch(&HomeSelectionS[MOTOR_AUX], "AUX", "Aux", ISS_OFF);
-    IUFillSwitchVector(&HomeSelectionSP, HomeSelectionS, 3, getDeviceName(), "HOME_SELECTION", "Home Select", SETTINGS_TAB,
+    HomeSelectionSP[MOTOR_FOCUS].fill("FOCUS", "Focuser", ISS_ON);
+    HomeSelectionSP[MOTOR_ROTATOR].fill("ROTATOR", "Rotator", ISS_ON);
+    HomeSelectionSP[MOTOR_AUX].fill("AUX", "Aux", ISS_OFF);
+    HomeSelectionSP.fill(getDeviceName(), "HOME_SELECTION", "Home Select", SETTINGS_TAB,
                        IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
 
     // Home Find
-    IUFillSwitch(&FindHomeS[0], "FIND", "Start", ISS_OFF);
-    IUFillSwitchVector(&FindHomeSP, FindHomeS, 1, getDeviceName(), "FIND_HOME", "Home Find", SETTINGS_TAB, IP_RW, ISR_1OFMANY,
+    FindHomeSP[0].fill("FIND", "Start", ISS_OFF);
+    FindHomeSP.fill(getDeviceName(), "FIND_HOME", "Home Find", SETTINGS_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
     // Encoders
-    IUFillSwitch(&EncoderS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_ON);
-    IUFillSwitch(&EncoderS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_OFF);
-    IUFillSwitchVector(&EncoderSP, EncoderS, 2, getDeviceName(), "ENCODERS", "Encoders", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0,
+    EncoderSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_ON);
+    EncoderSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_OFF);
+    EncoderSP.fill(getDeviceName(), "ENCODERS", "Encoders", SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Brightness
-    IUFillNumber(&BrightnessN[BRIGHTNESS_DISPLAY], "BRIGHTNESS_DISPLAY", "Display", "%.f", 0, 255., 10., 150.);
-    IUFillNumber(&BrightnessN[BRIGHTNESS_SLEEP], "BRIGHTNESS_SLEEP", "Sleep", "%.f", 1, 255., 10., 16.);
-    IUFillNumberVector(&BrightnessNP, BrightnessN, 2, getDeviceName(), "BRIGHTNESS", "Brightness", SETTINGS_TAB, IP_RW, 0,
+    BrightnessNP[BRIGHTNESS_DISPLAY].fill("BRIGHTNESS_DISPLAY", "Display", "%.f", 0, 255., 10., 150.);
+    BrightnessNP[BRIGHTNESS_SLEEP].fill("BRIGHTNESS_SLEEP", "Sleep", "%.f", 1, 255., 10., 16.);
+    BrightnessNP.fill(getDeviceName(), "BRIGHTNESS", "Brightness", SETTINGS_TAB, IP_RW, 0,
                        IPS_IDLE );
 
     //////////////////////////////////////////////////////
@@ -155,13 +155,13 @@ bool NightCrawler::initProperties()
     INDI::RotatorInterface::initProperties(ROTATOR_TAB);
 
     // Rotator Ticks
-    IUFillNumber(&RotatorAbsPosN[0], "ROTATOR_ABSOLUTE_POSITION", "Ticks", "%.f", 0., 100000., 1000., 0.);
-    IUFillNumberVector(&RotatorAbsPosNP, RotatorAbsPosN, 1, getDeviceName(), "ABS_ROTATOR_POSITION", "Goto", ROTATOR_TAB, IP_RW,
+    RotatorAbsPosNP[0].fill("ROTATOR_ABSOLUTE_POSITION", "Ticks", "%.f", 0., 100000., 1000., 0.);
+    RotatorAbsPosNP.fill(getDeviceName(), "ABS_ROTATOR_POSITION", "Goto", ROTATOR_TAB, IP_RW,
                        0, IPS_IDLE );
 
     // Rotator Step Delay
-    IUFillNumber(&RotatorStepDelayN[0], "ROTATOR_STEP", "Value", "%.f", 7, 100., 1., 7.);
-    IUFillNumberVector(&RotatorStepDelayNP, RotatorStepDelayN, 1, getDeviceName(), "ROTATOR_STEP_DELAY", "Step Rate",
+    RotatorStepDelayNP[0].fill("ROTATOR_STEP", "Value", "%.f", 7, 100., 1., 7.);
+    RotatorStepDelayNP.fill(getDeviceName(), "ROTATOR_STEP_DELAY", "Step Rate",
                        ROTATOR_TAB, IP_RW, 0, IPS_IDLE );
 
     //////////////////////////////////////////////////////
@@ -169,33 +169,33 @@ bool NightCrawler::initProperties()
     /////////////////////////////////////////////////////
 
     // Aux GOTO
-    IUFillNumber(&GotoAuxN[0], "AUX_ABSOLUTE_POSITION", "Ticks", "%.f", 0, 100000., 0., 0.);
-    IUFillNumberVector(&GotoAuxNP, GotoAuxN, 1, getDeviceName(), "ABS_AUX_POSITION", "Goto", AUX_TAB, IP_RW, 0, IPS_IDLE );
+    GotoAuxNP[0].fill("AUX_ABSOLUTE_POSITION", "Ticks", "%.f", 0, 100000., 0., 0.);
+    GotoAuxNP.fill(getDeviceName(), "ABS_AUX_POSITION", "Goto", AUX_TAB, IP_RW, 0, IPS_IDLE );
 
     // Abort Aux
-    IUFillSwitch(&AbortAuxS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&AbortAuxSP, AbortAuxS, 1, getDeviceName(), "AUX_ABORT_MOTION", "Abort Motion", AUX_TAB, IP_RW,
+    AbortAuxSP[0].fill("ABORT", "Abort", ISS_OFF);
+    AbortAuxSP.fill(getDeviceName(), "AUX_ABORT_MOTION", "Abort Motion", AUX_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
     // Aux Sync
-    IUFillNumber(&SyncAuxN[0], "AUX_SYNC_TICK", "Ticks", "%.f", 0, 100000., 0., 0.);
-    IUFillNumberVector(&SyncAuxNP, SyncAuxN, 1, getDeviceName(), "SYNC_AUX", "Sync", AUX_TAB, IP_RW, 0, IPS_IDLE );
+    SyncAuxNP[0].fill("AUX_SYNC_TICK", "Ticks", "%.f", 0, 100000., 0., 0.);
+    SyncAuxNP.fill(getDeviceName(), "SYNC_AUX", "Sync", AUX_TAB, IP_RW, 0, IPS_IDLE );
 
     // Aux Step Delay
-    IUFillNumber(&AuxStepDelayN[0], "AUX_STEP", "Value", "%.f", 7, 100., 1., 7.);
-    IUFillNumberVector(&AuxStepDelayNP, AuxStepDelayN, 1, getDeviceName(), "AUX_STEP_DELAY", "Step Rate", AUX_TAB, IP_RW, 0,
+    AuxStepDelayNP[0].fill("AUX_STEP", "Value", "%.f", 7, 100., 1., 7.);
+    AuxStepDelayNP.fill(getDeviceName(), "AUX_STEP_DELAY", "Step Rate", AUX_TAB, IP_RW, 0,
                        IPS_IDLE );
 
     /* Relative and absolute movement */
-    FocusRelPosN[0].min = 0.;
-    FocusRelPosN[0].max = 50000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(50000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
 
-    FocusAbsPosN[0].min = 0.;
-    FocusAbsPosN[0].max = 100000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step = 1000;
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(100000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     addDebugControl();
 
@@ -215,50 +215,50 @@ bool NightCrawler::updateProperties()
     if (isConnected())
     {
         // Focus
-        defineProperty(&SyncFocusNP);
-        defineProperty(&SensorNP);
-        defineProperty(&TemperatureOffsetNP);
-        defineProperty(&FocusStepDelayNP);
-        defineProperty(&LimitSwitchLP);
-        defineProperty(&EncoderSP);
-        defineProperty(&BrightnessNP);
-        defineProperty(&HomeSelectionSP);
-        defineProperty(&FindHomeSP);
+        defineProperty(SyncFocusNP);
+        defineProperty(SensorNP);
+        defineProperty(TemperatureOffsetNP);
+        defineProperty(FocusStepDelayNP);
+        defineProperty(LimitSwitchLP);
+        defineProperty(EncoderSP);
+        defineProperty(BrightnessNP);
+        defineProperty(HomeSelectionSP);
+        defineProperty(FindHomeSP);
 
         // Rotator
         INDI::RotatorInterface::updateProperties();
-        defineProperty(&RotatorAbsPosNP);
-        defineProperty(&RotatorStepDelayNP);
+        defineProperty(RotatorAbsPosNP);
+        defineProperty(RotatorStepDelayNP);
 
         // Aux
-        defineProperty(&GotoAuxNP);
-        defineProperty(&AbortAuxSP);
-        defineProperty(&SyncAuxNP);
-        defineProperty(&AuxStepDelayNP);
+        defineProperty(GotoAuxNP);
+        defineProperty(AbortAuxSP);
+        defineProperty(SyncAuxNP);
+        defineProperty(AuxStepDelayNP);
     }
     else
     {
         // Focus
-        deleteProperty(SyncFocusNP.name);
-        deleteProperty(SensorNP.name);
-        deleteProperty(TemperatureOffsetNP.name);
-        deleteProperty(FocusStepDelayNP.name);
-        deleteProperty(LimitSwitchLP.name);
-        deleteProperty(EncoderSP.name);
-        deleteProperty(BrightnessNP.name);
-        deleteProperty(FindHomeSP.name);
-        deleteProperty(HomeSelectionSP.name);
+        deleteProperty(SyncFocusNP.getName());
+        deleteProperty(SensorNP.getName());
+        deleteProperty(TemperatureOffsetNP.getName());
+        deleteProperty(FocusStepDelayNP.getName());
+        deleteProperty(LimitSwitchLP.getName());
+        deleteProperty(EncoderSP.getName());
+        deleteProperty(BrightnessNP.getName());
+        deleteProperty(FindHomeSP.getName());
+        deleteProperty(HomeSelectionSP.getName());
 
         // Rotator
         INDI::RotatorInterface::updateProperties();
-        deleteProperty(RotatorAbsPosNP.name);
-        deleteProperty(RotatorStepDelayNP.name);
+        deleteProperty(RotatorAbsPosNP.getName());
+        deleteProperty(RotatorStepDelayNP.getName());
 
         // Aux
-        deleteProperty(GotoAuxNP.name);
-        deleteProperty(AbortAuxSP.name);
-        deleteProperty(SyncAuxNP.name);
-        deleteProperty(AuxStepDelayNP.name);
+        deleteProperty(GotoAuxNP.getName());
+        deleteProperty(AbortAuxSP.getName());
+        deleteProperty(SyncAuxNP.getName());
+        deleteProperty(AuxStepDelayNP.getName());
     }
 
     return true;
@@ -347,21 +347,21 @@ bool NightCrawler::getFocuserType()
 
     if (strcmp(resp, "2.5 NC") == 0)
     {
-        RotatorAbsPosN[0].min = -NC_25_STEPS;
-        RotatorAbsPosN[0].max = NC_25_STEPS;
+        RotatorAbsPosNP[0].setMin(-NC_25_STEPS);
+        RotatorAbsPosNP[0].setMax(NC_25_STEPS);
     }
     else if (strcmp(resp, "3.0 NC") == 0)
     {
-        RotatorAbsPosN[0].min = -NC_30_STEPS;
-        RotatorAbsPosN[0].max = NC_30_STEPS;
+        RotatorAbsPosNP[0].setMin(-NC_30_STEPS);
+        RotatorAbsPosNP[0].setMax(NC_30_STEPS);
     }
     else
     {
-        RotatorAbsPosN[0].min = -NC_35_STEPS;
-        RotatorAbsPosN[0].max = NC_35_STEPS;
+        RotatorAbsPosNP[0].setMin(-NC_35_STEPS);
+        RotatorAbsPosNP[0].setMax(NC_35_STEPS);
     }
 
-    ticksPerDegree = RotatorAbsPosN[0].max / 360.0;
+    ticksPerDegree = RotatorAbsPosNP[0].getMax() / 360.0;
 
     return true;
 }
@@ -439,11 +439,11 @@ bool NightCrawler::getPosition(MotorType type)
     if (position != -1e6)
     {
         if (type == MOTOR_FOCUS)
-            FocusAbsPosN[0].value = position;
+            FocusAbsPosNP[0].setValue(position);
         else if (type == MOTOR_ROTATOR)
-            RotatorAbsPosN[0].value = position;
+            RotatorAbsPosNP[0].setValue(position);
         else
-            GotoAuxN[0].value = position;
+            GotoAuxNP[0].setValue(position);
 
         return true;
     }
@@ -480,7 +480,7 @@ bool NightCrawler::ISNewSwitch (const char * dev, const char * name, ISState * s
 {
     if(strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, HomeSelectionSP.name) == 0)
+        if (HomeSelectionSP.isNameMatch(name))
         {
             bool atLeastOne = false;
 
@@ -495,63 +495,63 @@ bool NightCrawler::ISNewSwitch (const char * dev, const char * name, ISState * s
 
             if (!atLeastOne)
             {
-                HomeSelectionSP.s = IPS_ALERT;
+                HomeSelectionSP.setState(IPS_ALERT);
                 LOG_ERROR("At least one selection must be on.");
-                IDSetSwitch(&HomeSelectionSP, nullptr);
+                HomeSelectionSP.apply();
                 return false;
             }
 
-            IUUpdateSwitch(&HomeSelectionSP, states, names, n);
-            HomeSelectionSP.s = IPS_OK;
-            IDSetSwitch(&HomeSelectionSP, nullptr);
+            HomeSelectionSP.update(states, names, n);
+            HomeSelectionSP.setState(IPS_OK);
+            HomeSelectionSP.apply();
             return true;
         }
-        else if (strcmp(name, FindHomeSP.name) == 0)
+        else if (FindHomeSP.isNameMatch(name))
         {
             uint8_t selection = 0;
 
-            if (HomeSelectionS[MOTOR_FOCUS].s == ISS_ON)
+            if (HomeSelectionSP[MOTOR_FOCUS].getState() == ISS_ON)
                 selection |= 0x01;
-            if (HomeSelectionS[MOTOR_ROTATOR].s == ISS_ON)
+            if (HomeSelectionSP[MOTOR_ROTATOR].getState() == ISS_ON)
                 selection |= 0x02;
-            if (HomeSelectionS[MOTOR_AUX].s == ISS_ON)
+            if (HomeSelectionSP[MOTOR_AUX].getState() == ISS_ON)
                 selection |= 0x04;
 
             if (findHome(selection))
             {
-                FindHomeSP.s = IPS_BUSY;
-                FindHomeS[0].s = ISS_ON;
+                FindHomeSP.setState(IPS_BUSY);
+                FindHomeSP[0].setState(ISS_ON);
                 LOG_WARN("Homing process can take up to 10 minutes. You cannot control the unit until the process is fully complete.");
             }
             else
             {
-                FindHomeSP.s = IPS_ALERT;
-                FindHomeS[0].s = ISS_OFF;
+                FindHomeSP.setState(IPS_ALERT);
+                FindHomeSP[0].setState(ISS_OFF);
                 LOG_ERROR("Failed to start homing process.");
             }
 
-            IDSetSwitch(&FindHomeSP, nullptr);
+            FindHomeSP.apply();
             return true;
         }
-        else if (strcmp(name, EncoderSP.name) == 0)
+        else if (EncoderSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&EncoderSP, states, names, n);
-            EncoderSP.s = setEncodersEnabled(EncoderS[0].s == ISS_ON) ? IPS_OK : IPS_ALERT;
-            if (EncoderSP.s == IPS_OK)
-                LOGF_INFO("Encoders are %s", (EncoderS[0].s == ISS_ON) ? "ON" : "OFF");
-            IDSetSwitch(&EncoderSP, nullptr);
+            EncoderSP.update(states, names, n);
+            EncoderSP.setState(setEncodersEnabled(EncoderSP[0].getState() == ISS_ON) ? IPS_OK : IPS_ALERT);
+            if (EncoderSP.getState() == IPS_OK)
+                LOGF_INFO("Encoders are %s", (EncoderSP[0].getState() == ISS_ON) ? "ON" : "OFF");
+            EncoderSP.apply();
             return true;
         }
-        else if (strcmp(name, AbortAuxSP.name) == 0)
+        else if (AbortAuxSP.isNameMatch(name))
         {
-            AbortAuxSP.s = stopMotor(MOTOR_AUX) ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&AbortAuxSP, nullptr);
-            if (AbortAuxSP.s == IPS_OK)
+            AbortAuxSP.setState(stopMotor(MOTOR_AUX) ? IPS_OK : IPS_ALERT);
+            AbortAuxSP.apply();
+            if (AbortAuxSP.getState() == IPS_OK)
             {
-                if (GotoAuxNP.s != IPS_OK)
+                if (GotoAuxNP.getState() != IPS_OK)
                 {
-                    GotoAuxNP.s = IPS_OK;
-                    IDSetNumber(&GotoAuxNP, nullptr);
+                    GotoAuxNP.setState(IPS_OK);
+                    GotoAuxNP.apply();
                 }
             }
             return true;
@@ -570,86 +570,86 @@ bool NightCrawler::ISNewNumber (const char * dev, const char * name, double valu
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, SyncFocusNP.name) == 0)
+        if (SyncFocusNP.isNameMatch(name))
         {
             bool rc = syncMotor(MOTOR_FOCUS, static_cast<uint32_t>(values[0]));
-            SyncFocusNP.s = rc ? IPS_OK : IPS_ALERT;
+            SyncFocusNP.setState(rc ? IPS_OK : IPS_ALERT);
             if (rc)
-                SyncFocusN[0].value = values[0];
+                SyncFocusNP[0].setValue(values[0]);
 
-            IDSetNumber(&SyncFocusNP, nullptr);
+            SyncFocusNP.apply();
             return true;
         }
-        else if (strcmp(name, SyncAuxNP.name) == 0)
+        else if (SyncAuxNP.isNameMatch(name))
         {
             bool rc = syncMotor(MOTOR_AUX, static_cast<uint32_t>(values[0]));
-            SyncAuxNP.s = rc ? IPS_OK : IPS_ALERT;
+            SyncAuxNP.setState(rc ? IPS_OK : IPS_ALERT);
             if (rc)
-                SyncAuxN[0].value = values[0];
+                SyncAuxNP[0].setValue(values[0]);
 
-            IDSetNumber(&SyncAuxNP, nullptr);
+            SyncAuxNP.apply();
             return true;
         }
-        else if (strcmp(name, TemperatureOffsetNP.name) == 0)
+        else if (TemperatureOffsetNP.isNameMatch(name))
         {
             bool rc = setTemperatureOffset(values[0]);
-            TemperatureOffsetNP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetNumber(&TemperatureOffsetNP, nullptr);
+            TemperatureOffsetNP.setState(rc ? IPS_OK : IPS_ALERT);
+            TemperatureOffsetNP.apply();
             return true;
         }
-        else if (strcmp(name, FocusStepDelayNP.name) == 0)
+        else if (FocusStepDelayNP.isNameMatch(name))
         {
             bool rc = setStepDelay(MOTOR_FOCUS, static_cast<uint32_t>(values[0]));
-            FocusStepDelayNP.s = rc ? IPS_OK : IPS_ALERT;
+            FocusStepDelayNP.setState(rc ? IPS_OK : IPS_ALERT);
             if (rc)
-                FocusStepDelayN[0].value = values[0];
-            IDSetNumber(&FocusStepDelayNP, nullptr);
+                FocusStepDelayNP[0].setValue(values[0]);
+            FocusStepDelayNP.apply();
             return true;
         }
-        else if (strcmp(name, RotatorStepDelayNP.name) == 0)
+        else if (RotatorStepDelayNP.isNameMatch(name))
         {
             bool rc = setStepDelay(MOTOR_ROTATOR, static_cast<uint32_t>(values[0]));
-            RotatorStepDelayNP.s = rc ? IPS_OK : IPS_ALERT;
+            RotatorStepDelayNP.setState(rc ? IPS_OK : IPS_ALERT);
             if (rc)
-                RotatorStepDelayN[0].value = values[0];
-            IDSetNumber(&RotatorStepDelayNP, nullptr);
+                RotatorStepDelayNP[0].setValue(values[0]);
+            RotatorStepDelayNP.apply();
             return true;
         }
-        else if (strcmp(name, AuxStepDelayNP.name) == 0)
+        else if (AuxStepDelayNP.isNameMatch(name))
         {
             bool rc = setStepDelay(MOTOR_AUX, static_cast<uint32_t>(values[0]));
-            AuxStepDelayNP.s = rc ? IPS_OK : IPS_ALERT;
+            AuxStepDelayNP.setState(rc ? IPS_OK : IPS_ALERT);
             if (rc)
-                AuxStepDelayN[0].value = values[0];
-            IDSetNumber(&AuxStepDelayNP, nullptr);
+                AuxStepDelayNP[0].setValue(values[0]);
+            AuxStepDelayNP.apply();
             return true;
         }
-        else if (strcmp(name, BrightnessNP.name) == 0)
+        else if (BrightnessNP.isNameMatch(name))
         {
-            IUUpdateNumber(&BrightnessNP, values, names, n);
-            bool rcDisplay = setDisplayBrightness(static_cast<uint8_t>(BrightnessN[BRIGHTNESS_DISPLAY].value));
-            bool rcSleep = setSleepBrightness(static_cast<uint8_t>(BrightnessN[BRIGHTNESS_SLEEP].value));
+            BrightnessNP.update(values, names, n);
+            bool rcDisplay = setDisplayBrightness(static_cast<uint8_t>(BrightnessNP[BRIGHTNESS_DISPLAY].value));
+            bool rcSleep = setSleepBrightness(static_cast<uint8_t>(BrightnessNP[BRIGHTNESS_SLEEP].value));
             if (rcDisplay && rcSleep)
-                BrightnessNP.s = IPS_OK;
+                BrightnessNP.setState(IPS_OK);
             else
-                BrightnessNP.s = IPS_ALERT;
+                BrightnessNP.setState(IPS_ALERT);
 
-            IDSetNumber(&BrightnessNP, nullptr);
+            BrightnessNP.apply();
             return true;
         }
-        else if (strcmp(name, GotoAuxNP.name) == 0)
+        else if (GotoAuxNP.isNameMatch(name))
         {
             bool rc = gotoMotor(MOTOR_AUX, static_cast<int32_t>(values[0]));
-            GotoAuxNP.s = rc ? IPS_BUSY : IPS_OK;
-            IDSetNumber(&GotoAuxNP, nullptr);
+            GotoAuxNP.setState(rc ? IPS_BUSY : IPS_OK);
+            GotoAuxNP.apply();
             LOGF_INFO("Aux moving to %.f...", values[0]);
             return true;
         }
-        else if (strcmp(name, RotatorAbsPosNP.name) == 0)
+        else if (RotatorAbsPosNP.isNameMatch(name))
         {
-            RotatorAbsPosNP.s = (gotoMotor(MOTOR_ROTATOR, static_cast<int32_t>(values[0])) ? IPS_BUSY : IPS_ALERT);
-            IDSetNumber(&RotatorAbsPosNP, nullptr);
-            if (RotatorAbsPosNP.s == IPS_BUSY)
+            RotatorAbsPosNP.setState((gotoMotor(MOTOR_ROTATOR, static_cast<int32_t>(values[0])) ? IPS_BUSY : IPS_ALERT));
+            RotatorAbsPosNP.apply();
+            if (RotatorAbsPosNP.getState() == IPS_BUSY)
                 LOGF_INFO("Rotator moving to %.f ticks...", values[0]);
             return true;
         }
@@ -674,7 +674,7 @@ IPState NightCrawler::MoveAbsFocuser(uint32_t targetTicks)
     if (!rc)
         return IPS_ALERT;
 
-    FocusAbsPosNP.s = IPS_BUSY;
+    FocusAbsPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -685,17 +685,17 @@ IPState NightCrawler::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     bool rc = false;
 
     if (dir == FOCUS_INWARD)
-        newPosition = FocusAbsPosN[0].value - ticks;
+        newPosition = FocusAbsPosNP[0].getValue() - ticks;
     else
-        newPosition = FocusAbsPosN[0].value + ticks;
+        newPosition = FocusAbsPosNP[0].getValue() + ticks;
 
     rc = gotoMotor(MOTOR_FOCUS, newPosition);
 
     if (!rc)
         return IPS_ALERT;
 
-    FocusRelPosN[0].value = ticks;
-    FocusRelPosNP.s = IPS_BUSY;
+    FocusRelPosNP[0].setValue(ticks);
+    FocusRelPosNP.setState(IPS_BUSY);
 
     return IPS_BUSY;
 }
@@ -712,17 +712,17 @@ void NightCrawler::TimerHit()
     bool sensorsUpdated = false;
 
     // #1 If we're homing, we check if homing is complete as we cannot check for anything else
-    if (FindHomeSP.s == IPS_BUSY || HomeRotatorSP.s == IPS_BUSY)
+    if (FindHomeSP.getState() == IPS_BUSY || HomeRotatorSP.getState() == IPS_BUSY)
     {
         if (isHomingComplete())
         {
-            HomeRotatorS[0].s = ISS_OFF;
-            HomeRotatorSP.s = IPS_OK;
-            IDSetSwitch(&HomeRotatorSP, nullptr);
+            HomeRotatorSP[0].setState(ISS_OFF);
+            HomeRotatorSP.setState(IPS_OK);
+            HomeRotatorSP.apply();
 
-            FindHomeS[0].s = ISS_OFF;
-            FindHomeSP.s = IPS_OK;
-            IDSetSwitch(&FindHomeSP, nullptr);
+            FindHomeSP[0].setState(ISS_OFF);
+            FindHomeSP.setState(IPS_OK);
+            FindHomeSP.apply();
 
             LOG_INFO("Homing is complete.");
         }
@@ -733,108 +733,108 @@ void NightCrawler::TimerHit()
 
     // #2 Get Temperature
     rc = getTemperature();
-    if (rc && fabs(SensorN[SENSOR_TEMPERATURE].value - lastTemperature) > NIGHTCRAWLER_THRESHOLD)
+    if (rc && fabs(SensorNP[SENSOR_TEMPERATURE].value - lastTemperature) > NIGHTCRAWLER_THRESHOLD)
     {
-        lastTemperature = SensorN[SENSOR_TEMPERATURE].value;
+        lastTemperature = SensorNP[SENSOR_TEMPERATURE].getValue();
         sensorsUpdated = true;
     }
 
     // #3 Get Voltage
     rc = getVoltage();
-    if (rc && fabs(SensorN[SENSOR_VOLTAGE].value - lastVoltage) > NIGHTCRAWLER_THRESHOLD)
+    if (rc && fabs(SensorNP[SENSOR_VOLTAGE].value - lastVoltage) > NIGHTCRAWLER_THRESHOLD)
     {
-        lastVoltage = SensorN[SENSOR_VOLTAGE].value;
+        lastVoltage = SensorNP[SENSOR_VOLTAGE].getValue();
         sensorsUpdated = true;
     }
 
     if (sensorsUpdated)
-        IDSetNumber(&SensorNP, nullptr);
+        SensorNP.apply();
 
     // #4 Get Limit Switch Status
     rc = getLimitSwitchStatus();
-    if (rc && (LimitSwitchL[ROTATION_SWITCH].s != rotationLimit || LimitSwitchL[OUT_SWITCH].s != outSwitchLimit
-               || LimitSwitchL[IN_SWITCH].s != inSwitchLimit))
+    if (rc && (LimitSwitchLP[ROTATION_SWITCH].getState() != rotationLimit || LimitSwitchLP[OUT_SWITCH].getState() != outSwitchLimit
+               || LimitSwitchLP[IN_SWITCH].getState() != inSwitchLimit))
     {
-        rotationLimit = LimitSwitchL[ROTATION_SWITCH].s;
-        outSwitchLimit = LimitSwitchL[OUT_SWITCH].s;
-        inSwitchLimit = LimitSwitchL[IN_SWITCH].s;
-        IDSetLight(&LimitSwitchLP, nullptr);
+        rotationLimit = LimitSwitchLP[ROTATION_SWITCH].getState();
+        outSwitchLimit = LimitSwitchLP[OUT_SWITCH].getState();
+        inSwitchLimit = LimitSwitchLP[IN_SWITCH].getState();
+        LimitSwitchLP.apply();
     }
 
     // #5 Focus Position & Status
     bool absFocusUpdated = false;
 
-    if (FocusAbsPosNP.s == IPS_BUSY)
+    if (FocusAbsPosNP.getState() == IPS_BUSY)
     {
         // Stopped moving
         if (!isMotorMoving(MOTOR_FOCUS))
         {
-            FocusAbsPosNP.s = IPS_OK;
-            if (FocusRelPosNP.s != IPS_OK)
+            FocusAbsPosNP.setState(IPS_OK);
+            if (FocusRelPosNP.getState() != IPS_OK)
             {
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusRelPosNP, nullptr);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusRelPosNP.apply();
             }
             absFocusUpdated = true;
         }
     }
     rc = getPosition(MOTOR_FOCUS);
-    if (rc && FocusAbsPosN[0].value != lastFocuserPosition)
+    if (rc && FocusAbsPosNP[0].getValue() != lastFocuserPosition)
     {
-        lastFocuserPosition = FocusAbsPosN[0].value;
+        lastFocuserPosition = FocusAbsPosNP[0].getValue();
         absFocusUpdated = true;
     }
     if (absFocusUpdated)
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
 
     // #6 Rotator Position & Status
     bool absRotatorUpdated = false;
 
-    if (RotatorAbsPosNP.s == IPS_BUSY)
+    if (RotatorAbsPosNP.getState() == IPS_BUSY)
     {
         // Stopped moving
         if (!isMotorMoving(MOTOR_ROTATOR))
         {
-            RotatorAbsPosNP.s = IPS_OK;
-            GotoRotatorNP.s = IPS_OK;
+            RotatorAbsPosNP.setState(IPS_OK);
+            GotoRotatorNP.setState(IPS_OK);
             absRotatorUpdated = true;
             LOG_INFO("Rotator motion complete.");
         }
     }
     rc = getPosition(MOTOR_ROTATOR);
-    if (rc && RotatorAbsPosN[0].value != lastRotatorPosition)
+    if (rc && RotatorAbsPosNP[0].getValue() != lastRotatorPosition)
     {
-        lastRotatorPosition = RotatorAbsPosN[0].value;
-        GotoRotatorN[0].value = range360(RotatorAbsPosN[0].value / ticksPerDegree);
+        lastRotatorPosition = RotatorAbsPosNP[0].getValue();
+        GotoRotatorNP[0].setValue(range360(RotatorAbsPosNP[0].value / ticksPerDegree));
         absRotatorUpdated = true;
     }
     if (absRotatorUpdated)
     {
-        IDSetNumber(&RotatorAbsPosNP, nullptr);
-        IDSetNumber(&GotoRotatorNP, nullptr);
+        RotatorAbsPosNP.apply();
+        GotoRotatorNP.apply();
     }
 
     // #7 Aux Position & Status
     bool absAuxUpdated = false;
 
-    if (GotoAuxNP.s == IPS_BUSY)
+    if (GotoAuxNP.getState() == IPS_BUSY)
     {
         // Stopped moving
         if (!isMotorMoving(MOTOR_AUX))
         {
-            GotoAuxNP.s = IPS_OK;
+            GotoAuxNP.setState(IPS_OK);
             absAuxUpdated = true;
             LOG_INFO("Aux motion complete.");
         }
     }
     rc = getPosition(MOTOR_AUX);
-    if (rc && GotoAuxN[0].value != lastAuxPosition)
+    if (rc && GotoAuxNP[0].getValue() != lastAuxPosition)
     {
-        lastAuxPosition = GotoAuxN[0].value;
+        lastAuxPosition = GotoAuxNP[0].getValue();
         absAuxUpdated = true;
     }
     if (absAuxUpdated)
-        IDSetNumber(&GotoAuxNP, nullptr);
+        GotoAuxNP.apply();
 
     SetTimer(getCurrentPollingPeriod());
 }
@@ -1014,7 +1014,7 @@ bool NightCrawler::getTemperature()
 
     LOGF_DEBUG("RES <%s>", res);
 
-    SensorN[SENSOR_TEMPERATURE].value = atoi(res) / 10.0;
+    SensorNP[SENSOR_TEMPERATURE].setValue(atoi(res) / 10.0);
 
     return true;
 }
@@ -1049,7 +1049,7 @@ bool NightCrawler::getVoltage()
 
     LOGF_DEBUG("RES <%s>", res);
 
-    SensorN[SENSOR_VOLTAGE].value = atoi(res) / 10.0;
+    SensorNP[SENSOR_VOLTAGE].setValue(atoi(res) / 10.0);
 
     return true;
 }
@@ -1110,11 +1110,11 @@ bool NightCrawler::getStepDelay(MotorType type)
     LOGF_DEBUG("RES <%s>", res);
 
     if (type == MOTOR_FOCUS)
-        FocusStepDelayN[0].value = atoi(res);
+        FocusStepDelayNP[0].setValue(atoi(res));
     else if (type == MOTOR_ROTATOR)
-        RotatorStepDelayN[0].value = atoi(res);
+        RotatorStepDelayNP[0].setValue(atoi(res));
     else
-        AuxStepDelayN[0].value = atoi(res);
+        AuxStepDelayNP[0].setValue(atoi(res));
 
     return true;
 }
@@ -1186,9 +1186,9 @@ bool NightCrawler::getLimitSwitchStatus()
 
     int value = atoi(res);
 
-    LimitSwitchL[ROTATION_SWITCH].s = (value & 0x01) ? IPS_ALERT : IPS_OK;
-    LimitSwitchL[OUT_SWITCH].s      = (value & 0x02) ? IPS_ALERT : IPS_OK;
-    LimitSwitchL[IN_SWITCH].s       = (value & 0x04) ? IPS_ALERT : IPS_OK;
+    LimitSwitchLP[ROTATION_SWITCH].setState((value & 0x01) ? IPS_ALERT : IPS_OK);
+    LimitSwitchLP[OUT_SWITCH].setState((value & 0x02) ? IPS_ALERT : IPS_OK);
+    LimitSwitchLP[IN_SWITCH].setState((value & 0x04) ? IPS_ALERT : IPS_OK);
 
     return true;
 }
@@ -1356,10 +1356,10 @@ bool NightCrawler::saveConfigItems(FILE *fp)
 {
     Focuser::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &BrightnessNP);
-    IUSaveConfigNumber(fp, &FocusStepDelayNP);
-    IUSaveConfigNumber(fp, &RotatorStepDelayNP);
-    IUSaveConfigNumber(fp, &AuxStepDelayNP);
+    BrightnessNP.save(fp);
+    FocusStepDelayNP.save(fp);
+    RotatorStepDelayNP.save(fp);
+    AuxStepDelayNP.save(fp);
 
     return true;
 }
@@ -1368,17 +1368,17 @@ IPState NightCrawler::HomeRotator()
 {
     if (findHome(0x02))
     {
-        FindHomeSP.s = IPS_BUSY;
-        FindHomeS[0].s = ISS_ON;
-        IDSetSwitch(&FindHomeSP, nullptr);
+        FindHomeSP.setState(IPS_BUSY);
+        FindHomeSP[0].setState(ISS_ON);
+        FindHomeSP.apply();
         LOG_WARN("Homing process can take up to 10 minutes. You cannot control the unit until the process is fully complete.");
         return IPS_BUSY;
     }
     else
     {
-        FindHomeSP.s = IPS_ALERT;
-        FindHomeS[0].s = ISS_OFF;
-        IDSetSwitch(&FindHomeSP, nullptr);
+        FindHomeSP.setState(IPS_ALERT);
+        FindHomeSP[0].setState(ISS_OFF);
+        FindHomeSP.apply();
         LOG_ERROR("Failed to start homing process.");
         return IPS_ALERT;
     }
@@ -1388,7 +1388,7 @@ IPState NightCrawler::MoveRotator(double angle)
 {
     // Find shortest distance given target degree
     double a = angle;
-    double b = GotoRotatorN[0].value;
+    double b = GotoRotatorNP[0].getValue();
     double d = fabs(a - b);
     double r = (d > 180) ? 360 - d : d;
     int sign = (a - b >= 0 && a - b <= 180) || (a - b <= -180 && a - b >= -360) ? 1 : -1;
@@ -1397,17 +1397,17 @@ IPState NightCrawler::MoveRotator(double angle)
 
     double newTarget = (r + b) * ticksPerDegree;
 
-    if (newTarget < RotatorAbsPosN[0].min)
-        newTarget -= RotatorAbsPosN[0].min;
-    else if (newTarget > RotatorAbsPosN[0].max)
-        newTarget -= RotatorAbsPosN[0].max;
+    if (newTarget < RotatorAbsPosNP[0].min)
+        newTarget -= RotatorAbsPosNP[0].min;
+    else if (newTarget > RotatorAbsPosNP[0].max)
+        newTarget -= RotatorAbsPosNP[0].getMax();
 
     bool rc = gotoMotor(MOTOR_ROTATOR, static_cast<int32_t>(newTarget));
 
     if (rc)
     {
-        RotatorAbsPosNP.s = IPS_BUSY;
-        IDSetNumber(&RotatorAbsPosNP, nullptr);
+        RotatorAbsPosNP.setState(IPS_BUSY);
+        RotatorAbsPosNP.apply();
         return IPS_BUSY;
     }
 
@@ -1418,7 +1418,7 @@ bool NightCrawler::SyncRotator(double angle)
 {
     // Find shortest distance given target degree
     double a = angle;
-    double b = GotoRotatorN[0].value;
+    double b = GotoRotatorNP[0].getValue();
     double d = fabs(a - b);
     double r = (d > 180) ? 360 - d : d;
     int sign = (a - b >= 0 && a - b <= 180) || (a - b <= -180 && a - b >= -360) ? 1 : -1;
@@ -1427,10 +1427,10 @@ bool NightCrawler::SyncRotator(double angle)
 
     double newTarget = (r + b) * ticksPerDegree;
 
-    if (newTarget < RotatorAbsPosN[0].min)
-        newTarget -= RotatorAbsPosN[0].min;
-    else if (newTarget > RotatorAbsPosN[0].max)
-        newTarget -= RotatorAbsPosN[0].max;
+    if (newTarget < RotatorAbsPosNP[0].min)
+        newTarget -= RotatorAbsPosNP[0].min;
+    else if (newTarget > RotatorAbsPosNP[0].max)
+        newTarget -= RotatorAbsPosNP[0].getMax();
 
     return syncMotor(MOTOR_ROTATOR, static_cast<int32_t>(newTarget));
 }
@@ -1438,10 +1438,10 @@ bool NightCrawler::SyncRotator(double angle)
 bool NightCrawler::AbortRotator()
 {
     bool rc = stopMotor(MOTOR_ROTATOR);
-    if (rc && RotatorAbsPosNP.s != IPS_OK)
+    if (rc && RotatorAbsPosNP.getState() != IPS_OK)
     {
-        RotatorAbsPosNP.s = IPS_OK;
-        IDSetNumber(&RotatorAbsPosNP, nullptr);
+        RotatorAbsPosNP.setState(IPS_OK);
+        RotatorAbsPosNP.apply();
     }
 
     return rc;

--- a/drivers/rotator/nightcrawler.h
+++ b/drivers/rotator/nightcrawler.h
@@ -23,6 +23,11 @@
 #include "indifocuser.h"
 #include "indirotatorinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
+
 class NightCrawler : public INDI::Focuser, public INDI::RotatorInterface
 {
     public:
@@ -97,51 +102,36 @@ class NightCrawler : public INDI::Focuser, public INDI::RotatorInterface
         bool setSleepBrightness(uint8_t value);
 
 
-        INumber GotoAuxN[1];
-        INumberVectorProperty GotoAuxNP;
+        INDI::PropertyNumber GotoAuxNP {1};
 
-        INumber SyncFocusN[1];
-        INumberVectorProperty SyncFocusNP;
+        INDI::PropertyNumber SyncFocusNP {1};
 
-        INumber SyncAuxN[1];
-        INumberVectorProperty SyncAuxNP;
+        INDI::PropertyNumber SyncAuxNP {1};
 
-        ISwitch AbortAuxS[1];
-        ISwitchVectorProperty AbortAuxSP;
+        INDI::PropertySwitch AbortAuxSP {1};
 
-        INumber SensorN[2];
-        INumberVectorProperty SensorNP;
+        INDI::PropertyNumber SensorNP {2};
         enum { SENSOR_TEMPERATURE, SENSOR_VOLTAGE };
 
-        INumber TemperatureOffsetN[1];
-        INumberVectorProperty TemperatureOffsetNP;
+        INDI::PropertyNumber TemperatureOffsetNP {1};
 
-        INumber FocusStepDelayN[1];
-        INumberVectorProperty FocusStepDelayNP;
-        INumber RotatorStepDelayN[1];
-        INumberVectorProperty RotatorStepDelayNP;
-        INumber AuxStepDelayN[1];
-        INumberVectorProperty AuxStepDelayNP;
+        INDI::PropertyNumber FocusStepDelayNP {1};
+        INDI::PropertyNumber RotatorStepDelayNP {1};
+        INDI::PropertyNumber AuxStepDelayNP {1};
 
-        ILight LimitSwitchL[3];
-        ILightVectorProperty LimitSwitchLP;
+        INDI::PropertyLight LimitSwitchLP {3};
         enum { ROTATION_SWITCH, OUT_SWITCH, IN_SWITCH };
 
-        ISwitch HomeSelectionS[3];
-        ISwitchVectorProperty HomeSelectionSP;
-        ISwitch FindHomeS[1];
-        ISwitchVectorProperty FindHomeSP;
+        INDI::PropertySwitch HomeSelectionSP {3};
+        INDI::PropertySwitch FindHomeSP {1};
 
-        ISwitch EncoderS[2];
-        ISwitchVectorProperty EncoderSP;
+        INDI::PropertySwitch EncoderSP {2};
 
-        INumber BrightnessN[2];
-        INumberVectorProperty BrightnessNP;
+        INDI::PropertyNumber BrightnessNP {2};
         enum { BRIGHTNESS_DISPLAY, BRIGHTNESS_SLEEP };
 
         // Rotator Steps
-        INumber RotatorAbsPosN[1];
-        INumberVectorProperty RotatorAbsPosNP;
+        INDI::PropertyNumber RotatorAbsPosNP {1};
 
         double lastTemperature { 0 };
         double lastVoltage { 0 };

--- a/drivers/rotator/pegasus_falcon.cpp
+++ b/drivers/rotator/pegasus_falcon.cpp
@@ -96,19 +96,19 @@ bool PegasusFalcon::initProperties()
     /// Main Control Panel
     ////////////////////////////////////////////////////////////////////////////
     // Reload Firmware
-    IUFillSwitch(&ReloadFirmwareS[0], "RELOAD", "Reload", ISS_OFF);
-    IUFillSwitchVector(&ReloadFirmwareSP, ReloadFirmwareS, 1, getDeviceName(), "RELOAD_FIRMWARE", "Firmware", MAIN_CONTROL_TAB,
+    ReloadFirmwareSP[0].fill("RELOAD", "Reload", ISS_OFF);
+    ReloadFirmwareSP.fill(getDeviceName(), "RELOAD_FIRMWARE", "Firmware", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1,
                        60, IPS_IDLE);
 
     // Derotate
-    IUFillNumber(&DerotateN[0], "INTERVAL", "Interval (ms)", "%.f", 0, 10000, 1000, 0);
-    IUFillNumberVector(&DerotateNP, DerotateN, 1, getDeviceName(), "ROTATOR_DEROTATE", "Derotation", MAIN_CONTROL_TAB, IP_RW,
+    DerotateNP[0].fill("INTERVAL", "Interval (ms)", "%.f", 0, 10000, 1000, 0);
+    DerotateNP.fill(getDeviceName(), "ROTATOR_DEROTATE", "Derotation", MAIN_CONTROL_TAB, IP_RW,
                        60, IPS_IDLE);
 
     // Firmware
-    IUFillText(&FirmwareT[0], "VERSION", "Version", "NA");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "FIRMWARE_INFO", "Firmware", MAIN_CONTROL_TAB, IP_RO, 60,
+    FirmwareTP[0].fill("VERSION", "Version", "NA");
+    FirmwareTP.fill(getDeviceName(), "FIRMWARE_INFO", "Firmware", MAIN_CONTROL_TAB, IP_RO, 60,
                      IPS_IDLE);
 
     return true;
@@ -121,17 +121,17 @@ bool PegasusFalcon::updateProperties()
     if (isConnected())
     {
         // Main Control
-        defineProperty(&DerotateNP);
-        defineProperty(&FirmwareTP);
-        defineProperty(&ReloadFirmwareSP);
+        defineProperty(DerotateNP);
+        defineProperty(FirmwareTP);
+        defineProperty(ReloadFirmwareSP);
 
     }
     else
     {
         // Main Control
-        deleteProperty(DerotateNP.name);
-        deleteProperty(FirmwareTP.name);
-        deleteProperty(ReloadFirmwareSP.name);
+        deleteProperty(DerotateNP.getName());
+        deleteProperty(FirmwareTP.getName());
+        deleteProperty(ReloadFirmwareSP.getName());
     }
 
     return true;
@@ -158,20 +158,20 @@ bool PegasusFalcon::ISNewNumber(const char *dev, const char *name, double values
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // De-rotation
-        if (!strcmp(name, DerotateNP.name))
+        if (DerotateNP.isNameMatch(name))
         {
             const uint32_t ms = static_cast<uint32_t>(values[0]);
             if (setDerotation(ms))
             {
-                DerotateN[0].value = values[0];
+                DerotateNP[0].setValue(values[0]);
                 if (values[0] > 0)
                     LOGF_INFO("De-rotation is enabled and set to 1 step per %u milliseconds.", ms);
                 else
                     LOG_INFO("De-rotaiton is disabled.");
             }
             else
-                DerotateNP.s = IPS_ALERT;
-            IDSetNumber(&DerotateNP, nullptr);
+                DerotateNP.setState(IPS_ALERT);
+            DerotateNP.apply();
             return true;
         }
     }
@@ -187,10 +187,10 @@ bool PegasusFalcon::ISNewSwitch(const char * dev, const char * name, ISState * s
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // ReloadFirmware
-        if (!strcmp(name, ReloadFirmwareSP.name))
+        if (ReloadFirmwareSP.isNameMatch(name))
         {
-            ReloadFirmwareSP.s = reloadFirmware() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&ReloadFirmwareSP, nullptr);
+            ReloadFirmwareSP.setState(reloadFirmware() ? IPS_OK : IPS_ALERT);
+            ReloadFirmwareSP.apply();
             LOG_INFO("Reloading firmware...");
             return true;
         }
@@ -277,7 +277,7 @@ bool PegasusFalcon::setDerotation(uint32_t ms)
 bool PegasusFalcon::saveConfigItems(FILE * fp)
 {
     INDI::Rotator::saveConfigItems(fp);
-    IUSaveConfigNumber(fp, &DerotateNP);
+    DerotateNP.save(fp);
     return true;
 }
 
@@ -300,7 +300,7 @@ bool PegasusFalcon::getFirmware()
     char res[DRIVER_LEN] = {0};
     if (sendCommand("FV", res))
     {
-        IUSaveText(&FirmwareT[0], res + 3);
+        FirmwareTP[0].setText(res + 3);
         return true;
     }
 
@@ -331,32 +331,32 @@ bool PegasusFalcon::getStatusData()
         const IPState motionState = std::stoi(result[3]) == 1 ? IPS_BUSY : IPS_OK;
 
         // Update Absolute Position property if either position changes, or status changes.
-        if (std::abs(position - GotoRotatorN[0].value) > 0.01 || GotoRotatorNP.s != motionState)
+        if (std::abs(position - GotoRotatorNP[0].getValue()) > 0.01 || GotoRotatorNP.getState() != motionState)
         {
-            GotoRotatorN[0].value = position;
-            GotoRotatorNP.s = motionState;
-            IDSetNumber(&GotoRotatorNP, nullptr);
+            GotoRotatorNP[0].setValue(position);
+            GotoRotatorNP.setState(motionState);
+            GotoRotatorNP.apply();
         }
 
         // TODO add this later to properties (Light?)
         //const bool limit = std::stoi(result[4]) == 1;
 
         const bool derotation = std::stoi(result[5]) == 1;
-        const bool wasDerotated = DerotateN[0].value > 0;
+        const bool wasDerotated = DerotateNP[0].getValue() > 0;
         // TODO check if we get value from firmware
         if (derotation != wasDerotated)
         {
-            DerotateNP.s = derotation ? IPS_BUSY : IPS_IDLE;;
-            IDSetNumber(&DerotateNP, nullptr);
+            DerotateNP.setState(derotation ? IPS_BUSY : IPS_IDLE);;
+            DerotateNP.apply();
         }
 
         const bool reversed = std::stoi(result[6]) == 1;
-        const bool wasReversed = ReverseRotatorS[INDI_ENABLED].s == ISS_ON;
+        const bool wasReversed = ReverseRotatorSP[INDI_ENABLED].getState() == ISS_ON;
         if (reversed != wasReversed)
         {
-            ReverseRotatorS[INDI_ENABLED].s = reversed ? ISS_ON : ISS_OFF;
-            ReverseRotatorS[INDI_DISABLED].s = reversed ? ISS_OFF : ISS_ON;
-            IDSetSwitch(&ReverseRotatorSP, nullptr);
+            ReverseRotatorSP[INDI_ENABLED].setState(reversed ? ISS_ON : ISS_OFF);
+            ReverseRotatorSP[INDI_DISABLED].setState(reversed ? ISS_OFF : ISS_ON);
+            ReverseRotatorSP.apply();
         }
 
         lastStatusData = result;

--- a/drivers/rotator/pegasus_falcon.h
+++ b/drivers/rotator/pegasus_falcon.h
@@ -27,6 +27,11 @@
 #include "indirotator.h"
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class PegasusFalcon : public INDI::Rotator
 {
     public:
@@ -94,14 +99,11 @@ class PegasusFalcon : public INDI::Rotator
         /// Properties
         ////////////////////////////////////////////////////////////////////////////////////
         /// Reboot Device
-        ISwitchVectorProperty ReloadFirmwareSP;
-        ISwitch ReloadFirmwareS[1];
+        INDI::PropertySwitch ReloadFirmwareSP {1};
         /// Derotation
-        INumberVectorProperty DerotateNP;
-        INumber DerotateN[1];
+        INDI::PropertyNumber DerotateNP {1};
         /// Firmware
-        ITextVectorProperty FirmwareTP;
-        IText FirmwareT[1] {};
+        INDI::PropertyText FirmwareTP {1};
 
         std::vector<std::string> lastStatusData;
 

--- a/drivers/rotator/pyxis.cpp
+++ b/drivers/rotator/pyxis.cpp
@@ -97,26 +97,26 @@ bool Pyxis::initProperties()
     INDI::Rotator::initProperties();
 
     // Rotation Rate
-    IUFillNumber(&RotationRateN[0], "RATE", "Rate", "%.f", 0, 99, 10, 8);
-    IUFillNumberVector(&RotationRateNP, RotationRateN, 1, getDeviceName(), "ROTATION_RATE", "Rotation", SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
+    RotationRateNP[0].fill("RATE", "Rate", "%.f", 0, 99, 10, 8);
+    RotationRateNP.fill(getDeviceName(), "ROTATION_RATE", "Rotation", SETTINGS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Stepping
-    IUFillSwitch(&SteppingS[FULL_STEP], "FULL_STEP", "Full", ISS_OFF);
-    IUFillSwitch(&SteppingS[HALF_STEP], "HALF_STEP", "Half", ISS_OFF);
-    IUFillSwitchVector(&SteppingSP, SteppingS, 2, getDeviceName(), "STEPPING_RATE", "Stepping", SETTINGS_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+    SteppingSP[FULL_STEP].fill("FULL_STEP", "Full", ISS_OFF);
+    SteppingSP[HALF_STEP].fill("HALF_STEP", "Half", ISS_OFF);
+    SteppingSP.fill(getDeviceName(), "STEPPING_RATE", "Stepping", SETTINGS_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Power
-    IUFillSwitch(&PowerS[POWER_SLEEP], "POWER_SLEEP", "Sleep", ISS_OFF);
-    IUFillSwitch(&PowerS[POWER_WAKEUP], "POWER_WAKEUP", "Wake Up", ISS_OFF);
-    IUFillSwitchVector(&PowerSP, PowerS, 2, getDeviceName(), "POWER_STATE", "Power", SETTINGS_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+    PowerSP[POWER_SLEEP].fill("POWER_SLEEP", "Sleep", ISS_OFF);
+    PowerSP[POWER_WAKEUP].fill("POWER_WAKEUP", "Wake Up", ISS_OFF);
+    PowerSP.fill(getDeviceName(), "POWER_STATE", "Power", SETTINGS_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Firmware version
-    IUFillText(&FirmwareT[0], "FIRMWARE_VERSION", "Version", "Unknown");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "FIRMWARE_VERSION", "Firmware", INFO_TAB, IP_RO, 0, IPS_IDLE);
+    FirmwareTP[0].fill("FIRMWARE_VERSION", "Version", "Unknown");
+    FirmwareTP.fill(getDeviceName(), "FIRMWARE_VERSION", "Firmware", INFO_TAB, IP_RO, 0, IPS_IDLE);
 
     // Firmware version
-    IUFillText(&ModelT[0], "HARDWARE_MODEL", "Model", "Unknown");
-    IUFillTextVector(&ModelTP, ModelT, 1, getDeviceName(), "HARDWARE_MODEL", "Model", INFO_TAB, IP_RO, 0, IPS_IDLE);
+    ModelTP[0].fill("HARDWARE_MODEL", "Model", "Unknown");
+    ModelTP.fill(getDeviceName(), "HARDWARE_MODEL", "Model", INFO_TAB, IP_RO, 0, IPS_IDLE);
 
 
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
@@ -145,8 +145,8 @@ bool Pyxis::updateProperties()
     if (isConnected())
     {
         defineProperty(&RotationRateNP)  ;
-        defineProperty(&SteppingSP);
-        defineProperty(&PowerSP);
+        defineProperty(SteppingSP);
+        defineProperty(PowerSP);
         defineProperty(&FirmwareTP) ;
         defineProperty(&ModelTP) ;
 
@@ -154,11 +154,11 @@ bool Pyxis::updateProperties()
     }
     else
     {
-        deleteProperty(RotationRateNP.name);
-        deleteProperty(SteppingSP.name);
-        deleteProperty(PowerSP.name);
-        deleteProperty(FirmwareTP.name) ;
-        deleteProperty(ModelTP.name) ;
+        deleteProperty(RotationRateNP.getName());
+        deleteProperty(SteppingSP.getName());
+        deleteProperty(PowerSP.getName());
+        deleteProperty(FirmwareTP.getName()) ;
+        deleteProperty(ModelTP.getName()) ;
     }
 
     return true;
@@ -171,22 +171,22 @@ void Pyxis::queryParams()
     ////////////////////////////////////////////
     int dir = getReverseStatus();
 
-    IUResetSwitch(&ReverseRotatorSP);
-    ReverseRotatorSP.s = IPS_OK;
+    ReverseRotatorSP.reset();
+    ReverseRotatorSP.setState(IPS_OK);
     if (dir == 0)
-        ReverseRotatorS[INDI_DISABLED].s = ISS_ON;
+        ReverseRotatorSP[INDI_DISABLED].setState(ISS_ON);
     else if (dir == 1)
-        ReverseRotatorS[INDI_ENABLED].s = ISS_ON;
+        ReverseRotatorSP[INDI_ENABLED].setState(ISS_ON);
     else
-        ReverseRotatorSP.s = IPS_ALERT;
+        ReverseRotatorSP.setState(IPS_ALERT);
 
-    IDSetSwitch(&ReverseRotatorSP, nullptr);
+    ReverseRotatorSP.apply();
 
     // Firmware version parameter
     std::string sversion = getVersion() ;
-    IUSaveText(&FirmwareT[0], sversion.c_str()) ;
-    FirmwareTP.s = IPS_OK;
-    IDSetText(&FirmwareTP, nullptr) ;
+    IUSaveText(&FirmwareTP[0], sversion.c_str()) ;
+    FirmwareTP.setState(IPS_OK);
+    FirmwareTP.apply(nullptr) ;
 
     LOGF_DEBUG("queryParms firmware = %s", sversion.c_str()) ;
 
@@ -198,20 +198,20 @@ void Pyxis::queryParams()
         LOGF_DEBUG("queryParms rate = %d, firmware = %s", rate, sversion.c_str()) ;
         if (rc)
         {
-            RotationRateNP.s = IPS_OK ;
-            RotationRateN[0].value = rate ;
-            IDSetNumber(&RotationRateNP, nullptr) ;
+            RotationRateNP.setState(IPS_OK );
+            RotationRateNP[0].setValue(rate );
+            RotationRateNP.apply(nullptr) ;
 
-            IUSaveText(&ModelT[0], "Pyxis 3 Inch") ;
-            ModelTP.s = IPS_OK;
-            IDSetText(&ModelTP, nullptr)  ;
+            IUSaveText(&ModelTP[0], "Pyxis 3 Inch") ;
+            ModelTP.setState(IPS_OK);
+            ModelTP.apply(nullptr)  ;
         }
     }
     else
     {
-        IUSaveText(&ModelT[0], "Pyxis 2 Inch") ;
-        ModelTP.s = IPS_OK;
-        IDSetText(&ModelTP, nullptr) ;
+        IUSaveText(&ModelTP[0], "Pyxis 2 Inch") ;
+        ModelTP.setState(IPS_OK);
+        ModelTP.apply(nullptr) ;
     }
 
 }
@@ -259,18 +259,18 @@ bool Pyxis::ISNewNumber(const char *dev, const char *name, double values[], char
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, RotationRateNP.name))
+        if (RotationRateNP.isNameMatch(name))
         {
             bool rc = setRotationRate(static_cast<uint8_t>(values[0]));
             if (rc)
             {
-                RotationRateNP.s = IPS_OK;
-                RotationRateN[0].value = values[0];
+                RotationRateNP.setState(IPS_OK);
+                RotationRateNP[0].setValue(values[0]);
             }
             else
-                RotationRateNP.s = IPS_ALERT;
+                RotationRateNP.setState(IPS_ALERT);
 
-            IDSetNumber(&RotationRateNP, nullptr);
+            RotationRateNP.apply();
             return true;
         }
     }
@@ -285,10 +285,10 @@ bool Pyxis::ISNewSwitch(const char *dev, const char *name, ISState *states, char
         /////////////////////////////////////////////////////
         // Stepping
         ////////////////////////////////////////////////////
-        if (!strcmp(name, SteppingSP.name))
+        if (SteppingSP.isNameMatch(name))
         {
             bool rc = false;
-            if (!strcmp(IUFindOnSwitchName(states, names, n), SteppingS[FULL_STEP].name))
+            if (!strcmp(IUFindOnSwitchName(states, names, n), SteppingSP[FULL_STEP].getName()))
                 rc = setSteppingMode(FULL_STEP);
             else
                 rc = setSteppingMode(HALF_STEP);
@@ -296,30 +296,30 @@ bool Pyxis::ISNewSwitch(const char *dev, const char *name, ISState *states, char
 
             if (rc)
             {
-                IUUpdateSwitch(&SteppingSP, states, names, n);
-                SteppingSP.s = IPS_OK;
+                SteppingSP.update(states, names, n);
+                SteppingSP.setState(IPS_OK);
             }
             else
-                SteppingSP.s = IPS_ALERT;
+                SteppingSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&SteppingSP, nullptr);
+            SteppingSP.apply();
             return true;
         }
 
         /////////////////////////////////////////////////////
         // Power
         ////////////////////////////////////////////////////
-        if (!strcmp(name, PowerSP.name))
+        if (PowerSP.isNameMatch(name))
         {
             bool rc = false;
-            if (!strcmp(IUFindOnSwitchName(states, names, n), PowerS[POWER_WAKEUP].name))
+            if (!strcmp(IUFindOnSwitchName(states, names, n), PowerSP[POWER_WAKEUP].getName()))
             {
                 // If not sleeping
-                if (PowerS[POWER_SLEEP].s == ISS_OFF)
+                if (PowerSP[POWER_SLEEP].getState() == ISS_OFF)
                 {
-                    PowerSP.s = IPS_OK;
+                    PowerSP.setState(IPS_OK);
                     LOG_WARN("Controller is not in sleep mode.");
-                    IDSetSwitch(&PowerSP, nullptr);
+                    PowerSP.apply();
                     return true;
                 }
 
@@ -327,30 +327,30 @@ bool Pyxis::ISNewSwitch(const char *dev, const char *name, ISState *states, char
 
                 if (rc)
                 {
-                    IUResetSwitch(&PowerSP);
-                    PowerSP.s = IPS_OK;
+                    PowerSP.reset();
+                    PowerSP.setState(IPS_OK);
                     LOG_INFO("Controller is awake.");
                 }
                 else
-                    PowerSP.s = IPS_ALERT;
+                    PowerSP.setState(IPS_ALERT);
 
-                IDSetSwitch(&PowerSP, nullptr);
+                PowerSP.apply();
                 return true;
             }
             else
             {
                 bool rc = sleepController();
-                IUResetSwitch(&PowerSP);
+                PowerSP.reset();
                 if (rc)
                 {
-                    PowerSP.s = IPS_OK;
-                    PowerS[POWER_SLEEP].s = ISS_ON;
+                    PowerSP.setState(IPS_OK);
+                    PowerSP[POWER_SLEEP].setState(ISS_ON);
                     LOG_INFO("Controller in sleep mode. No functions can be used until controller is waken up.");
                 }
                 else
-                    PowerSP.s = IPS_ALERT;
+                    PowerSP.setState(IPS_ALERT);
 
-                IDSetSwitch(&PowerSP, nullptr);
+                PowerSP.apply();
                 return true;
             }
         }
@@ -500,7 +500,7 @@ IPState Pyxis::MoveRotator(double angle)
     int nbytes_written = 0, rc = -1;
     char errstr[MAXRBUF];
 
-    uint16_t current = static_cast<uint16_t>(GotoRotatorN[0].value) ;
+    uint16_t current = static_cast<uint16_t>(GotoRotatorNP[0].value) ;
 
     targetPA = static_cast<uint16_t>(round(angle));
 
@@ -559,19 +559,19 @@ bool Pyxis::ReverseRotator(bool enabled)
 
 void Pyxis::TimerHit()
 {
-    if (!isConnected() || PowerS[POWER_SLEEP].s == ISS_ON)
+    if (!isConnected() || PowerSP[POWER_SLEEP].getState() == ISS_ON)
     {
         SetTimer(getCurrentPollingPeriod());
         return;
     }
 
-    if (HomeRotatorSP.s == IPS_BUSY)
+    if (HomeRotatorSP.getState() == IPS_BUSY)
     {
         if (isMotionComplete())
         {
-            HomeRotatorSP.s = IPS_OK;
-            HomeRotatorS[0].s = ISS_OFF;
-            IDSetSwitch(&HomeRotatorSP, nullptr);
+            HomeRotatorSP.setState(IPS_OK);
+            HomeRotatorSP[0].setState(ISS_OFF);
+            HomeRotatorSP.apply();
             LOG_INFO("Homing is complete.");
         }
         else
@@ -581,7 +581,7 @@ void Pyxis::TimerHit()
             return;
         }
     }
-    else if (GotoRotatorNP.s == IPS_BUSY)
+    else if (GotoRotatorNP.getState() == IPS_BUSY)
     {
         if (!isMotionComplete())
         {
@@ -589,14 +589,14 @@ void Pyxis::TimerHit()
             SetTimer(POLL_100MS) ;
             return ;
         }
-        GotoRotatorNP.s = IPS_OK;
+        GotoRotatorNP.setState(IPS_OK);
     }
 
     uint16_t PA = 0;
-    if (getPA(PA) && (PA != static_cast<uint16_t>(GotoRotatorN[0].value)))
+    if (getPA(PA) && (PA != static_cast<uint16_t>(GotoRotatorNP[0].value)))
     {
-        GotoRotatorN[0].value = PA;
-        IDSetNumber(&GotoRotatorNP, nullptr);
+        GotoRotatorNP[0].setValue(PA);
+        GotoRotatorNP.apply();
     }
 
     SetTimer(getCurrentPollingPeriod());
@@ -608,7 +608,7 @@ bool Pyxis::isMotionComplete()
     char errstr[MAXRBUF];
     char res[PYXIS_3INCH_PER_DEG + 1] = { 0 };
 
-    bool pyxis3inch = atoi(FirmwareT[0].text) >= 3 ;
+    bool pyxis3inch = atoi(FirmwareTP[0].getText()) >= 3 ;
 
     if ( (rc = tty_nread_section(PortFD, res, (pyxis3inch ? PYXIS_3INCH_PER_DEG : PYXIS_2INCH_PER_DEG), 'F', 1, &nbytes_read)) != TTY_OK)
     {
@@ -619,14 +619,14 @@ bool Pyxis::isMotionComplete()
         {
             LOGF_DEBUG("RES <%s>", res);
 
-            int current = static_cast<uint16_t>(GotoRotatorN[0].value) ;
+            int current = static_cast<uint16_t>(GotoRotatorNP[0].value) ;
 
             current = current + direction ;
             if (current < 0) current = 359 ;
             if (current > 360) current = 1 ;
 
-            GotoRotatorN[0].value = current ;
-            IDSetNumber(&GotoRotatorNP, nullptr);
+            GotoRotatorNP[0].setValue(current );
+            GotoRotatorNP.apply();
 
             LOGF_DEBUG("ANGLE = %d", current) ;
             LOGF_DEBUG("TTY_OVERFLOW, nbytes_read = %d", nbytes_read) ;
@@ -636,10 +636,10 @@ bool Pyxis::isMotionComplete()
         tty_error_msg(rc, errstr, MAXRBUF);
         LOGF_ERROR("%s error: %s.", __FUNCTION__, errstr);
 
-        if (HomeRotatorSP.s == IPS_BUSY)
+        if (HomeRotatorSP.getState() == IPS_BUSY)
         {
-            HomeRotatorS[0].s = ISS_OFF;
-            HomeRotatorSP.s = IPS_ALERT;
+            HomeRotatorSP[0].setState(ISS_OFF);
+            HomeRotatorSP.setState(IPS_ALERT);
             LOG_ERROR("Homing failed. Check possible jam.");
             tcflush(PortFD, TCIOFLUSH);
         }
@@ -675,10 +675,10 @@ bool Pyxis::isMotionComplete()
     else if (res[0] == 'F')
         return true;
     // Error
-    else if (HomeRotatorSP.s == IPS_BUSY)
+    else if (HomeRotatorSP.getState() == IPS_BUSY)
     {
-        HomeRotatorS[0].s = ISS_OFF;
-        HomeRotatorSP.s = IPS_ALERT;
+        HomeRotatorSP[0].setState(ISS_OFF);
+        HomeRotatorSP.setState(IPS_ALERT);
         LOG_ERROR("Homing failed. Check possible jam.");
         tcflush(PortFD, TCIOFLUSH);
     }

--- a/drivers/rotator/pyxis.h
+++ b/drivers/rotator/pyxis.h
@@ -23,6 +23,11 @@
 #include "indirotator.h"
 #include "string.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class Pyxis : public INDI::Rotator
 {
   public:
@@ -62,24 +67,19 @@ class Pyxis : public INDI::Rotator
     void queryParams();
 
     // Rotation Rate
-    INumber RotationRateN[1];
-    INumberVectorProperty RotationRateNP;
+    INDI::PropertyNumber RotationRateNP {1};
 
     // Stepping
-    ISwitch SteppingS[2];
-    ISwitchVectorProperty SteppingSP;
+    INDI::PropertySwitch SteppingSP {2};
     enum { FULL_STEP, HALF_STEP};
 
     // Power
-    ISwitch PowerS[2];
-    ISwitchVectorProperty PowerSP;
+    INDI::PropertySwitch PowerSP {2};
     enum { POWER_SLEEP, POWER_WAKEUP};
 
     // Firmware version; tells us if 2 inch or 3 inch device
-    IText FirmwareT[1] {};
-    ITextVectorProperty FirmwareTP;
-    IText ModelT[1] {};
-    ITextVectorProperty ModelTP;
+    INDI::PropertyText FirmwareTP {1};
+    INDI::PropertyText ModelTP {1};
 
     uint16_t targetPA = {0};
 

--- a/drivers/rotator/rotator_simulator.cpp
+++ b/drivers/rotator/rotator_simulator.cpp
@@ -112,25 +112,25 @@ void RotatorSimulator::TimerHit()
         return;
     }
 
-    if (GotoRotatorNP.s == IPS_BUSY)
+    if (GotoRotatorNP.getState() == IPS_BUSY)
     {
-        if (std::fabs(m_TargetAngle - GotoRotatorN[0].value) <= ROTATION_RATE)
+        if (std::fabs(m_TargetAngle - GotoRotatorNP[0].getValue()) <= ROTATION_RATE)
         {
-            GotoRotatorN[0].value = m_TargetAngle;
-            GotoRotatorNP.s = IPS_OK;
+            GotoRotatorNP[0].setValue(m_TargetAngle);
+            GotoRotatorNP.setState(IPS_OK);
         }
         else
         {
             // Find shortest distance given target degree
             double a = m_TargetAngle;
-            double b = GotoRotatorN[0].value;
+            double b = GotoRotatorNP[0].getValue();
             int sign = (a - b >= 0 && a - b <= 180) || (a - b <= -180 && a - b >= -360) ? 1 : -1;
             double diff = ROTATION_RATE * sign;
-            GotoRotatorN[0].value += diff;
-            GotoRotatorN[0].value = range360(GotoRotatorN[0].value);
+            GotoRotatorNP[0].value += diff;
+            GotoRotatorNP[0].setValue(range360(GotoRotatorNP[0].value));
         }
 
-        IDSetNumber(&GotoRotatorNP, nullptr);
+        GotoRotatorNP.apply();
     }
     SetTimer(getCurrentPollingPeriod());
 }

--- a/drivers/skeleton/mount_driver.cpp
+++ b/drivers/skeleton/mount_driver.cpp
@@ -93,9 +93,9 @@ bool MountDriver::initProperties()
     INDI::Telescope::initProperties();
 
     // How fast do we guide compared to sidereal rate
-    IUFillNumber(&GuideRateN[AXIS_RA], "GUIDE_RATE_WE", "W/E Rate", "%.1f", 0, 1, 0.1, 0.5);
-    IUFillNumber(&GuideRateN[AXIS_DE], "GUIDE_RATE_NS", "N/S Rate", "%.1f", 0, 1, 0.1, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
+    GuideRateNP[AXIS_RA].fill("GUIDE_RATE_WE", "W/E Rate", "%.1f", 0, 1, 0.1, 0.5);
+    GuideRateNP[AXIS_DE].fill("GUIDE_RATE_NS", "N/S Rate", "%.1f", 0, 1, 0.1, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // Since we have 4 slew rates, let's fill them out
@@ -144,7 +144,7 @@ bool MountDriver::updateProperties()
     {
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
-        defineProperty(&GuideRateNP);
+        defineProperty(GuideRateNP);
 
         // Read the parking file, and check if we can load any saved parking information.
         if (InitPark())
@@ -167,7 +167,7 @@ bool MountDriver::updateProperties()
     {
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
-        deleteProperty(GuideRateNP.name);
+        deleteProperty(GuideRateNP.getName());
     }
 
     return true;
@@ -291,9 +291,9 @@ bool MountDriver::ISNewNumber(const char *dev, const char *name, double values[]
         // Guide Rate
         if (strcmp(name, "GUIDE_RATE") == 0)
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
-            GuideRateNP.s = IPS_OK;
-            IDSetNumber(&GuideRateNP, nullptr);
+            GuideRateNP.update(values, names, n);
+            GuideRateNP.setState(IPS_OK);
+            GuideRateNP.apply();
             return true;
         }
 
@@ -408,9 +408,9 @@ bool MountDriver::SetDefaultPark()
     // For RA_DE park, we can use something like this:
 
     // By default set RA to HA
-    SetAxis1Park(get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value));
+    SetAxis1Park(get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].value));
     // Set DEC to 90 or -90 depending on the hemisphere
-    SetAxis2Park((LocationN[LOCATION_LATITUDE].value > 0) ? 90 : -90);
+    SetAxis2Park((LocationNP[LOCATION_LATITUDE].value > 0) ? 90 : -90);
 
     // For Az/Alt, we can use something like this:
 

--- a/drivers/spectrograph/spectrograph_simulator.cpp
+++ b/drivers/spectrograph/spectrograph_simulator.cpp
@@ -180,7 +180,7 @@ void RadioSim::setupParams(float sr, float freq, float bw, float gain)
 bool RadioSim::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
 {
     bool r = false;
-    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, SpectrographSettingsNP.name)) {
+    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, SpectrographSettingsNP.getName())) {
         for(int i = 0; i < n; i++) {
             if (!strcmp(names[i], "SPECTROGRAPH_GAIN")) {
                 setupParams(getSampleRate(), getFrequency(), getBandwidth(), values[i]);
@@ -192,7 +192,7 @@ bool RadioSim::ISNewNumber(const char *dev, const char *name, double values[], c
                 setupParams(values[i], getFrequency(), getBandwidth(), getGain());
             }
         }
-        IDSetNumber(&SpectrographSettingsNP, nullptr);
+        SpectrographSettingsNP.apply();
     }
     return processNumber(dev, name, values, names, n) & !r;
 }

--- a/drivers/telescope/celestrongps.cpp
+++ b/drivers/telescope/celestrongps.cpp
@@ -146,46 +146,46 @@ bool CelestronGPS::initProperties()
     FI::initProperties(FOCUS_TAB);
 
     // Firmware
-    IUFillText(&FirmwareT[FW_MODEL], "Model", "", nullptr);
-    IUFillText(&FirmwareT[FW_VERSION], "HC Version", "", nullptr);
-    IUFillText(&FirmwareT[FW_RA], "Ra Version", "", nullptr);
-    IUFillText(&FirmwareT[FW_DEC], "Dec Version", "", nullptr);
-    IUFillText(&FirmwareT[FW_ISGEM], "Mount Type", "", nullptr);
-    IUFillText(&FirmwareT[FW_CAN_AUX], "Guide Method", "", nullptr);
-    IUFillText(&FirmwareT[FW_HAS_FOC], "Has Focuser", "", nullptr);
-    IUFillTextVector(&FirmwareTP, FirmwareT, 7, getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
+    FirmwareTP[FW_MODEL].fill("Model", "", nullptr);
+    FirmwareTP[FW_VERSION].fill("HC Version", "", nullptr);
+    FirmwareTP[FW_RA].fill("Ra Version", "", nullptr);
+    FirmwareTP[FW_DEC].fill("Dec Version", "", nullptr);
+    FirmwareTP[FW_ISGEM].fill("Mount Type", "", nullptr);
+    FirmwareTP[FW_CAN_AUX].fill("Guide Method", "", nullptr);
+    FirmwareTP[FW_HAS_FOC].fill("Has Focuser", "", nullptr);
+    FirmwareTP.fill(getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
                      IPS_IDLE);
 
     // Celestron Track Modes are Off, AltAz, EQ N, EQ S and Ra and Dec (StarSense only)
     // off is not provided as these are used to set the track mode when tracking is enabled
     // may be required for set up, value will be read from the mount if possible
-    IUFillSwitchVector(&CelestronTrackModeSP, CelestronTrackModeS, 4, getDeviceName(), "CELESTRON_TRACK_MODE", "Track Mode",
+    CelestronTrackModeSP.fill(getDeviceName(), "CELESTRON_TRACK_MODE", "Track Mode",
                        MOUNTINFO_TAB, IP_RO, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&CelestronTrackModeS[0], "MODE_ALTAZ", "Alt Az", ISS_OFF);
-    IUFillSwitch(&CelestronTrackModeS[1], "MODE_EQ_N", "EQ N", ISS_ON);
-    IUFillSwitch(&CelestronTrackModeS[2], "MODE_EQ_S", "EQ S", ISS_OFF);
-    IUFillSwitch(&CelestronTrackModeS[3], "MODE_RA_DEC", "Ra and Dec", ISS_OFF);
+    CelestronTrackModeSP[0].fill("MODE_ALTAZ", "Alt Az", ISS_OFF);
+    CelestronTrackModeSP[1].fill("MODE_EQ_N", "EQ N", ISS_ON);
+    CelestronTrackModeSP[2].fill("MODE_EQ_S", "EQ S", ISS_OFF);
+    CelestronTrackModeSP[3].fill("MODE_RA_DEC", "Ra and Dec", ISS_OFF);
 
     // INDI track modes are sidereal, solar and lunar
     AddTrackMode("TRACK_SIDEREAL", "Sidereal", true);
     AddTrackMode("TRACK_SOLAR", "Solar");
     AddTrackMode("TRACK_LUNAR", "Lunar");
 
-    IUFillSwitch(&UseHibernateS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&UseHibernateS[1], "Disable", "", ISS_ON);
-    IUFillSwitchVector(&UseHibernateSP, UseHibernateS, 2, getDeviceName(), "Hibernate", "", OPTIONS_TAB, IP_RW,
+    UseHibernateSP[0].fill("Enable", "", ISS_OFF);
+    UseHibernateSP[1].fill("Disable", "", ISS_ON);
+    UseHibernateSP.fill(getDeviceName(), "Hibernate", "", OPTIONS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     //GUIDE Define "Use Pulse Cmd" property (Switch).
-    //    IUFillSwitch(&UsePulseCmdS[0], "Off", "", ISS_OFF);
-    //    IUFillSwitch(&UsePulseCmdS[1], "On", "", ISS_ON);
-    //    IUFillSwitchVector(&UsePulseCmdSP, UsePulseCmdS, 2, getDeviceName(), "Use Pulse Cmd", "", MAIN_CONTROL_TAB, IP_RW,
+    //    UsePulseCmdSP[0].fill("Off", "", ISS_OFF);
+    //    UsePulseCmdSP[1].fill("On", "", ISS_ON);
+    //    UsePulseCmdSP.fill(getDeviceName(), "Use Pulse Cmd", "", MAIN_CONTROL_TAB, IP_RW,
     //                       ISR_1OFMANY, 0, IPS_IDLE);
 
     // experimental last align control
-    IUFillSwitchVector(&LastAlignSP, LastAlignS, 1, getDeviceName(), "Align", "Align", MAIN_CONTROL_TAB,
+    LastAlignSP.fill(getDeviceName(), "Align", "Align", MAIN_CONTROL_TAB,
                        IP_WO, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LastAlignS[0], "Align", "Align", ISS_OFF);
+    LastAlignSP[0].fill("Align", "Align", ISS_OFF);
     // maybe a second switch which confirms the align
 
     SetParkDataType(PARK_AZ_ALT);
@@ -197,36 +197,36 @@ bool CelestronGPS::initProperties()
     /// Guide Rate; units and min/max as specified in the INDI Standard Properties SLEW_GUIDE
     /// https://indilib.org/developers/developer-manual/101-standard-properties.html#h3-telescopes
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    IUFillNumber(&GuideRateN[AXIS_RA], "GUIDE_RATE_WE", "W/E Rate", "%0.2f", 0, 1, 0.1, GuideRateN[AXIS_RA].value);
-    IUFillNumber(&GuideRateN[AXIS_DE], "GUIDE_RATE_NS", "N/S Rate", "%0.2f", 0, 1, 0.1, GuideRateN[AXIS_DE].value);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guide Rate x sidereal", GUIDE_TAB, IP_RW, 0,
+    GuideRateNP[AXIS_RA].fill("GUIDE_RATE_WE", "W/E Rate", "%0.2f", 0, 1, 0.1, GuideRateNP[AXIS_RA].getValue());
+    GuideRateNP[AXIS_DE].fill("GUIDE_RATE_NS", "N/S Rate", "%0.2f", 0, 1, 0.1, GuideRateNP[AXIS_DE].getValue());
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guide Rate x sidereal", GUIDE_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     ////////////////////////////////////////////////////////////////////////////////////////
     /// PEC
     /////////////////////////////////////////////////////////////////////////////////////////
 
-    IUFillSwitch(&PecControlS[PEC_Seek], "PEC_SEEK_INDEX", "Seek Index", ISS_OFF);
-    IUFillSwitch(&PecControlS[PEC_Stop], "PEC_STOP", "Stop", ISS_OFF);
-    IUFillSwitch(&PecControlS[PEC_Playback], "PEC_PLAYBACK", "Playback", ISS_OFF);
-    IUFillSwitch(&PecControlS[PEC_Record], "PEC_RECORD", "Record", ISS_OFF);
-    IUFillSwitchVector(&PecControlSP, PecControlS, 4, getDeviceName(), "PEC_CONTROL", "PEC Control", MOTION_TAB, IP_RW,
+    PecControlSP[PEC_Seek].fill("PEC_SEEK_INDEX", "Seek Index", ISS_OFF);
+    PecControlSP[PEC_Stop].fill("PEC_STOP", "Stop", ISS_OFF);
+    PecControlSP[PEC_Playback].fill("PEC_PLAYBACK", "Playback", ISS_OFF);
+    PecControlSP[PEC_Record].fill("PEC_RECORD", "Record", ISS_OFF);
+    PecControlSP.fill(getDeviceName(), "PEC_CONTROL", "PEC Control", MOTION_TAB, IP_RW,
                        ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillText(&PecInfoT[0], "PEC_STATE", "Pec State", "undefined");
-    IUFillText(&PecInfoT[1], "PEC_INDEX", "Pec Index", " ");
-    IUFillTextVector(&PecInfoTP, PecInfoT, 2, getDeviceName(), "PEC_INFO", "Pec Info", MOTION_TAB, IP_RO,  60, IPS_IDLE);
+    PecInfoTP[0].fill("PEC_STATE", "Pec State", "undefined");
+    PecInfoTP[1].fill("PEC_INDEX", "Pec Index", " ");
+    PecInfoTP.fill(getDeviceName(), "PEC_INFO", "Pec Info", MOTION_TAB, IP_RO,  60, IPS_IDLE);
 
     // load Pec data from file
-    IUFillText(&PecFileNameT[0], "PEC_FILE_NAME", "File Name", "");
-    IUFillTextVector(&PecFileNameTP, PecFileNameT, 1, getDeviceName(), "PEC_LOAD", "Load PEC", MOTION_TAB, IP_WO, 60, IPS_IDLE);
+    PecFileNameTP[0].fill("PEC_FILE_NAME", "File Name", "");
+    PecFileNameTP.fill(getDeviceName(), "PEC_LOAD", "Load PEC", MOTION_TAB, IP_WO, 60, IPS_IDLE);
 
     /////////////////////////////
     /// DST setting
     /////////////////////////////
 
-    IUFillSwitch(&DSTSettingS[0], "DST_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitchVector(&DSTSettingSP, DSTSettingS, 1, getDeviceName(), "DST_STATE", "DST", SITE_TAB, IP_RW, ISR_NOFMANY, 60,
+    DSTSettingSP[0].fill("DST_ENABLED", "Enabled", ISS_OFF);
+    DSTSettingSP.fill(getDeviceName(), "DST_STATE", "DST", SITE_TAB, IP_RW, ISR_NOFMANY, 60,
                        IPS_IDLE);
 
     addAuxControls();
@@ -236,36 +236,36 @@ bool CelestronGPS::initProperties()
 
     //FocuserInterface
     //Initial, these will be updated later.
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 30000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 1000;
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 60000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 1000;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(30000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(1000);
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(60000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(1000);
 
     // Maximum Position Settings, will be read from the hardware
-    FocusMaxPosN[0].max   = 60000;
-    FocusMaxPosN[0].min   = 1000;
-    FocusMaxPosN[0].value = 60000;
-    FocusMaxPosNP.p = IP_RO;
+    FocusMaxPosNP[0].setMax(60000);
+    FocusMaxPosNP[0].setMin(1000);
+    FocusMaxPosNP[0].setValue(60000);
+    FocusMaxPosNP.setPermission(IP_RO);
 
     // Focuser backlash
     // CR this is a value, positive or negative to define the direction.  It is implemented
     // in the driver.
 
-    FocusBacklashN[0].min = -1000;
-    FocusBacklashN[0].max = 1000;
-    FocusBacklashN[0].step = 1;
-    FocusBacklashN[0].value = 0;
-    //    IUFillNumber(&FocusBacklashN[0], "STEPS", "Steps", "%.f", -500., 500, 1., 0.);
-    //    IUFillNumberVector(&FocusBacklashNP, FocusBacklashN, 1, getDeviceName(), "FOCUS_BACKLASH", "Backlash",
+    FocusBacklashNP[0].setMin(-1000);
+    FocusBacklashNP[0].setMax(1000);
+    FocusBacklashNP[0].setStep(1);
+    FocusBacklashNP[0].setValue(0);
+    //    FocusBacklashNP[0].fill("STEPS", "Steps", "%.f", -500., 500, 1., 0.);
+    //    FocusBacklashNP.fill(getDeviceName(), "FOCUS_BACKLASH", "Backlash",
     //                       FOCUS_TAB, IP_RW, 0, IPS_IDLE);
 
     // Focuser min limit, read from the hardware
-    IUFillNumber(&FocusMinPosN[0], "FOCUS_MIN_VALUE", "Steps", "%.f", 0, 40000., 1., 0.);
-    IUFillNumberVector(&FocusMinPosNP, FocusMinPosN, 1, getDeviceName(), "FOCUS_MIN", "Min. Position",
+    FocusMinPosNP[0].fill("FOCUS_MIN_VALUE", "Steps", "%.f", 0, 40000., 1., 0.);
+    FocusMinPosNP.fill(getDeviceName(), "FOCUS_MIN", "Min. Position",
                        FOCUS_TAB, IP_RO, 0, IPS_IDLE);
 
     return true;
@@ -280,8 +280,8 @@ void CelestronGPS::ISGetProperties(const char *dev)
 
     INDI::Telescope::ISGetProperties(dev);
 
-    defineProperty(&UseHibernateSP);
-    defineProperty(&CelestronTrackModeSP);
+    defineProperty(UseHibernateSP);
+    defineProperty(CelestronTrackModeSP);
     if (configLoaded == false)
     {
         configLoaded = true;
@@ -297,18 +297,18 @@ bool CelestronGPS::updateProperties()
 
         if (driver.get_firmware(&fwInfo))
         {
-            IUSaveText(&FirmwareT[FW_MODEL], fwInfo.Model.c_str());
-            IUSaveText(&FirmwareT[FW_VERSION], fwInfo.Version.c_str());
-            IUSaveText(&FirmwareT[FW_RA], fwInfo.RAFirmware.c_str());
-            IUSaveText(&FirmwareT[FW_DEC], fwInfo.DEFirmware.c_str());
-            IUSaveText(&FirmwareT[FW_ISGEM], fwInfo.isGem ? "GEM" : "Fork");
+            FirmwareTP[FW_MODEL].setText(fwInfo.Model);
+            FirmwareTP[FW_VERSION].setText(fwInfo.Version);
+            FirmwareTP[FW_RA].setText(fwInfo.RAFirmware);
+            FirmwareTP[FW_DEC].setText(fwInfo.DEFirmware);
+            FirmwareTP[FW_ISGEM].setText(fwInfo.isGem ? "GEM" : "Fork");
             canAuxGuide = (atof(fwInfo.RAFirmware.c_str()) >= 6.12 && atof(fwInfo.DEFirmware.c_str()) >= 6.12);
-            IUSaveText(&FirmwareT[FW_CAN_AUX], canAuxGuide ? "Mount" : "Time Guide");
-            IUSaveText(&FirmwareT[FW_HAS_FOC], fwInfo.hasFocuser ? "True" : "False");
+            FirmwareTP[FW_CAN_AUX].setText(canAuxGuide ? "Mount" : "Time Guide");
+            FirmwareTP[FW_HAS_FOC].setText(fwInfo.hasFocuser ? "True" : "False");
 
             usePreciseCoords = (checkMinVersion(2.2, "usePreciseCoords"));
             // set the default switch index, will be updated from the mount if possible
-            fwInfo.celestronTrackMode = static_cast<CELESTRON_TRACK_MODE>(IUFindOnSwitchIndex(&CelestronTrackModeSP) + 1);
+            fwInfo.celestronTrackMode = static_cast<CELESTRON_TRACK_MODE>(CelestronTrackModeSP.findOnSwitchIndex() + 1);
         }
         else
         {
@@ -359,12 +359,12 @@ bool CelestronGPS::updateProperties()
                 if (ctm != CTM_OFF)
                 {
                     fwInfo.celestronTrackMode = ctm;
-                    IUResetSwitch(&CelestronTrackModeSP);
-                    CelestronTrackModeS[ctm - 1].s = ISS_ON;
-                    CelestronTrackModeSP.s      = IPS_OK;
+                    CelestronTrackModeSP.reset();
+                    CelestronTrackModeSP[ctm - 1].setState(ISS_ON);
+                    CelestronTrackModeSP.setState(IPS_OK);
 
                     saveConfig(true, "CELESTRON_TRACK_MODE");
-                    LOGF_DEBUG("Celestron mount tracking, mode %s", CelestronTrackModeS[ctm - 1].label);
+                    LOGF_DEBUG("Celestron mount tracking, mode %s", CelestronTrackModeSP[ctm - 1].label);
                 }
                 else
                 {
@@ -375,10 +375,10 @@ bool CelestronGPS::updateProperties()
             else
             {
                 LOG_DEBUG("get_track_mode failed");
-                CelestronTrackModeSP.s = IPS_ALERT;
+                CelestronTrackModeSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&CelestronTrackModeSP, nullptr);
+            CelestronTrackModeSP.apply();
         }
 
         if (fwInfo.celestronTrackMode != CTM_ALTAZ)
@@ -394,21 +394,21 @@ bool CelestronGPS::updateProperties()
         INDI::Telescope::updateProperties();
 
         if (fwInfo.Version != "Invalid")
-            defineProperty(&FirmwareTP);
+            defineProperty(FirmwareTP);
 
         if (InitPark())
         {
             // If loading parking data is successful, we just set the default parking values.
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
         else
         {
             // Otherwise, we set all parking data to default in case no parking data is found.
-            SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
 
         // InitPark sets TrackState to IDLE or PARKED so this is the earliest we can
@@ -430,17 +430,17 @@ bool CelestronGPS::updateProperties()
                 fwInfo.celestronTrackMode == CELESTRON_TRACK_MODE::CTM_EQS ||
                 fwInfo.celestronTrackMode == CELESTRON_TRACK_MODE::CTM_RADEC)
         {
-            defineProperty(&GuideRateNP);
+            defineProperty(GuideRateNP);
             uint8_t rate;
             if (driver.get_guide_rate(CELESTRON_AXIS::RA_AXIS, &rate))
             {
-                GuideRateN[AXIS_RA].value = std::min(std::max(static_cast<double>(rate) / 255.0, 0.0), 1.0);
-                LOGF_DEBUG("Get Guide Rate: RA %f", GuideRateN[AXIS_RA].value);
+                GuideRateNP[AXIS_RA].setValue(std::min(std::max(static_cast<double>(rate) / 255.0, 0.0), 1.0));
+                LOGF_DEBUG("Get Guide Rate: RA %f", GuideRateNP[AXIS_RA].getValue());
                 if (driver.get_guide_rate(CELESTRON_AXIS::DEC_AXIS, &rate))
                 {
-                    GuideRateN[AXIS_DE].value = std::min(std::max(static_cast<double>(rate) / 255.0, 0.0), 1.0);
-                    IDSetNumber(&GuideRateNP, nullptr);
-                    LOGF_DEBUG("Get Guide Rate: Dec %f", GuideRateN[AXIS_DE].value);
+                    GuideRateNP[AXIS_DE].setValue(std::min(std::max(static_cast<double>(rate) / 255.0, 0.0), 1.0));
+                    GuideRateNP.apply();
+                    LOGF_DEBUG("Get Guide Rate: Dec %f", GuideRateNP[AXIS_DE].getValue());
                 }
             }
             else
@@ -455,7 +455,7 @@ bool CelestronGPS::updateProperties()
             LOG_INFO("Mount does not support guiding. Tracking mode must be set in handset to either EQ-North or EQ-South.");
 
 
-        defineProperty(&CelestronTrackModeSP);
+        defineProperty(CelestronTrackModeSP);
 
         // JM 2014-04-14: User (davidw) reported AVX mount serial communication times out issuing "h" command with firmware 5.28
         // JM 2018-09-27: User (suramara) reports that it works with AVX mount with Star Sense firmware version 1.19
@@ -475,26 +475,26 @@ bool CelestronGPS::updateProperties()
                 snprintf(isoDateTime, 32, "%04d-%02d-%02dT%02d:%02d:%02d", yy, mm, dd, hh, minute, ss);
                 snprintf(utcOffset, 8, "%4.2f", utc_offset);
 
-                IUSaveText(IUFindText(&TimeTP, "UTC"), isoDateTime);
-                IUSaveText(IUFindText(&TimeTP, "OFFSET"), utcOffset);
+                IUSaveText(TimeTP.findWidgetByName("UTC"), isoDateTime);
+                IUSaveText(TimeTP.findWidgetByName("OFFSET"), utcOffset);
 
-                defineProperty(&DSTSettingSP);
-                DSTSettingS[0].s = dst ? ISS_ON : ISS_OFF;
+                defineProperty(DSTSettingSP);
+                DSTSettingSP[0].setState(dst ? ISS_ON : ISS_OFF);
 
                 LOGF_INFO("Mount UTC offset: %s. UTC time: %s. DST: %s", utcOffset, isoDateTime, dst ? "On" : "Off");
                 //LOGF_DEBUG("Mount UTC offset is %s. UTC time is %s", utcOffset, isoDateTime);
 
-                TimeTP.s = IPS_OK;
-                IDSetText(&TimeTP, nullptr);
-                IDSetSwitch(&DSTSettingSP, nullptr);
+                TimeTP.setState(IPS_OK);
+                TimeTP.apply();
+                DSTSettingSP.apply();
             }
             double longitude, latitude;
             if (driver.get_location(&longitude, &latitude))
             {
-                LocationNP.np[LOCATION_LATITUDE].value = latitude;
-                LocationNP.np[LOCATION_LONGITUDE].value = longitude;
-                LocationNP.np[LOCATION_ELEVATION].value = 0;
-                LocationNP.s = IPS_OK;
+                LocationNP[LOCATION_LATITUDE].setValue(latitude);
+                LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+                LocationNP[LOCATION_ELEVATION].setValue(0);
+                LocationNP.setState(IPS_OK);
                 LOGF_DEBUG("Mount latitude %8.4f longitude %8.4f", latitude, longitude);
             }
         }
@@ -506,7 +506,7 @@ bool CelestronGPS::updateProperties()
         // comment out this line and rebuild if you want to run with other mounts - at your own risk!
         if (strcmp(fwInfo.Model.c_str(), "CGX") == 0)
         {
-            defineProperty(&LastAlignSP);
+            defineProperty(LastAlignSP);
         }
 
         // Sometimes users start their mount when it is NOT yet aligned and then try to proceed to use it
@@ -514,26 +514,26 @@ bool CelestronGPS::updateProperties()
         checkAlignment();
 
         // PEC, must have PEC index and be equatorially mounted
-        if (fwInfo.canPec && CelestronTrackModeS[CTM_ALTAZ].s != ISS_OFF)
+        if (fwInfo.canPec && CelestronTrackModeSP[CTM_ALTAZ].s != ISS_OFF)
         {
             driver.pecState = PEC_STATE::PEC_AVAILABLE;
-            defineProperty(&PecControlSP);
-            defineProperty(&PecInfoTP);
-            defineProperty(&PecFileNameTP);
+            defineProperty(PecControlSP);
+            defineProperty(PecInfoTP);
+            defineProperty(PecFileNameTP);
         }
 
         //  handle the focuser
         if (fwInfo.hasFocuser)
         {
             LOG_INFO("update focuser properties");
-            //defineProperty(&FocusBacklashNP);
-            defineProperty(&FocusMinPosNP);
+            //defineProperty(FocusBacklashNP);
+            defineProperty(FocusMinPosNP);
             if (focusReadLimits())
             {
-                IUUpdateMinMax(&FocusAbsPosNP);
+                FocusAbsPosNP.updateMinMax();
 
-                IDSetNumber(&FocusMaxPosNP, nullptr);
-                IDSetNumber(&FocusMinPosNP, nullptr);
+                FocusMaxPosNP.apply();
+                FocusMinPosNP.apply();
                 // focuser move capability is only set if the focus limits are valid
                 FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_CAN_ABORT);
             }
@@ -549,26 +549,26 @@ bool CelestronGPS::updateProperties()
         INDI::Telescope::updateProperties();
 
         FI::updateProperties();
-        //deleteProperty(FocusBacklashNP.name);
-        deleteProperty(FocusMinPosNP.name);
+        //deleteProperty(FocusBacklashNP.getName());
+        deleteProperty(FocusMinPosNP.getName());
 
         //GUIDE Delete properties.
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
 
-        deleteProperty(GuideRateNP.name);
+        deleteProperty(GuideRateNP.getName());
 
-        deleteProperty(LastAlignSP.name);
-        deleteProperty(CelestronTrackModeSP.name);
+        deleteProperty(LastAlignSP.getName());
+        deleteProperty(CelestronTrackModeSP.getName());
 
-        deleteProperty(DSTSettingSP.name);
+        deleteProperty(DSTSettingSP.getName());
 
-        deleteProperty(PecInfoTP.name);
-        deleteProperty(PecControlSP.name);
-        deleteProperty(PecFileNameTP.name);
+        deleteProperty(PecInfoTP.getName());
+        deleteProperty(PecControlSP.getName());
+        deleteProperty(PecFileNameTP.getName());
 
         if (fwInfo.Version != "Invalid")
-            deleteProperty(FirmwareTP.name);
+            deleteProperty(FirmwareTP.getName());
     }
 
     return true;
@@ -579,7 +579,7 @@ bool CelestronGPS::Goto(double ra, double dec)
     targetRA  = ra;
     targetDEC = dec;
 
-    if (EqNP.s == IPS_BUSY || MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY || MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
     {
         driver.abort();
         // sleep for 500 mseconds
@@ -638,8 +638,8 @@ bool CelestronGPS::GotoAzAlt(double az, double alt)
 
         ln_lnlat_posn observer;
 
-        observer.lat = LocationN[LOCATION_LATITUDE].value;
-        observer.lng = LocationN[LOCATION_LONGITUDE].value;
+        observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+        observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
 
         if (observer.lng > 180)
             observer.lng -= 360;
@@ -651,7 +651,7 @@ bool CelestronGPS::GotoAzAlt(double az, double alt)
         targetDEC = equatorialPos.dec;
     }
 
-    if (driver.slew_azalt(LocationN[LOCATION_LATITUDE].value, az, alt) == false)
+    if (driver.slew_azalt(LocationNP[LOCATION_LATITUDE].value, az, alt) == false)
     {
         LOG_ERROR("Failed to slew telescope in Az/Alt.");
         return false;
@@ -662,7 +662,7 @@ bool CelestronGPS::GotoAzAlt(double az, double alt)
 
     TrackState = SCOPE_SLEWING;
 
-    HorizontalCoordsNP.s = IPS_BUSY;
+    HorizontalCoordsNP.setState(IPS_BUSY);
 
     char AZStr[16], ALTStr[16];
     fs_sexa(AZStr, targetAZ, 3, 3600);
@@ -764,7 +764,7 @@ bool CelestronGPS::ReadScopeStatus()
             // manage version and hemisphere nonsense
             // HC versions less than 5.24 reverse the side of pier if the mount
             // is in the Southern hemisphere.  StarSense doesn't
-            if (LocationN[LOCATION_LATITUDE].value < 0)
+            if (LocationNP[LOCATION_LATITUDE].value < 0)
             {
                 if (fwInfo.controllerVersion <= 5.24 && fwInfo.controllerVariant != ISSTARSENSE)
                 {
@@ -795,7 +795,7 @@ bool CelestronGPS::ReadScopeStatus()
         }
 
         LOGF_DEBUG("latitude %g, sop %c, PierSide %c",
-                   LocationN[LOCATION_LATITUDE].value,
+                   LocationNP[LOCATION_LATITUDE].getValue(),
                    sop, psc);
     }
 
@@ -828,8 +828,8 @@ bool CelestronGPS::ReadScopeStatus()
                 return false;
             }
 
-            LastAlignSP.s = IPS_IDLE;
-            IDSetSwitch(&LastAlignSP, "Align finished");
+            LastAlignSP.setState(IPS_IDLE);
+            LastAlignSP.apply("Align finished");
 
             bool isAligned;
             if (!driver.check_aligned(&isAligned))
@@ -881,7 +881,7 @@ bool CelestronGPS::ReadScopeStatus()
                 saveConfig(true);
 
                 // Check if we need to hibernate
-                if (UseHibernateS[0].s == ISS_ON)
+                if (UseHibernateSP[0].getState() == ISS_ON)
                 {
                     LOG_INFO("Hibernating mount...");
                     if (driver.hibernate())
@@ -921,8 +921,8 @@ bool CelestronGPS::ReadScopeStatus()
             if (pecIndex != lastPecIndex)
             {
                 LOGF_DEBUG("PEC state %s, index %d", driver.PecStateStr(), pecIndex);
-                IUSaveText(&PecInfoT[1], std::to_string(pecIndex).c_str());
-                IDSetText(&PecInfoTP, nullptr);
+                PecInfoTP[1].setText(std::to_string(pecIndex));
+                PecInfoTP.apply();
                 lastPecIndex = pecIndex;
 
                 // count the PEC records
@@ -940,24 +940,24 @@ bool CelestronGPS::ReadScopeStatus()
             LOGF_DEBUG("PEC last state %s, new State %s", driver.PecStateStr(lastPecState), driver.PecStateStr());
 
             // update the state string
-            IUSaveText(&PecInfoT[0], driver.PecStateStr());
-            IDSetText(&PecInfoTP, nullptr);
+            PecInfoTP[0].setText(driver.PecStateStr());
+            PecInfoTP.apply();
 
             // no need to check both current and last because they must be different
             switch (lastPecState)
             {
                 case PEC_STATE::PEC_SEEKING:
                     // finished seeking
-                    PecControlS[PEC_Seek].s = ISS_OFF;
-                    PecControlSP.s = IPS_IDLE;
-                    IDSetSwitch(&PecControlSP, nullptr);
+                    PecControlSP[PEC_Seek].setState(ISS_OFF);
+                    PecControlSP.setState(IPS_IDLE);
+                    PecControlSP.apply();
                     LOG_INFO("PEC index Seek completed.");
                     break;
                 case PEC_STATE::PEC_PLAYBACK:
                     // finished playback
-                    PecControlS[PEC_Playback].s = ISS_OFF;
-                    PecControlSP.s = IPS_IDLE;
-                    IDSetSwitch(&PecControlSP, nullptr);
+                    PecControlSP[PEC_Playback].setState(ISS_OFF);
+                    PecControlSP.setState(IPS_IDLE);
+                    PecControlSP.apply();
                     LOG_INFO("PEC playback finished");
                     break;
                 case PEC_STATE::PEC_RECORDING:
@@ -969,10 +969,10 @@ bool CelestronGPS::ReadScopeStatus()
                         savePecData();
                     }
 
-                    PecControlS[PEC_Record].s = ISS_OFF;
-                    PecControlSP.s = IPS_IDLE;
+                    PecControlSP[PEC_Record].setState(ISS_OFF);
+                    PecControlSP.setState(IPS_IDLE);
                     LOG_INFO("PEC record finished");
-                    IDSetSwitch(&PecControlSP, nullptr);
+                    PecControlSP.apply();
 
                     break;
                 default:
@@ -986,18 +986,18 @@ bool CelestronGPS::ReadScopeStatus()
     if (fwInfo.hasFocuser)
     {
         // Check position
-        double lastPosition = FocusAbsPosN[0].value;
+        double lastPosition = FocusAbsPosNP[0].getValue();
 
         int pos = driver.foc_position();
         if (pos >= 0)
         {
-            FocusAbsPosN[0].value = pos;
+            FocusAbsPosNP[0].setValue(pos);
             // Only update if there is actual change
-            if (fabs(lastPosition - FocusAbsPosN[0].value) > 1)
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+            if (fabs(lastPosition - FocusAbsPosNP[0].getValue()) > 1)
+                FocusAbsPosNP.apply();
         }
 
-        if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+        if (FocusAbsPosNP.getState() == IPS_BUSY || FocusRelPosNP.getState() == IPS_BUSY)
         {
             // The backlash handling is done here, if the move state
             // shows that a backlash move has been done then the final move needs to be started
@@ -1015,10 +1015,10 @@ bool CelestronGPS::ReadScopeStatus()
                 }
                 else
                 {
-                    FocusAbsPosNP.s = IPS_OK;
-                    FocusRelPosNP.s = IPS_OK;
-                    IDSetNumber(&FocusAbsPosNP, nullptr);
-                    IDSetNumber(&FocusRelPosNP, nullptr);
+                    FocusAbsPosNP.setState(IPS_OK);
+                    FocusRelPosNP.setState(IPS_OK);
+                    FocusAbsPosNP.apply();
+                    FocusRelPosNP.apply();
                     LOG_INFO("Focuser reached requested position.");
                 }
             }
@@ -1091,21 +1091,21 @@ bool CelestronGPS::ISNewSwitch(const char *dev, const char *name, ISState *state
     if (dev && std::string(getDeviceName()) == dev)
     {
         // Enable/Disable hibernate
-        if (name && std::string(name) == UseHibernateSP.name)
+        if (name && std::string(name) == UseHibernateSP.getName())
         {
-            IUUpdateSwitch(&UseHibernateSP, states, names, n);
+            UseHibernateSP.update(states, names, n);
             if (fwInfo.controllerVersion > 0)
             {
-                if (UseHibernateS[0].s == ISS_ON && (checkMinVersion(4.22, "hibernation", true) == false))
+                if (UseHibernateSP[0].getState() == ISS_ON && (checkMinVersion(4.22, "hibernation", true) == false))
                 {
-                    UseHibernateS[0].s = ISS_OFF;
-                    UseHibernateS[1].s = ISS_ON;
-                    UseHibernateSP.s = IPS_ALERT;
+                    UseHibernateSP[0].setState(ISS_OFF);
+                    UseHibernateSP[1].setState(ISS_ON);
+                    UseHibernateSP.setState(IPS_ALERT);
                 }
                 else
-                    UseHibernateSP.s = IPS_OK;
+                    UseHibernateSP.setState(IPS_OK);
             }
-            IDSetSwitch(&UseHibernateSP, nullptr);
+            UseHibernateSP.apply();
             return true;
         }
 
@@ -1117,7 +1117,7 @@ bool CelestronGPS::ISNewSwitch(const char *dev, const char *name, ISState *state
         //  send a Last Align command "Y"
 
 
-        if (name && std::string(name) == LastAlignSP.name)
+        if (name && std::string(name) == LastAlignSP.getName())
         {
             if (strcmp(fwInfo.Model.c_str(), "CGX") != 0)
             {
@@ -1128,22 +1128,22 @@ bool CelestronGPS::ISNewSwitch(const char *dev, const char *name, ISState *state
             // start move to switch positions
             if (!driver.startmovetoindex())
             {
-                LastAlignSP.s = IPS_ALERT;
+                LastAlignSP.setState(IPS_ALERT);
                 return false;
             }
             // wait for the move to finish
             // done in ReadScopeStatus
             slewToIndex = true;
-            LastAlignSP.s = IPS_BUSY;
-            IDSetSwitch(&LastAlignSP, "Align in progress");
+            LastAlignSP.setState(IPS_BUSY);
+            LastAlignSP.apply("Align in progress");
             return true;
         }
 
         // handle the PEC commands
-        if (name && std::string(name) == PecControlSP.name)
+        if (name && std::string(name) == PecControlSP.getName())
         {
-            IUUpdateSwitch(&PecControlSP, states, names, n);
-            int idx = IUFindOnSwitchIndex(&PecControlSP);
+            PecControlSP.update(states, names, n);
+            int idx = PecControlSP.findOnSwitchIndex();
 
             switch(idx)
             {
@@ -1154,19 +1154,19 @@ bool CelestronGPS::ISNewSwitch(const char *dev, const char *name, ISState *state
                     {
                         if (playback ? driver.PecPlayback(false) : driver.PecRecord(false))
                         {
-                            PecControlSP.s = IPS_IDLE;
+                            PecControlSP.setState(IPS_IDLE);
                         }
                         else
                         {
-                            PecControlSP.s = IPS_ALERT;
+                            PecControlSP.setState(IPS_ALERT);
                         }
                     }
                     else
                     {
                         LOG_WARN("Incorrect state to stop PEC Playback or Record");
-                        PecControlSP.s = IPS_ALERT;
+                        PecControlSP.setState(IPS_ALERT);
                     }
-                    IUResetSwitch(&PecControlSP);
+                    PecControlSP.reset();
                     break;
                 case PEC_Playback:
                     LOG_DEBUG("start PEC Playback");
@@ -1175,12 +1175,12 @@ bool CelestronGPS::ISNewSwitch(const char *dev, const char *name, ISState *state
                         // start playback
                         if (driver.PecPlayback(true))
                         {
-                            PecControlSP.s = IPS_BUSY;
+                            PecControlSP.setState(IPS_BUSY);
                             LOG_INFO("PEC Playback started");
                         }
                         else
                         {
-                            PecControlSP.s = IPS_ALERT;
+                            PecControlSP.setState(IPS_ALERT);
                             return false;
                         }
                     }
@@ -1200,12 +1200,12 @@ bool CelestronGPS::ISNewSwitch(const char *dev, const char *name, ISState *state
                     {
                         if (driver.PecRecord(true))
                         {
-                            PecControlSP.s = IPS_BUSY;
+                            PecControlSP.setState(IPS_BUSY);
                             LOG_INFO("PEC Record started");
                         }
                         else
                         {
-                            PecControlSP.s = IPS_ALERT;
+                            PecControlSP.setState(IPS_ALERT);
                             return false;
                         }
                     }
@@ -1219,25 +1219,25 @@ bool CelestronGPS::ISNewSwitch(const char *dev, const char *name, ISState *state
                     if (driver.isPecAtIndex(true))
                     {
                         LOG_INFO("PEC index already found");
-                        PecControlS[PEC_Seek].s = ISS_OFF;
+                        PecControlSP[PEC_Seek].setState(ISS_OFF);
                     }
                     else if (driver.pecState == PEC_STATE::PEC_AVAILABLE)
                     {
                         // start seek, moves up to 2 degrees in Ra
                         if (driver.PecSeekIndex())
                         {
-                            PecControlSP.s = IPS_BUSY;
+                            PecControlSP.setState(IPS_BUSY);
                             LOG_INFO("Seek PEC index started");
                         }
                         else
                         {
-                            PecControlSP.s = IPS_ALERT;
+                            PecControlSP.setState(IPS_ALERT);
                             return false;
                         }
                     }
                     break;
             }
-            IDSetSwitch(&PecControlSP, nullptr);
+            PecControlSP.apply();
             return true;
         }
 
@@ -1258,14 +1258,14 @@ bool CelestronGPS::ISNewNumber(const char *dev, const char *name, double values[
         // Guide Rate
         if (strcmp(name, "GUIDE_RATE") == 0)
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
-            GuideRateNP.s = IPS_OK;
-            IDSetNumber(&GuideRateNP, nullptr);
-            uint8_t grRa  = static_cast<uint8_t>(std::min(GuideRateN[AXIS_RA].value * 256.0, 255.0));
-            uint8_t grDec = static_cast<uint8_t>(std::min(GuideRateN[AXIS_DE].value * 256.0, 255.0));
-            //LOGF_DEBUG("Set Guide Rates (0-1x sidereal): Ra %f, Dec %f", GuideRateN[AXIS_RA].value, GuideRateN[AXIS_DE].value);
+            GuideRateNP.update(values, names, n);
+            GuideRateNP.setState(IPS_OK);
+            GuideRateNP.apply();
+            uint8_t grRa  = static_cast<uint8_t>(std::min(GuideRateNP[AXIS_RA].value * 256.0, 255.0));
+            uint8_t grDec = static_cast<uint8_t>(std::min(GuideRateNP[AXIS_DE].value * 256.0, 255.0));
+            //LOGF_DEBUG("Set Guide Rates (0-1x sidereal): Ra %f, Dec %f", GuideRateNP[AXIS_RA].getValue(), GuideRateNP[AXIS_DE].getValue());
             //LOGF_DEBUG("Set Guide Rates         (0-255): Ra %i, Dec %i", grRa, grDec);
-            LOGF_DEBUG("Set Guide Rates: Ra %f, Dec %f", GuideRateN[AXIS_RA].value, GuideRateN[AXIS_DE].value);
+            LOGF_DEBUG("Set Guide Rates: Ra %f, Dec %f", GuideRateNP[AXIS_RA].getValue(), GuideRateNP[AXIS_DE].getValue());
             driver.set_guide_rate(CELESTRON_AXIS::RA_AXIS, grRa);
             driver.set_guide_rate(CELESTRON_AXIS::DEC_AXIS, grDec);
             LOG_WARN("Changing guide rates may require recalibration of guiding.");
@@ -1295,26 +1295,26 @@ bool CelestronGPS::ISNewText(const char *dev, const char *name, char **texts, ch
         if (name && std::string(name) == "PEC_LOAD")
         {
 
-            IUUpdateText(&PecFileNameTP, texts, names, n);
-            IDSetText(&PecFileNameTP, nullptr);
+            PecFileNameTP.update(texts, names, n);
+            PecFileNameTP.apply();
 
-            LOGF_DEBUG("PEC Set %s", PecFileNameT[0].text);
+            LOGF_DEBUG("PEC Set %s", PecFileNameTP[0].getText());
 
             PecData pecData;
 
             // load from file
-            if (!pecData.Load(PecFileNameT[0].text))
+            if (!pecData.Load(PecFileNameTP[0].getText()))
             {
-                LOGF_WARN("File %s load failed", PecFileNameT[0].text);
+                LOGF_WARN("File %s load failed", PecFileNameTP[0].getText());
                 return false;
             }
             // save to mount
             if (!pecData.Save(&driver))
             {
-                LOGF_WARN("PEC Data file %s save to mount failed", PecFileNameT[0].text);
+                LOGF_WARN("PEC Data file %s save to mount failed", PecFileNameTP[0].getText());
                 return false;
             }
-            LOGF_INFO("PEC Data file %s sent to mount", PecFileNameT[0].text);
+            LOGF_INFO("PEC Data file %s sent to mount", PecFileNameTP[0].getText());
         }
     }
 
@@ -1360,7 +1360,7 @@ void CelestronGPS::mountSim()
     else
         da_dec = FINE_SLEW_RATE * dt;
 
-    if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+    if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
     {
         int rate = IUFindOnSwitchIndex(&SlewRateSP);
 
@@ -1387,12 +1387,12 @@ void CelestronGPS::mountSim()
                 break;
         }
 
-        switch (MovementNSSP.s)
+        switch (MovementNSSP.getState())
         {
             case IPS_BUSY:
-                if (MovementNSS[DIRECTION_NORTH].s == ISS_ON)
+                if (MovementNSSP[DIRECTION_NORTH].getState() == ISS_ON)
                     currentDEC += da_dec;
-                else if (MovementNSS[DIRECTION_SOUTH].s == ISS_ON)
+                else if (MovementNSSP[DIRECTION_SOUTH].getState() == ISS_ON)
                     currentDEC -= da_dec;
                 break;
 
@@ -1400,12 +1400,12 @@ void CelestronGPS::mountSim()
                 break;
         }
 
-        switch (MovementWESP.s)
+        switch (MovementWESP.getState())
         {
             case IPS_BUSY:
-                if (MovementWES[DIRECTION_WEST].s == ISS_ON)
+                if (MovementWESP[DIRECTION_WEST].getState() == ISS_ON)
                     currentRA += da_ra / 15.;
-                else if (MovementWES[DIRECTION_EAST].s == ISS_ON)
+                else if (MovementWESP[DIRECTION_EAST].getState() == ISS_ON)
                     currentRA -= da_ra / 15.;
                 break;
 
@@ -1547,7 +1547,7 @@ bool CelestronGPS::updateTime(ln_date *utc, double utc_offset)
     // starsense HC doesn't seem to support the precise time setting
     bool precise = fwInfo.controllerVersion >= 5.28;
 
-    bool dst = DSTSettingS[0].s == ISS_ON;
+    bool dst = DSTSettingSP[0].getState() == ISS_ON;
 
     LOGF_DEBUG("Update time: offset %f %s UTC %i-%02i-%02iT%02i:%02i:%02.0f", utc_offset, dst ? "DST" : "", utc->years,
                utc->months, utc->days,
@@ -1588,7 +1588,7 @@ bool CelestronGPS::UnPark()
     // 1. Park data exists in ParkData.xml
     // 2. Mount is currently parked
     // 3. Hibernate option is enabled
-    if (parkDataValid && isParked() && UseHibernateS[0].s == ISS_ON)
+    if (parkDataValid && isParked() && UseHibernateSP[0].s == ISS_ON)
     {
         LOG_INFO("Waking up mount...");
 
@@ -1605,12 +1605,12 @@ bool CelestronGPS::UnPark()
 
     //loadConfig(true, "TELESCOPE_TRACK_MODE");
     // Read Saved Track State from config file
-    for (int i = 0; i < TrackStateSP.nsp; i++)
-        IUGetConfigSwitch(getDeviceName(), TrackStateSP.name, TrackStateS[i].name, &(TrackStateS[i].s));
+    for (size_t i = 0; i < TrackStateSP.size(); i++)
+        IUGetConfigSwitch(getDeviceName(), TrackStateSP.getName(), TrackStateSP[i].getName(), &(TrackStateSP[i].s));
 
     // set the mount tracking state
-    LOGF_DEBUG("track state %s", IUFindOnSwitch(&TrackStateSP)->label);
-    SetTrackEnabled(IUFindOnSwitchIndex(&TrackStateSP) == TRACK_ON);
+    LOGF_DEBUG("track state %s", TrackStateSP.findOnSwitch()->label);
+    SetTrackEnabled(TrackStateSP.findOnSwitchIndex() == TRACK_ON);
 
     // reinit PEC
     if (driver.pecState >= PEC_STATE::PEC_AVAILABLE)
@@ -1669,11 +1669,11 @@ bool CelestronGPS::saveConfigItems(FILE *fp)
     INDI::Telescope::saveConfigItems(fp);
     FI::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &UseHibernateSP);
-    IUSaveConfigSwitch(fp, &CelestronTrackModeSP);
-    IUSaveConfigSwitch(fp, &DSTSettingSP);
+    UseHibernateSP.save(fp);
+    CelestronTrackModeSP.save(fp);
+    DSTSettingSP.save(fp);
 
-    IUSaveConfigNumber(fp, &FocusMinPosNP);
+    FocusMinPosNP.save(fp);
 
     return true;
 }
@@ -1683,7 +1683,7 @@ bool CelestronGPS::setCelestronTrackMode(CELESTRON_TRACK_MODE mode)
     if (driver.set_track_mode(mode))
     {
         TrackState = (mode == CTM_OFF) ? SCOPE_IDLE : SCOPE_TRACKING;
-        LOGF_DEBUG("Tracking mode set to %i, %s.", mode, CelestronTrackModeS[mode - 1].label);
+        LOGF_DEBUG("Tracking mode set to %i, %s.", mode, CelestronTrackModeSP[mode - 1].label);
         return true;
     }
 
@@ -1728,8 +1728,8 @@ IPState CelestronGPS::Guide(CELESTRON_DIRECTION dirn, uint32_t ms)
 {
     // set up direction properties
     char dc = 'x';
-    ISwitchVectorProperty *moveSP = &MovementNSSP;
-    ISwitch moveS = MovementNSS[0];
+    ISwitchVectorProperty *moveSP = MovementNSSP.getSwitch(); // #PS: refactor needed
+    ISwitch moveS = MovementNSSP[0];
     int* guideTID = &GuideNSTID;
     int* ticks = &ticksNS;
     uint8_t rate = 50;
@@ -1739,45 +1739,45 @@ IPState CelestronGPS::Guide(CELESTRON_DIRECTION dirn, uint32_t ms)
     {
         case CELESTRON_N:
             dc = 'N';
-            moveSP = &MovementNSSP;
-            moveS = MovementNSS[0];
+            moveSP = MovementNSSP.getSwitch(); // #PS: refactor needed
+            moveS = MovementNSSP[0];
             guideTID = &GuideNSTID;
             ticks = &ticksNS;
             /* Scale guide rates to uint8 in [0..100] for sending to telescopoe, see  CelestronDriver::send_pulse() */
-            rate = guideRateDec = static_cast<uint8_t>(GuideRateN[AXIS_DE].value * 100.0);
+            rate = guideRateDec = static_cast<uint8_t>(GuideRateNP[AXIS_DE].value * 100.0);
             break;
         case CELESTRON_S:
             dc = 'S';
-            moveSP = &MovementNSSP;
-            moveS = MovementNSS[1];
+            moveSP = MovementNSSP.getSwitch(); // #PS: refactor needed
+            moveS = MovementNSSP[1];
             guideTID = &GuideNSTID;
             ticks = &ticksNS;
             /* Scale guide rates to uint8 in [0..100] for sending to telescopoe, see  CelestronDriver::send_pulse() */
-            rate = guideRateDec = static_cast<uint8_t>(GuideRateN[AXIS_DE].value * 100.0);
+            rate = guideRateDec = static_cast<uint8_t>(GuideRateNP[AXIS_DE].value * 100.0);
             break;
         case CELESTRON_E:
             dc = 'E';
-            moveSP = &MovementWESP;
-            moveS = MovementWES[1];
+            moveSP = MovementWESP.getSwitch(); // #PS: refactor needed
+            moveS = MovementWESP[1];
             guideTID = &GuideWETID;
             ticks = &ticksWE;
             /* Scale guide rates to uint8 in [0..100] for sending to telescopoe, see  CelestronDriver::send_pulse() */
-            rate = guideRateRa = static_cast<uint8_t>(GuideRateN[AXIS_RA].value * 100.0);
+            rate = guideRateRa = static_cast<uint8_t>(GuideRateNP[AXIS_RA].value * 100.0);
             break;
         case CELESTRON_W:
             dc = 'W';
-            moveSP = &MovementWESP;
-            moveS = MovementWES[0];
+            moveSP = MovementWESP.getSwitch(); // #PS: refactor needed
+            moveS = MovementWESP[0];
             guideTID = &GuideWETID;
             ticks = &ticksWE;
             /* Scale guide rates to uint8 in [0..100] for sending to telescopoe, see  CelestronDriver::send_pulse() */
-            rate = guideRateRa = static_cast<uint8_t>(GuideRateN[AXIS_RA].value * 100.0);
+            rate = guideRateRa = static_cast<uint8_t>(GuideRateNP[AXIS_RA].value * 100.0);
             break;
     }
 
     LOGF_DEBUG("GUIDE CMD: %c %u ms, %s guide", dc, ms, canAuxGuide ? "Aux" : "Time");
 
-    if (!canAuxGuide && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (!canAuxGuide && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot guide while moving.");
         return IPS_ALERT;
@@ -1913,8 +1913,8 @@ void CelestronGPS::guideTimer(CELESTRON_DIRECTION dirn)
     {
         case CELESTRON_N:
         case CELESTRON_S:
-            IUResetSwitch(&MovementNSSP);
-            IDSetSwitch(&MovementNSSP, nullptr);
+            MovementNSSP.reset();
+            MovementNSSP.apply();
             GuideNSNP.np[0].value = 0;
             GuideNSNP.np[1].value = 0;
             GuideNSNP.s           = IPS_IDLE;
@@ -1923,8 +1923,8 @@ void CelestronGPS::guideTimer(CELESTRON_DIRECTION dirn)
             break;
         case CELESTRON_E:
         case CELESTRON_W:
-            IUResetSwitch(&MovementWESP);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementWESP.reset();
+            MovementWESP.apply();
             GuideWENP.np[0].value = 0;
             GuideWENP.np[1].value = 0;
             GuideWENP.s           = IPS_IDLE;
@@ -2032,8 +2032,8 @@ bool CelestronGPS::savePecData()
     snprintf(pecFileBuf, MAXRBUF, "%s/pecData_%s.csv", dir, ts_time);
 
     // show the file name
-    IUSaveText(&PecFileNameT[0], pecFileBuf);
-    IDSetText(&PecFileNameTP, nullptr);
+    PecFileNameTP[0].setText(pecFileBuf);
+    PecFileNameTP.apply();
 
     // get the PEC data from the mount
     PecData pecdata;
@@ -2066,14 +2066,14 @@ IPState CelestronGPS::MoveAbsFocuser(uint32_t targetTicks)
     }
 
     // implement backlash
-    int delta = static_cast<int>(targetTicks - FocusAbsPosN[0].value);
+    int delta = static_cast<int>(targetTicks - FocusAbsPosNP[0].getValue());
 
-    if ((FocusBacklashN[0].value < 0 && delta > 0) ||
-            (FocusBacklashN[0].value > 0 && delta < 0))
+    if ((FocusBacklashNP[0].value < 0 && delta > 0) ||
+            (FocusBacklashNP[0].value > 0 && delta < 0))
     {
         focusBacklashMove = true;
         focusPosition = position;
-        position -= FocusBacklashN[0].value;
+        position -= FocusBacklashNP[0].getValue();
     }
 
     LOGF_INFO("Focus %s move %d", focusBacklashMove ? "backlash" : "direct", position);
@@ -2089,12 +2089,12 @@ IPState CelestronGPS::MoveRelFocuser(INDI::FocuserInterface::FocusDirection dir,
     uint32_t newPosition = 0;
 
     if (dir == FOCUS_INWARD)
-        newPosition = static_cast<uint32_t>(FocusAbsPosN[0].value) - ticks;
+        newPosition = static_cast<uint32_t>(FocusAbsPosNP[0].value) - ticks;
     else
-        newPosition = static_cast<uint32_t>(FocusAbsPosN[0].value) + ticks;
+        newPosition = static_cast<uint32_t>(FocusAbsPosNP[0].value) + ticks;
 
     // Clamp
-    newPosition = std::min(static_cast<uint32_t>(FocusAbsPosN[0].max), newPosition);
+    newPosition = std::min(static_cast<uint32_t>(FocusAbsPosNP[0].max), newPosition);
     return MoveAbsFocuser(newPosition);
 }
 
@@ -2109,18 +2109,18 @@ bool CelestronGPS::focusReadLimits()
     int low, high;
     bool valid = driver.foc_limits(&low, &high);
 
-    FocusAbsPosN[0].max = high;
-    FocusAbsPosN[0].min = low;
-    FocusAbsPosNP.s = IPS_OK;
-    IUUpdateMinMax(&FocusAbsPosNP);
+    FocusAbsPosNP[0].setMax(high);
+    FocusAbsPosNP[0].setMin(low);
+    FocusAbsPosNP.setState(IPS_OK);
+    FocusAbsPosNP.updateMinMax();
 
-    FocusMaxPosN[0].value = high;
-    FocusMaxPosNP.s = IPS_OK;
-    IDSetNumber(&FocusMaxPosNP, nullptr);
+    FocusMaxPosNP[0].setValue(high);
+    FocusMaxPosNP.setState(IPS_OK);
+    FocusMaxPosNP.apply();
 
-    FocusMinPosN[0].value = low;
-    FocusMinPosNP.s = IPS_OK;
-    IDSetNumber(&FocusMinPosNP, nullptr);
+    FocusMinPosNP[0].setValue(low);
+    FocusMinPosNP.setState(IPS_OK);
+    FocusMinPosNP.apply();
 
     focuserIsCalibrated = valid;
 

--- a/drivers/telescope/celestrongps.h
+++ b/drivers/telescope/celestrongps.h
@@ -30,6 +30,11 @@
 #include "inditelescope.h"
 #include "indifocuserinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, public INDI::FocuserInterface
 {
     public:
@@ -68,8 +73,7 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, publi
         IPState Guide(CELESTRON_DIRECTION dirn, uint32_t ms);
 
         // Guide Rate
-        INumber GuideRateN[2];  // 0 to 1 corresponding to 0 to 1.0x sidereal
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};  // 0 to 1 corresponding to 0 to 1.0x sidereal
 
         uint8_t guideRateRa;    // 0 to 255 corresponding to 0 to 100% sidereal
         uint8_t guideRateDec;
@@ -111,8 +115,7 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, publi
         //CELESTRON_DIRECTION guide_direction;
 
         /* Firmware */
-        IText FirmwareT[7] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {7};
 
         //INumberVectorProperty HorizontalCoordsNP;
         //INumber HorizontalCoordsN[2];
@@ -121,28 +124,22 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, publi
         //ISwitchVectorProperty TrackSP;
 
         // Celestron Track Mode (AltAz, EQ N, EQ S, Ra and Dec)
-        ISwitchVectorProperty CelestronTrackModeSP;
-        ISwitch CelestronTrackModeS[4];
+        INDI::PropertySwitch CelestronTrackModeSP {4};
 
         //GUIDE Pulse guide switch
-        //        ISwitchVectorProperty UsePulseCmdSP;
-        //        ISwitch UsePulseCmdS[2];
-
-        ISwitchVectorProperty UseHibernateSP;
-        ISwitch UseHibernateS[2];
+        //
+        //        INDI::PropertySwitch UsePulseCmdSP {2};
+        INDI::PropertySwitch UseHibernateSP {2};
 
         // PEC - implemented without using the base definition because this doesn't match what is required
         // shows status and index
-        IText PecInfoT[2] {};
-        ITextVectorProperty PecInfoTP;
+        INDI::PropertyText PecInfoTP {2};
 
-        ISwitch PecControlS[4];     // Find Index, Stop, Playback, Record
-        ISwitchVectorProperty PecControlSP;
+        INDI::PropertySwitch PecControlSP {4};     // Find Index, Stop, Playback, Record
         enum { PEC_Seek, PEC_Stop, PEC_Playback, PEC_Record } PecControl;
 
         // move PEC data from file to mount
-        IText PecFileNameT[1] {};
-        ITextVectorProperty PecFileNameTP;
+        INDI::PropertyText PecFileNameTP {1};
 
         // FocuserInterface
 
@@ -170,12 +167,10 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, publi
         //CelestronGuide guider;
 
         // Last align property
-        ISwitch LastAlignS[1];
-        ISwitchVectorProperty LastAlignSP;
+        INDI::PropertySwitch LastAlignSP {1};
 
         // DST setting
-        ISwitch DSTSettingS[1];
-        ISwitchVectorProperty DSTSettingSP;
+        INDI::PropertySwitch DSTSettingSP {1};
 
         bool slewToIndex;
 
@@ -187,11 +182,10 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, publi
         double SlewOffsetRa = 0.0;
 
         // focuser
-        //        INumber FocusBacklashN[1];
-        //        INumberVectorProperty FocusBacklashNP;
+        //        INDI::PropertyNumber FocusBacklashNP {1};
+        //
 
-        INumber FocusMinPosN[1];
-        INumberVectorProperty FocusMinPosNP;
+        INDI::PropertyNumber FocusMinPosNP {1};
 
         bool focusBacklashMove;      // set if a final move is needed
         uint32_t focusPosition;

--- a/drivers/telescope/crux_mount.cpp
+++ b/drivers/telescope/crux_mount.cpp
@@ -166,22 +166,22 @@ bool TitanTCS::initProperties()
 
 #if USE_PEC
     // PEC Training
-    IUFillSwitch(&PECTrainingS[0], "PEC_Start", "Start", ISS_OFF);
-    IUFillSwitch(&PECTrainingS[1], "PEC_Stop", "Stop", ISS_OFF);
-    IUFillSwitchVector(&PECTrainingSP, PECTrainingS, 2, getDeviceName(), "PEC_TRAINING", "PEC Training", MOTION_TAB, IP_RW,
+    PECTrainingSP[0].fill("PEC_Start", "Start", ISS_OFF);
+    PECTrainingSP[1].fill("PEC_Stop", "Stop", ISS_OFF);
+    PECTrainingSP.fill(getDeviceName(), "PEC_TRAINING", "PEC Training", MOTION_TAB, IP_RW,
                        ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // PEC Details
-    IUFillText(&PECInfoT[0], "PEC_INFO", "PEC", "");
-    IUFillText(&PECInfoT[1], "PEC_TR_INFO", "Training", "");
-    IUFillTextVector(&PECInfoTP, PECInfoT, 2, getDeviceName(), "PEC_INFOS", "PEC Info", MOTION_TAB,
+    PECInfoTP[0].fill("PEC_INFO", "PEC", "");
+    PECInfoTP[1].fill("PEC_TR_INFO", "Training", "");
+    PECInfoTP.fill(getDeviceName(), "PEC_INFOS", "PEC Info", MOTION_TAB,
                      IP_RO, 60, IPS_IDLE);
 #endif
     // Mount Details
-    IUFillText(&MountInfoT[0], "MOUNT_PARK", "Park", "");
-    IUFillText(&MountInfoT[1], "MOUNT_TRACKING", "Tracking", "");
-    IUFillTextVector(&MountInfoTP, MountInfoT, 2, getDeviceName(), "MOUNT_INFOS", "Mount Info", MAIN_CONTROL_TAB,
+    MountInfoTP[0].fill("MOUNT_PARK", "Park", "");
+    MountInfoTP[1].fill("MOUNT_TRACKING", "Tracking", "");
+    MountInfoTP.fill(getDeviceName(), "MOUNT_INFOS", "Mount Info", MAIN_CONTROL_TAB,
                      IP_RO, 60, IPS_IDLE);
 
     TrackState = SCOPE_IDLE;
@@ -197,10 +197,10 @@ bool TitanTCS::updateProperties()
     if (isConnected())
     {
 #if USE_PEC
-        defineProperty(&PECTrainingSP);
-        defineProperty(&PECInfoTP);
+        defineProperty(PECTrainingSP);
+        defineProperty(PECInfoTP);
 #endif
-        defineProperty(&MountInfoTP);
+        defineProperty(MountInfoTP);
         //
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
@@ -214,10 +214,10 @@ bool TitanTCS::updateProperties()
     else
     {
 #if USE_PEC
-        deleteProperty(PECTrainingSP.name);
-        deleteProperty(PECInfoTP.name);
+        deleteProperty(PECTrainingSP.getName());
+        deleteProperty(PECInfoTP.getName());
 #endif
-        deleteProperty(MountInfoTP.name);
+        deleteProperty(MountInfoTP.getName());
         //
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
@@ -232,15 +232,15 @@ bool TitanTCS::ISNewNumber(const char *dev, const char *name, double values[], c
     {
         /*
         if (strcmp(name, "JOG_RATE") == 0) {
-            IUUpdateNumber(&JogRateNP, values, names, n);
-            JogRateNP.s = IPS_OK;
-            IDSetNumber(&JogRateNP, nullptr);
+            JogRateNP.update(values, names, n);
+            JogRateNP.setState(IPS_OK);
+            JogRateNP.apply();
             return true;
         }
-        if (strcmp(name, GuideRateNP.name) == 0) {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
-            GuideRateNP.s = IPS_OK;
-            IDSetNumber(&GuideRateNP, nullptr);
+        if (GuideRateNP.isNameMatch(name)) {
+            GuideRateNP.update(values, names, n);
+            GuideRateNP.setState(IPS_OK);
+            GuideRateNP.apply();
             return true;
         }
         */
@@ -262,10 +262,10 @@ bool TitanTCS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
         int iVal = 0;
         // ---------------------------------------------------------------------
         // Park $$$
-        if (!strcmp(name, ParkSP.name))
+        if (ParkSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ParkSP, states, names, n);
-            int nowIndex = IUFindOnSwitchIndex(&ParkSP);
+            ParkSP.update(states, names, n);
+            int nowIndex = ParkSP.findOnSwitchIndex();
             if(nowIndex == 0)
                 Park();
             else if(nowIndex == 1)
@@ -291,13 +291,13 @@ bool TitanTCS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
         }
         //
 #if USE_PEC
-        if (!strcmp(name, PECStateSP.name))
+        if (PECStateSP.isNameMatch(name))
         {
-            //int preIndex = IUFindOnSwitchIndex(&PECStateSP);
-            IUUpdateSwitch(&PECStateSP, states, names, n);
-            int nowIndex = IUFindOnSwitchIndex(&PECStateSP);
+            //int preIndex = PECStateSP.findOnSwitchIndex();
+            PECStateSP.update(states, names, n);
+            int nowIndex = PECStateSP.findOnSwitchIndex();
 
-            IDSetSwitch(&PECStateSP, nullptr);
+            PECStateSP.apply();
 
             if(nowIndex == 0)
             {
@@ -310,13 +310,13 @@ bool TitanTCS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
             return true;
         }
         //
-        if (!strcmp(name, PECTrainingSP.name))
+        if (PECTrainingSP.isNameMatch(name))
         {
-            //int preIndex = IUFindOnSwitchIndex(&PECTrainingSP);
-            IUUpdateSwitch(&PECTrainingSP, states, names, n);
-            int nowIndex = IUFindOnSwitchIndex(&PECTrainingSP);
+            //int preIndex = PECTrainingSP.findOnSwitchIndex();
+            PECTrainingSP.update(states, names, n);
+            int nowIndex = PECTrainingSP.findOnSwitchIndex();
 
-            IDSetSwitch(&PECTrainingSP, nullptr);
+            PECTrainingSP.apply();
 
             if(nowIndex == 0)
             {
@@ -330,12 +330,12 @@ bool TitanTCS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
         }
 #endif
         //
-        if (!strcmp(name, TrackStateSP.name))
+        if (TrackStateSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&TrackStateSP, states, names, n);
-            int nowIndex = IUFindOnSwitchIndex(&TrackStateSP);
+            TrackStateSP.update(states, names, n);
+            int nowIndex = TrackStateSP.findOnSwitchIndex();
 
-            IDSetSwitch(&TrackStateSP, nullptr);
+            TrackStateSP.apply();
 
             if(nowIndex == 0)
             {
@@ -576,7 +576,7 @@ IPState TitanTCS::GuideNorth(uint32_t ms)
 {
     SendCommand(":Mgn%d#", (int)ms);
     //
-    if(MovementNSSP.s == IPS_BUSY)
+    if(MovementNSSP.getState() == IPS_BUSY)
         return IPS_ALERT;
 
     if (GuideNSTID)
@@ -593,7 +593,7 @@ IPState TitanTCS::GuideSouth(uint32_t ms)
 {
     SendCommand(":Mgs%d#", (int)ms);
     //
-    if(MovementNSSP.s == IPS_BUSY)
+    if(MovementNSSP.getState() == IPS_BUSY)
         return IPS_ALERT;
 
     if (GuideNSTID)
@@ -610,7 +610,7 @@ IPState TitanTCS::GuideEast(uint32_t ms)
 {
     SendCommand(":Mge%d#", (int)ms);
     //
-    if(MovementWESP.s == IPS_BUSY)
+    if(MovementWESP.getState() == IPS_BUSY)
         return IPS_ALERT;
 
     if (GuideWETID)
@@ -627,7 +627,7 @@ IPState TitanTCS::GuideWest(uint32_t ms)
 {
     SendCommand(":Mgw%d#", (int)ms);
     //
-    if(MovementWESP.s == IPS_BUSY)
+    if(MovementWESP.getState() == IPS_BUSY)
         return IPS_ALERT;
 
     if (GuideWETID)
@@ -1150,43 +1150,43 @@ bool TitanTCS::GetMountParams(bool bAll)
         if(info.Parking == 1)
         {
             TrackState = SCOPE_PARKING;
-            ParkS[0].s = ISS_ON;
-            ParkS[1].s = ISS_OFF;
-            ParkSP.s   = IPS_BUSY;
-            IUSaveText(&MountInfoT[0], "Parking");
+            ParkSP[0].setState(ISS_ON);
+            ParkSP[1].setState(ISS_OFF);
+            ParkSP.setState(IPS_BUSY);
+            MountInfoTP[0].setText("Parking");
         }
         else if(info.Parking == 2)
         {
             TrackState = SCOPE_PARKED;
-            ParkS[0].s = ISS_ON;
-            ParkS[1].s = ISS_OFF;
-            ParkSP.s   = IPS_IDLE;
-            IUSaveText(&MountInfoT[0], "Parked");
+            ParkSP[0].setState(ISS_ON);
+            ParkSP[1].setState(ISS_OFF);
+            ParkSP.setState(IPS_IDLE);
+            MountInfoTP[0].setText("Parked");
         }
         else if(info.Parking == 0)
         {
-            ParkSP.s   = IPS_IDLE;
-            ParkS[0].s = ISS_OFF;
-            ParkS[1].s = ISS_ON;
-            IUSaveText(&MountInfoT[0], "Unpark");
+            ParkSP.setState(IPS_IDLE);
+            ParkSP[0].setState(ISS_OFF);
+            ParkSP[1].setState(ISS_ON);
+            MountInfoTP[0].setText("Unpark");
         }
 
-        IDSetSwitch(&ParkSP, nullptr);
+        ParkSP.apply();
     }
     // Tracking On / Off
     if((TrackState == SCOPE_SLEWING) || (TrackState == SCOPE_PARKING) || (TrackState == SCOPE_PARKED))
     {
-        TrackStateS[TRACK_ON].s = ISS_OFF;
-        TrackStateS[TRACK_OFF].s = ISS_ON;
-        TrackStateSP.s = IPS_IDLE;
-        IDSetSwitch(&TrackStateSP, nullptr);
+        TrackStateSP[TRACK_ON].setState(ISS_OFF);
+        TrackStateSP[TRACK_OFF].setState(ISS_ON);
+        TrackStateSP.setState(IPS_IDLE);
+        TrackStateSP.apply();
 
         if(TrackState == SCOPE_PARKING)
-            IUSaveText(&MountInfoT[1], "Parking");
+            MountInfoTP[1].setText("Parking");
         else if(TrackState == SCOPE_PARKED)
-            IUSaveText(&MountInfoT[1], "Parked");
+            MountInfoTP[1].setText("Parked");
         else if(TrackState == SCOPE_SLEWING)
-            IUSaveText(&MountInfoT[1], "Slewing");
+            MountInfoTP[1].setText("Slewing");
     }
     else
     {
@@ -1196,30 +1196,30 @@ bool TitanTCS::GetMountParams(bool bAll)
 
             if((TrackState == SCOPE_TRACKING) && (info.Landscape == 0))
             {
-                TrackStateS[TRACK_ON].s = ISS_ON;
-                TrackStateS[TRACK_OFF].s = ISS_OFF;
-                TrackStateSP.s = IPS_IDLE;
-                IDSetSwitch(&TrackStateSP, nullptr);
+                TrackStateSP[TRACK_ON].setState(ISS_ON);
+                TrackStateSP[TRACK_OFF].setState(ISS_OFF);
+                TrackStateSP.setState(IPS_IDLE);
+                TrackStateSP.apply();
 
-                IUSaveText(&MountInfoT[1], "Tracking ON / Skyview");
+                MountInfoTP[1].setText("Tracking ON / Skyview");
             }
             else
             {
-                TrackStateS[TRACK_ON].s = ISS_OFF;
-                TrackStateS[TRACK_OFF].s = ISS_ON;
-                TrackStateSP.s = IPS_IDLE;
-                IDSetSwitch(&TrackStateSP, nullptr);
+                TrackStateSP[TRACK_ON].setState(ISS_OFF);
+                TrackStateSP[TRACK_OFF].setState(ISS_ON);
+                TrackStateSP.setState(IPS_IDLE);
+                TrackStateSP.apply();
 
                 if(info.Landscape == 1)
-                    IUSaveText(&MountInfoT[1], "Tracking OFF / Landscape");
+                    MountInfoTP[1].setText("Tracking OFF / Landscape");
                 else
-                    IUSaveText(&MountInfoT[1], "Tracking OFF / Idle");
+                    MountInfoTP[1].setText("Tracking OFF / Idle");
             }
         }
     }
     //
-    MountInfoTP.s = IPS_OK;
-    IDSetText(&MountInfoTP, nullptr);
+    MountInfoTP.setState(IPS_OK);
+    MountInfoTP.apply();
     //
     if(GetParamNumber(szResponse, szToken, sizeof(szToken) - 1, "$?tr", '#', NULL, &info.TrackingRate))
     {
@@ -1275,18 +1275,18 @@ void TitanTCS::_setPECState(int pec_status)
         if(pec_status & 0x30)
         {
             // Training ...
-            PECTrainingS[0].s = ISS_OFF;
-            PECTrainingS[1].s = ISS_ON;
+            PECTrainingSP[0].setState(ISS_OFF);
+            PECTrainingSP[1].setState(ISS_ON);
 
             sprintf(szText, "PEC Training %d %%", (pec_status >> 8));
-            IUSaveText(&PECInfoT[1], szText);
+            PECInfoTP[1].setText(szText);
         }
         else
         {
-            PECTrainingS[0].s = ISS_ON;
-            PECTrainingS[1].s = ISS_OFF;
+            PECTrainingSP[0].setState(ISS_ON);
+            PECTrainingSP[1].setState(ISS_OFF);
 
-            IUSaveText(&PECInfoT[1], "");
+            PECInfoTP[1].setText("");
         }
 
         if(pec_status & 2)
@@ -1294,41 +1294,41 @@ void TitanTCS::_setPECState(int pec_status)
             // Valid
             if(pec_status & 1)
             {
-                PECStateS[PEC_OFF].s = ISS_OFF;
-                PECStateS[PEC_ON].s  = ISS_ON;
+                PECStateSP[PEC_OFF].setState(ISS_OFF);
+                PECStateSP[PEC_ON].setState(ISS_ON);
 
-                IUSaveText(&PECInfoT[0], "PEC is running.");
+                PECInfoTP[0].setText("PEC is running.");
             }
             else
             {
-                PECStateS[PEC_OFF].s = ISS_OFF;
-                PECStateS[PEC_ON].s  = ISS_ON;
+                PECStateSP[PEC_OFF].setState(ISS_OFF);
+                PECStateSP[PEC_ON].setState(ISS_ON);
 
-                IUSaveText(&PECInfoT[0], "PEC is available.");
+                PECInfoTP[0].setText("PEC is available.");
             }
-            PECStateSP.s = IPS_OK;
+            PECStateSP.setState(IPS_OK);
         }
         else
         {
             // Invalid
-            PECStateS[PEC_OFF].s = ISS_OFF;
-            PECStateS[PEC_ON].s  = ISS_OFF;
-            PECStateSP.s = IPS_ALERT;
+            PECStateSP[PEC_OFF].setState(ISS_OFF);
+            PECStateSP[PEC_ON].setState(ISS_OFF);
+            PECStateSP.setState(IPS_ALERT);
 
             if(pec_status & 0x30)
-                IUSaveText(&PECInfoT[0], "");
+                PECInfoTP[0].setText("");
             else
-                IUSaveText(&PECInfoT[0], "PEC training is required.");
+                PECInfoTP[0].setText("PEC training is required.");
         }
 
-        PECStateSP.s = IPS_OK;
-        IDSetSwitch(&PECStateSP, nullptr);
+        PECStateSP.setState(IPS_OK);
+        PECStateSP.apply();
 
-        PECTrainingSP.s = IPS_OK;
-        IDSetSwitch(&PECTrainingSP, nullptr);
+        PECTrainingSP.setState(IPS_OK);
+        PECTrainingSP.apply();
         //
-        PECInfoTP.s = IPS_OK;
-        IDSetText(&PECInfoTP, nullptr);
+        PECInfoTP.setState(IPS_OK);
+        PECInfoTP.apply();
     }
 }
 #endif
@@ -1479,7 +1479,7 @@ bool TitanTCS::Park()
 
     if(SendCommand(":hP8#"))
     {
-        ParkSP.s   = IPS_BUSY;
+        ParkSP.setState(IPS_BUSY);
         TrackState = SCOPE_PARKING;
         return true;
     }
@@ -1492,7 +1492,7 @@ bool TitanTCS::UnPark()
 
     if(SendCommand(":hP0#"))
     {
-        ParkSP.s   = IPS_BUSY;
+        ParkSP.setState(IPS_BUSY);
         TrackState = SCOPE_PARKING;
         return true;
     }

--- a/drivers/telescope/crux_mount.h
+++ b/drivers/telescope/crux_mount.h
@@ -23,6 +23,10 @@
 #include "inditelescope.h"
 #include "indiguiderinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+
 #define RESPONSE_TIMEOUT  3
 #define USE_PEC           1
 
@@ -65,8 +69,7 @@ class TitanTCS : public INDI::Telescope, public INDI::GuiderInterface
 
     private:
         // Mount Info.
-        ITextVectorProperty MountInfoTP;
-        IText MountInfoT[2] {};
+        INDI::PropertyText MountInfoTP {2};
         int GuideNSTID { -1 };
         int GuideWETID { -1 };
 
@@ -76,11 +79,9 @@ class TitanTCS : public INDI::Telescope, public INDI::GuiderInterface
         int _PECStatus {0};
 
         // PEC Training
-        ISwitch PECTrainingS[2];
-        ISwitchVectorProperty PECTrainingSP;
+        INDI::PropertySwitch PECTrainingSP {2};
         // PEC Info.
-        ITextVectorProperty PECInfoTP;
-        IText PECInfoT[2] {};
+        INDI::PropertyText PECInfoTP {2};
 #endif
 
     protected:

--- a/drivers/telescope/dsc.cpp
+++ b/drivers/telescope/dsc.cpp
@@ -90,33 +90,33 @@ bool DSC::initProperties()
     INDI::Telescope::initProperties();
 
     // Raw encoder values
-    IUFillNumber(&EncoderN[AXIS1_ENCODER], "AXIS1_ENCODER", "Axis 1", "%0.f", 0, 1e6, 0, 0);
-    IUFillNumber(&EncoderN[AXIS2_ENCODER], "AXIS2_ENCODER", "Axis 2", "%0.f", 0, 1e6, 0, 0);
-    IUFillNumber(&EncoderN[AXIS1_RAW_ENCODER], "AXIS1_RAW_ENCODER", "RAW Axis 1", "%0.f", -1e6, 1e6, 0, 0);
-    IUFillNumber(&EncoderN[AXIS2_RAW_ENCODER], "AXIS2_RAW_ENCODER", "RAW Axis 2", "%0.f", -1e6, 1e6, 0, 0);
-    IUFillNumberVector(&EncoderNP, EncoderN, 4, getDeviceName(), "DCS_ENCODER", "Encoders", MAIN_CONTROL_TAB, IP_RO, 0,
+    EncoderNP[AXIS1_ENCODER].fill("AXIS1_ENCODER", "Axis 1", "%0.f", 0, 1e6, 0, 0);
+    EncoderNP[AXIS2_ENCODER].fill("AXIS2_ENCODER", "Axis 2", "%0.f", 0, 1e6, 0, 0);
+    EncoderNP[AXIS1_RAW_ENCODER].fill("AXIS1_RAW_ENCODER", "RAW Axis 1", "%0.f", -1e6, 1e6, 0, 0);
+    EncoderNP[AXIS2_RAW_ENCODER].fill("AXIS2_RAW_ENCODER", "RAW Axis 2", "%0.f", -1e6, 1e6, 0, 0);
+    EncoderNP.fill(getDeviceName(), "DCS_ENCODER", "Encoders", MAIN_CONTROL_TAB, IP_RO, 0,
                        IPS_IDLE);
 
     // Encoder Settings
-    IUFillNumber(&AxisSettingsN[AXIS1_TICKS], "AXIS1_TICKS", "#1 ticks/rev", "%g", 256, 1e6, 0, 4096);
-    IUFillNumber(&AxisSettingsN[AXIS1_DEGREE_OFFSET], "AXIS1_DEGREE_OFFSET", "#1 Degrees Offset", "%g", -180, 180, 30,
+    AxisSettingsNP[AXIS1_TICKS].fill("AXIS1_TICKS", "#1 ticks/rev", "%g", 256, 1e6, 0, 4096);
+    AxisSettingsNP[AXIS1_DEGREE_OFFSET].fill("AXIS1_DEGREE_OFFSET", "#1 Degrees Offset", "%g", -180, 180, 30,
                  0);
-    IUFillNumber(&AxisSettingsN[AXIS2_TICKS], "AXIS2_TICKS", "#2 ticks/rev", "%g", 256, 1e6, 0, 4096);
-    IUFillNumber(&AxisSettingsN[AXIS2_DEGREE_OFFSET], "AXIS2_DEGREE_OFFSET", "#2 Degrees Offset", "%g", -180, 180, 30,
+    AxisSettingsNP[AXIS2_TICKS].fill("AXIS2_TICKS", "#2 ticks/rev", "%g", 256, 1e6, 0, 4096);
+    AxisSettingsNP[AXIS2_DEGREE_OFFSET].fill("AXIS2_DEGREE_OFFSET", "#2 Degrees Offset", "%g", -180, 180, 30,
                  0);
-    IUFillNumberVector(&AxisSettingsNP, AxisSettingsN, 4, getDeviceName(), "AXIS_SETTINGS", "Axis Resolution", AXIS_TAB,
+    AxisSettingsNP.fill(getDeviceName(), "AXIS_SETTINGS", "Axis Resolution", AXIS_TAB,
                        IP_RW, 0, IPS_IDLE);
 
     // Axis Range
-    IUFillSwitch(&AxisRangeS[AXIS_FULL_STEP], "AXIS_FULL_STEP", "Full Step", ISS_ON);
-    IUFillSwitch(&AxisRangeS[AXIS_HALF_STEP], "AXIS_HALF_STEP", "Half Step", ISS_OFF);
-    IUFillSwitchVector(&AxisRangeSP, AxisRangeS, 2, getDeviceName(), "AXIS_RANGE", "Axis Range", AXIS_TAB, IP_RW,
+    AxisRangeSP[AXIS_FULL_STEP].fill("AXIS_FULL_STEP", "Full Step", ISS_ON);
+    AxisRangeSP[AXIS_HALF_STEP].fill("AXIS_HALF_STEP", "Half Step", ISS_OFF);
+    AxisRangeSP.fill(getDeviceName(), "AXIS_RANGE", "Axis Range", AXIS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Reverse Encoder Direction
-    IUFillSwitch(&ReverseS[AXIS1_ENCODER], "AXIS1_REVERSE", "Axis 1", ISS_OFF);
-    IUFillSwitch(&ReverseS[AXIS2_ENCODER], "AXIS2_REVERSE", "Axis 2", ISS_OFF);
-    IUFillSwitchVector(&ReverseSP, ReverseS, 2, getDeviceName(), "AXIS_REVERSE", "Reverse", AXIS_TAB, IP_RW,
+    ReverseSP[AXIS1_ENCODER].fill("AXIS1_REVERSE", "Axis 1", ISS_OFF);
+    ReverseSP[AXIS2_ENCODER].fill("AXIS2_REVERSE", "Axis 2", ISS_OFF);
+    ReverseSP.fill(getDeviceName(), "AXIS_REVERSE", "Reverse", AXIS_TAB, IP_RW,
                        ISR_NOFMANY, 0, IPS_IDLE);
 
 // Offsets applied to raw encoder values to adjust them as necessary
@@ -131,15 +131,15 @@ bool DSC::initProperties()
 #endif
 
     // Mount Type
-    IUFillSwitch(&MountTypeS[MOUNT_EQUATORIAL], "MOUNT_EQUATORIAL", "Equatorial", ISS_ON);
-    IUFillSwitch(&MountTypeS[MOUNT_ALTAZ], "MOUNT_ALTAZ", "AltAz", ISS_OFF);
-    IUFillSwitchVector(&MountTypeSP, MountTypeS, 2, getDeviceName(), "MOUNT_TYPE", "Mount Type", MAIN_CONTROL_TAB,
+    MountTypeSP[MOUNT_EQUATORIAL].fill("MOUNT_EQUATORIAL", "Equatorial", ISS_ON);
+    MountTypeSP[MOUNT_ALTAZ].fill("MOUNT_ALTAZ", "AltAz", ISS_OFF);
+    MountTypeSP.fill(getDeviceName(), "MOUNT_TYPE", "Mount Type", MAIN_CONTROL_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Simulation encoder values
-    IUFillNumber(&SimEncoderN[AXIS1_ENCODER], "AXIS1_ENCODER", "Axis 1", "%0.f", -1e6, 1e6, 0, 0);
-    IUFillNumber(&SimEncoderN[AXIS2_ENCODER], "AXIS2_ENCODER", "Axis 2", "%0.f", -1e6, 1e6, 0, 0);
-    IUFillNumberVector(&SimEncoderNP, SimEncoderN, 2, getDeviceName(), "SIM_ENCODER", "Sim Encoders", MAIN_CONTROL_TAB,
+    SimEncoderNP[AXIS1_ENCODER].fill("AXIS1_ENCODER", "Axis 1", "%0.f", -1e6, 1e6, 0, 0);
+    SimEncoderNP[AXIS2_ENCODER].fill("AXIS2_ENCODER", "Axis 2", "%0.f", -1e6, 1e6, 0, 0);
+    SimEncoderNP.fill(getDeviceName(), "SIM_ENCODER", "Sim Encoders", MAIN_CONTROL_TAB,
                        IP_RW, 0, IPS_IDLE);
 
     addAuxControls();
@@ -155,29 +155,29 @@ bool DSC::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&EncoderNP);
-        defineProperty(&AxisSettingsNP);
-        defineProperty(&AxisRangeSP);
-        defineProperty(&ReverseSP);
+        defineProperty(EncoderNP);
+        defineProperty(AxisSettingsNP);
+        defineProperty(AxisRangeSP);
+        defineProperty(ReverseSP);
         //defineProperty(&EncoderOffsetNP);
-        defineProperty(&MountTypeSP);
+        defineProperty(MountTypeSP);
 
         if (isSimulation())
-            defineProperty(&SimEncoderNP);
+            defineProperty(SimEncoderNP);
 
         SetAlignmentSubsystemActive(true);
     }
     else
     {
-        deleteProperty(EncoderNP.name);
-        deleteProperty(AxisSettingsNP.name);
-        deleteProperty(AxisRangeSP.name);
-        deleteProperty(ReverseSP.name);
+        deleteProperty(EncoderNP.getName());
+        deleteProperty(AxisSettingsNP.getName());
+        deleteProperty(AxisRangeSP.getName());
+        deleteProperty(ReverseSP.getName());
         //deleteProperty(EncoderOffsetNP.name);
-        deleteProperty(MountTypeSP.name);
+        deleteProperty(MountTypeSP.getName());
 
         if (isSimulation())
-            deleteProperty(SimEncoderNP.name);
+            deleteProperty(SimEncoderNP.getName());
     }
 
     return true;
@@ -187,11 +187,11 @@ bool DSC::saveConfigItems(FILE *fp)
 {
     INDI::Telescope::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &AxisSettingsNP);
+    AxisSettingsNP.save(fp);
     //IUSaveConfigNumber(fp, &EncoderOffsetNP);
-    IUSaveConfigSwitch(fp, &AxisRangeSP);
-    IUSaveConfigSwitch(fp, &ReverseSP);
-    IUSaveConfigSwitch(fp, &MountTypeSP);
+    AxisRangeSP.save(fp);
+    ReverseSP.save(fp);
+    MountTypeSP.save(fp);
 
     return true;
 }
@@ -207,11 +207,11 @@ bool DSC::ISNewNumber(const char *dev, const char *name, double values[], char *
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, AxisSettingsNP.name) == 0)
+        if (AxisSettingsNP.isNameMatch(name))
         {
-            IUUpdateNumber(&AxisSettingsNP, values, names, n);
-            AxisSettingsNP.s = IPS_OK;
-            IDSetNumber(&AxisSettingsNP, nullptr);
+            AxisSettingsNP.update(values, names, n);
+            AxisSettingsNP.setState(IPS_OK);
+            AxisSettingsNP.apply();
             return true;
         }
 
@@ -223,11 +223,11 @@ bool DSC::ISNewNumber(const char *dev, const char *name, double values[], char *
             return true;
         }*/
 
-        if (strcmp(name, SimEncoderNP.name) == 0)
+        if (SimEncoderNP.isNameMatch(name))
         {
-            IUUpdateNumber(&SimEncoderNP, values, names, n);
-            SimEncoderNP.s = IPS_OK;
-            IDSetNumber(&SimEncoderNP, nullptr);
+            SimEncoderNP.update(values, names, n);
+            SimEncoderNP.setState(IPS_OK);
+            SimEncoderNP.apply();
             return true;
         }
 
@@ -241,37 +241,37 @@ bool DSC::ISNewSwitch(const char *dev, const char *name, ISState *states, char *
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, ReverseSP.name) == 0)
+        if (ReverseSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ReverseSP, states, names, n);
-            ReverseSP.s = IPS_OK;
-            IDSetSwitch(&ReverseSP, nullptr);
+            ReverseSP.update(states, names, n);
+            ReverseSP.setState(IPS_OK);
+            ReverseSP.apply();
             return true;
         }
 
-        if (strcmp(name, MountTypeSP.name) == 0)
+        if (MountTypeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MountTypeSP, states, names, n);
-            MountTypeSP.s = IPS_OK;
-            IDSetSwitch(&MountTypeSP, nullptr);
+            MountTypeSP.update(states, names, n);
+            MountTypeSP.setState(IPS_OK);
+            MountTypeSP.apply();
             return true;
         }
 
-        if (strcmp(name, AxisRangeSP.name) == 0)
+        if (AxisRangeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&AxisRangeSP, states, names, n);
-            AxisRangeSP.s = IPS_OK;
+            AxisRangeSP.update(states, names, n);
+            AxisRangeSP.setState(IPS_OK);
 
-            if (AxisRangeS[AXIS_FULL_STEP].s == ISS_ON)
+            if (AxisRangeSP[AXIS_FULL_STEP].getState() == ISS_ON)
             {
-                LOGF_INFO("Axis range is from 0 to %.f", AxisSettingsN[AXIS1_TICKS].value);
+                LOGF_INFO("Axis range is from 0 to %.f", AxisSettingsNP[AXIS1_TICKS].getValue());
             }
             else
             {
                 LOGF_INFO("Axis range is from -%.f to %.f",
-                       AxisSettingsN[AXIS1_TICKS].value / 2, AxisSettingsN[AXIS1_TICKS].value / 2);
+                       AxisSettingsNP[AXIS1_TICKS].value / 2, AxisSettingsNP[AXIS1_TICKS].value / 2);
             }
-            IDSetSwitch(&AxisRangeSP, nullptr);
+            AxisRangeSP.apply();
             return true;
         }
 
@@ -298,7 +298,7 @@ bool DSC::ReadScopeStatus()
 
     if (isSimulation())
     {
-        snprintf(response, 16, "%06.f\t%06.f", SimEncoderN[AXIS1_ENCODER].value, SimEncoderN[AXIS2_ENCODER].value);
+        snprintf(response, 16, "%06.f\t%06.f", SimEncoderNP[AXIS1_ENCODER].getValue(), SimEncoderNP[AXIS2_ENCODER].getValue());
     }
     else
     {
@@ -342,41 +342,41 @@ bool DSC::ReadScopeStatus()
     else
     {
         LOGF_ERROR("Error processing response: %s", response);
-        EncoderNP.s = IPS_ALERT;
-        IDSetNumber(&EncoderNP, nullptr);
+        EncoderNP.setState(IPS_ALERT);
+        EncoderNP.apply();
         return false;
     }
 
     LOGF_DEBUG("Raw Axis encoders. Axis1: %g Axis2: %g", Axis1Encoder, Axis2Encoder);
 
-    EncoderN[AXIS1_RAW_ENCODER].value = Axis1Encoder;
-    EncoderN[AXIS2_RAW_ENCODER].value = Axis2Encoder;
+    EncoderNP[AXIS1_RAW_ENCODER].setValue(Axis1Encoder);
+    EncoderNP[AXIS2_RAW_ENCODER].setValue(Axis2Encoder);
 
     // Convert Half Step to Full Step
-    if (AxisRangeS[AXIS_HALF_STEP].s == ISS_ON)
+    if (AxisRangeSP[AXIS_HALF_STEP].getState() == ISS_ON)
     {
         if (Axis1Encoder < 0)
-            Axis1Encoder += AxisSettingsN[AXIS1_TICKS].value;
+            Axis1Encoder += AxisSettingsNP[AXIS1_TICKS].getValue();
 
         if (Axis2Encoder < 0)
-            Axis2Encoder += AxisSettingsN[AXIS2_TICKS].value;
+            Axis2Encoder += AxisSettingsNP[AXIS2_TICKS].getValue();
     }
 
     // Calculate reverse values
     double Axis1 = Axis1Encoder;
-    if (ReverseS[AXIS1_ENCODER].s == ISS_ON)
-        Axis1 = AxisSettingsN[AXIS1_TICKS].value - Axis1;
+    if (ReverseSP[AXIS1_ENCODER].getState() == ISS_ON)
+        Axis1 = AxisSettingsNP[AXIS1_TICKS].getValue() - Axis1;
 
 #if 0
     if (Axis1Diff < 0)
-        Axis1Diff += AxisSettingsN[AXIS1_TICKS].value;
-    else if (Axis1Diff > AxisSettingsN[AXIS1_TICKS].value)
-        Axis1Diff -= AxisSettingsN[AXIS1_TICKS].value;
+        Axis1Diff += AxisSettingsNP[AXIS1_TICKS].getValue();
+    else if (Axis1Diff > AxisSettingsNP[AXIS1_TICKS].getValue())
+        Axis1Diff -= AxisSettingsNP[AXIS1_TICKS].getValue();
 #endif
 
     double Axis2 = Axis2Encoder;
-    if (ReverseS[AXIS2_ENCODER].s == ISS_ON)
-        Axis2 = AxisSettingsN[AXIS2_TICKS].value - Axis2;
+    if (ReverseSP[AXIS2_ENCODER].getState() == ISS_ON)
+        Axis2 = AxisSettingsNP[AXIS2_TICKS].getValue() - Axis2;
 
     LOGF_DEBUG("Axis encoders after reverse. Axis1: %g Axis2: %g", Axis1, Axis2);
 
@@ -388,13 +388,13 @@ bool DSC::ReadScopeStatus()
 
     //LOGF_DEBUG("Axis encoders after raw offsets. Axis1: %g Axis2: %g", Axis1, Axis2);
 
-    EncoderN[AXIS1_ENCODER].value = Axis1;
-    EncoderN[AXIS2_ENCODER].value = Axis2;
-    EncoderNP.s                   = IPS_OK;
-    IDSetNumber(&EncoderNP, nullptr);
+    EncoderNP[AXIS1_ENCODER].setValue(Axis1);
+    EncoderNP[AXIS2_ENCODER].setValue(Axis2);
+    EncoderNP.setState(IPS_OK);
+    EncoderNP.apply();
 
-    double Axis1Degrees = (Axis1 / AxisSettingsN[AXIS1_TICKS].value * 360.0) + AxisSettingsN[AXIS1_DEGREE_OFFSET].value;
-    double Axis2Degrees = (Axis2 / AxisSettingsN[AXIS2_TICKS].value * 360.0) + AxisSettingsN[AXIS2_DEGREE_OFFSET].value;
+    double Axis1Degrees = (Axis1 / AxisSettingsNP[AXIS1_TICKS].value * 360.0) + AxisSettingsNP[AXIS1_DEGREE_OFFSET].getValue();
+    double Axis2Degrees = (Axis2 / AxisSettingsNP[AXIS2_TICKS].value * 360.0) + AxisSettingsNP[AXIS2_DEGREE_OFFSET].getValue();
 
     Axis1Degrees = range360(Axis1Degrees);
     Axis2Degrees = range360(Axis2Degrees);
@@ -406,7 +406,7 @@ bool DSC::ReadScopeStatus()
     ln_equ_posn eq { 0, 0 };
 
     // Now we proceed depending on mount type
-    if (MountTypeS[MOUNT_EQUATORIAL].s == ISS_ON)
+    if (MountTypeSP[MOUNT_EQUATORIAL].getState() == ISS_ON)
     {
         encoderEquatorialCoordinates.ra = Axis1Degrees / 15.0;
 
@@ -452,7 +452,7 @@ bool DSC::Sync(double ra, double dec)
     struct ln_equ_posn RaDec { 0, 0 };
     struct ln_hrz_posn AltAz { 0, 0 };
 
-    if (MountTypeS[MOUNT_EQUATORIAL].s == ISS_ON)
+    if (MountTypeSP[MOUNT_EQUATORIAL].getState() == ISS_ON)
     {
         double LST = get_local_sidereal_time(observer.lng);
         RaDec.ra   = ((LST - encoderEquatorialCoordinates.ra) * 360.0) / 24.0;
@@ -468,7 +468,7 @@ bool DSC::Sync(double ra, double dec)
     NewEntry.RightAscension        = ra;
     NewEntry.Declination           = dec;
 
-    if (MountTypeS[MOUNT_EQUATORIAL].s == ISS_ON)
+    if (MountTypeSP[MOUNT_EQUATORIAL].getState() == ISS_ON)
         NewEntry.TelescopeDirection = TelescopeDirectionVectorFromLocalHourAngleDeclination(RaDec);
     else
         NewEntry.TelescopeDirection = TelescopeDirectionVectorFromAltitudeAzimuth(AltAz);
@@ -505,7 +505,7 @@ ln_equ_posn DSC::TelescopeEquatorialToSky()
 
         /*  and here we convert from ra/dec to hour angle / dec before calling alignment stuff */
         double lha, lst;
-        lst = get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value);
+        lst = get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].value);
         lha = get_local_hour_angle(lst, encoderEquatorialCoordinates.ra);
         //  convert lha to degrees
         lha    = lha * 360 / 24;
@@ -598,10 +598,10 @@ void DSC::simulationTriggered(bool enable)
 
     if (enable)
     {
-        defineProperty(&SimEncoderNP);
+        defineProperty(SimEncoderNP);
     }
     else
     {
-        deleteProperty(SimEncoderNP.name);
+        deleteProperty(SimEncoderNP.getName());
     }
 }

--- a/drivers/telescope/dsc.h
+++ b/drivers/telescope/dsc.h
@@ -28,6 +28,10 @@
 
 #include <libnova/ln_types.h>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class DSC : public INDI::Telescope, INDI::AlignmentSubsystem::AlignmentSubsystemForDrivers
 {
   public:
@@ -56,8 +60,7 @@ class DSC : public INDI::Telescope, INDI::AlignmentSubsystem::AlignmentSubsystem
     ln_equ_posn TelescopeEquatorialToSky();
     ln_equ_posn TelescopeHorizontalToSky();
 
-    INumber EncoderN[4];
-    INumberVectorProperty EncoderNP;
+    INDI::PropertyNumber EncoderNP {4};
     enum
     {
         AXIS1_ENCODER,
@@ -66,8 +69,7 @@ class DSC : public INDI::Telescope, INDI::AlignmentSubsystem::AlignmentSubsystem
         AXIS2_RAW_ENCODER
     };
 
-    INumber AxisSettingsN[4];
-    INumberVectorProperty AxisSettingsNP;
+    INDI::PropertyNumber AxisSettingsNP {4};
     //enum { AXIS1_TICKS, AXIS2_TICKS};
     enum
     {
@@ -77,19 +79,16 @@ class DSC : public INDI::Telescope, INDI::AlignmentSubsystem::AlignmentSubsystem
         AXIS2_DEGREE_OFFSET
     };
 
-    ISwitch AxisRangeS[2];
-    ISwitchVectorProperty AxisRangeSP;
+    INDI::PropertySwitch AxisRangeSP {2};
     enum
     {
         AXIS_FULL_STEP,
         AXIS_HALF_STEP
     };
 
-    ISwitch ReverseS[2];
-    ISwitchVectorProperty ReverseSP;
+    INDI::PropertySwitch ReverseSP {2};
 
-    ISwitch MountTypeS[2];
-    ISwitchVectorProperty MountTypeSP;
+    INDI::PropertySwitch MountTypeSP {2};
     enum
     {
         MOUNT_EQUATORIAL,
@@ -101,8 +100,7 @@ class DSC : public INDI::Telescope, INDI::AlignmentSubsystem::AlignmentSubsystem
     //enum { OFFSET_AXIS1_SCALE, OFFSET_AXIS1_OFFSET, AXIS1_DEGREE_OFFSET, OFFSET_AXIS2_SCALE, OFFSET_AXIS2_OFFSET, AXIS2_DEGREE_OFFSET };
 
     // Simulation Only
-    INumber SimEncoderN[2];
-    INumberVectorProperty SimEncoderNP;
+    INDI::PropertyNumber SimEncoderNP {2};
 
     ln_lnlat_posn observer { 0, 0 };
     ln_hrz_posn encoderHorizontalCoordinates { 0, 0 };

--- a/drivers/telescope/ieqpro.cpp
+++ b/drivers/telescope/ieqpro.cpp
@@ -109,12 +109,12 @@ bool IEQPro::initProperties()
     INDI::Telescope::initProperties();
 
     /* Firmware */
-    IUFillText(&FirmwareT[FW_MODEL], "Model", "", nullptr);
-    IUFillText(&FirmwareT[FW_BOARD], "Board", "", nullptr);
-    IUFillText(&FirmwareT[FW_CONTROLLER], "Controller", "", nullptr);
-    IUFillText(&FirmwareT[FW_RA], "RA", "", nullptr);
-    IUFillText(&FirmwareT[FW_DEC], "DEC", "", nullptr);
-    IUFillTextVector(&FirmwareTP, FirmwareT, 5, getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
+    FirmwareTP[FW_MODEL].fill("Model", "", nullptr);
+    FirmwareTP[FW_BOARD].fill("Board", "", nullptr);
+    FirmwareTP[FW_CONTROLLER].fill("Controller", "", nullptr);
+    FirmwareTP[FW_RA].fill("RA", "", nullptr);
+    FirmwareTP[FW_DEC].fill("DEC", "", nullptr);
+    FirmwareTP.fill(getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
                      IPS_IDLE);
 
     /* Tracking Mode */
@@ -139,42 +139,42 @@ bool IEQPro::initProperties()
     SlewRateS[4].s = ISS_ON;
 
     // Set TrackRate limits within +/- 0.0100 of Sidereal rate
-    TrackRateN[AXIS_RA].min = TRACKRATE_SIDEREAL - 0.01;
-    TrackRateN[AXIS_RA].max = TRACKRATE_SIDEREAL + 0.01;
-    TrackRateN[AXIS_DE].min = -0.01;
-    TrackRateN[AXIS_DE].max = 0.01;
+    TrackRateNP[AXIS_RA].setMin(TRACKRATE_SIDEREAL - 0.01);
+    TrackRateNP[AXIS_RA].setMax(TRACKRATE_SIDEREAL + 0.01);
+    TrackRateNP[AXIS_DE].setMin(-0.01);
+    TrackRateNP[AXIS_DE].setMax(0.01);
 
     /* GPS Status */
-    IUFillSwitch(&GPSStatusS[GPS_OFF], "Off", "", ISS_ON);
-    IUFillSwitch(&GPSStatusS[GPS_ON], "On", "", ISS_OFF);
-    IUFillSwitch(&GPSStatusS[GPS_DATA_OK], "Data OK", "", ISS_OFF);
-    IUFillSwitchVector(&GPSStatusSP, GPSStatusS, 3, getDeviceName(), "GPS_STATUS", "GPS", MOUNTINFO_TAB, IP_RO,
+    GPSStatusSP[GPS_OFF].fill("Off", "", ISS_ON);
+    GPSStatusSP[GPS_ON].fill("On", "", ISS_OFF);
+    GPSStatusSP[GPS_DATA_OK].fill("Data OK", "", ISS_OFF);
+    GPSStatusSP.fill(getDeviceName(), "GPS_STATUS", "GPS", MOUNTINFO_TAB, IP_RO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Time Source */
-    IUFillSwitch(&TimeSourceS[TS_RS232], "RS232", "", ISS_ON);
-    IUFillSwitch(&TimeSourceS[TS_CONTROLLER], "Controller", "", ISS_OFF);
-    IUFillSwitch(&TimeSourceS[TS_GPS], "GPS", "", ISS_OFF);
-    IUFillSwitchVector(&TimeSourceSP, TimeSourceS, 3, getDeviceName(), "TIME_SOURCE", "Time Source", MOUNTINFO_TAB,
+    TimeSourceSP[TS_RS232].fill("RS232", "", ISS_ON);
+    TimeSourceSP[TS_CONTROLLER].fill("Controller", "", ISS_OFF);
+    TimeSourceSP[TS_GPS].fill("GPS", "", ISS_OFF);
+    TimeSourceSP.fill(getDeviceName(), "TIME_SOURCE", "Time Source", MOUNTINFO_TAB,
                        IP_RO, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Hemisphere */
-    IUFillSwitch(&HemisphereS[HEMI_SOUTH], "South", "", ISS_OFF);
-    IUFillSwitch(&HemisphereS[HEMI_NORTH], "North", "", ISS_ON);
-    IUFillSwitchVector(&HemisphereSP, HemisphereS, 2, getDeviceName(), "HEMISPHERE", "Hemisphere", MOUNTINFO_TAB, IP_RO,
+    HemisphereSP[HEMI_SOUTH].fill("South", "", ISS_OFF);
+    HemisphereSP[HEMI_NORTH].fill("North", "", ISS_ON);
+    HemisphereSP.fill(getDeviceName(), "HEMISPHERE", "Hemisphere", MOUNTINFO_TAB, IP_RO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Home */
-    IUFillSwitch(&HomeS[IEQ_SET_HOME], "IEQ_SET_HOME", "Set current as Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IEQ_GOTO_HOME], "IEQ_GOTO_HOME", "Go to Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IEQ_FIND_HOME], "IEQ_FIND_HOME", "Find Home", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 3, getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
+    HomeSP[IEQ_SET_HOME].fill("IEQ_SET_HOME", "Set current as Home", ISS_OFF);
+    HomeSP[IEQ_GOTO_HOME].fill("IEQ_GOTO_HOME", "Go to Home", ISS_OFF);
+    HomeSP[IEQ_FIND_HOME].fill("IEQ_FIND_HOME", "Find Home", ISS_OFF);
+    HomeSP.fill(getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
                        IPS_IDLE);
 
     /* How fast do we guide compared to sidereal rate */
-    IUFillNumber(&GuideRateN[RA_AXIS], "RA_GUIDE_RATE", "RA", "%.2f", 0.01, 0.9, 0.1, 0.5);
-    IUFillNumber(&GuideRateN[DEC_AXIS], "DE_GUIDE_RATE", "DE", "%.2f", 0.1, 0.99, 0.1, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
+    GuideRateNP[RA_AXIS].fill("RA_GUIDE_RATE", "RA", "%.2f", 0.01, 0.9, 0.1, 0.5);
+    GuideRateNP[DEC_AXIS].fill("DE_GUIDE_RATE", "DE", "%.2f", 0.1, 0.99, 0.1, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     TrackState = SCOPE_IDLE;
@@ -214,38 +214,38 @@ bool IEQPro::updateProperties()
 
         // Remove find home if we do not support it.
         if (!canFindHome)
-            HomeSP.nsp = 2;
+            HomeSP.resize(2);
 
-        defineProperty(&HomeSP);
+        defineProperty(HomeSP);
 
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
 
         if (canGuideRate)
-            defineProperty(&GuideRateNP);
+            defineProperty(GuideRateNP);
 
-        defineProperty(&FirmwareTP);
-        defineProperty(&GPSStatusSP);
-        defineProperty(&TimeSourceSP);
-        defineProperty(&HemisphereSP);
+        defineProperty(FirmwareTP);
+        defineProperty(GPSStatusSP);
+        defineProperty(TimeSourceSP);
+        defineProperty(HemisphereSP);
     }
     else
     {
         INDI::Telescope::updateProperties();
 
-        HomeSP.nsp = 3;
-        deleteProperty(HomeSP.name);
+        HomeSP.resize(3);
+        deleteProperty(HomeSP.getName());
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
 
         if (canGuideRate)
-            deleteProperty(GuideRateNP.name);
+            deleteProperty(GuideRateNP.getName());
 
-        deleteProperty(FirmwareTP.name);
-        deleteProperty(GPSStatusSP.name);
-        deleteProperty(TimeSourceSP.name);
-        deleteProperty(HemisphereSP.name);
+        deleteProperty(FirmwareTP.getName());
+        deleteProperty(GPSStatusSP.getName());
+        deleteProperty(TimeSourceSP.getName());
+        deleteProperty(HemisphereSP.getName());
     }
 
     return true;
@@ -257,23 +257,23 @@ void IEQPro::getStartupData()
 
     firmwareInfo = driver->getFirmwareInfo();
 
-    IUSaveText(&FirmwareT[0], firmwareInfo.Model.c_str());
-    IUSaveText(&FirmwareT[1], firmwareInfo.MainBoardFirmware.c_str());
-    IUSaveText(&FirmwareT[2], firmwareInfo.ControllerFirmware.c_str());
-    IUSaveText(&FirmwareT[3], firmwareInfo.RAFirmware.c_str());
-    IUSaveText(&FirmwareT[4], firmwareInfo.DEFirmware.c_str());
+    FirmwareTP[0].setText(firmwareInfo.Model);
+    FirmwareTP[1].setText(firmwareInfo.MainBoardFirmware);
+    FirmwareTP[2].setText(firmwareInfo.ControllerFirmware);
+    FirmwareTP[3].setText(firmwareInfo.RAFirmware);
+    FirmwareTP[4].setText(firmwareInfo.DEFirmware);
 
-    FirmwareTP.s = IPS_OK;
-    IDSetText(&FirmwareTP, nullptr);
+    FirmwareTP.setState(IPS_OK);
+    FirmwareTP.apply();
 
 
     LOG_DEBUG("Getting guiding rate...");
     double raGuideRate = 0, deGuideRate = 0;
     if (driver->getGuideRate(&raGuideRate, &deGuideRate))
     {
-        GuideRateN[RA_AXIS].value = raGuideRate;
-        GuideRateN[DEC_AXIS].value = deGuideRate;
-        IDSetNumber(&GuideRateNP, nullptr);
+        GuideRateNP[RA_AXIS].setValue(raGuideRate);
+        GuideRateNP[DEC_AXIS].setValue(deGuideRate);
+        GuideRateNP.apply();
     }
 
     double utc_offset;
@@ -286,13 +286,13 @@ void IEQPro::getStartupData()
         snprintf(isoDateTime, 32, "%04d-%02d-%02dT%02d:%02d:%02d", yy, mm, dd, hh, minute, ss);
         snprintf(utcOffset, 8, "%4.2f", utc_offset);
 
-        IUSaveText(IUFindText(&TimeTP, "UTC"), isoDateTime);
-        IUSaveText(IUFindText(&TimeTP, "OFFSET"), utcOffset);
+        IUSaveText(TimeTP.findWidgetByName("UTC"), isoDateTime);
+        IUSaveText(TimeTP.findWidgetByName("OFFSET"), utcOffset);
 
         LOGF_INFO("Mount UTC offset is %s. UTC time is %s", utcOffset, isoDateTime);
 
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
     }
 
     // Get Longitude and Latitude from mount
@@ -308,37 +308,37 @@ void IEQPro::getStartupData()
 
         LOGF_INFO("Mount Longitude %g Latitude %g", longitude, latitude);
 
-        LocationN[LOCATION_LATITUDE].value  = latitude;
-        LocationN[LOCATION_LONGITUDE].value = longitude;
-        LocationNP.s                        = IPS_OK;
+        LocationNP[LOCATION_LATITUDE].setValue(latitude);
+        LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+        LocationNP.setState(IPS_OK);
 
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
 
         saveConfig(true, "GEOGRAPHIC_COORD");
     }
     else if (IUGetConfigNumber(getDeviceName(), "GEOGRAPHIC_COORD", "LONG", &longitude) == 0 &&
              IUGetConfigNumber(getDeviceName(), "GEOGRAPHIC_COORD", "LAT", &latitude) == 0)
     {
-        LocationN[LOCATION_LATITUDE].value  = latitude;
-        LocationN[LOCATION_LONGITUDE].value = longitude;
-        LocationNP.s                        = IPS_OK;
+        LocationNP[LOCATION_LATITUDE].setValue(latitude);
+        LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+        LocationNP.setState(IPS_OK);
 
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
     }
 
     if (InitPark())
     {
         // If loading parking data is successful, we just set the default parking values.
-        SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+        SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
     }
     else
     {
         // Otherwise, we set all parking data to default in case no parking data is found.
-        SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
-        SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+        SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
+        SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
     }
 
     // can we read pier side?
@@ -365,16 +365,16 @@ bool IEQPro::ISNewNumber(const char *dev, const char *name, double values[], cha
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Guiding Rate
-        if (!strcmp(name, GuideRateNP.name))
+        if (GuideRateNP.isNameMatch(name))
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
+            GuideRateNP.update(values, names, n);
 
-            if (driver->setGuideRate(GuideRateN[RA_AXIS].value, GuideRateN[DEC_AXIS].value))
-                GuideRateNP.s = IPS_OK;
+            if (driver->setGuideRate(GuideRateNP[RA_AXIS].value, GuideRateNP[DEC_AXIS].getValue()))
+                GuideRateNP.setState(IPS_OK);
             else
-                GuideRateNP.s = IPS_ALERT;
+                GuideRateNP.setState(IPS_ALERT);
 
-            IDSetNumber(&GuideRateNP, nullptr);
+            GuideRateNP.apply();
 
             return true;
         }
@@ -393,26 +393,26 @@ bool IEQPro::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
 {
     if (!strcmp(getDeviceName(), dev))
     {
-        if (!strcmp(name, HomeSP.name))
+        if (HomeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&HomeSP, states, names, n);
+            HomeSP.update(states, names, n);
 
-            HomeOperation operation = static_cast<HomeOperation>(IUFindOnSwitchIndex(&HomeSP));
+            HomeOperation operation = static_cast<HomeOperation>(HomeSP.findOnSwitchIndex());
 
-            IUResetSwitch(&HomeSP);
+            HomeSP.reset();
 
             switch (operation)
             {
                 case IEQ_SET_HOME:
                     if (driver->setCurrentHome() == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Home position set to current coordinates.");
                     return true;
 
@@ -425,26 +425,26 @@ bool IEQPro::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
 
                     if (driver->gotoHome() == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Slewing to home position...");
                     return true;
 
                 case IEQ_FIND_HOME:
                     if (driver->findHome() == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Searching for home position...");
                     return true;
             }
@@ -467,17 +467,17 @@ bool IEQPro::ReadScopeStatus()
 
     if (rc)
     {
-        IUResetSwitch(&GPSStatusSP);
-        GPSStatusS[newInfo.gpsStatus].s = ISS_ON;
-        IDSetSwitch(&GPSStatusSP, nullptr);
+        GPSStatusSP.reset();
+        GPSStatusSP[newInfo.gpsStatus].setState(ISS_ON);
+        GPSStatusSP.apply();
 
-        IUResetSwitch(&TimeSourceSP);
-        TimeSourceS[newInfo.timeSource].s = ISS_ON;
-        IDSetSwitch(&TimeSourceSP, nullptr);
+        TimeSourceSP.reset();
+        TimeSourceSP[newInfo.timeSource].setState(ISS_ON);
+        TimeSourceSP.apply();
 
-        IUResetSwitch(&HemisphereSP);
-        HemisphereS[newInfo.hemisphere].s = ISS_ON;
-        IDSetSwitch(&HemisphereSP, nullptr);
+        HemisphereSP.reset();
+        HemisphereSP[newInfo.hemisphere].setState(ISS_ON);
+        HemisphereSP.apply();
 
         /*
         TelescopeTrackMode trackMode = TRACK_SIDEREAL;
@@ -652,7 +652,7 @@ bool IEQPro::Sync(double ra, double dec)
         LOG_ERROR("Failed to sync.");
     }
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     currentRA  = ra;
     currentDEC = dec;
@@ -723,8 +723,8 @@ bool IEQPro::Park()
 
     // Otherwise fallback to Alt/Az --> RA/DE parking
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -984,15 +984,15 @@ bool IEQPro::saveConfigItems(FILE *fp)
 //    switch (TrackState)
 //    {
 //        case SCOPE_IDLE:
-//            currentRA += (TrackRateN[AXIS_RA].value / 3600.0 * dt) / 15.0;
+//            currentRA += (TrackRateNP[AXIS_RA].value / 3600.0 * dt) / 15.0;
 //            currentRA = range24(currentRA);
 //            break;
 
 //        case SCOPE_TRACKING:
 //            if (TrackModeS[1].s == ISS_ON)
 //            {
-//                currentRA  += ( ((TRACKRATE_SIDEREAL / 3600.0) - (TrackRateN[AXIS_RA].value / 3600.0)) * dt) / 15.0;
-//                currentDEC += ( (TrackRateN[AXIS_DE].value / 3600.0) * dt);
+//                currentRA  += ( ((TRACKRATE_SIDEREAL / 3600.0) - (TrackRateNP[AXIS_RA].value / 3600.0)) * dt) / 15.0;
+//                currentDEC += ( (TrackRateNP[AXIS_DE].value / 3600.0) * dt);
 //            }
 //            break;
 
@@ -1057,8 +1057,8 @@ bool IEQPro::SetCurrentPark()
     // Libnova south = 0, west = 90, north = 180, east = 270
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -1088,7 +1088,7 @@ bool IEQPro::SetDefaultPark()
     SetAxis1Park(0);
 
     // Altitude = latitude of observer
-    SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+    SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
 
     return true;
 }
@@ -1130,7 +1130,7 @@ bool IEQPro::SetTrackEnabled(bool enabled)
         // NOTE: Is this the correct order? or should tracking be switched on first before making these changes? Need to test.
         SetTrackMode(IUFindOnSwitchIndex(&TrackModeSP));
         if (TrackModeS[TR_CUSTOM].s == ISS_ON)
-            SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+            SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
     }
 
     return driver->setTrackEnabled(enabled);

--- a/drivers/telescope/ieqpro.h
+++ b/drivers/telescope/ieqpro.h
@@ -26,6 +26,11 @@
 #include "indiguiderinterface.h"
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class IEQPro : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -94,8 +99,7 @@ class IEQPro : public INDI::Telescope, public INDI::GuiderInterface
         void getStartupData();
 
         /* Firmware */
-        IText FirmwareT[5] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {5};
 
         /* Tracking Mode */
         //ISwitchVectorProperty TrackModeSP;
@@ -106,24 +110,19 @@ class IEQPro : public INDI::Telescope, public INDI::GuiderInterface
         //INumberVectorProperty CustomTrackRateNP;
 
         /* GPS Status */
-        ISwitch GPSStatusS[3];
-        ISwitchVectorProperty GPSStatusSP;
+        INDI::PropertySwitch GPSStatusSP {3};
 
         /* Time Source */
-        ISwitch TimeSourceS[3];
-        ISwitchVectorProperty TimeSourceSP;
+        INDI::PropertySwitch TimeSourceSP {3};
 
         /* Hemisphere */
-        ISwitch HemisphereS[2];
-        ISwitchVectorProperty HemisphereSP;
+        INDI::PropertySwitch HemisphereSP {2};
 
         /* Home Control */
-        ISwitch HomeS[3];
-        ISwitchVectorProperty HomeSP;
+        INDI::PropertySwitch HomeSP {3};
 
         /* Guide Rate */
-        INumber GuideRateN[2];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};
 
         unsigned int DBG_SCOPE;
         double currentRA = 0, currentDEC = 0;

--- a/drivers/telescope/ieqprolegacy.cpp
+++ b/drivers/telescope/ieqprolegacy.cpp
@@ -104,12 +104,12 @@ bool IEQProLegacy::initProperties()
     INDI::Telescope::initProperties();
 
     /* Firmware */
-    IUFillText(&FirmwareT[FW_MODEL], "Model", "", nullptr);
-    IUFillText(&FirmwareT[FW_BOARD], "Board", "", nullptr);
-    IUFillText(&FirmwareT[FW_CONTROLLER], "Controller", "", nullptr);
-    IUFillText(&FirmwareT[FW_RA], "RA", "", nullptr);
-    IUFillText(&FirmwareT[FW_DEC], "DEC", "", nullptr);
-    IUFillTextVector(&FirmwareTP, FirmwareT, 5, getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
+    FirmwareTP[FW_MODEL].fill("Model", "", nullptr);
+    FirmwareTP[FW_BOARD].fill("Board", "", nullptr);
+    FirmwareTP[FW_CONTROLLER].fill("Controller", "", nullptr);
+    FirmwareTP[FW_RA].fill("RA", "", nullptr);
+    FirmwareTP[FW_DEC].fill("DEC", "", nullptr);
+    FirmwareTP.fill(getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
                      IPS_IDLE);
 
     /* Tracking Mode */
@@ -134,42 +134,42 @@ bool IEQProLegacy::initProperties()
     SlewRateS[4].s = ISS_ON;
 
     // Set TrackRate limits within +/- 0.0100 of Sidereal rate
-    TrackRateN[AXIS_RA].min = TRACKRATE_SIDEREAL - 0.01;
-    TrackRateN[AXIS_RA].max = TRACKRATE_SIDEREAL + 0.01;
-    TrackRateN[AXIS_DE].min = -0.01;
-    TrackRateN[AXIS_DE].max = 0.01;
+    TrackRateNP[AXIS_RA].setMin(TRACKRATE_SIDEREAL - 0.01);
+    TrackRateNP[AXIS_RA].setMax(TRACKRATE_SIDEREAL + 0.01);
+    TrackRateNP[AXIS_DE].setMin(-0.01);
+    TrackRateNP[AXIS_DE].setMax(0.01);
 
     /* GPS Status */
-    IUFillSwitch(&GPSStatusS[GPS_OFF], "Off", "", ISS_ON);
-    IUFillSwitch(&GPSStatusS[GPS_ON], "On", "", ISS_OFF);
-    IUFillSwitch(&GPSStatusS[GPS_DATA_OK], "Data OK", "", ISS_OFF);
-    IUFillSwitchVector(&GPSStatusSP, GPSStatusS, 3, getDeviceName(), "GPS_STATUS", "GPS", MOUNTINFO_TAB, IP_RO,
+    GPSStatusSP[GPS_OFF].fill("Off", "", ISS_ON);
+    GPSStatusSP[GPS_ON].fill("On", "", ISS_OFF);
+    GPSStatusSP[GPS_DATA_OK].fill("Data OK", "", ISS_OFF);
+    GPSStatusSP.fill(getDeviceName(), "GPS_STATUS", "GPS", MOUNTINFO_TAB, IP_RO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Time Source */
-    IUFillSwitch(&TimeSourceS[TS_RS232], "RS232", "", ISS_ON);
-    IUFillSwitch(&TimeSourceS[TS_CONTROLLER], "Controller", "", ISS_OFF);
-    IUFillSwitch(&TimeSourceS[TS_GPS], "GPS", "", ISS_OFF);
-    IUFillSwitchVector(&TimeSourceSP, TimeSourceS, 3, getDeviceName(), "TIME_SOURCE", "Time Source", MOUNTINFO_TAB,
+    TimeSourceSP[TS_RS232].fill("RS232", "", ISS_ON);
+    TimeSourceSP[TS_CONTROLLER].fill("Controller", "", ISS_OFF);
+    TimeSourceSP[TS_GPS].fill("GPS", "", ISS_OFF);
+    TimeSourceSP.fill(getDeviceName(), "TIME_SOURCE", "Time Source", MOUNTINFO_TAB,
                        IP_RO, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Hemisphere */
-    IUFillSwitch(&HemisphereS[HEMI_SOUTH], "South", "", ISS_OFF);
-    IUFillSwitch(&HemisphereS[HEMI_NORTH], "North", "", ISS_ON);
-    IUFillSwitchVector(&HemisphereSP, HemisphereS, 2, getDeviceName(), "HEMISPHERE", "Hemisphere", MOUNTINFO_TAB, IP_RO,
+    HemisphereSP[HEMI_SOUTH].fill("South", "", ISS_OFF);
+    HemisphereSP[HEMI_NORTH].fill("North", "", ISS_ON);
+    HemisphereSP.fill(getDeviceName(), "HEMISPHERE", "Hemisphere", MOUNTINFO_TAB, IP_RO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Home */
-    IUFillSwitch(&HomeS[IEQ_FIND_HOME], "FindHome", "Find Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IEQ_SET_HOME], "SetCurrentAsHome", "Set current as Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IEQ_GOTO_HOME], "GoToHome", "Go to Home", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 3, getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
+    HomeSP[IEQ_FIND_HOME].fill("FindHome", "Find Home", ISS_OFF);
+    HomeSP[IEQ_SET_HOME].fill("SetCurrentAsHome", "Set current as Home", ISS_OFF);
+    HomeSP[IEQ_GOTO_HOME].fill("GoToHome", "Go to Home", ISS_OFF);
+    HomeSP.fill(getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
                        IPS_IDLE);
 
     /* How fast do we guide compared to sidereal rate */
-    IUFillNumber(&GuideRateN[RA_AXIS], "RA_GUIDE_RATE", "x Sidereal", "%.2f", 0.01, 0.9, 0.1, 0.5);
-    IUFillNumber(&GuideRateN[DEC_AXIS], "DE_GUIDE_RATE", "x Sidereal", "%.2f", 0.1, 0.99, 0.1, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
+    GuideRateNP[RA_AXIS].fill("RA_GUIDE_RATE", "x Sidereal", "%.2f", 0.01, 0.9, 0.1, 0.5);
+    GuideRateNP[DEC_AXIS].fill("DE_GUIDE_RATE", "x Sidereal", "%.2f", 0.1, 0.99, 0.1, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     TrackState = SCOPE_IDLE;
@@ -204,31 +204,31 @@ bool IEQProLegacy::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&HomeSP);
+        defineProperty(HomeSP);
 
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
-        defineProperty(&GuideRateNP);
+        defineProperty(GuideRateNP);
 
-        defineProperty(&FirmwareTP);
-        defineProperty(&GPSStatusSP);
-        defineProperty(&TimeSourceSP);
-        defineProperty(&HemisphereSP);
+        defineProperty(FirmwareTP);
+        defineProperty(GPSStatusSP);
+        defineProperty(TimeSourceSP);
+        defineProperty(HemisphereSP);
 
         getStartupData();
     }
     else
     {
-        deleteProperty(HomeSP.name);
+        deleteProperty(HomeSP.getName());
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
-        deleteProperty(GuideRateNP.name);
+        deleteProperty(GuideRateNP.getName());
 
-        deleteProperty(FirmwareTP.name);
-        deleteProperty(GPSStatusSP.name);
-        deleteProperty(TimeSourceSP.name);
-        deleteProperty(HemisphereSP.name);
+        deleteProperty(FirmwareTP.getName());
+        deleteProperty(GPSStatusSP.getName());
+        deleteProperty(TimeSourceSP.getName());
+        deleteProperty(HemisphereSP.getName());
     }
 
     return true;
@@ -239,23 +239,23 @@ void IEQProLegacy::getStartupData()
     LOG_DEBUG("Getting firmware data...");
     if (get_ieqpro_firmware(PortFD, &firmwareInfo))
     {
-        IUSaveText(&FirmwareT[0], firmwareInfo.Model.c_str());
-        IUSaveText(&FirmwareT[1], firmwareInfo.MainBoardFirmware.c_str());
-        IUSaveText(&FirmwareT[2], firmwareInfo.ControllerFirmware.c_str());
-        IUSaveText(&FirmwareT[3], firmwareInfo.RAFirmware.c_str());
-        IUSaveText(&FirmwareT[4], firmwareInfo.DEFirmware.c_str());
+        FirmwareTP[0].setText(firmwareInfo.Model);
+        FirmwareTP[1].setText(firmwareInfo.MainBoardFirmware);
+        FirmwareTP[2].setText(firmwareInfo.ControllerFirmware);
+        FirmwareTP[3].setText(firmwareInfo.RAFirmware);
+        FirmwareTP[4].setText(firmwareInfo.DEFirmware);
 
-        FirmwareTP.s = IPS_OK;
-        IDSetText(&FirmwareTP, nullptr);
+        FirmwareTP.setState(IPS_OK);
+        FirmwareTP.apply();
     }
 
     LOG_DEBUG("Getting guiding rate...");
     double raGuideRate = 0, deGuideRate = 0;
     if (get_ieqpro_guide_rate(PortFD, &raGuideRate, &deGuideRate))
     {
-        GuideRateN[RA_AXIS].value = raGuideRate;
-        GuideRateN[DEC_AXIS].value = deGuideRate;
-        IDSetNumber(&GuideRateNP, nullptr);
+        GuideRateNP[RA_AXIS].setValue(raGuideRate);
+        GuideRateNP[DEC_AXIS].setValue(deGuideRate);
+        GuideRateNP.apply();
     }
 
     double utc_offset;
@@ -268,13 +268,13 @@ void IEQProLegacy::getStartupData()
         snprintf(isoDateTime, 32, "%04d-%02d-%02dT%02d:%02d:%02d", yy, mm, dd, hh, minute, ss);
         snprintf(utcOffset, 8, "%4.2f", utc_offset);
 
-        IUSaveText(IUFindText(&TimeTP, "UTC"), isoDateTime);
-        IUSaveText(IUFindText(&TimeTP, "OFFSET"), utcOffset);
+        IUSaveText(TimeTP.findWidgetByName("UTC"), isoDateTime);
+        IUSaveText(TimeTP.findWidgetByName("OFFSET"), utcOffset);
 
         LOGF_INFO("Mount UTC offset is %s. UTC time is %s", utcOffset, isoDateTime);
 
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
     }
 
     // Get Longitude and Latitude from mount
@@ -287,37 +287,37 @@ void IEQProLegacy::getStartupData()
 
         LOGF_INFO("Mount Longitude %g Latitude %g", longitude, latitude);
 
-        LocationN[LOCATION_LATITUDE].value  = latitude;
-        LocationN[LOCATION_LONGITUDE].value = longitude;
-        LocationNP.s                        = IPS_OK;
+        LocationNP[LOCATION_LATITUDE].setValue(latitude);
+        LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+        LocationNP.setState(IPS_OK);
 
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
 
         saveConfig(true, "GEOGRAPHIC_COORD");
     }
     else if (IUGetConfigNumber(getDeviceName(), "GEOGRAPHIC_COORD", "LONG", &longitude) == 0 &&
              IUGetConfigNumber(getDeviceName(), "GEOGRAPHIC_COORD", "LAT", &latitude) == 0)
     {
-        LocationN[LOCATION_LATITUDE].value  = latitude;
-        LocationN[LOCATION_LONGITUDE].value = longitude;
-        LocationNP.s                        = IPS_OK;
+        LocationNP[LOCATION_LATITUDE].setValue(latitude);
+        LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+        LocationNP.setState(IPS_OK);
 
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
     }
 
     if (InitPark())
     {
         // If loading parking data is successful, we just set the default parking values.
-        SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+        SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
     }
     else
     {
         // Otherwise, we set all parking data to default in case no parking data is found.
-        SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
-        SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+        SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
+        SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
     }
 
     if (isSimulation())
@@ -334,16 +334,16 @@ bool IEQProLegacy::ISNewNumber(const char *dev, const char *name, double values[
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Guiding Rate
-        if (!strcmp(name, GuideRateNP.name))
+        if (GuideRateNP.isNameMatch(name))
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
+            GuideRateNP.update(values, names, n);
 
-            if (set_ieqpro_guide_rate(PortFD, GuideRateN[RA_AXIS].value, GuideRateN[DEC_AXIS].value))
-                GuideRateNP.s = IPS_OK;
+            if (set_ieqpro_guide_rate(PortFD, GuideRateNP[RA_AXIS].getValue(), GuideRateNP[DEC_AXIS].getValue()))
+                GuideRateNP.setState(IPS_OK);
             else
-                GuideRateNP.s = IPS_ALERT;
+                GuideRateNP.setState(IPS_ALERT);
 
-            IDSetNumber(&GuideRateNP, nullptr);
+            GuideRateNP.apply();
 
             return true;
         }
@@ -362,60 +362,60 @@ bool IEQProLegacy::ISNewSwitch(const char *dev, const char *name, ISState *state
 {
     if (!strcmp(getDeviceName(), dev))
     {
-        if (!strcmp(name, HomeSP.name))
+        if (HomeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&HomeSP, states, names, n);
+            HomeSP.update(states, names, n);
 
-            IEQ_HOME_OPERATION operation = static_cast<IEQ_HOME_OPERATION>(IUFindOnSwitchIndex(&HomeSP));
+            IEQ_HOME_OPERATION operation = static_cast<IEQ_HOME_OPERATION>(HomeSP.findOnSwitchIndex());
 
-            IUResetSwitch(&HomeSP);
+            HomeSP.reset();
 
             switch (operation)
             {
                 case IEQ_FIND_HOME:
                     if (firmwareInfo.Model.find("CEM") == std::string::npos)
                     {
-                        HomeSP.s = IPS_IDLE;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_IDLE);
+                        HomeSP.apply();
                         LOG_WARN("Home search is not supported in this model.");
                         return true;
                     }
 
                     if (find_ieqpro_home(PortFD) == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Searching for home position...");
                     return true;
 
                 case IEQ_SET_HOME:
                     if (set_ieqpro_current_home(PortFD) == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Home position set to current coordinates.");
                     return true;
 
                 case IEQ_GOTO_HOME:
                     if (goto_ieqpro_home(PortFD) == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Slewing to home position...");
                     return true;
             }
@@ -440,17 +440,17 @@ bool IEQProLegacy::ReadScopeStatus()
 
     if (rc)
     {
-        IUResetSwitch(&GPSStatusSP);
-        GPSStatusS[newInfo.gpsStatus].s = ISS_ON;
-        IDSetSwitch(&GPSStatusSP, nullptr);
+        GPSStatusSP.reset();
+        GPSStatusSP[newInfo.gpsStatus].setState(ISS_ON);
+        GPSStatusSP.apply();
 
-        IUResetSwitch(&TimeSourceSP);
-        TimeSourceS[newInfo.timeSource].s = ISS_ON;
-        IDSetSwitch(&TimeSourceSP, nullptr);
+        TimeSourceSP.reset();
+        TimeSourceSP[newInfo.timeSource].setState(ISS_ON);
+        TimeSourceSP.apply();
 
-        IUResetSwitch(&HemisphereSP);
-        HemisphereS[newInfo.hemisphere].s = ISS_ON;
-        IDSetSwitch(&HemisphereSP, nullptr);
+        HemisphereSP.reset();
+        HemisphereSP[newInfo.hemisphere].setState(ISS_ON);
+        HemisphereSP.apply();
 
         /*
         TelescopeTrackMode trackMode = TRACK_SIDEREAL;
@@ -568,7 +568,7 @@ bool IEQProLegacy::Sync(double ra, double dec)
         LOG_ERROR("Failed to sync.");
     }
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     currentRA  = ra;
     currentDEC = dec;
@@ -620,8 +620,8 @@ bool IEQProLegacy::Park()
     LOGF_DEBUG("Parking to Az (%s) Alt (%s)...", AzStr, AltStr);
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -875,15 +875,15 @@ void IEQProLegacy::mountSim()
     switch (TrackState)
     {
         case SCOPE_IDLE:
-            currentRA += (TrackRateN[AXIS_RA].value / 3600.0 * dt) / 15.0;
+            currentRA += (TrackRateNP[AXIS_RA].value / 3600.0 * dt) / 15.0;
             currentRA = range24(currentRA);
             break;
 
         case SCOPE_TRACKING:
             if (TrackModeS[1].s == ISS_ON)
             {
-                currentRA  += ( ((TRACKRATE_SIDEREAL / 3600.0) - (TrackRateN[AXIS_RA].value / 3600.0)) * dt) / 15.0;
-                currentDEC += ( (TrackRateN[AXIS_DE].value / 3600.0) * dt);
+                currentRA  += ( ((TRACKRATE_SIDEREAL / 3600.0) - (TrackRateNP[AXIS_RA].value / 3600.0)) * dt) / 15.0;
+                currentDEC += ( (TrackRateNP[AXIS_DE].value / 3600.0) * dt);
             }
             break;
 
@@ -948,8 +948,8 @@ bool IEQProLegacy::SetCurrentPark()
     // Libnova south = 0, west = 90, north = 180, east = 270
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -979,7 +979,7 @@ bool IEQProLegacy::SetDefaultPark()
     SetAxis1Park(0);
 
     // Altitude = latitude of observer
-    SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+    SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
 
     return true;
 }
@@ -1021,7 +1021,7 @@ bool IEQProLegacy::SetTrackEnabled(bool enabled)
         // NOTE: Is this the correct order? or should tracking be switched on first before making these changes? Need to test.
         SetTrackMode(IUFindOnSwitchIndex(&TrackModeSP));
         if (TrackModeS[TR_CUSTOM].s == ISS_ON)
-            SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+            SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
     }
 
     return set_ieqpro_track_enabled(PortFD, enabled);

--- a/drivers/telescope/ieqprolegacy.h
+++ b/drivers/telescope/ieqprolegacy.h
@@ -24,6 +24,11 @@
 #include "indiguiderinterface.h"
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class IEQProLegacy : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -93,8 +98,7 @@ class IEQProLegacy : public INDI::Telescope, public INDI::GuiderInterface
         void getStartupData();
 
         /* Firmware */
-        IText FirmwareT[5] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {5};
 
         /* Tracking Mode */
         //ISwitchVectorProperty TrackModeSP;
@@ -105,24 +109,19 @@ class IEQProLegacy : public INDI::Telescope, public INDI::GuiderInterface
         //INumberVectorProperty CustomTrackRateNP;
 
         /* GPS Status */
-        ISwitch GPSStatusS[3];
-        ISwitchVectorProperty GPSStatusSP;
+        INDI::PropertySwitch GPSStatusSP {3};
 
         /* Time Source */
-        ISwitch TimeSourceS[3];
-        ISwitchVectorProperty TimeSourceSP;
+        INDI::PropertySwitch TimeSourceSP {3};
 
         /* Hemisphere */
-        ISwitch HemisphereS[2];
-        ISwitchVectorProperty HemisphereSP;
+        INDI::PropertySwitch HemisphereSP {2};
 
         /* Home Control */
-        ISwitch HomeS[3];
-        ISwitchVectorProperty HomeSP;
+        INDI::PropertySwitch HomeSP {3};
 
         /* Guide Rate */
-        INumber GuideRateN[2];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};
 
         unsigned int DBG_SCOPE;
         double currentRA = 0, currentDEC = 0;

--- a/drivers/telescope/ioptronHC8406.cpp
+++ b/drivers/telescope/ioptronHC8406.cpp
@@ -123,30 +123,30 @@ bool ioptronHC8406::initProperties()
     LX200Generic::initProperties();
 
     // Sync Type
-    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], "USE_REGULAR_SYNC", ":CM#", ISS_ON);
-    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], "USE_CMR_SYNC", ":CMR#", ISS_OFF);
-    IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNC_MODE", "Sync", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
+    SyncCMRSP[USE_REGULAR_SYNC].fill("USE_REGULAR_SYNC", ":CM#", ISS_ON);
+    SyncCMRSP[USE_CMR_SYNC].fill("USE_CMR_SYNC", ":CMR#", ISS_OFF);
+    SyncCMRSP.fill(getDeviceName(), "SYNC_MODE", "Sync", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Cursor move Guiding/Center
-    IUFillSwitch(&CursorMoveSpeedS[USE_GUIDE_SPEED], "USE_GUIDE_SPEED", "Guide Speed", ISS_ON);
-    IUFillSwitch(&CursorMoveSpeedS[USE_CENTERING_SPEED], "USE_CENTERING_SPEED", "Centering Speed", ISS_OFF);
-    IUFillSwitchVector(&CursorMoveSpeedSP, CursorMoveSpeedS, 2, getDeviceName(),
+    CursorMoveSpeedSP[USE_GUIDE_SPEED].fill("USE_GUIDE_SPEED", "Guide Speed", ISS_ON);
+    CursorMoveSpeedSP[USE_CENTERING_SPEED].fill("USE_CENTERING_SPEED", "Centering Speed", ISS_OFF);
+    CursorMoveSpeedSP.fill(getDeviceName(),
                        "CURSOR_MOVE_MODE", "Cursor Move Speed", MOTION_TAB, IP_RO, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Guide Rate
-    IUFillSwitch(&GuideRateS[0], "0.25x", "", ISS_OFF);
-    IUFillSwitch(&GuideRateS[1], "0.50x", "", ISS_ON);
-    IUFillSwitch(&GuideRateS[2], "1.0x", "", ISS_OFF);
-    IUFillSwitchVector(&GuideRateSP, GuideRateS, 3, getDeviceName(),
+    GuideRateSP[0].fill("0.25x", "", ISS_OFF);
+    GuideRateSP[1].fill("0.50x", "", ISS_ON);
+    GuideRateSP[2].fill("1.0x", "", ISS_OFF);
+    GuideRateSP.fill(getDeviceName(),
                        "GUIDE_RATE", "Guide Speed", MOTION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Center Rate
-    IUFillSwitch(&CenterRateS[0], "12x", "", ISS_OFF);
-    IUFillSwitch(&CenterRateS[1], "64x", "", ISS_ON);
-    IUFillSwitch(&CenterRateS[2], "600x", "", ISS_OFF);
-    IUFillSwitch(&CenterRateS[3], "1200x", "", ISS_OFF);
-    IUFillSwitchVector(&CenterRateSP, CenterRateS, 4, getDeviceName(),
+    CenterRateSP[0].fill("12x", "", ISS_OFF);
+    CenterRateSP[1].fill("64x", "", ISS_ON);
+    CenterRateSP[2].fill("600x", "", ISS_OFF);
+    CenterRateSP[3].fill("1200x", "", ISS_OFF);
+    CenterRateSP.fill(getDeviceName(),
                        "CENTER_RATE", "Center Speed", MOTION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     TrackModeSP.nsp = 3;
@@ -160,18 +160,18 @@ bool ioptronHC8406::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&SyncCMRSP);
-        defineProperty(&GuideRateSP);
-        defineProperty(&CenterRateSP);
-        defineProperty(&CursorMoveSpeedSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(GuideRateSP);
+        defineProperty(CenterRateSP);
+        defineProperty(CursorMoveSpeedSP);
         ioptronHC8406Init();
     }
     else
     {
-        deleteProperty(SyncCMRSP.name);
-        deleteProperty(GuideRateSP.name);
-        deleteProperty(CenterRateSP.name);
-        deleteProperty(CursorMoveSpeedSP.name);
+        deleteProperty(SyncCMRSP.getName());
+        deleteProperty(GuideRateSP.getName());
+        deleteProperty(CenterRateSP.getName());
+        deleteProperty(CursorMoveSpeedSP.getName());
     }
 
     return true;
@@ -237,79 +237,79 @@ bool ioptronHC8406::ISNewSwitch(const char *dev, const char *name, ISState *stat
     {
 
         // Sync type
-        if (!strcmp(name, SyncCMRSP.name))
+        if (SyncCMRSP.isNameMatch(name))
         {
-            IUResetSwitch(&SyncCMRSP);
-            IUUpdateSwitch(&SyncCMRSP, states, names, n);
-            IUFindOnSwitchIndex(&SyncCMRSP);
-            SyncCMRSP.s = IPS_OK;
-            IDSetSwitch(&SyncCMRSP, nullptr);
+            SyncCMRSP.reset();
+            SyncCMRSP.update(states, names, n);
+            SyncCMRSP.findOnSwitchIndex();
+            SyncCMRSP.setState(IPS_OK);
+            SyncCMRSP.apply();
             return true;
         }
 
         // Cursor move type
-        if (!strcmp(name, CursorMoveSpeedSP.name))
+        if (CursorMoveSpeedSP.isNameMatch(name))
         {
-            int currentSwitch = IUFindOnSwitchIndex(&CursorMoveSpeedSP);
-            IUUpdateSwitch(&CursorMoveSpeedSP, states, names, n);
-            if (setioptronHC8406CursorMoveSpeed(IUFindOnSwitchIndex(&CursorMoveSpeedSP)) == TTY_OK)
-                CursorMoveSpeedSP.s = IPS_OK;
+            int currentSwitch = CursorMoveSpeedSP.findOnSwitchIndex();
+            CursorMoveSpeedSP.update(states, names, n);
+            if (setioptronHC8406CursorMoveSpeed(CursorMoveSpeedSP.findOnSwitchIndex()) == TTY_OK)
+                CursorMoveSpeedSP.setState(IPS_OK);
             else
             {
-                IUResetSwitch(&CursorMoveSpeedSP);
-                CursorMoveSpeedS[currentSwitch].s = ISS_ON;
-                CursorMoveSpeedSP.s = IPS_ALERT;
+                CursorMoveSpeedSP.reset();
+                CursorMoveSpeedSP[currentSwitch].setState(ISS_ON);
+                CursorMoveSpeedSP.setState(IPS_ALERT);
             }
             return true;
         }
 
         // Guide Rate
-        if (!strcmp(GuideRateSP.name, name))
+        if (GuideRateSP.isNameMatch(name))
         {
-            int currentSwitch = IUFindOnSwitchIndex(&GuideRateSP);
-            IUUpdateSwitch(&GuideRateSP, states, names, n);
-            if (setioptronHC8406GuideRate(IUFindOnSwitchIndex(&GuideRateSP)) == TTY_OK)
+            int currentSwitch = GuideRateSP.findOnSwitchIndex();
+            GuideRateSP.update(states, names, n);
+            if (setioptronHC8406GuideRate(GuideRateSP.findOnSwitchIndex()) == TTY_OK)
             {
-                GuideRateSP.s = IPS_OK;
+                GuideRateSP.setState(IPS_OK);
                 //Shows guide speed selected
-                CursorMoveSpeedS[USE_GUIDE_SPEED].s = ISS_ON;
-                CursorMoveSpeedS[USE_CENTERING_SPEED].s = ISS_OFF;
-                CursorMoveSpeedSP.s = IPS_OK;
-                IDSetSwitch(&CursorMoveSpeedSP, nullptr);
+                CursorMoveSpeedSP[USE_GUIDE_SPEED].setState(ISS_ON);
+                CursorMoveSpeedSP[USE_CENTERING_SPEED].setState(ISS_OFF);
+                CursorMoveSpeedSP.setState(IPS_OK);
+                CursorMoveSpeedSP.apply();
             }
             else
             {
-                IUResetSwitch(&GuideRateSP);
-                GuideRateS[currentSwitch].s = ISS_ON;
-                GuideRateSP.s = IPS_ALERT;
+                GuideRateSP.reset();
+                GuideRateSP[currentSwitch].setState(ISS_ON);
+                GuideRateSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&GuideRateSP, nullptr);
+            GuideRateSP.apply();
             return true;
         }
 
         // Center Rate
-        if (!strcmp(CenterRateSP.name, name))
+        if (CenterRateSP.isNameMatch(name))
         {
-            int currentSwitch = IUFindOnSwitchIndex(&CenterRateSP);
-            IUUpdateSwitch(&CenterRateSP, states, names, n);
-            if (setioptronHC8406CenterRate(IUFindOnSwitchIndex(&CenterRateSP)) == TTY_OK)
+            int currentSwitch = CenterRateSP.findOnSwitchIndex();
+            CenterRateSP.update(states, names, n);
+            if (setioptronHC8406CenterRate(CenterRateSP.findOnSwitchIndex()) == TTY_OK)
             {
-                CenterRateSP.s = IPS_OK;
+                CenterRateSP.setState(IPS_OK);
                 //Shows centering speed selected
-                CursorMoveSpeedS[USE_GUIDE_SPEED].s = ISS_OFF;
-                CursorMoveSpeedS[USE_CENTERING_SPEED].s = ISS_ON;
-                CursorMoveSpeedSP.s = IPS_OK;
-                IDSetSwitch(&CursorMoveSpeedSP, nullptr);
+                CursorMoveSpeedSP[USE_GUIDE_SPEED].setState(ISS_OFF);
+                CursorMoveSpeedSP[USE_CENTERING_SPEED].setState(ISS_ON);
+                CursorMoveSpeedSP.setState(IPS_OK);
+                CursorMoveSpeedSP.apply();
             }
             else
             {
-                IUResetSwitch(&CenterRateSP);
-                CenterRateS[currentSwitch].s = ISS_ON;
-                CenterRateSP.s = IPS_ALERT;
+                CenterRateSP.reset();
+                CenterRateSP[currentSwitch].setState(ISS_ON);
+                CenterRateSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&CenterRateSP, nullptr);
+            CenterRateSP.apply();
             return true;
         }
 
@@ -380,29 +380,29 @@ bool ioptronHC8406::Goto(double r, double d)
     LOGF_DEBUG("<GOTO RA/DEC> %s/%s", RAStr, DecStr);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
-        if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
         {
-            MovementNSSP.s = IPS_IDLE;
-            MovementWESP.s = IPS_IDLE;
-            EqNP.s = IPS_IDLE;
-            IUResetSwitch(&MovementNSSP);
-            IUResetSwitch(&MovementWESP);
-            IDSetSwitch(&MovementNSSP, nullptr);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementNSSP.setState(IPS_IDLE);
+            MovementWESP.setState(IPS_IDLE);
+            EqNP.setState(IPS_IDLE);
+            MovementNSSP.reset();
+            MovementWESP.reset();
+            MovementNSSP.apply();
+            MovementWESP.apply();
         }
 
         // sleep for 100 mseconds
@@ -413,15 +413,15 @@ bool ioptronHC8406::Goto(double r, double d)
     {
         if (setObjectRA(PortFD, targetRA) < 0 || (setObjectDEC(PortFD, targetDEC)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
         if (slewioptronHC8406() == 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
             slewError(1);
             return false;
         }
@@ -435,14 +435,14 @@ bool ioptronHC8406::Goto(double r, double d)
 bool ioptronHC8406::Sync(double ra, double dec)
 {
     char syncString[256];
-    int syncType = IUFindOnSwitchIndex(&SyncCMRSP);
+    int syncType = SyncCMRSP.findOnSwitchIndex();
 
     if (!isSimulation())
     {
         if (setObjectRA(PortFD, ra) < 0 || setObjectDEC(PortFD, dec) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC. Unable to Sync.");
             return false;
         }
 
@@ -466,8 +466,8 @@ bool ioptronHC8406::Sync(double ra, double dec)
 
         if (syncOK == false)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Synchronization failed.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Synchronization failed.");
             return false;
         }
 
@@ -873,7 +873,7 @@ bool ioptronHC8406::ReadScopeStatus()
         if (isSlewComplete())
         {
             nanosleep(&timeout, nullptr); //Wait until :MS# finish
-            if (IUFindSwitch(&CoordSP, "SYNC")->s == ISS_ON || IUFindSwitch(&CoordSP, "SLEW")->s == ISS_ON)
+            if (CoordSP.findWidgetByName("SYNC")->s == ISS_ON || CoordSP.findWidgetByName("SLEW")->s == ISS_ON)
             {
                 TrackState = SCOPE_IDLE;
                 LOG_WARN("Slew is complete. IDLE");
@@ -899,8 +899,8 @@ bool ioptronHC8406::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -1113,7 +1113,7 @@ bool ioptronHC8406::saveConfigItems(FILE *fp)
 {
     LX200Generic::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &SyncCMRSP);
+    SyncCMRSP.save(fp);
 
     return true;
 }
@@ -1161,10 +1161,10 @@ void ioptronHC8406::sendScopeTime()
     {
         snprintf(cdate, 32, "%d-%02d-%02dT%02d:%02d:%02d", 1979, 6, 25, 3, 30, 30);
         IDLog("Telescope ISO date and time: %s\n", cdate);
-        IUSaveText(&TimeT[0], cdate);
-        IUSaveText(&TimeT[1], "3");
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP[0].setText(cdate);
+        TimeTP[1].setText("3");
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
         return;
     }
 
@@ -1182,8 +1182,8 @@ void ioptronHC8406::sendScopeTime()
     LOGF_DEBUG("<VAL> UTC offset: %d:%d:%d --->%g", utc_h, utc_m, utc_s, lx200_utc_offset);
     // LX200 TimeT Offset is defined at the number of hours added to LOCAL TIME to get TimeT. This is contrary to the normal definition.
     LOGF_DEBUG("<VAL> UTC offset str: %s", utc_offset_res);
-    IUSaveText(&TimeT[1], utc_offset_res);
-    //IUSaveText(&TimeT[1], lx200_utc_offset);
+    TimeTP[1].setText(utc_offset_res);
+    //TimeTP[1].setText(lx200_utc_offset);
 
     getLocalTime24(PortFD, &ctime);
     getSexComponents(ctime, &h, &m, &s);
@@ -1208,7 +1208,7 @@ void ioptronHC8406::sendScopeTime()
     time_epoch = mktime(&ltm);
 
     // Convert to TimeT
-    //time_epoch -= (int)(atof(TimeT[1].text) * 3600.0);
+    //time_epoch -= (int)(atof(TimeTP[1].getText()) * 3600.0);
     time_epoch -= (int)(lx200_utc_offset * 3600.0);
 
     // Get UTC (we're using localtime_r, but since we shifted time_epoch above by UTCOffset, we should be getting the real UTC time
@@ -1216,14 +1216,14 @@ void ioptronHC8406::sendScopeTime()
 
     /* Format it into ISO 8601 */
     strftime(cdate, 32, "%Y-%m-%dT%H:%M:%S", &utm);
-    IUSaveText(&TimeT[0], cdate);
+    TimeTP[0].setText(cdate);
 
     LOGF_DEBUG("Mount controller Local Time: %02d:%02d:%02d", h, m, s);
-    LOGF_DEBUG("Mount controller UTC Time: %s", TimeT[0].text);
+    LOGF_DEBUG("Mount controller UTC Time: %s", TimeTP[0].getText());
 
     // Let's send everything to the client
-    TimeTP.s = IPS_OK;
-    IDSetText(&TimeTP, nullptr);
+    TimeTP.setState(IPS_OK);
+    TimeTP.apply();
 }
 
 int ioptronHC8406::SendPulseCmd(int8_t direction, uint32_t duration_msec)

--- a/drivers/telescope/ioptronHC8406.h
+++ b/drivers/telescope/ioptronHC8406.h
@@ -22,6 +22,9 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertyswitch.h"
+
 
 
 class ioptronHC8406 : public LX200Generic
@@ -96,20 +99,16 @@ class ioptronHC8406 : public LX200Generic
     void mountSim();
 
     // Sync type
-    ISwitch SyncCMRS[2];
-    ISwitchVectorProperty SyncCMRSP;
+    INDI::PropertySwitch SyncCMRSP {2};
     enum { USE_REGULAR_SYNC, USE_CMR_SYNC };
 
     //Cursor move speed
-    ISwitch CursorMoveSpeedS[3];
-    ISwitchVectorProperty CursorMoveSpeedSP;
+    INDI::PropertySwitch CursorMoveSpeedSP {3};
     enum { USE_GUIDE_SPEED, USE_CENTERING_SPEED, USE_SLEW_SPEED };
     int setioptronHC8406CursorMoveSpeed(int type);
     /* Guide Rate */
-    ISwitch GuideRateS[3];
-    ISwitchVectorProperty GuideRateSP;
+    INDI::PropertySwitch GuideRateSP {3};
 
     /* Center Rate */
-    ISwitch CenterRateS[4];
-    ISwitchVectorProperty CenterRateSP;
+    INDI::PropertySwitch CenterRateSP {4};
 };

--- a/drivers/telescope/ioptronv3.cpp
+++ b/drivers/telescope/ioptronv3.cpp
@@ -130,12 +130,12 @@ bool IOptronV3::initProperties()
     SlewRateS[4].s = ISS_ON;
 
     /* Firmware */
-    IUFillText(&FirmwareT[FW_MODEL], "Model", "", nullptr);
-    IUFillText(&FirmwareT[FW_BOARD], "Board", "", nullptr);
-    IUFillText(&FirmwareT[FW_CONTROLLER], "Controller", "", nullptr);
-    IUFillText(&FirmwareT[FW_RA], "RA", "", nullptr);
-    IUFillText(&FirmwareT[FW_DEC], "DEC", "", nullptr);
-    IUFillTextVector(&FirmwareTP, FirmwareT, 5, getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
+    FirmwareTP[FW_MODEL].fill("Model", "", nullptr);
+    FirmwareTP[FW_BOARD].fill("Board", "", nullptr);
+    FirmwareTP[FW_CONTROLLER].fill("Controller", "", nullptr);
+    FirmwareTP[FW_RA].fill("RA", "", nullptr);
+    FirmwareTP[FW_DEC].fill("DEC", "", nullptr);
+    FirmwareTP.fill(getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
                      IPS_IDLE);
 
     /* Tracking Mode */
@@ -146,70 +146,70 @@ bool IOptronV3::initProperties()
     AddTrackMode("TRACK_CUSTOM", "Custom");
 
     /* GPS Status */
-    IUFillSwitch(&GPSStatusS[GPS_OFF], "Off", "", ISS_ON);
-    IUFillSwitch(&GPSStatusS[GPS_ON], "On", "", ISS_OFF);
-    IUFillSwitch(&GPSStatusS[GPS_DATA_OK], "Data OK", "", ISS_OFF);
-    IUFillSwitchVector(&GPSStatusSP, GPSStatusS, 3, getDeviceName(), "GPS_STATUS", "GPS", MOUNTINFO_TAB, IP_RO,
+    GPSStatusSP[GPS_OFF].fill("Off", "", ISS_ON);
+    GPSStatusSP[GPS_ON].fill("On", "", ISS_OFF);
+    GPSStatusSP[GPS_DATA_OK].fill("Data OK", "", ISS_OFF);
+    GPSStatusSP.fill(getDeviceName(), "GPS_STATUS", "GPS", MOUNTINFO_TAB, IP_RO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Time Source */
-    IUFillSwitch(&TimeSourceS[TS_RS232], "RS232", "", ISS_ON);
-    IUFillSwitch(&TimeSourceS[TS_CONTROLLER], "Controller", "", ISS_OFF);
-    IUFillSwitch(&TimeSourceS[TS_GPS], "GPS", "", ISS_OFF);
-    IUFillSwitchVector(&TimeSourceSP, TimeSourceS, 3, getDeviceName(), "TIME_SOURCE", "Time Source", MOUNTINFO_TAB,
+    TimeSourceSP[TS_RS232].fill("RS232", "", ISS_ON);
+    TimeSourceSP[TS_CONTROLLER].fill("Controller", "", ISS_OFF);
+    TimeSourceSP[TS_GPS].fill("GPS", "", ISS_OFF);
+    TimeSourceSP.fill(getDeviceName(), "TIME_SOURCE", "Time Source", MOUNTINFO_TAB,
                        IP_RO, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Hemisphere */
-    IUFillSwitch(&HemisphereS[HEMI_SOUTH], "South", "", ISS_OFF);
-    IUFillSwitch(&HemisphereS[HEMI_NORTH], "North", "", ISS_ON);
-    IUFillSwitchVector(&HemisphereSP, HemisphereS, 2, getDeviceName(), "HEMISPHERE", "Hemisphere", MOUNTINFO_TAB, IP_RO,
+    HemisphereSP[HEMI_SOUTH].fill("South", "", ISS_OFF);
+    HemisphereSP[HEMI_NORTH].fill("North", "", ISS_ON);
+    HemisphereSP.fill(getDeviceName(), "HEMISPHERE", "Hemisphere", MOUNTINFO_TAB, IP_RO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Home */
-    IUFillSwitch(&HomeS[IOP_FIND_HOME], "FindHome", "Find Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IOP_SET_HOME], "SetCurrentAsHome", "Set current as Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IOP_GOTO_HOME], "GoToHome", "Go to Home", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 3, getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
+    HomeSP[IOP_FIND_HOME].fill("FindHome", "Find Home", ISS_OFF);
+    HomeSP[IOP_SET_HOME].fill("SetCurrentAsHome", "Set current as Home", ISS_OFF);
+    HomeSP[IOP_GOTO_HOME].fill("GoToHome", "Go to Home", ISS_OFF);
+    HomeSP.fill(getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
                        IPS_IDLE);
 
     /* v3.0 Create PEC Training switches */
     // PEC Training
-    IUFillSwitch(&PECTrainingS[0], "PEC_Recording", "Record", ISS_OFF);
-    IUFillSwitch(&PECTrainingS[1], "PEC_Status", "Status", ISS_OFF);
-    IUFillSwitchVector(&PECTrainingSP, PECTrainingS, 2, getDeviceName(), "PEC_TRAINING", "Training", MOTION_TAB, IP_RW,
+    PECTrainingSP[0].fill("PEC_Recording", "Record", ISS_OFF);
+    PECTrainingSP[1].fill("PEC_Status", "Status", ISS_OFF);
+    PECTrainingSP.fill(getDeviceName(), "PEC_TRAINING", "Training", MOTION_TAB, IP_RW,
                        ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Create PEC Training Information */
-    IUFillText(&PECInfoT[0], "PEC_INFO", "Status", "");
-    IUFillTextVector(&PECInfoTP, PECInfoT, 1, getDeviceName(), "PEC_INFOS", "Data", MOTION_TAB,
+    PECInfoTP[0].fill("PEC_INFO", "Status", "");
+    PECInfoTP.fill(getDeviceName(), "PEC_INFOS", "Data", MOTION_TAB,
                      IP_RO, 60, IPS_IDLE);
     // End Mod */
 
     /* How fast do we guide compared to sidereal rate */
-    IUFillNumber(&GuideRateN[0], "RA_GUIDE_RATE", "x Sidereal", "%g", 0.01, 0.9, 0.1, 0.5);
-    IUFillNumber(&GuideRateN[1], "DE_GUIDE_RATE", "x Sidereal", "%g", 0.1, 0.99, 0.1, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
+    GuideRateNP[0].fill("RA_GUIDE_RATE", "x Sidereal", "%g", 0.01, 0.9, 0.1, 0.5);
+    GuideRateNP[1].fill("DE_GUIDE_RATE", "x Sidereal", "%g", 0.1, 0.99, 0.1, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
 
     /* Slew Mode. Normal vs Counter Weight up */
-    IUFillSwitch(&SlewModeS[IOP_CW_NORMAL], "Normal", "Normal", ISS_ON);
-    IUFillSwitch(&SlewModeS[IOP_CW_UP], "Counterweight UP", "Counterweight up", ISS_OFF);
-    IUFillSwitchVector(&SlewModeSP, SlewModeS, 2, getDeviceName(), "Slew Type", "Slew Type", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SlewModeSP[IOP_CW_NORMAL].fill("Normal", "Normal", ISS_ON);
+    SlewModeSP[IOP_CW_UP].fill("Counterweight UP", "Counterweight up", ISS_OFF);
+    SlewModeSP.fill(getDeviceName(), "Slew Type", "Slew Type", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     /* Daylight Savings */
-    IUFillSwitch(&DaylightS[0], "ON", "ON", ISS_OFF);
-    IUFillSwitch(&DaylightS[1], "OFF", "OFF", ISS_ON);
-    IUFillSwitchVector(&DaylightSP, DaylightS, 2, getDeviceName(), "DaylightSaving", "Daylight Savings", SITE_TAB, IP_RW,
+    DaylightSP[0].fill("ON", "ON", ISS_OFF);
+    DaylightSP[1].fill("OFF", "OFF", ISS_ON);
+    DaylightSP.fill(getDeviceName(), "DaylightSaving", "Daylight Savings", SITE_TAB, IP_RW,
                        ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     /* Counter Weight State */
-    IUFillSwitch(&CWStateS[IOP_CW_NORMAL], "Normal", "Normal", ISS_ON);
-    IUFillSwitch(&CWStateS[IOP_CW_UP], "Up", "Up", ISS_OFF);
-    IUFillSwitchVector(&CWStateSP, CWStateS, 2, getDeviceName(), "CWState", "Counter weights", MOTION_TAB, IP_RO, ISR_1OFMANY,
+    CWStateSP[IOP_CW_NORMAL].fill("Normal", "Normal", ISS_ON);
+    CWStateSP[IOP_CW_UP].fill("Up", "Up", ISS_OFF);
+    CWStateSP.fill(getDeviceName(), "CWState", "Counter weights", MOTION_TAB, IP_RO, ISR_1OFMANY,
                        0,
                        IPS_IDLE);
 
@@ -252,47 +252,47 @@ bool IOptronV3::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&HomeSP);
+        defineProperty(HomeSP);
 
         /* v3.0 Create PEC switches */
-        defineProperty(&PECTrainingSP);
-        defineProperty(&PECInfoTP);
+        defineProperty(PECTrainingSP);
+        defineProperty(PECInfoTP);
         // End Mod */
 
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
-        defineProperty(&GuideRateNP);
+        defineProperty(GuideRateNP);
 
-        defineProperty(&FirmwareTP);
-        defineProperty(&GPSStatusSP);
-        defineProperty(&TimeSourceSP);
-        defineProperty(&HemisphereSP);
-        defineProperty(&SlewModeSP);
-        defineProperty(&DaylightSP);
-        defineProperty(&CWStateSP);
+        defineProperty(FirmwareTP);
+        defineProperty(GPSStatusSP);
+        defineProperty(TimeSourceSP);
+        defineProperty(HemisphereSP);
+        defineProperty(SlewModeSP);
+        defineProperty(DaylightSP);
+        defineProperty(CWStateSP);
 
         getStartupData();
     }
     else
     {
-        deleteProperty(HomeSP.name);
+        deleteProperty(HomeSP.getName());
 
         /* v3.0 Delete PEC switches */
-        deleteProperty(PECTrainingSP.name);
-        deleteProperty(PECInfoTP.name);
+        deleteProperty(PECTrainingSP.getName());
+        deleteProperty(PECInfoTP.getName());
         // End Mod*/
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
-        deleteProperty(GuideRateNP.name);
+        deleteProperty(GuideRateNP.getName());
 
-        deleteProperty(FirmwareTP.name);
-        deleteProperty(GPSStatusSP.name);
-        deleteProperty(TimeSourceSP.name);
-        deleteProperty(HemisphereSP.name);
-        deleteProperty(SlewModeSP.name);
-        deleteProperty(DaylightSP.name);
-        deleteProperty(CWStateSP.name);
+        deleteProperty(FirmwareTP.getName());
+        deleteProperty(GPSStatusSP.getName());
+        deleteProperty(TimeSourceSP.getName());
+        deleteProperty(HemisphereSP.getName());
+        deleteProperty(SlewModeSP.getName());
+        deleteProperty(DaylightSP.getName());
+        deleteProperty(CWStateSP.getName());
     }
 
     return true;
@@ -303,23 +303,23 @@ void IOptronV3::getStartupData()
     LOG_DEBUG("Getting firmware data...");
     if (driver->getFirmwareInfo(&firmwareInfo))
     {
-        IUSaveText(&FirmwareT[0], firmwareInfo.Model.c_str());
-        IUSaveText(&FirmwareT[1], firmwareInfo.MainBoardFirmware.c_str());
-        IUSaveText(&FirmwareT[2], firmwareInfo.ControllerFirmware.c_str());
-        IUSaveText(&FirmwareT[3], firmwareInfo.RAFirmware.c_str());
-        IUSaveText(&FirmwareT[4], firmwareInfo.DEFirmware.c_str());
+        FirmwareTP[0].setText(firmwareInfo.Model);
+        FirmwareTP[1].setText(firmwareInfo.MainBoardFirmware);
+        FirmwareTP[2].setText(firmwareInfo.ControllerFirmware);
+        FirmwareTP[3].setText(firmwareInfo.RAFirmware);
+        FirmwareTP[4].setText(firmwareInfo.DEFirmware);
 
-        FirmwareTP.s = IPS_OK;
-        IDSetText(&FirmwareTP, nullptr);
+        FirmwareTP.setState(IPS_OK);
+        FirmwareTP.apply();
     }
 
     LOG_DEBUG("Getting guiding rate...");
     double RARate = 0, DERate = 0;
     if (driver->getGuideRate(&RARate, &DERate))
     {
-        GuideRateN[RA_AXIS].value = RARate;
-        GuideRateN[DEC_AXIS].value = DERate;
-        IDSetNumber(&GuideRateNP, nullptr);
+        GuideRateNP[RA_AXIS].setValue(RARate);
+        GuideRateNP[DEC_AXIS].setValue(DERate);
+        GuideRateNP.apply();
     }
 
     int utcOffsetMinutes = 0;
@@ -335,39 +335,39 @@ void IOptronV3::getStartupData()
         struct tm *utc;
         utc = gmtime(&utc_time);
         strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", utc);
-        IUSaveText(&TimeT[0], ts);
+        TimeTP[0].setText(ts);
         LOGF_INFO("Mount UTC: %s", ts);
 
         // UTC Offset
         char offset[8] = {0};
         snprintf(offset, 8, "%.2f", utcOffsetMinutes / 60.0);
-        IUSaveText(&TimeT[1], offset);
+        TimeTP[1].setText(offset);
         LOGF_INFO("Mount UTC Offset: %s", offset);
 
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
 
         LOGF_INFO("Mount Daylight Savings: %s", dayLightSavings ? "ON" : "OFF");
-        DaylightS[0].s = dayLightSavings ? ISS_ON : ISS_OFF;
-        DaylightS[1].s = !dayLightSavings ? ISS_ON : ISS_OFF;
-        DaylightSP.s = IPS_OK;
-        IDSetSwitch(&DaylightSP, nullptr);
+        DaylightSP[0].setState(dayLightSavings ? ISS_ON : ISS_OFF);
+        DaylightSP[1].setState(!dayLightSavings ? ISS_ON : ISS_OFF);
+        DaylightSP.setState(IPS_OK);
+        DaylightSP.apply();
     }
 
     // Get Longitude and Latitude from mount
     double longitude = 0, latitude = 0;
     if (driver->getStatus(&scopeInfo))
     {
-        LocationN[LOCATION_LATITUDE].value  = scopeInfo.latitude;
+        LocationNP[LOCATION_LATITUDE].setValue(scopeInfo.latitude);
         // Convert to INDI standard longitude (0 to 360 Eastward)
-        LocationN[LOCATION_LONGITUDE].value = (scopeInfo.longitude < 0) ? scopeInfo.longitude + 360 : scopeInfo.longitude;
-        LocationNP.s                        = IPS_OK;
+        LocationNP[LOCATION_LONGITUDE].setValue((scopeInfo.longitude < 0) ? scopeInfo.longitude + 360 : scopeInfo.longitude);
+        LocationNP.setState(IPS_OK);
 
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
 
         char l[32] = {0}, L[32] = {0};
-        fs_sexa(l, LocationN[LOCATION_LATITUDE].value, 3, 3600);
-        fs_sexa(L, LocationN[LOCATION_LONGITUDE].value, 4, 3600);
+        fs_sexa(l, LocationNP[LOCATION_LATITUDE].getValue(), 3, 3600);
+        fs_sexa(L, LocationNP[LOCATION_LONGITUDE].getValue(), 4, 3600);
 
         LOGF_INFO("Mount Location: Lat %.32s - Long %.32s", l, L);
 
@@ -376,15 +376,15 @@ void IOptronV3::getStartupData()
     else if (IUGetConfigNumber(getDeviceName(), "GEOGRAPHIC_COORD", "LONG", &longitude) == 0 &&
              IUGetConfigNumber(getDeviceName(), "GEOGRAPHIC_COORD", "LAT", &latitude) == 0)
     {
-        LocationN[LOCATION_LATITUDE].value  = latitude;
-        LocationN[LOCATION_LONGITUDE].value = longitude;
-        LocationNP.s                        = IPS_OK;
+        LocationNP[LOCATION_LATITUDE].setValue(latitude);
+        LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+        LocationNP.setState(IPS_OK);
 
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
     }
 
-    double parkAZ = LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180;
-    double parkAL = LocationN[LOCATION_LATITUDE].value;
+    double parkAZ = LocationNP[LOCATION_LATITUDE].getValue() >= 0 ? 0 : 180;
+    double parkAL = LocationNP[LOCATION_LATITUDE].getValue();
     if (InitPark())
     {
         // If loading parking data is successful, we just set the default parking values.
@@ -444,16 +444,16 @@ bool IOptronV3::ISNewNumber(const char *dev, const char *name, double values[], 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Guiding Rate
-        if (!strcmp(name, GuideRateNP.name))
+        if (GuideRateNP.isNameMatch(name))
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
+            GuideRateNP.update(values, names, n);
 
-            if (driver->setGuideRate(GuideRateN[RA_AXIS].value, GuideRateN[DEC_AXIS].value))
-                GuideRateNP.s = IPS_OK;
+            if (driver->setGuideRate(GuideRateNP[RA_AXIS].value, GuideRateNP[DEC_AXIS].getValue()))
+                GuideRateNP.setState(IPS_OK);
             else
-                GuideRateNP.s = IPS_ALERT;
+                GuideRateNP.setState(IPS_ALERT);
 
-            IDSetNumber(&GuideRateNP, nullptr);
+            GuideRateNP.apply();
 
             return true;
         }
@@ -475,13 +475,13 @@ bool IOptronV3::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         /*******************************************************
          * Home Operations
         *******************************************************/
-        if (!strcmp(name, HomeSP.name))
+        if (HomeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&HomeSP, states, names, n);
+            HomeSP.update(states, names, n);
 
-            IOP_HOME_OPERATION operation = (IOP_HOME_OPERATION)IUFindOnSwitchIndex(&HomeSP);
+            IOP_HOME_OPERATION operation = (IOP_HOME_OPERATION)HomeSP.findOnSwitchIndex();
 
-            IUResetSwitch(&HomeSP);
+            HomeSP.reset();
 
             switch (operation)
             {
@@ -489,47 +489,47 @@ bool IOptronV3::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                     if (firmwareInfo.Model.find("CEM") == std::string::npos &&
                             firmwareInfo.Model.find("GEM45") == std::string::npos)
                     {
-                        HomeSP.s = IPS_IDLE;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_IDLE);
+                        HomeSP.apply();
                         LOG_WARN("Home search is not supported in this model.");
                         return true;
                     }
 
                     if (driver->findHome() == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Searching for home position...");
                     return true;
 
                 case IOP_SET_HOME:
                     if (driver->setCurrentHome() == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Home position set to current coordinates.");
                     return true;
 
                 case IOP_GOTO_HOME:
                     if (driver->gotoHome() == false)
                     {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
+                        HomeSP.setState(IPS_ALERT);
+                        HomeSP.apply();
                         return false;
                     }
 
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
                     LOG_INFO("Slewing to home position...");
                     return true;
             }
@@ -540,37 +540,37 @@ bool IOptronV3::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         /*******************************************************
          * Slew Mode Operations
         *******************************************************/
-        if (!strcmp(name, SlewModeSP.name))
+        if (SlewModeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SlewModeSP, states, names, n);
-            SlewModeSP.s = IPS_OK;
-            IDSetSwitch(&SlewModeSP, nullptr);
+            SlewModeSP.update(states, names, n);
+            SlewModeSP.setState(IPS_OK);
+            SlewModeSP.apply();
             return true;
         }
 
         /*******************************************************
          * Daylight Savings Operations
         *******************************************************/
-        if (!strcmp(name, DaylightSP.name))
+        if (DaylightSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&DaylightSP, states, names, n);
+            DaylightSP.update(states, names, n);
 
-            if (driver->setDaylightSaving(DaylightS[0].s == ISS_ON))
-                DaylightSP.s = IPS_OK;
+            if (driver->setDaylightSaving(DaylightSP[0].getState() == ISS_ON))
+                DaylightSP.setState(IPS_OK);
             else
-                DaylightSP.s = IPS_ALERT;
+                DaylightSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&DaylightSP, nullptr);
+            DaylightSP.apply();
             return true;
         }
     }
 
     /* v3.0 PEC add controls and calls to the driver */
-    if (!strcmp(name, PECStateSP.name))
+    if (PECStateSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&PECStateSP, states, names, n);
+        PECStateSP.update(states, names, n);
 
-        if(IUFindOnSwitchIndex(&PECStateSP) == 0)
+        if(PECStateSP.findOnSwitchIndex() == 0)
         {
             // PEC OFF
             if(isTraining)
@@ -582,53 +582,53 @@ bool IOptronV3::ISNewSwitch(const char *dev, const char *name, ISState *states, 
             else
             {
                 driver->setPECEnabled(false);
-                PECStateSP.s = IPS_OK;
+                PECStateSP.setState(IPS_OK);
                 LOG_INFO("Disabling PEC Chip");
             }
         }
 
-        if(IUFindOnSwitchIndex(&PECStateSP) == 1)
+        if(PECStateSP.findOnSwitchIndex() == 1)
         {
             // PEC ON
             if (GetPECDataStatus(true))
             {
                 // Data Check
                 driver->setPECEnabled(true);
-                PECStateSP.s = IPS_BUSY;
+                PECStateSP.setState(IPS_BUSY);
                 LOG_INFO("Enabling PEC Chip");
             }
         }
-        IDSetSwitch(&PECStateSP, nullptr);
+        PECStateSP.apply();
         return true;
     }
     // End Mod */
 
     /* v3.0 PEC add Training Controls to the Driver */
-    if (!strcmp(name, PECTrainingSP.name))
+    if (PECTrainingSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&PECTrainingSP, states, names, n);
+        PECTrainingSP.update(states, names, n);
         if(isTraining)
         {
             // Check if already training
-            if(IUFindOnSwitchIndex(&PECTrainingSP) == 1)
+            if(PECTrainingSP.findOnSwitchIndex() == 1)
             {
                 // Train Check Status
                 sprintf(PECText, "Mount PEC busy recording, %d s", PECTime);
                 LOG_WARN(PECText);
             }
 
-            if(IUFindOnSwitchIndex(&PECTrainingSP) == 0)
+            if(PECTrainingSP.findOnSwitchIndex() == 0)
             {
                 // Train Cancel
                 driver->setPETEnabled(false);
                 isTraining = false;
-                PECTrainingSP.s = IPS_ALERT;
+                PECTrainingSP.setState(IPS_ALERT);
                 LOG_WARN("PEC Training cancelled by user, chip disabled");
             }
         }
         else
         {
-            if(IUFindOnSwitchIndex(&PECTrainingSP) == 0)
+            if(PECTrainingSP.findOnSwitchIndex() == 0)
             {
                 if(TrackState == SCOPE_TRACKING)
                 {
@@ -636,22 +636,22 @@ bool IOptronV3::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                     driver->setPETEnabled(true);
                     isTraining = true;
                     PECTime = 0;
-                    PECTrainingSP.s = IPS_BUSY;
+                    PECTrainingSP.setState(IPS_BUSY);
                     LOG_INFO("PEC recording started...");
                 }
                 else
                 {
                     LOG_WARN("PEC Training only possible while guiding");
-                    PECTrainingSP.s = IPS_IDLE;
+                    PECTrainingSP.setState(IPS_IDLE);
                 }
             }
-            if(IUFindOnSwitchIndex(&PECTrainingSP) == 1)
+            if(PECTrainingSP.findOnSwitchIndex() == 1)
             {
                 // Train Status
                 GetPECDataStatus(true);
             }
         }
-        IDSetSwitch(&PECTrainingSP, nullptr);
+        PECTrainingSP.apply();
         return true;
     }
     // End Mod */
@@ -672,25 +672,25 @@ bool IOptronV3::ReadScopeStatus()
 
     if (rc)
     {
-        if (IUFindOnSwitchIndex(&GPSStatusSP) != newInfo.gpsStatus)
+        if (GPSStatusSP.findOnSwitchIndex() != newInfo.gpsStatus)
         {
-            IUResetSwitch(&GPSStatusSP);
-            GPSStatusS[newInfo.gpsStatus].s = ISS_ON;
-            IDSetSwitch(&GPSStatusSP, nullptr);
+            GPSStatusSP.reset();
+            GPSStatusSP[newInfo.gpsStatus].setState(ISS_ON);
+            GPSStatusSP.apply();
         }
 
-        if (IUFindOnSwitchIndex(&TimeSourceSP) != newInfo.timeSource)
+        if (TimeSourceSP.findOnSwitchIndex() != newInfo.timeSource)
         {
-            IUResetSwitch(&TimeSourceSP);
-            TimeSourceS[newInfo.timeSource].s = ISS_ON;
-            IDSetSwitch(&TimeSourceSP, nullptr);
+            TimeSourceSP.reset();
+            TimeSourceSP[newInfo.timeSource].setState(ISS_ON);
+            TimeSourceSP.apply();
         }
 
-        if (IUFindOnSwitchIndex(&HemisphereSP) != newInfo.hemisphere)
+        if (HemisphereSP.findOnSwitchIndex() != newInfo.hemisphere)
         {
-            IUResetSwitch(&HemisphereSP);
-            HemisphereS[newInfo.hemisphere].s = ISS_ON;
-            IDSetSwitch(&HemisphereSP, nullptr);
+            HemisphereSP.reset();
+            HemisphereSP[newInfo.hemisphere].setState(ISS_ON);
+            HemisphereSP.apply();
         }
 
         if (IUFindOnSwitchIndex(&SlewRateSP) != newInfo.slewRate - 1)
@@ -780,26 +780,26 @@ bool IOptronV3::ReadScopeStatus()
             {
                 sprintf(PECText, "%d second worm cycle recorded", PECTime);
                 LOG_INFO(PECText);
-                PECTrainingSP.s = IPS_OK;
+                PECTrainingSP.setState(IPS_OK);
                 isTraining = false;
             }
             else
             {
                 PECTime = PECTime + 1 * getCurrentPollingPeriod() / 1000;
                 sprintf(PECText, "Recording: %d s", PECTime);
-                IUSaveText(&PECInfoT[0], PECText);
+                PECInfoTP[0].setText(PECText);
             }
         }
         else
         {
             driver->setPETEnabled(false);
-            PECTrainingSP.s = IPS_ALERT;
+            PECTrainingSP.setState(IPS_ALERT);
             sprintf(PECText, "Tracking error, recording cancelled %d s", PECTime);
             LOG_ERROR(PECText);
-            IUSaveText(&PECInfoT[0], "Cancelled");
+            PECInfoTP[0].setText("Cancelled");
         }
-        IDSetText(&PECInfoTP, nullptr);
-        IDSetSwitch(&PECTrainingSP, nullptr);
+        PECInfoTP.apply();
+        PECTrainingSP.apply();
     }
     // End Mod */
 
@@ -814,11 +814,11 @@ bool IOptronV3::ReadScopeStatus()
         else
             setPierSide(pierState == IOP_PIER_EAST ? PIER_EAST : PIER_WEST);
 
-        if (IUFindOnSwitchIndex(&CWStateSP) != cwState)
+        if (CWStateSP.findOnSwitchIndex() != cwState)
         {
-            IUResetSwitch(&CWStateSP);
-            CWStateS[cwState].s = ISS_ON;
-            IDSetSwitch(&CWStateSP, nullptr);
+            CWStateSP.reset();
+            CWStateSP[cwState].setState(ISS_ON);
+            CWStateSP.apply();
         }
 
         NewRaDec(currentRA, currentDEC);
@@ -843,7 +843,7 @@ bool IOptronV3::Goto(double ra, double de)
     }
 
     bool rc = false;
-    if (IUFindOnSwitchIndex(&SlewModeSP) == IOP_CW_NORMAL)
+    if (SlewModeSP.findOnSwitchIndex() == IOP_CW_NORMAL)
         rc = driver->slewNormal();
     else
         rc = driver->slewCWUp();
@@ -873,7 +873,7 @@ bool IOptronV3::Sync(double ra, double de)
         LOG_ERROR("Failed to sync.");
     }
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     currentRA  = ra;
     currentDEC = de;
@@ -1088,8 +1088,8 @@ bool IOptronV3::saveConfigItems(FILE *fp)
 {
     INDI::Telescope::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &SlewModeSP);
-    IUSaveConfigSwitch(fp, &DaylightSP);
+    SlewModeSP.save(fp);
+    DaylightSP.save(fp);
 
     return true;
 }
@@ -1116,15 +1116,15 @@ void IOptronV3::mountSim()
     switch (TrackState)
     {
         case SCOPE_IDLE:
-            currentRA += (TrackRateN[AXIS_RA].value / 3600.0 * dt) / 15.0;
+            currentRA += (TrackRateNP[AXIS_RA].value / 3600.0 * dt) / 15.0;
             currentRA = range24(currentRA);
             break;
 
         case SCOPE_TRACKING:
             if (TrackModeS[TR_CUSTOM].s == ISS_ON)
             {
-                currentRA  += ( ((TRACKRATE_SIDEREAL / 3600.0) - (TrackRateN[AXIS_RA].value / 3600.0)) * dt) / 15.0;
-                currentDEC += ( (TrackRateN[AXIS_DE].value / 3600.0) * dt);
+                currentRA  += ( ((TRACKRATE_SIDEREAL / 3600.0) - (TrackRateNP[AXIS_RA].value / 3600.0)) * dt) / 15.0;
+                currentDEC += ( (TrackRateNP[AXIS_DE].value / 3600.0) * dt);
             }
             break;
 
@@ -1189,8 +1189,8 @@ bool IOptronV3::SetCurrentPark()
     // Libnova south = 0, west = 90, north = 180, east = 270
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -1220,9 +1220,9 @@ bool IOptronV3::SetDefaultPark()
     // By defualt azimuth 0
     SetAxis1Park(0);
     // Altitude = latitude of observer
-    SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+    SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
     driver->setParkAz(0);
-    driver->setParkAlt(LocationN[LOCATION_LATITUDE].value);
+    driver->setParkAlt(LocationNP[LOCATION_LATITUDE].value);
     return true;
 }
 
@@ -1264,7 +1264,7 @@ bool IOptronV3::SetTrackEnabled(bool enabled)
         // NOTE: Is this the correct order? or should tracking be switched on first before making these changes? Need to test.
         SetTrackMode(IUFindOnSwitchIndex(&TrackModeSP));
         if (TrackModeS[TR_CUSTOM].s == ISS_ON)
-            SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+            SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
     }
 
     return driver->setTrackEnabled(enabled);
@@ -1277,8 +1277,8 @@ bool IOptronV3::GetPECDataStatus(bool enabled)
     {
         if (enabled)
         {
-            IUSaveText(&PECInfoT[0], "Recorded");
-            IDSetText(&PECInfoTP, nullptr);
+            PECInfoTP[0].setText("Recorded");
+            PECInfoTP.apply();
             LOG_INFO("Mount PEC Chip Ready and Trained");
         }
         return true;
@@ -1287,8 +1287,8 @@ bool IOptronV3::GetPECDataStatus(bool enabled)
     {
         if (enabled)
         {
-            IUSaveText(&PECInfoT[0], "None");
-            IDSetText(&PECInfoTP, nullptr);
+            PECInfoTP[0].setText("None");
+            PECInfoTP.apply();
             LOG_INFO("Mount PEC Chip Needs Training");
         }
     }

--- a/drivers/telescope/ioptronv3.h
+++ b/drivers/telescope/ioptronv3.h
@@ -28,6 +28,11 @@
 #include "indiguiderinterface.h"
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class IOptronV3 : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -104,50 +109,39 @@ class IOptronV3 : public INDI::Telescope, public INDI::GuiderInterface
         bool GetPECDataStatus(bool enabled);
         
         /* Mod v3.0 Adding PEC Recording Switches  */
-        ISwitch PECTrainingS[2]; 
-        ISwitchVectorProperty PECTrainingSP; 
-        ITextVectorProperty PECInfoTP;
-        IText PECInfoT[2] {};
+        INDI::PropertySwitch PECTrainingSP {2};
+        INDI::PropertyText PECInfoTP {2};
         char PECText[128];
         int PECTime = 0;
         bool isTraining;
         // End Mod */
 
         /* Firmware */
-        IText FirmwareT[5] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {5};
 
         /* GPS Status */
-        ISwitch GPSStatusS[3];
-        ISwitchVectorProperty GPSStatusSP;
+        INDI::PropertySwitch GPSStatusSP {3};
 
         /* Time Source */
-        ISwitch TimeSourceS[3];
-        ISwitchVectorProperty TimeSourceSP;
+        INDI::PropertySwitch TimeSourceSP {3};
 
         /* Hemisphere */
-        ISwitch HemisphereS[2];
-        ISwitchVectorProperty HemisphereSP;
+        INDI::PropertySwitch HemisphereSP {2};
 
         /* Home Control */
-        ISwitch HomeS[3];
-        ISwitchVectorProperty HomeSP;
+        INDI::PropertySwitch HomeSP {3};
 
         /* Guide Rate */
-        INumber GuideRateN[2];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};
 
         /* Slew Mode */
-        ISwitch SlewModeS[2];
-        ISwitchVectorProperty SlewModeSP;
+        INDI::PropertySwitch SlewModeSP {2};
 
         /* Counterweight Status */
-        ISwitch CWStateS[2];
-        ISwitchVectorProperty CWStateSP;
+        INDI::PropertySwitch CWStateSP {2};
 
         /* Daylight Saving */
-        ISwitch DaylightS[2];
-        ISwitchVectorProperty DaylightSP;
+        INDI::PropertySwitch DaylightSP {2};
 
         uint32_t DBG_SCOPE;
 

--- a/drivers/telescope/lx200_10micron.cpp
+++ b/drivers/telescope/lx200_10micron.cpp
@@ -122,65 +122,65 @@ bool LX200_10MICRON::initProperties()
     if (result)
     {
         // TODO initialize properties additional to INDI::Telescope
-        IUFillSwitch(&UnattendedFlipS[UNATTENDED_FLIP_DISABLED], "Disabled", "Disabled", ISS_ON);
-        IUFillSwitch(&UnattendedFlipS[UNATTENDED_FLIP_ENABLED], "Enabled", "Enabled", ISS_OFF);
-        IUFillSwitchVector(&UnattendedFlipSP, UnattendedFlipS, UNATTENDED_FLIP_COUNT, getDeviceName(),
+        UnattendedFlipSP[UNATTENDED_FLIP_DISABLED].fill("Disabled", "Disabled", ISS_ON);
+        UnattendedFlipSP[UNATTENDED_FLIP_ENABLED].fill("Enabled", "Enabled", ISS_OFF);
+        UnattendedFlipSP.fill(getDeviceName(),
                            UNATTENDED_FLIP, "Unattended Flip", MOTION_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
-        IUFillNumber(&RefractionModelTemperatureN[0], "TEMPERATURE", "Celsius", "%+6.1f", -999.9, 999.9, 0, 0.);
-        IUFillNumberVector(&RefractionModelTemperatureNP, RefractionModelTemperatureN, 1, getDeviceName(),
+        RefractionModelTemperatureNP[0].fill("TEMPERATURE", "Celsius", "%+6.1f", -999.9, 999.9, 0, 0.);
+        RefractionModelTemperatureNP.fill(getDeviceName(),
                            REFRACTION_MODEL_TEMPERATURE, "Temperature", ALIGNMENT_TAB, IP_RW, 60, IPS_IDLE);
 
-        IUFillNumber(&RefractionModelPressureN[0], "PRESSURE", "hPa", "%6.1f", 0.0, 9999.9, 0, 0.);
-        IUFillNumberVector(&RefractionModelPressureNP, RefractionModelPressureN, 1, getDeviceName(),
+        RefractionModelPressureNP[0].fill("PRESSURE", "hPa", "%6.1f", 0.0, 9999.9, 0, 0.);
+        RefractionModelPressureNP.fill(getDeviceName(),
                            REFRACTION_MODEL_PRESSURE, "Pressure", ALIGNMENT_TAB, IP_RW, 60, IPS_IDLE);
 
-        IUFillNumber(&ModelCountN[0], "COUNT", "#", "%.0f", 0, 999, 0, 0);
-        IUFillNumberVector(&ModelCountNP, ModelCountN, 1, getDeviceName(),
+        ModelCountNP[0].fill("COUNT", "#", "%.0f", 0, 999, 0, 0);
+        ModelCountNP.fill(getDeviceName(),
                            MODEL_COUNT, "Models", ALIGNMENT_TAB, IP_RO, 60, IPS_IDLE);
 
-        IUFillNumber(&AlignmentPointsN[0], "COUNT", "#", "%.0f", 0, 100, 0, 0);
-        IUFillNumberVector(&AlignmentPointsNP, AlignmentPointsN, 1, getDeviceName(),
+        AlignmentPointsNP[0].fill("COUNT", "#", "%.0f", 0, 100, 0, 0);
+        AlignmentPointsNP.fill(getDeviceName(),
                            ALIGNMENT_POINTS, "Points", ALIGNMENT_TAB, IP_RO, 60, IPS_IDLE);
 
-        IUFillSwitch(&AlignmentStateS[ALIGN_IDLE], "Idle", "Idle", ISS_ON);
-        IUFillSwitch(&AlignmentStateS[ALIGN_START], "Start", "Start new model", ISS_OFF);
-        IUFillSwitch(&AlignmentStateS[ALIGN_END], "End", "End new model", ISS_OFF);
-        IUFillSwitch(&AlignmentStateS[ALIGN_DELETE_CURRENT], "Del", "Delete current model", ISS_OFF);
-        IUFillSwitchVector(&AlignmentStateSP, AlignmentStateS, ALIGN_COUNT, getDeviceName(),
+        AlignmentStateSP[ALIGN_IDLE].fill("Idle", "Idle", ISS_ON);
+        AlignmentStateSP[ALIGN_START].fill("Start", "Start new model", ISS_OFF);
+        AlignmentStateSP[ALIGN_END].fill("End", "End new model", ISS_OFF);
+        AlignmentStateSP[ALIGN_DELETE_CURRENT].fill("Del", "Delete current model", ISS_OFF);
+        AlignmentStateSP.fill(getDeviceName(),
                            ALIGNMENT_STATE, "Alignment", ALIGNMENT_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
-        IUFillNumber(&MiniNewAlpRON[MALPRO_MRA], "MRA", "Mount RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-        IUFillNumber(&MiniNewAlpRON[MALPRO_MDEC], "MDEC", "Mount DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-        IUFillNumber(&MiniNewAlpRON[MALPRO_MSIDE], "MSIDE", "Pier Side (0=E 1=W)", "%.0f", 0, 1, 0, 0);
-        IUFillNumber(&MiniNewAlpRON[MALPRO_SIDTIME], "SIDTIME", "Sidereal Time (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-        IUFillNumberVector(&MiniNewAlpRONP, MiniNewAlpRON, MALPRO_COUNT, getDeviceName(),
+        MiniNewAlpRONP[MALPRO_MRA].fill("MRA", "Mount RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        MiniNewAlpRONP[MALPRO_MDEC].fill("MDEC", "Mount DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+        MiniNewAlpRONP[MALPRO_MSIDE].fill("MSIDE", "Pier Side (0=E 1=W)", "%.0f", 0, 1, 0, 0);
+        MiniNewAlpRONP[MALPRO_SIDTIME].fill("SIDTIME", "Sidereal Time (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        MiniNewAlpRONP.fill(getDeviceName(),
                            MINIMAL_NEW_ALIGNMENT_POINT_RO, "Actual", ALIGNMENT_TAB, IP_RO, 60, IPS_IDLE);
 
-        IUFillNumber(&MiniNewAlpN[MALP_PRA], "PRA", "Solved RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-        IUFillNumber(&MiniNewAlpN[MALP_PDEC], "PDEC", "Solved DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-        IUFillNumberVector(&MiniNewAlpNP, MiniNewAlpN, MALP_COUNT, getDeviceName(),
+        MiniNewAlpNP[MALP_PRA].fill("PRA", "Solved RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        MiniNewAlpNP[MALP_PDEC].fill("PDEC", "Solved DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+        MiniNewAlpNP.fill(getDeviceName(),
                            MINIMAL_NEW_ALIGNMENT_POINT, "New Point", ALIGNMENT_TAB, IP_RW, 60, IPS_IDLE);
 
-        IUFillNumber(&NewAlpN[ALP_MRA], "MRA", "Mount RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-        IUFillNumber(&NewAlpN[ALP_MDEC], "MDEC", "Mount DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-        IUFillNumber(&NewAlpN[ALP_MSIDE], "MSIDE", "Pier Side (0=E 1=W)", "%.0f", 0, 1, 0, 0);
-        IUFillNumber(&NewAlpN[ALP_SIDTIME], "SIDTIME", "Sidereal Time (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-        IUFillNumber(&NewAlpN[ALP_PRA], "PRA", "Solved RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-        IUFillNumber(&NewAlpN[ALP_PDEC], "PDEC", "Solved DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-        IUFillNumberVector(&NewAlpNP, NewAlpN, ALP_COUNT, getDeviceName(),
+        NewAlpNP[ALP_MRA].fill("MRA", "Mount RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        NewAlpNP[ALP_MDEC].fill("MDEC", "Mount DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+        NewAlpNP[ALP_MSIDE].fill("MSIDE", "Pier Side (0=E 1=W)", "%.0f", 0, 1, 0, 0);
+        NewAlpNP[ALP_SIDTIME].fill("SIDTIME", "Sidereal Time (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        NewAlpNP[ALP_PRA].fill("PRA", "Solved RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        NewAlpNP[ALP_PDEC].fill("PDEC", "Solved DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+        NewAlpNP.fill(getDeviceName(),
                            NEW_ALIGNMENT_POINT, "New Point", ALIGNMENT_TAB, IP_RW, 60, IPS_IDLE);
 
-        IUFillNumber(&NewAlignmentPointsN[0], "COUNT", "#", "%.0f", 0, 100, 1, 0);
-        IUFillNumberVector(&NewAlignmentPointsNP, NewAlignmentPointsN, 1, getDeviceName(),
+        NewAlignmentPointsNP[0].fill("COUNT", "#", "%.0f", 0, 100, 1, 0);
+        NewAlignmentPointsNP.fill(getDeviceName(),
                            NEW_ALIGNMENT_POINTS, "New Points", ALIGNMENT_TAB, IP_RO, 60, IPS_IDLE);
 
-        IUFillText(&NewModelNameT[0], "NAME", "Model Name", "newmodel");
-        IUFillTextVector(&NewModelNameTP, NewModelNameT, 1, getDeviceName(),
+        NewModelNameTP[0].fill("NAME", "Model Name", "newmodel");
+        NewModelNameTP.fill(getDeviceName(),
                          NEW_MODEL_NAME, "New Name", ALIGNMENT_TAB, IP_RW, 60, IPS_IDLE);
 
-        IUFillNumber(&TLEfromDatabaseN[0], "NUMBER", "#", "%.0f", 1, 999, 1, 1);
-        IUFillNumberVector(&TLEfromDatabaseNP, TLEfromDatabaseN, 1, getDeviceName(),
+        TLEfromDatabaseNP[0].fill("NUMBER", "#", "%.0f", 1, 999, 1, 1);
+        TLEfromDatabaseNP.fill(getDeviceName(),
                            "TLE_NUMBER", "Database TLE ", SATELLITE_TAB, IP_RW, 60, IPS_IDLE);
     }
     return result;
@@ -189,7 +189,7 @@ bool LX200_10MICRON::initProperties()
 bool LX200_10MICRON::saveConfigItems(FILE *fp)
 {
     INDI::Telescope::saveConfigItems(fp);
-    IUSaveConfigSwitch(fp, &UnattendedFlipSP);
+    UnattendedFlipSP.save(fp);
     return true;
 }
 
@@ -200,39 +200,39 @@ bool LX200_10MICRON::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&UnattendedFlipSP);
+        defineProperty(UnattendedFlipSP);
         // getMountInfo defines ProductTP
-        defineProperty(&RefractionModelTemperatureNP);
-        defineProperty(&RefractionModelPressureNP);
-        defineProperty(&ModelCountNP);
-        defineProperty(&AlignmentPointsNP);
-        defineProperty(&AlignmentStateSP);
-        defineProperty(&MiniNewAlpRONP);
-        defineProperty(&MiniNewAlpNP);
-        defineProperty(&NewAlpNP);
-        defineProperty(&NewAlignmentPointsNP);
-        defineProperty(&NewModelNameTP);
-        defineProperty(&TLEfromDatabaseNP);
+        defineProperty(RefractionModelTemperatureNP);
+        defineProperty(RefractionModelPressureNP);
+        defineProperty(ModelCountNP);
+        defineProperty(AlignmentPointsNP);
+        defineProperty(AlignmentStateSP);
+        defineProperty(MiniNewAlpRONP);
+        defineProperty(MiniNewAlpNP);
+        defineProperty(NewAlpNP);
+        defineProperty(NewAlignmentPointsNP);
+        defineProperty(NewModelNameTP);
+        defineProperty(TLEfromDatabaseNP);
 
         // read UnAttendedFlip setting from config and apply if available
         int readit = 0;
-        for (int i = 0; readit == 0 && i < UnattendedFlipSP.nsp; i++)
+        for (size_t i = 0; readit == 0 && i < UnattendedFlipSP.size(); i++)
         {
-            readit = IUGetConfigSwitch(getDeviceName(), UnattendedFlipSP.name, UnattendedFlipS[i].name, &(UnattendedFlipS[i].s));
+            readit = IUGetConfigSwitch(getDeviceName(), UnattendedFlipSP.getName(), UnattendedFlipSP[i].getName(), &(UnattendedFlipSP[i].s));
         }
         if (readit == 0)
         {
-            if (UnattendedFlipS[UnattendedFlip].s == ISS_ON)
+            if (UnattendedFlipSP[UnattendedFlip].getState() == ISS_ON)
             {
                 LOGF_INFO("Unattended Flip from config and mount are %s",
-                          (UnattendedFlipS[UNATTENDED_FLIP_ENABLED].s == ISS_ON) ? "enabled" : "disabled");
+                          (UnattendedFlipSP[UNATTENDED_FLIP_ENABLED].getState() == ISS_ON) ? "enabled" : "disabled");
             }
             else
             {
                 LOGF_INFO("Read Unattended Flip %s from config while mount has %s, updating mount",
-                          (UnattendedFlipS[UNATTENDED_FLIP_ENABLED].s == ISS_ON) ? "enabled" : "disabled",
+                          (UnattendedFlipSP[UNATTENDED_FLIP_ENABLED].getState() == ISS_ON) ? "enabled" : "disabled",
                           (UnattendedFlip == UNATTENDED_FLIP_ENABLED) ? "enabled" : "disabled");
-                setUnattendedFlipSetting(UnattendedFlipS[UNATTENDED_FLIP_ENABLED].s == ISS_ON);
+                setUnattendedFlipSetting(UnattendedFlipSP[UNATTENDED_FLIP_ENABLED].getState() == ISS_ON);
             }
         }
         else
@@ -242,19 +242,19 @@ bool LX200_10MICRON::updateProperties()
     }
     else
     {
-        deleteProperty(UnattendedFlipSP.name);
-        deleteProperty(ProductTP.name);
-        deleteProperty(RefractionModelTemperatureNP.name);
-        deleteProperty(RefractionModelPressureNP.name);
-        deleteProperty(ModelCountNP.name);
-        deleteProperty(AlignmentPointsNP.name);
-        deleteProperty(AlignmentStateSP.name);
-        deleteProperty(MiniNewAlpRONP.name);
-        deleteProperty(MiniNewAlpNP.name);
-        deleteProperty(NewAlpNP.name);
-        deleteProperty(NewAlignmentPointsNP.name);
-        deleteProperty(NewModelNameTP.name);
-        deleteProperty(TLEfromDatabaseNP.name);
+        deleteProperty(UnattendedFlipSP.getName());
+        deleteProperty(ProductTP.getName());
+        deleteProperty(RefractionModelTemperatureNP.getName());
+        deleteProperty(RefractionModelPressureNP.getName());
+        deleteProperty(ModelCountNP.getName());
+        deleteProperty(AlignmentPointsNP.getName());
+        deleteProperty(AlignmentStateSP.getName());
+        deleteProperty(MiniNewAlpRONP.getName());
+        deleteProperty(MiniNewAlpNP.getName());
+        deleteProperty(NewAlpNP.getName());
+        deleteProperty(NewAlignmentPointsNP.getName());
+        deleteProperty(NewModelNameTP.getName());
+        deleteProperty(TLEfromDatabaseNP.getName());
     }
 
     return result;
@@ -274,58 +274,58 @@ void LX200_10MICRON::getBasicData()
         checkLX200EquatorialFormat(fd);
         timeFormat = LX200_24;
 
-        if (getTrackFreq(PortFD, &TrackFreqN[0].value) < 0)
+        if (getTrackFreq(PortFD, &TrackFreqNP[0].value) < 0)
         {
             LOG_WARN("Failed to get tracking frequency from device.");
         }
         else
         {
-            LOGF_INFO("Tracking frequency is %.1f Hz", TrackFreqN[0].value);
-            IDSetNumber(&TrackFreqNP, nullptr);
+            LOGF_INFO("Tracking frequency is %.1f Hz", TrackFreqNP[0].getValue());
+            TrackFreqNP.apply();
         }
 
         char RefractionModelTemperature[80];
         getCommandString(PortFD, RefractionModelTemperature, "#:GRTMP#");
         float rmtemp;
         sscanf(RefractionModelTemperature, "%f#", &rmtemp);
-        RefractionModelTemperatureN[0].value = (double) rmtemp;
-        LOGF_INFO("RefractionModelTemperature is %0+6.1f degrees C", RefractionModelTemperatureN[0].value);
-        IDSetNumber(&RefractionModelTemperatureNP, nullptr);
+        RefractionModelTemperatureNP[0].setValue((double) rmtemp);
+        LOGF_INFO("RefractionModelTemperature is %0+6.1f degrees C", RefractionModelTemperatureNP[0].getValue());
+        RefractionModelTemperatureNP.apply();
 
         char RefractionModelPressure[80];
         getCommandString(PortFD, RefractionModelPressure, "#:GRPRS#");
         float rmpres;
         sscanf(RefractionModelPressure, "%f#", &rmpres);
-        RefractionModelPressureN[0].value = (double) rmpres;
-        LOGF_INFO("RefractionModelPressure is %06.1f hPa", RefractionModelPressureN[0].value);
-        IDSetNumber(&RefractionModelPressureNP, nullptr);
+        RefractionModelPressureNP[0].setValue((double) rmpres);
+        LOGF_INFO("RefractionModelPressure is %06.1f hPa", RefractionModelPressureNP[0].getValue());
+        RefractionModelPressureNP.apply();
 
         int ModelCount;
         getCommandInt(PortFD, &ModelCount, "#:modelcnt#");
-        ModelCountN[0].value = (double) ModelCount;
-        LOGF_INFO("%d Alignment Models", (int) ModelCountN[0].value);
-        IDSetNumber(&ModelCountNP, nullptr);
+        ModelCountNP[0].setValue((double) ModelCount);
+        LOGF_INFO("%d Alignment Models", (int) ModelCountNP[0].getValue());
+        ModelCountNP.apply();
 
         int AlignmentPoints;
         getCommandInt(PortFD, &AlignmentPoints, "#:getalst#");
-        AlignmentPointsN[0].value = (double) AlignmentPoints;
-        LOGF_INFO("%d Alignment Stars in active model", (int) AlignmentPointsN[0].value);
-        IDSetNumber(&AlignmentPointsNP, nullptr);
+        AlignmentPointsNP[0].setValue((double) AlignmentPoints);
+        LOGF_INFO("%d Alignment Stars in active model", (int) AlignmentPointsNP[0].getValue());
+        AlignmentPointsNP.apply();
 
         if (false == getUnattendedFlipSetting())
         {
-            UnattendedFlipS[UNATTENDED_FLIP_DISABLED].s = ISS_ON;
-            UnattendedFlipS[UNATTENDED_FLIP_ENABLED].s = ISS_OFF;
+            UnattendedFlipSP[UNATTENDED_FLIP_DISABLED].setState(ISS_ON);
+            UnattendedFlipSP[UNATTENDED_FLIP_ENABLED].setState(ISS_OFF);
             LOG_INFO("Unattended Flip is disabled.");
         }
         else
         {
-            UnattendedFlipS[UNATTENDED_FLIP_DISABLED].s = ISS_OFF;
-            UnattendedFlipS[UNATTENDED_FLIP_ENABLED].s = ISS_ON;
+            UnattendedFlipSP[UNATTENDED_FLIP_DISABLED].setState(ISS_OFF);
+            UnattendedFlipSP[UNATTENDED_FLIP_ENABLED].setState(ISS_ON);
             LOG_INFO("Unattended Flip is enabled.");
         }
-        UnattendedFlipSP.s = IPS_OK;
-        IDSetSwitch(&UnattendedFlipSP, nullptr);
+        UnattendedFlipSP.setState(IPS_OK);
+        UnattendedFlipSP.apply();
     }
 
     if (sendLocationOnStartup)
@@ -369,14 +369,14 @@ bool LX200_10MICRON::getMountInfo()
 
     LOGF_INFO("Product:%s Control box:%s Firmware:%s of %s", ProductName, ControlBox, FirmwareVersion, FirmwareDate);
 
-    IUFillText(&ProductT[PRODUCT_NAME], "NAME", "Product Name", ProductName);
-    IUFillText(&ProductT[PRODUCT_CONTROL_BOX], "CONTROL_BOX", "Control Box", ControlBox);
-    IUFillText(&ProductT[PRODUCT_FIRMWARE_VERSION], "FIRMWARE_VERSION", "Firmware Version", FirmwareVersion);
-    IUFillText(&ProductT[PRODUCT_FIRMWARE_DATE], "FIRMWARE_DATE", "Firmware Date", FirmwareDate);
-    IUFillTextVector(&ProductTP, ProductT, PRODUCT_COUNT, getDeviceName(),
+    ProductTP[PRODUCT_NAME].fill("NAME", "Product Name", ProductName);
+    ProductTP[PRODUCT_CONTROL_BOX].fill("CONTROL_BOX", "Control Box", ControlBox);
+    ProductTP[PRODUCT_FIRMWARE_VERSION].fill("FIRMWARE_VERSION", "Firmware Version", FirmwareVersion);
+    ProductTP[PRODUCT_FIRMWARE_DATE].fill("FIRMWARE_DATE", "Firmware Date", FirmwareDate);
+    ProductTP.fill(getDeviceName(),
                      PRODUCT_INFO, "Product", PRODUCT_TAB, IP_RO, 60, IPS_IDLE);
 
-    defineProperty(&ProductTP);
+    defineProperty(ProductTP);
 
     return true;
 }
@@ -522,11 +522,11 @@ bool LX200_10MICRON::ReadScopeStatus()
     char LocalSiderealTimeS[80];
     getCommandString(fd, LocalSiderealTimeS, "#:GS#");
     f_scansexa(LocalSiderealTimeS, &Ginfo.SiderealTime);
-    MiniNewAlpRON[MALPRO_MRA].value = Ginfo.RA_JNOW;
-    MiniNewAlpRON[MALPRO_MDEC].value = Ginfo.DEC_JNOW;
-    MiniNewAlpRON[MALPRO_MSIDE].value = (toupper(Ginfo.SideOfPier) == 'E') ? 0 : 1;
-    MiniNewAlpRON[MALPRO_SIDTIME].value = Ginfo.SiderealTime;
-    IDSetNumber(&MiniNewAlpRONP, nullptr);
+    MiniNewAlpRONP[MALPRO_MRA].setValue(Ginfo.RA_JNOW);
+    MiniNewAlpRONP[MALPRO_MDEC].setValue(Ginfo.DEC_JNOW);
+    MiniNewAlpRONP[MALPRO_MSIDE].setValue((toupper(Ginfo.SideOfPier) == 'E') ? 0 : 1);
+    MiniNewAlpRONP[MALPRO_SIDTIME].setValue(Ginfo.SiderealTime);
+    MiniNewAlpRONP.apply();
 
     return true;
 }
@@ -956,8 +956,8 @@ int LX200_10MICRON::AddSyncPoint(double MRa, double MDec, double MSide, double P
         return 1;
     }
     LOGF_INFO("AddSyncPoint responded [%4s], there are now %d new alignment points", response, points);
-    NewAlignmentPointsN[0].value = points;
-    IDSetNumber(&NewAlignmentPointsNP, nullptr);
+    NewAlignmentPointsNP[0].setValue(points);
+    NewAlignmentPointsNP.apply();
 
     return 0;
 }
@@ -974,47 +974,47 @@ bool LX200_10MICRON::ISNewNumber(const char *dev, const char *name, double value
     {
         if (strcmp(name, REFRACTION_MODEL_TEMPERATURE) == 0)
         {
-            IUUpdateNumber(&RefractionModelTemperatureNP, values, names, n);
-            if (0 != SetRefractionModelTemperature(RefractionModelTemperatureN[0].value))
+            RefractionModelTemperatureNP.update(values, names, n);
+            if (0 != SetRefractionModelTemperature(RefractionModelTemperatureNP[0].value))
             {
                 LOG_ERROR("SetRefractionModelTemperature error");
-                RefractionModelTemperatureNP.s = IPS_ALERT;
-                IDSetNumber(&RefractionModelTemperatureNP, nullptr);
+                RefractionModelTemperatureNP.setState(IPS_ALERT);
+                RefractionModelTemperatureNP.apply();
                 return false;
             }
-            RefractionModelTemperatureNP.s = IPS_OK;
-            IDSetNumber(&RefractionModelTemperatureNP, nullptr);
-            LOGF_INFO("RefractionModelTemperature set to %0+6.1f degrees C", RefractionModelTemperatureN[0].value);
+            RefractionModelTemperatureNP.setState(IPS_OK);
+            RefractionModelTemperatureNP.apply();
+            LOGF_INFO("RefractionModelTemperature set to %0+6.1f degrees C", RefractionModelTemperatureNP[0].getValue());
             return true;
         }
         if (strcmp(name, REFRACTION_MODEL_PRESSURE) == 0)
         {
-            IUUpdateNumber(&RefractionModelPressureNP, values, names, n);
-            if (0 != SetRefractionModelPressure(RefractionModelPressureN[0].value))
+            RefractionModelPressureNP.update(values, names, n);
+            if (0 != SetRefractionModelPressure(RefractionModelPressureNP[0].value))
             {
                 LOG_ERROR("SetRefractionModelPressure error");
-                RefractionModelPressureNP.s = IPS_ALERT;
-                IDSetNumber(&RefractionModelPressureNP, nullptr);
+                RefractionModelPressureNP.setState(IPS_ALERT);
+                RefractionModelPressureNP.apply();
                 return false;
             }
-            RefractionModelPressureNP.s = IPS_OK;
-            IDSetNumber(&RefractionModelPressureNP, nullptr);
-            LOGF_INFO("RefractionModelPressure set to %06.1f hPa", RefractionModelPressureN[0].value);
+            RefractionModelPressureNP.setState(IPS_OK);
+            RefractionModelPressureNP.apply();
+            LOGF_INFO("RefractionModelPressure set to %06.1f hPa", RefractionModelPressureNP[0].getValue());
             return true;
         }
         if (strcmp(name, MODEL_COUNT) == 0)
         {
-            IUUpdateNumber(&ModelCountNP, values, names, n);
-            ModelCountNP.s = IPS_OK;
-            IDSetNumber(&ModelCountNP, nullptr);
-            LOGF_INFO("ModelCount %d", ModelCountN[0].value);
+            ModelCountNP.update(values, names, n);
+            ModelCountNP.setState(IPS_OK);
+            ModelCountNP.apply();
+            LOGF_INFO("ModelCount %d", ModelCountNP[0].getValue());
             return true;
         }
         if (strcmp(name, MINIMAL_NEW_ALIGNMENT_POINT_RO) == 0)
         {
-            IUUpdateNumber(&MiniNewAlpNP, values, names, n);
-            MiniNewAlpRONP.s = IPS_OK;
-            IDSetNumber(&MiniNewAlpRONP, nullptr);
+            MiniNewAlpNP.update(values, names, n);
+            MiniNewAlpRONP.setState(IPS_OK);
+            MiniNewAlpRONP.apply();
             return true;
         }
         if (strcmp(name, MINIMAL_NEW_ALIGNMENT_POINT) == 0)
@@ -1025,16 +1025,16 @@ bool LX200_10MICRON::ISNewNumber(const char *dev, const char *name, double value
                 return false;
             }
 
-            IUUpdateNumber(&MiniNewAlpNP, values, names, n);
-            if (0 != AddSyncPointHere(MiniNewAlpN[MALP_PRA].value, MiniNewAlpN[MALP_PDEC].value))
+            MiniNewAlpNP.update(values, names, n);
+            if (0 != AddSyncPointHere(MiniNewAlpNP[MALP_PRA].value, MiniNewAlpNP[MALP_PDEC].getValue()))
             {
                 LOG_ERROR("AddSyncPointHere error");
-                MiniNewAlpNP.s = IPS_ALERT;
-                IDSetNumber(&MiniNewAlpNP, nullptr);
+                MiniNewAlpNP.setState(IPS_ALERT);
+                MiniNewAlpNP.apply();
                 return false;
             }
-            MiniNewAlpNP.s = IPS_OK;
-            IDSetNumber(&MiniNewAlpNP, nullptr);
+            MiniNewAlpNP.setState(IPS_OK);
+            MiniNewAlpNP.apply();
             return true;
         }
         if (strcmp(name, NEW_ALIGNMENT_POINT) == 0)
@@ -1045,43 +1045,43 @@ bool LX200_10MICRON::ISNewNumber(const char *dev, const char *name, double value
                 return false;
             }
 
-            IUUpdateNumber(&NewAlpNP, values, names, n);
-            if (0 != AddSyncPoint(NewAlpN[ALP_MRA].value, NewAlpN[ALP_MDEC].value, NewAlpN[ALP_MSIDE].value,
-                                  NewAlpN[ALP_PRA].value, NewAlpN[ALP_PDEC].value, NewAlpN[ALP_SIDTIME].value))
+            NewAlpNP.update(values, names, n);
+            if (0 != AddSyncPoint(NewAlpNP[ALP_MRA].value, NewAlpNP[ALP_MDEC].getValue(), NewAlpNP[ALP_MSIDE].getValue(),
+                                  NewAlpNP[ALP_PRA].getValue(), NewAlpNP[ALP_PDEC].getValue(), NewAlpNP[ALP_SIDTIME].getValue()))
             {
                 LOG_ERROR("AddSyncPoint error");
-                NewAlpNP.s = IPS_ALERT;
-                IDSetNumber(&NewAlpNP, nullptr);
+                NewAlpNP.setState(IPS_ALERT);
+                NewAlpNP.apply();
                 return false;
             }
-            NewAlpNP.s = IPS_OK;
-            IDSetNumber(&NewAlpNP, nullptr);
+            NewAlpNP.setState(IPS_OK);
+            NewAlpNP.apply();
             return true;
         }
         if (strcmp(name, NEW_ALIGNMENT_POINTS) == 0)
         {
-            IUUpdateNumber(&NewAlignmentPointsNP, values, names, n);
-            NewAlignmentPointsNP.s = IPS_OK;
-            IDSetNumber(&NewAlignmentPointsNP, nullptr);
-            LOGF_INFO("New unnamed Model now has %d alignment points", NewAlignmentPointsN[0].value);
+            NewAlignmentPointsNP.update(values, names, n);
+            NewAlignmentPointsNP.setState(IPS_OK);
+            NewAlignmentPointsNP.apply();
+            LOGF_INFO("New unnamed Model now has %d alignment points", NewAlignmentPointsNP[0].getValue());
             return true;
         }
         if (strcmp(name, "TLE_NUMBER") == 0)
         {
             LOG_INFO("I am trying to set from Database");
 
-            IUUpdateNumber(&TLEfromDatabaseNP, values, names, n);
-            if ( 0 != SetTLEfromDatabase(TLEfromDatabaseN[0].value) )
+            TLEfromDatabaseNP.update(values, names, n);
+            if ( 0 != SetTLEfromDatabase(TLEfromDatabaseNP[0].value) )
             {
-                TLEfromDatabaseNP.s = IPS_ALERT;
-                IDSetNumber(&TLEfromDatabaseNP, nullptr);
+                TLEfromDatabaseNP.setState(IPS_ALERT);
+                TLEfromDatabaseNP.apply();
                 return false;
             }
-            TLEfromDatabaseNP.s = IPS_OK;
-            TLEtoTrackTP.s = IPS_IDLE;
-            IDSetText(&TLEtoTrackTP, nullptr);
-            IDSetNumber(&TLEfromDatabaseNP, nullptr);
-            LOGF_INFO("Selected TLE nr %.0f from database", TLEfromDatabaseN[0].value);
+            TLEfromDatabaseNP.setState(IPS_OK);
+            TLEtoTrackTP.setState(IPS_IDLE);
+            TLEtoTrackTP.apply();
+            TLEfromDatabaseNP.apply();
+            LOGF_INFO("Selected TLE nr %.0f from database", TLEfromDatabaseNP[0].getValue());
 
             return true;
         }
@@ -1095,10 +1095,10 @@ bool LX200_10MICRON::ISNewSwitch(const char *dev, const char *name, ISState *sta
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(AlignmentStateSP.name, name) == 0)
+        if (AlignmentStateSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&AlignmentStateSP, states, names, n);
-            int index    = IUFindOnSwitchIndex(&AlignmentStateSP);
+            AlignmentStateSP.update(states, names, n);
+            int index    = AlignmentStateSP.findOnSwitchIndex();
 
             switch (index)
             {
@@ -1116,8 +1116,8 @@ bool LX200_10MICRON::ISNewSwitch(const char *dev, const char *name, ISState *sta
                     if (0 != setStandardProcedureAndExpect(fd, "#:newalig#", "V"))
                     {
                         LOG_ERROR("New alignment start error");
-                        AlignmentStateSP.s = IPS_ALERT;
-                        IDSetSwitch(&AlignmentStateSP, nullptr);
+                        AlignmentStateSP.setState(IPS_ALERT);
+                        AlignmentStateSP.apply();
                         return false;
                     }
                     LOG_INFO("New Alignment started");
@@ -1136,8 +1136,8 @@ bool LX200_10MICRON::ISNewSwitch(const char *dev, const char *name, ISState *sta
                     if (0 != setStandardProcedureAndExpect(fd, "#:endalig#", "V"))
                     {
                         LOG_ERROR("New alignment end error");
-                        AlignmentStateSP.s = IPS_ALERT;
-                        IDSetSwitch(&AlignmentStateSP, nullptr);
+                        AlignmentStateSP.setState(IPS_ALERT);
+                        AlignmentStateSP.apply();
                         return false;
                     }
                     LOG_INFO("New Alignment ended");
@@ -1152,8 +1152,8 @@ bool LX200_10MICRON::ISNewSwitch(const char *dev, const char *name, ISState *sta
                     if (0 != setStandardProcedureAndExpect(fd, "#:delalig#", "#"))
                     {
                         LOG_ERROR("Delete current alignment error");
-                        AlignmentStateSP.s = IPS_ALERT;
-                        IDSetSwitch(&AlignmentStateSP, nullptr);
+                        AlignmentStateSP.setState(IPS_ALERT);
+                        AlignmentStateSP.apply();
                         return false;
                     }
                     LOG_INFO("Current Alignment deleted");
@@ -1161,67 +1161,67 @@ bool LX200_10MICRON::ISNewSwitch(const char *dev, const char *name, ISState *sta
                     break;
 
                 default:
-                    AlignmentStateSP.s = IPS_ALERT;
-                    IDSetSwitch(&AlignmentStateSP, "Unknown alignment index %d", index);
+                    AlignmentStateSP.setState(IPS_ALERT);
+                    AlignmentStateSP.apply("Unknown alignment index %d", index);
                     AlignmentState = ALIGN_IDLE;
                     return false;
             }
 
-            AlignmentStateSP.s = IPS_OK;
-            IDSetSwitch(&AlignmentStateSP, nullptr);
+            AlignmentStateSP.setState(IPS_OK);
+            AlignmentStateSP.apply();
             return true;
         }
-        if (strcmp(TrackSatSP.name, name) == 0)
+        if (TrackSatSP.isNameMatch(name))
         {
 
-            IUUpdateSwitch(&TrackSatSP, states, names, n);
-            int index    = IUFindOnSwitchIndex(&TrackSatSP);
+            TrackSatSP.update(states, names, n);
+            int index    = TrackSatSP.findOnSwitchIndex();
 
             switch (index)
             {
                 case SAT_TRACK:
                     if ( 0 != TrackSat() )
                     {
-                        TrackSatSP.s = IPS_ALERT;
-                        IDSetSwitch(&TrackSatSP, nullptr);
+                        TrackSatSP.setState(IPS_ALERT);
+                        TrackSatSP.apply();
                         LOG_ERROR("Tracking failed");
                         return false;
                     }
-                    TrackSatSP.s = IPS_OK;
-                    IDSetSwitch(&TrackSatSP, nullptr);
+                    TrackSatSP.setState(IPS_OK);
+                    TrackSatSP.apply();
                     LOG_INFO("Tracking satellite");
                     return true;
                 case SAT_HALT:
                     if ( !Abort() )
                     {
-                        TrackSatSP.s = IPS_ALERT;
-                        IDSetSwitch(&TrackSatSP, nullptr);
+                        TrackSatSP.setState(IPS_ALERT);
+                        TrackSatSP.apply();
                         LOG_ERROR("Halt failed");
                         return false;
                     }
-                    TrackSatSP.s = IPS_OK;
-                    IDSetSwitch(&TrackSatSP, nullptr);
+                    TrackSatSP.setState(IPS_OK);
+                    TrackSatSP.apply();
                     LOG_INFO("Halt tracking");
                     return true;
                 default:
-                    TrackSatSP.s = IPS_ALERT;
-                    IDSetSwitch(&TrackSatSP, "Unknown tracking modus %d", index);
+                    TrackSatSP.setState(IPS_ALERT);
+                    TrackSatSP.apply("Unknown tracking modus %d", index);
                     return false;
             }
         }
 
-        if (strcmp(UnattendedFlipSP.name, name) == 0)
+        if (UnattendedFlipSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&UnattendedFlipSP, states, names, n);
-            int index    = IUFindOnSwitchIndex(&UnattendedFlipSP);
+            UnattendedFlipSP.update(states, names, n);
+            int index    = UnattendedFlipSP.findOnSwitchIndex();
             switch (index)
             {
                 case UNATTENDED_FLIP_DISABLED:
                     if (false == setUnattendedFlipSetting(false))
                     {
                         LOG_ERROR("Setting unattended flip failed");
-                        UnattendedFlipSP.s = IPS_ALERT;
-                        IDSetSwitch(&UnattendedFlipSP, nullptr);
+                        UnattendedFlipSP.setState(IPS_ALERT);
+                        UnattendedFlipSP.apply();
                         return false;
                     }
                     LOG_INFO("Unattended flip disabled");
@@ -1230,19 +1230,19 @@ bool LX200_10MICRON::ISNewSwitch(const char *dev, const char *name, ISState *sta
                     if (false == setUnattendedFlipSetting(true))
                     {
                         LOG_ERROR("Setting unattended flip failed");
-                        UnattendedFlipSP.s = IPS_ALERT;
-                        IDSetSwitch(&UnattendedFlipSP, nullptr);
+                        UnattendedFlipSP.setState(IPS_ALERT);
+                        UnattendedFlipSP.apply();
                         return false;
                     }
                     LOG_INFO("Unattended flip enabled");
                     break;
                 default:
-                    UnattendedFlipSP.s = IPS_ALERT;
-                    IDSetSwitch(&UnattendedFlipSP, "Unknown unattended flip setting %d", index);
+                    UnattendedFlipSP.setState(IPS_ALERT);
+                    UnattendedFlipSP.apply("Unknown unattended flip setting %d", index);
                     return false;
             }
-            UnattendedFlipSP.s = IPS_OK;
-            IDSetSwitch(&UnattendedFlipSP, nullptr);
+            UnattendedFlipSP.setState(IPS_OK);
+            UnattendedFlipSP.apply();
             return true;
         }
     }
@@ -1256,31 +1256,31 @@ bool LX200_10MICRON::ISNewText(const char *dev, const char *name, char *texts[],
     {
         if (strcmp(name, NEW_MODEL_NAME) == 0)
         {
-            IUUpdateText(&NewModelNameTP, texts, names, n);
-            NewModelNameTP.s = IPS_OK;
-            IDSetText(&NewModelNameTP, nullptr);
-            LOGF_INFO("Model saved with name %s", NewModelNameT[0].text);
+            NewModelNameTP.update(texts, names, n);
+            NewModelNameTP.setState(IPS_OK);
+            NewModelNameTP.apply();
+            LOGF_INFO("Model saved with name %s", NewModelNameTP[0].getText());
             return true;
         }
         if (strcmp(name, "SAT_TLE_TEXT") == 0)
         {
 
-            IUUpdateText(&TLEtoTrackTP, texts, names, n);
-            if (0 == SetTLEtoFollow(TLEtoTrackT[0].text))
+            TLEtoTrackTP.update(texts, names, n);
+            if (0 == SetTLEtoFollow(TLEtoTrackTP[0].getText()))
             {
-                TLEtoTrackTP.s = IPS_OK;
-                TLEfromDatabaseNP.s = IPS_IDLE;
-                IDSetText(&TLEtoTrackTP, nullptr);
-                IDSetNumber(&TLEfromDatabaseNP, nullptr);
-                LOGF_INFO("Selected TLE %s", TLEtoTrackT[0].text);
+                TLEtoTrackTP.setState(IPS_OK);
+                TLEfromDatabaseNP.setState(IPS_IDLE);
+                TLEtoTrackTP.apply();
+                TLEfromDatabaseNP.apply();
+                LOGF_INFO("Selected TLE %s", TLEtoTrackTP[0].getText());
                 return true;
             }
             else
             {
-                TLEtoTrackTP.s = IPS_ALERT;
-                TLEfromDatabaseNP.s = IPS_IDLE;
-                IDSetText(&TLEtoTrackTP, nullptr);
-                IDSetNumber(&TLEfromDatabaseNP, nullptr);
+                TLEtoTrackTP.setState(IPS_ALERT);
+                TLEfromDatabaseNP.setState(IPS_IDLE);
+                TLEtoTrackTP.apply();
+                TLEfromDatabaseNP.apply();
                 LOG_ERROR("TLE was not correctly uploaded");
                 return false;
             }
@@ -1289,18 +1289,18 @@ bool LX200_10MICRON::ISNewText(const char *dev, const char *name, char *texts[],
         }
         if (strcmp(name, "SAT_PASS_WINDOW") == 0)
         {
-            IUUpdateText(&SatPassWindowTP, texts, names, n);
-            if (0 == CalculateSatTrajectory(SatPassWindowT[SAT_PASS_WINDOW_START].text, SatPassWindowT[SAT_PASS_WINDOW_END].text))
+            SatPassWindowTP.update(texts, names, n);
+            if (0 == CalculateSatTrajectory(SatPassWindowTP[SAT_PASS_WINDOW_START].getText(), SatPassWindowTP[SAT_PASS_WINDOW_END].getText()))
             {
-                SatPassWindowTP.s = IPS_OK;
-                IDSetText(&SatPassWindowTP, nullptr);
+                SatPassWindowTP.setState(IPS_OK);
+                SatPassWindowTP.apply();
                 LOG_INFO("Trajectory set");
                 return true;
             }
             else
             {
-                SatPassWindowTP.s = IPS_ALERT;
-                IDSetText(&SatPassWindowTP, nullptr);
+                SatPassWindowTP.setState(IPS_ALERT);
+                SatPassWindowTP.apply();
                 LOG_ERROR("Trajectory could not be calculated");
                 return false;
             }

--- a/drivers/telescope/lx200_10micron.h
+++ b/drivers/telescope/lx200_10micron.h
@@ -22,6 +22,11 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200_10MICRON : public LX200Generic
 {
     public:
@@ -135,45 +140,32 @@ class LX200_10MICRON : public LX200Generic
         void getBasicData() override;
 
         int UnattendedFlip = -1;
-        ISwitch UnattendedFlipS[UNATTENDED_FLIP_COUNT];
-        ISwitchVectorProperty UnattendedFlipSP;
+        INDI::PropertySwitch UnattendedFlipSP {UNATTENDED_FLIP_COUNT};
 
-        IText ProductT[4] {};
-        ITextVectorProperty ProductTP;
+        INDI::PropertyText ProductTP {4};
 
         virtual int SetRefractionModelTemperature(double temperature);
-        INumber RefractionModelTemperatureN[1];
-        INumberVectorProperty RefractionModelTemperatureNP;
+        INDI::PropertyNumber RefractionModelTemperatureNP {1};
 
         virtual int SetRefractionModelPressure(double pressure);
-        INumber RefractionModelPressureN[1];
-        INumberVectorProperty RefractionModelPressureNP;
+        INDI::PropertyNumber RefractionModelPressureNP {1};
 
-        INumber ModelCountN[1];
-        INumberVectorProperty ModelCountNP;
+        INDI::PropertyNumber ModelCountNP {1};
 
-        INumber AlignmentPointsN[1];
-        INumberVectorProperty AlignmentPointsNP;
+        INDI::PropertyNumber AlignmentPointsNP {1};
 
-        ISwitch AlignmentStateS[ALIGN_COUNT];
-        ISwitchVectorProperty AlignmentStateSP;
+        INDI::PropertySwitch AlignmentStateSP {ALIGN_COUNT};
 
-        INumber MiniNewAlpRON[MALPRO_COUNT];
-        INumberVectorProperty MiniNewAlpRONP;
-        INumber MiniNewAlpN[MALP_COUNT];
-        INumberVectorProperty MiniNewAlpNP;
+        INDI::PropertyNumber MiniNewAlpRONP {MALPRO_COUNT};
+        INDI::PropertyNumber MiniNewAlpNP {MALP_COUNT};
 
-        INumber NewAlpN[ALP_COUNT];
-        INumberVectorProperty NewAlpNP;
+        INDI::PropertyNumber NewAlpNP {ALP_COUNT};
 
-        INumber NewAlignmentPointsN[1];
-        INumberVectorProperty NewAlignmentPointsNP;
+        INDI::PropertyNumber NewAlignmentPointsNP {1};
 
-        IText NewModelNameT[1] {};
-        ITextVectorProperty NewModelNameTP;
+        INDI::PropertyText NewModelNameTP {1};
 
-        INumber TLEfromDatabaseN[1];
-        INumberVectorProperty TLEfromDatabaseNP;
+        INDI::PropertyNumber TLEfromDatabaseNP {1};
 
 
     private:

--- a/drivers/telescope/lx200_16.cpp
+++ b/drivers/telescope/lx200_16.cpp
@@ -43,24 +43,24 @@ bool LX200_16::initProperties()
 {
     LX200GPS::initProperties();
 
-    IUFillSwitch(&FanStatusS[0], "On", "", ISS_OFF);
-    IUFillSwitch(&FanStatusS[1], "Off", "", ISS_OFF);
-    IUFillSwitchVector(&FanStatusSP, FanStatusS, 2, getDeviceName(), "Fan", "", LX16_TAB, IP_RW, ISR_1OFMANY, 0,
+    FanStatusSP[0].fill("On", "", ISS_OFF);
+    FanStatusSP[1].fill("Off", "", ISS_OFF);
+    FanStatusSP.fill(getDeviceName(), "Fan", "", LX16_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&HomeSearchS[0], "Save Home", "", ISS_OFF);
-    IUFillSwitch(&HomeSearchS[1], "Set Home", "", ISS_OFF);
-    IUFillSwitchVector(&HomeSearchSP, HomeSearchS, 2, getDeviceName(), "Home", "", LX16_TAB, IP_RW, ISR_1OFMANY, 0,
+    HomeSearchSP[0].fill("Save Home", "", ISS_OFF);
+    HomeSearchSP[1].fill("Set Home", "", ISS_OFF);
+    HomeSearchSP.fill(getDeviceName(), "Home", "", LX16_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&FieldDeRotatorS[0], "On", "", ISS_OFF);
-    IUFillSwitch(&FieldDeRotatorS[1], "Off", "", ISS_OFF);
-    IUFillSwitchVector(&FieldDeRotatorSP, FieldDeRotatorS, 2, getDeviceName(), "Field De-Rotator", "", LX16_TAB, IP_RW,
+    FieldDeRotatorSP[0].fill("On", "", ISS_OFF);
+    FieldDeRotatorSP[1].fill("Off", "", ISS_OFF);
+    FieldDeRotatorSP.fill(getDeviceName(), "Field De-Rotator", "", LX16_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&HorizontalCoordsN[0], "ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
-    IUFillNumber(&HorizontalCoordsN[1], "AZ", "Az D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
-    IUFillNumberVector(&HorizontalCoordsNP, HorizontalCoordsN, 2, getDeviceName(), "HORIZONTAL_COORD",
+    HorizontalCoordsNP[0].fill("ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
+    HorizontalCoordsNP[1].fill("AZ", "Az D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
+    HorizontalCoordsNP.fill(getDeviceName(), "HORIZONTAL_COORD",
                        "Horizontal Coord", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     return true;
@@ -77,10 +77,10 @@ void LX200_16::ISGetProperties(const char *dev)
     /*
     if (isConnected())
     {
-        defineProperty(&HorizontalCoordsNP);
-        defineProperty(&FanStatusSP);
-        defineProperty(&HomeSearchSP);
-        defineProperty(&FieldDeRotatorSP);
+        defineProperty(HorizontalCoordsNP);
+        defineProperty(FanStatusSP);
+        defineProperty(HomeSearchSP);
+        defineProperty(FieldDeRotatorSP);
     }
     */
 }
@@ -92,17 +92,17 @@ bool LX200_16::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&HorizontalCoordsNP);
-        defineProperty(&FanStatusSP);
-        defineProperty(&HomeSearchSP);
-        defineProperty(&FieldDeRotatorSP);
+        defineProperty(HorizontalCoordsNP);
+        defineProperty(FanStatusSP);
+        defineProperty(HomeSearchSP);
+        defineProperty(FieldDeRotatorSP);
     }
     else
     {
-        deleteProperty(HorizontalCoordsNP.name);
-        deleteProperty(FanStatusSP.name);
-        deleteProperty(HomeSearchSP.name);
-        deleteProperty(FieldDeRotatorSP.name);
+        deleteProperty(HorizontalCoordsNP.getName());
+        deleteProperty(FanStatusSP.getName());
+        deleteProperty(HomeSearchSP.getName());
+        deleteProperty(FieldDeRotatorSP.getName());
     }
 
     return true;
@@ -114,19 +114,19 @@ bool LX200_16::ISNewNumber(const char *dev, const char *name, double values[], c
 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, HorizontalCoordsNP.name))
+        if (HorizontalCoordsNP.isNameMatch(name))
         {
             int i = 0, nset = 0;
 
             for (nset = i = 0; i < n; i++)
             {
-                INumber *horp = IUFindNumber(&HorizontalCoordsNP, names[i]);
-                if (horp == &HorizontalCoordsN[0])
+                INumber *horp = HorizontalCoordsNP.findWidgetByName(names[i]);
+                if (horp == &HorizontalCoordsNP[0])
                 {
                     newAlt = values[i];
                     nset += newAlt >= -90. && newAlt <= 90.0;
                 }
-                else if (horp == &HorizontalCoordsN[1])
+                else if (horp == &HorizontalCoordsNP[1])
                 {
                     newAz = values[i];
                     nset += newAz >= 0. && newAz <= 360.0;
@@ -137,8 +137,8 @@ bool LX200_16::ISNewNumber(const char *dev, const char *name, double values[], c
             {
                 if (!isSimulation() && (setObjAz(PortFD, newAz) < 0 || setObjAlt(PortFD, newAlt) < 0))
                 {
-                    HorizontalCoordsNP.s = IPS_ALERT;
-                    IDSetNumber(&HorizontalCoordsNP, "Error setting Alt/Az.");
+                    HorizontalCoordsNP.setState(IPS_ALERT);
+                    HorizontalCoordsNP.apply("Error setting Alt/Az.");
                     return false;
                 }
                 targetAZ  = newAz;
@@ -148,8 +148,8 @@ bool LX200_16::ISNewNumber(const char *dev, const char *name, double values[], c
             }
             else
             {
-                HorizontalCoordsNP.s = IPS_ALERT;
-                IDSetNumber(&HorizontalCoordsNP, "Altitude or Azimuth missing or invalid");
+                HorizontalCoordsNP.setState(IPS_ALERT);
+                HorizontalCoordsNP.apply("Altitude or Azimuth missing or invalid");
                 return false;
             }
         }
@@ -165,18 +165,18 @@ bool LX200_16::ISNewSwitch(const char *dev, const char *name, ISState *states, c
 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, FanStatusSP.name))
+        if (FanStatusSP.isNameMatch(name))
         {
-            IUResetSwitch(&FanStatusSP);
-            IUUpdateSwitch(&FanStatusSP, states, names, n);
-            index = IUFindOnSwitchIndex(&FanStatusSP);
+            FanStatusSP.reset();
+            FanStatusSP.update(states, names, n);
+            index = FanStatusSP.findOnSwitchIndex();
 
             if (index == 0)
             {
                 if (turnFanOn(PortFD) < 0)
                 {
-                    FanStatusSP.s = IPS_ALERT;
-                    IDSetSwitch(&FanStatusSP, "Error changing fan status.");
+                    FanStatusSP.setState(IPS_ALERT);
+                    FanStatusSP.apply("Error changing fan status.");
                     return false;
                 }
             }
@@ -184,50 +184,50 @@ bool LX200_16::ISNewSwitch(const char *dev, const char *name, ISState *states, c
             {
                 if (turnFanOff(PortFD) < 0)
                 {
-                    FanStatusSP.s = IPS_ALERT;
-                    IDSetSwitch(&FanStatusSP, "Error changing fan status.");
+                    FanStatusSP.setState(IPS_ALERT);
+                    FanStatusSP.apply("Error changing fan status.");
                     return false;
                 }
             }
 
-            FanStatusSP.s = IPS_OK;
-            IDSetSwitch(&FanStatusSP, index == 0 ? "Fan is ON" : "Fan is OFF");
+            FanStatusSP.setState(IPS_OK);
+            FanStatusSP.apply(index == 0 ? "Fan is ON" : "Fan is OFF");
             return true;
         }
 
-        if (!strcmp(name, HomeSearchSP.name))
+        if (HomeSearchSP.isNameMatch(name))
         {
             int ret = 0;
 
-            IUResetSwitch(&HomeSearchSP);
-            IUUpdateSwitch(&HomeSearchSP, states, names, n);
-            index = IUFindOnSwitchIndex(&HomeSearchSP);
+            HomeSearchSP.reset();
+            HomeSearchSP.update(states, names, n);
+            index = HomeSearchSP.findOnSwitchIndex();
 
             if (index == 0)
                 ret = seekHomeAndSave(PortFD);
             else
                 ret = seekHomeAndSet(PortFD);
 
-            HomeSearchSP.s = IPS_BUSY;
-            IDSetSwitch(&HomeSearchSP, index == 0 ? "Seek Home and Save" : "Seek Home and Set");
+            HomeSearchSP.setState(IPS_BUSY);
+            HomeSearchSP.apply(index == 0 ? "Seek Home and Save" : "Seek Home and Set");
             return true;
         }
 
-        if (!strcmp(name, FieldDeRotatorSP.name))
+        if (FieldDeRotatorSP.isNameMatch(name))
         {
             int ret = 0;
 
-            IUResetSwitch(&FieldDeRotatorSP);
-            IUUpdateSwitch(&FieldDeRotatorSP, states, names, n);
-            index = IUFindOnSwitchIndex(&FieldDeRotatorSP);
+            FieldDeRotatorSP.reset();
+            FieldDeRotatorSP.update(states, names, n);
+            index = FieldDeRotatorSP.findOnSwitchIndex();
 
             if (index == 0)
                 ret = turnFieldDeRotatorOn(PortFD);
             else
                 ret = turnFieldDeRotatorOff(PortFD);
 
-            FieldDeRotatorSP.s = IPS_OK;
-            IDSetSwitch(&FieldDeRotatorSP, index == 0 ? "Field deRotator is ON" : "Field deRotator is OFF");
+            FieldDeRotatorSP.setState(IPS_OK);
+            FieldDeRotatorSP.apply(index == 0 ? "Field deRotator is ON" : "Field deRotator is OFF");
             return true;
         }
     }
@@ -240,7 +240,7 @@ bool LX200_16::handleAltAzSlew()
     const struct timespec timeout = {0, 100000000L};
     char altStr[64], azStr[64];
 
-    if (HorizontalCoordsNP.s == IPS_BUSY)
+    if (HorizontalCoordsNP.getState() == IPS_BUSY)
     {
         abortSlew(PortFD);
 
@@ -250,17 +250,17 @@ bool LX200_16::handleAltAzSlew()
 
     if (!isSimulation() && slewToAltAz(PortFD))
     {
-        HorizontalCoordsNP.s = IPS_ALERT;
-        IDSetNumber(&HorizontalCoordsNP, "Slew is not possible.");
+        HorizontalCoordsNP.setState(IPS_ALERT);
+        HorizontalCoordsNP.apply("Slew is not possible.");
         return false;
     }
 
-    HorizontalCoordsNP.s = IPS_BUSY;
+    HorizontalCoordsNP.setState(IPS_BUSY);
     fs_sexa(azStr, targetAZ, 2, 3600);
     fs_sexa(altStr, targetALT, 2, 3600);
 
     TrackState = SCOPE_SLEWING;
-    IDSetNumber(&HorizontalCoordsNP, "Slewing to Alt %s - Az %s", altStr, azStr);
+    HorizontalCoordsNP.apply("Slewing to Alt %s - Az %s", altStr, azStr);
     return true;
 }
 
@@ -271,7 +271,7 @@ bool LX200_16::ReadScopeStatus()
 
     LX200Generic::ReadScopeStatus();
 
-    switch (HomeSearchSP.s)
+    switch (HomeSearchSP.getState())
     {
         case IPS_IDLE:
             break;
@@ -282,27 +282,27 @@ bool LX200_16::ReadScopeStatus()
                 searchResult = 1;
             else if (getHomeSearchStatus(PortFD, &searchResult) < 0)
             {
-                HomeSearchSP.s = IPS_ALERT;
-                IDSetSwitch(&HomeSearchSP, "Error updating home search status.");
+                HomeSearchSP.setState(IPS_ALERT);
+                HomeSearchSP.apply("Error updating home search status.");
                 return false;
             }
 
             if (searchResult == 0)
             {
-                HomeSearchSP.s = IPS_ALERT;
-                IDSetSwitch(&HomeSearchSP, "Home search failed.");
+                HomeSearchSP.setState(IPS_ALERT);
+                HomeSearchSP.apply("Home search failed.");
             }
             else if (searchResult == 1)
             {
-                HomeSearchSP.s = IPS_OK;
-                IDSetSwitch(&HomeSearchSP, "Home search successful.");
+                HomeSearchSP.setState(IPS_OK);
+                HomeSearchSP.apply("Home search successful.");
             }
             else if (searchResult == 2)
-                IDSetSwitch(&HomeSearchSP, "Home search in progress...");
+                HomeSearchSP.apply("Home search in progress...");
             else
             {
-                HomeSearchSP.s = IPS_ALERT;
-                IDSetSwitch(&HomeSearchSP, "Home search error.");
+                HomeSearchSP.setState(IPS_ALERT);
+                HomeSearchSP.apply("Home search error.");
             }
             break;
 
@@ -312,7 +312,7 @@ bool LX200_16::ReadScopeStatus()
             break;
     }
 
-    switch (HorizontalCoordsNP.s)
+    switch (HorizontalCoordsNP.getState())
     {
         case IPS_IDLE:
             break;
@@ -328,27 +328,27 @@ bool LX200_16::ReadScopeStatus()
             }
             if (getLX200Az(PortFD, &currentAZ) < 0 || getLX200Alt(PortFD, &currentALT) < 0)
             {
-                HorizontalCoordsNP.s = IPS_ALERT;
-                IDSetNumber(&HorizontalCoordsNP, "Error geting Alt/Az.");
+                HorizontalCoordsNP.setState(IPS_ALERT);
+                HorizontalCoordsNP.apply("Error geting Alt/Az.");
                 return false;
             }
 
             dx = targetAZ - currentAZ;
             dy = targetALT - currentALT;
 
-            HorizontalCoordsNP.np[0].value = currentALT;
-            HorizontalCoordsNP.np[1].value = currentAZ;
+            HorizontalCoordsNP[0].setValue(currentALT);
+            HorizontalCoordsNP[1].setValue(currentAZ);
 
             // accuracy threshold (3'), can be changed as desired.
             if (fabs(dx) <= 0.05 && fabs(dy) <= 0.05)
             {
-                HorizontalCoordsNP.s = IPS_OK;
+                HorizontalCoordsNP.setState(IPS_OK);
                 currentAZ            = targetAZ;
                 currentALT           = targetALT;
-                IDSetNumber(&HorizontalCoordsNP, "Slew is complete.");
+                HorizontalCoordsNP.apply("Slew is complete.");
             }
             else
-                IDSetNumber(&HorizontalCoordsNP, nullptr);
+                HorizontalCoordsNP.apply();
             break;
 
         case IPS_OK:
@@ -369,8 +369,8 @@ void LX200_16::getBasicData()
     {
         getLX200Az(PortFD, &currentAZ);
         getLX200Alt(PortFD, &currentALT);
-        HorizontalCoordsNP.np[0].value = currentALT;
-        HorizontalCoordsNP.np[1].value = currentAZ;
-        IDSetNumber(&HorizontalCoordsNP, nullptr);
+        HorizontalCoordsNP[0].setValue(currentALT);
+        HorizontalCoordsNP[1].setValue(currentAZ);
+        HorizontalCoordsNP.apply();
     }
 }

--- a/drivers/telescope/lx200_16.h
+++ b/drivers/telescope/lx200_16.h
@@ -22,6 +22,10 @@
 
 #include "lx200gps.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200_16 : public LX200GPS
 {
   public:
@@ -39,17 +43,10 @@ class LX200_16 : public LX200GPS
     bool handleAltAzSlew();
 
   protected:
-    ISwitchVectorProperty FieldDeRotatorSP;
-    ISwitch FieldDeRotatorS[2];
-
-    ISwitchVectorProperty HomeSearchSP;
-    ISwitch HomeSearchS[2];
-
-    ISwitchVectorProperty FanStatusSP;
-    ISwitch FanStatusS[2];
-
-    INumberVectorProperty HorizontalCoordsNP;
-    INumber HorizontalCoordsN[2];
+    INDI::PropertySwitch FieldDeRotatorSP {2};
+    INDI::PropertySwitch HomeSearchSP {2};
+    INDI::PropertySwitch FanStatusSP {2};
+    INDI::PropertyNumber HorizontalCoordsNP {2};
 
   private:
     double targetAZ, targetALT;

--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -79,29 +79,29 @@ bool LX200_OnStep::initProperties()
 
     //FocuserInterface
     //Initial, these will be updated later.
-    FocusRelPosN[0].min   = 0.;
-    FocusRelPosN[0].max   = 30000.;
-    FocusRelPosN[0].value = 0;
-    FocusRelPosN[0].step  = 10;
-    FocusAbsPosN[0].min   = 0.;
-    FocusAbsPosN[0].max   = 60000.;
-    FocusAbsPosN[0].value = 0;
-    FocusAbsPosN[0].step  = 10;
+    FocusRelPosNP[0].setMin(0.);
+    FocusRelPosNP[0].setMax(30000.);
+    FocusRelPosNP[0].setValue(0);
+    FocusRelPosNP[0].setStep(10);
+    FocusAbsPosNP[0].setMin(0.);
+    FocusAbsPosNP[0].setMax(60000.);
+    FocusAbsPosNP[0].setValue(0);
+    FocusAbsPosNP[0].setStep(10);
 
 
     // ============== MAIN_CONTROL_TAB
-    IUFillSwitch(&ReticS[0], "PLUS", "Light", ISS_OFF);
-    IUFillSwitch(&ReticS[1], "MOINS", "Dark", ISS_OFF);
-    IUFillSwitchVector(&ReticSP, ReticS, 2, getDeviceName(), "RETICULE_BRIGHTNESS", "Reticule +/-", MAIN_CONTROL_TAB, IP_RW,
+    ReticSP[0].fill("PLUS", "Light", ISS_OFF);
+    ReticSP[1].fill("MOINS", "Dark", ISS_OFF);
+    ReticSP.fill(getDeviceName(), "RETICULE_BRIGHTNESS", "Reticule +/-", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillNumber(&ElevationLimitN[0], "minAlt", "Elev Min", "%+03f", -90.0, 90.0, 1.0, -30.0);
-    IUFillNumber(&ElevationLimitN[1], "maxAlt", "Elev Max", "%+03f", -90.0, 90.0, 1.0, 89.0);
-    IUFillNumberVector(&ElevationLimitNP, ElevationLimitN, 2, getDeviceName(), "Slew elevation Limit", "", MAIN_CONTROL_TAB,
+    ElevationLimitNP[0].fill("minAlt", "Elev Min", "%+03f", -90.0, 90.0, 1.0, -30.0);
+    ElevationLimitNP[1].fill("maxAlt", "Elev Max", "%+03f", -90.0, 90.0, 1.0, 89.0);
+    ElevationLimitNP.fill(getDeviceName(), "Slew elevation Limit", "", MAIN_CONTROL_TAB,
                        IP_RW, 0, IPS_IDLE);
 
-    IUFillText(&ObjectInfoT[0], "Info", "", "");
-    IUFillTextVector(&ObjectInfoTP, ObjectInfoT, 1, getDeviceName(), "Object Info", "", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    ObjectInfoTP[0].fill("Info", "", "");
+    ObjectInfoTP.fill(getDeviceName(), "Object Info", "", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     // ============== CONNECTION_TAB
 
@@ -127,67 +127,67 @@ bool LX200_OnStep::initProperties()
     IUFillSwitchVector(&SlewRateSP, SlewRateS, nSlewRate, getDeviceName(), "TELESCOPE_SLEW_RATE", "Slew Rate", MOTION_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&MaxSlewRateN[0], "maxSlew", "Rate", "%f", 0.0, 9.0, 1.0, 5.0);    //2.0, 9.0, 1.0, 9.0
-    IUFillNumberVector(&MaxSlewRateNP, MaxSlewRateN, 1, getDeviceName(), "Max slew Rate", "", MOTION_TAB, IP_RW, 0, IPS_IDLE);
+    MaxSlewRateNP[0].fill("maxSlew", "Rate", "%f", 0.0, 9.0, 1.0, 5.0);    //2.0, 9.0, 1.0, 9.0
+    MaxSlewRateNP.fill(getDeviceName(), "Max slew Rate", "", MOTION_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillSwitch(&TrackCompS[0], "1", "Full Compensation", ISS_OFF);
-    IUFillSwitch(&TrackCompS[1], "2", "Refraction", ISS_OFF);
-    IUFillSwitch(&TrackCompS[2], "3", "Off", ISS_ON);
-    IUFillSwitchVector(&TrackCompSP, TrackCompS, 3, getDeviceName(), "Compensation", "Compensation Tracking", MOTION_TAB, IP_RW,
+    TrackCompSP[0].fill("1", "Full Compensation", ISS_OFF);
+    TrackCompSP[1].fill("2", "Refraction", ISS_OFF);
+    TrackCompSP[2].fill("3", "Off", ISS_ON);
+    TrackCompSP.fill(getDeviceName(), "Compensation", "Compensation Tracking", MOTION_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&TrackAxisS[0], "1", "Single Axis", ISS_OFF);
-    IUFillSwitch(&TrackAxisS[1], "2", "Dual Axis", ISS_OFF);
-    IUFillSwitchVector(&TrackAxisSP, TrackAxisS, 2, getDeviceName(), "Multi-Axis", "Multi-Axis Tracking", MOTION_TAB, IP_RW,
+    TrackAxisSP[0].fill("1", "Single Axis", ISS_OFF);
+    TrackAxisSP[1].fill("2", "Dual Axis", ISS_OFF);
+    TrackAxisSP.fill(getDeviceName(), "Multi-Axis", "Multi-Axis Tracking", MOTION_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&TrackAxisS[0], "1", "Single Axis", ISS_OFF);
-    IUFillSwitch(&TrackAxisS[1], "2", "Dual Axis", ISS_OFF);
-    IUFillSwitchVector(&TrackAxisSP, TrackAxisS, 2, getDeviceName(), "Multi-Axis", "Multi-Axis Tracking", MOTION_TAB, IP_RW,
+    TrackAxisSP[0].fill("1", "Single Axis", ISS_OFF);
+    TrackAxisSP[1].fill("2", "Dual Axis", ISS_OFF);
+    TrackAxisSP.fill(getDeviceName(), "Multi-Axis", "Multi-Axis Tracking", MOTION_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&BacklashN[0], "Backlash DEC", "DE", "%g", 0, 999, 1, 15);
-    IUFillNumber(&BacklashN[1], "Backlash RA", "RA", "%g", 0, 999, 1, 15);
-    IUFillNumberVector(&BacklashNP, BacklashN, 2, getDeviceName(), "Backlash", "", MOTION_TAB, IP_RW, 0, IPS_IDLE);
+    BacklashNP[0].fill("Backlash DEC", "DE", "%g", 0, 999, 1, 15);
+    BacklashNP[1].fill("Backlash RA", "RA", "%g", 0, 999, 1, 15);
+    BacklashNP.fill(getDeviceName(), "Backlash", "", MOTION_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillNumber(&GuideRateN[RA_AXIS], "GUIDE_RATE_WE", "W/E Rate", "%g", 0, 1, 0.25, 0.5);
-    IUFillNumber(&GuideRateN[DEC_AXIS], "GUIDE_RATE_NS", "N/S Rate", "%g", 0, 1, 0.25, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RO, 0,
+    GuideRateNP[RA_AXIS].fill("GUIDE_RATE_WE", "W/E Rate", "%g", 0, 1, 0.25, 0.5);
+    GuideRateNP[DEC_AXIS].fill("GUIDE_RATE_NS", "N/S Rate", "%g", 0, 1, 0.25, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RO, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&AutoFlipS[0], "1", "AutoFlip: OFF", ISS_OFF);
-    IUFillSwitch(&AutoFlipS[1], "2", "AutoFlip: ON", ISS_OFF);
-    IUFillSwitchVector(&AutoFlipSP, AutoFlipS, 2, getDeviceName(), "AutoFlip", "Meridian Auto Flip", MOTION_TAB, IP_RW,
+    AutoFlipSP[0].fill("1", "AutoFlip: OFF", ISS_OFF);
+    AutoFlipSP[1].fill("2", "AutoFlip: ON", ISS_OFF);
+    AutoFlipSP.fill(getDeviceName(), "AutoFlip", "Meridian Auto Flip", MOTION_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&HomePauseS[0], "1", "HomePause: OFF", ISS_OFF);
-    IUFillSwitch(&HomePauseS[1], "2", "HomePause: ON", ISS_OFF);
-    IUFillSwitch(&HomePauseS[2], "3", "HomePause: Continue", ISS_OFF);
-    IUFillSwitchVector(&HomePauseSP, HomePauseS, 3, getDeviceName(), "HomePause", "Pause at Home", MOTION_TAB, IP_RW,
+    HomePauseSP[0].fill("1", "HomePause: OFF", ISS_OFF);
+    HomePauseSP[1].fill("2", "HomePause: ON", ISS_OFF);
+    HomePauseSP[2].fill("3", "HomePause: Continue", ISS_OFF);
+    HomePauseSP.fill(getDeviceName(), "HomePause", "Pause at Home", MOTION_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&FrequencyAdjustS[0], "1", "Frequency -", ISS_OFF);
-    IUFillSwitch(&FrequencyAdjustS[1], "2", "Frequency +", ISS_OFF);
-    IUFillSwitch(&FrequencyAdjustS[2], "3", "Reset Sidereal Frequency", ISS_OFF);
-    IUFillSwitchVector(&FrequencyAdjustSP, FrequencyAdjustS, 3, getDeviceName(), "FrequencyAdjust", "Frequency Adjust",
+    FrequencyAdjustSP[0].fill("1", "Frequency -", ISS_OFF);
+    FrequencyAdjustSP[1].fill("2", "Frequency +", ISS_OFF);
+    FrequencyAdjustSP[2].fill("3", "Reset Sidereal Frequency", ISS_OFF);
+    FrequencyAdjustSP.fill(getDeviceName(), "FrequencyAdjust", "Frequency Adjust",
                        MOTION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&PreferredPierSideS[0], "1", "West", ISS_OFF);
-    IUFillSwitch(&PreferredPierSideS[1], "2", "East", ISS_OFF);
-    IUFillSwitch(&PreferredPierSideS[2], "3", "Best", ISS_OFF);
-    IUFillSwitchVector(&PreferredPierSideSP, PreferredPierSideS, 3, getDeviceName(), "Preferred Pier Side",
+    PreferredPierSideSP[0].fill("1", "West", ISS_OFF);
+    PreferredPierSideSP[1].fill("2", "East", ISS_OFF);
+    PreferredPierSideSP[2].fill("3", "Best", ISS_OFF);
+    PreferredPierSideSP.fill(getDeviceName(), "Preferred Pier Side",
                        "Preferred Pier Side", MOTION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&minutesPastMeridianN[0], "East", "East", "%g", 0, 180, 1, 30);
-    IUFillNumber(&minutesPastMeridianN[1], "West", "West", "%g", 0, 180, 1, 30);
-    IUFillNumberVector(&minutesPastMeridianNP, minutesPastMeridianN, 2, getDeviceName(), "Minutes Past Meridian",
+    minutesPastMeridianNP[0].fill("East", "East", "%g", 0, 180, 1, 30);
+    minutesPastMeridianNP[1].fill("West", "West", "%g", 0, 180, 1, 30);
+    minutesPastMeridianNP.fill(getDeviceName(), "Minutes Past Meridian",
                        "Minutes Past Meridian", MOTION_TAB, IP_RW, 0, IPS_IDLE);
 
 
     // ============== SITE_MANAGEMENT_TAB
-    IUFillSwitch(&SetHomeS[0], "RETURN_HOME", "Return  Home", ISS_OFF);
-    IUFillSwitch(&SetHomeS[1], "AT_HOME", "At Home (Reset)", ISS_OFF);
-    IUFillSwitchVector(&SetHomeSP, SetHomeS, 2, getDeviceName(), "HOME_INIT", "Homing", SITE_TAB, IP_RW, ISR_ATMOST1, 60,
+    SetHomeSP[0].fill("RETURN_HOME", "Return  Home", ISS_OFF);
+    SetHomeSP[1].fill("AT_HOME", "At Home (Reset)", ISS_OFF);
+    SetHomeSP.fill(getDeviceName(), "HOME_INIT", "Homing", SITE_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_IDLE);
 
     // ============== GUIDE_TAB
@@ -195,10 +195,10 @@ bool LX200_OnStep::initProperties()
     // ============== FOCUS_TAB
     // Focuser 1
 
-    IUFillSwitch(&OSFocus1InitializeS[0], "Focus1_0", "Zero", ISS_OFF);
-    IUFillSwitch(&OSFocus1InitializeS[1], "Focus1_2", "Mid", ISS_OFF);
-    //     IUFillSwitch(&OSFocus1InitializeS[2], "Focus1_3", "max", ISS_OFF);
-    IUFillSwitchVector(&OSFocus1InitializeSP, OSFocus1InitializeS, 2, getDeviceName(), "Foc1Rate", "Initialize", FOCUS_TAB,
+    OSFocus1InitializeSP[0].fill("Focus1_0", "Zero", ISS_OFF);
+    OSFocus1InitializeSP[1].fill("Focus1_2", "Mid", ISS_OFF);
+    //     OSFocus1InitializeSP[2].fill("Focus1_3", "max", ISS_OFF);
+    OSFocus1InitializeSP.fill(getDeviceName(), "Foc1Rate", "Initialize", FOCUS_TAB,
                        IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
 
@@ -207,21 +207,21 @@ bool LX200_OnStep::initProperties()
     //IUFillSwitch(&OSFocus2SelS[1], "Focus2_Sel2", "Foc 2", ISS_OFF);
     //IUFillSwitchVector(&OSFocus2SelSP, OSFocus2SelS, 2, getDeviceName(), "Foc2Sel", "Foc 2", FOCUS_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OSFocus2MotionS[0], "Focus2_In", "In", ISS_OFF);
-    IUFillSwitch(&OSFocus2MotionS[1], "Focus2_Out", "Out", ISS_OFF);
-    IUFillSwitch(&OSFocus2MotionS[2], "Focus2_Stop", "Stop", ISS_OFF);
-    IUFillSwitchVector(&OSFocus2MotionSP, OSFocus2MotionS, 3, getDeviceName(), "Foc2Mot", "Foc 2 Motion", FOCUS_TAB, IP_RW,
+    OSFocus2MotionSP[0].fill("Focus2_In", "In", ISS_OFF);
+    OSFocus2MotionSP[1].fill("Focus2_Out", "Out", ISS_OFF);
+    OSFocus2MotionSP[2].fill("Focus2_Stop", "Stop", ISS_OFF);
+    OSFocus2MotionSP.fill(getDeviceName(), "Foc2Mot", "Foc 2 Motion", FOCUS_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OSFocus2RateS[0], "Focus2_1", "min", ISS_OFF);
-    IUFillSwitch(&OSFocus2RateS[1], "Focus2_2", "0.01", ISS_OFF);
-    IUFillSwitch(&OSFocus2RateS[2], "Focus2_3", "0.1", ISS_OFF);
-    IUFillSwitch(&OSFocus2RateS[3], "Focus2_4", "1", ISS_OFF);
-    IUFillSwitchVector(&OSFocus2RateSP, OSFocus2RateS, 4, getDeviceName(), "Foc2Rate", "Foc 2 Rates", FOCUS_TAB, IP_RW,
+    OSFocus2RateSP[0].fill("Focus2_1", "min", ISS_OFF);
+    OSFocus2RateSP[1].fill("Focus2_2", "0.01", ISS_OFF);
+    OSFocus2RateSP[2].fill("Focus2_3", "0.1", ISS_OFF);
+    OSFocus2RateSP[3].fill("Focus2_4", "1", ISS_OFF);
+    OSFocus2RateSP.fill(getDeviceName(), "Foc2Rate", "Foc 2 Rates", FOCUS_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillNumber(&OSFocus2TargN[0], "FocusTarget2", "Abs Pos", "%g", -25000, 25000, 1, 0);
-    IUFillNumberVector(&OSFocus2TargNP, OSFocus2TargN, 1, getDeviceName(), "Foc2Targ", "Foc 2 Target", FOCUS_TAB, IP_RW, 0,
+    OSFocus2TargNP[0].fill("FocusTarget2", "Abs Pos", "%g", -25000, 25000, 1, 0);
+    OSFocus2TargNP.fill(getDeviceName(), "Foc2Targ", "Foc 2 Target", FOCUS_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // ============== FIRMWARE_TAB
@@ -232,89 +232,89 @@ bool LX200_OnStep::initProperties()
     IUFillTextVector(&VersionTP, VersionT, 4, getDeviceName(), "Firmware Info", "", FIRMWARE_TAB, IP_RO, 0, IPS_IDLE);
 
     //PEC Tab
-    IUFillSwitch(&OSPECStatusS[0], "OFF", "OFF", ISS_OFF);
-    IUFillSwitch(&OSPECStatusS[1], "Playing", "Playing", ISS_OFF);
-    IUFillSwitch(&OSPECStatusS[2], "Recording", "Recording", ISS_OFF);
-    IUFillSwitch(&OSPECStatusS[3], "Will Play", "Will Play", ISS_OFF);
-    IUFillSwitch(&OSPECStatusS[4], "Will Record", "Will Record", ISS_OFF);
-    IUFillSwitchVector(&OSPECStatusSP, OSPECStatusS, 5, getDeviceName(), "PEC Status", "PEC Status", PEC_TAB, IP_RO,
+    OSPECStatusSP[0].fill("OFF", "OFF", ISS_OFF);
+    OSPECStatusSP[1].fill("Playing", "Playing", ISS_OFF);
+    OSPECStatusSP[2].fill("Recording", "Recording", ISS_OFF);
+    OSPECStatusSP[3].fill("Will Play", "Will Play", ISS_OFF);
+    OSPECStatusSP[4].fill("Will Record", "Will Record", ISS_OFF);
+    OSPECStatusSP.fill(getDeviceName(), "PEC Status", "PEC Status", PEC_TAB, IP_RO,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OSPECIndexS[0], "Not Detected", "Not Detected", ISS_ON);
-    IUFillSwitch(&OSPECIndexS[1], "Detected", "Detected", ISS_OFF);
-    IUFillSwitchVector(&OSPECIndexSP, OSPECIndexS, 2, getDeviceName(), "PEC Index Detect", "PEC Index", PEC_TAB, IP_RO,
+    OSPECIndexSP[0].fill("Not Detected", "Not Detected", ISS_ON);
+    OSPECIndexSP[1].fill("Detected", "Detected", ISS_OFF);
+    OSPECIndexSP.fill(getDeviceName(), "PEC Index Detect", "PEC Index", PEC_TAB, IP_RO,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OSPECRecordS[0], "Clear", "Clear", ISS_OFF);
-    IUFillSwitch(&OSPECRecordS[1], "Record", "Record", ISS_OFF);
-    IUFillSwitch(&OSPECRecordS[2], "Write to EEPROM", "Write to EEPROM", ISS_OFF);
-    IUFillSwitchVector(&OSPECRecordSP, OSPECRecordS, 3, getDeviceName(), "PEC Operations", "PEC Recording", PEC_TAB, IP_RW,
+    OSPECRecordSP[0].fill("Clear", "Clear", ISS_OFF);
+    OSPECRecordSP[1].fill("Record", "Record", ISS_OFF);
+    OSPECRecordSP[2].fill("Write to EEPROM", "Write to EEPROM", ISS_OFF);
+    OSPECRecordSP.fill(getDeviceName(), "PEC Operations", "PEC Recording", PEC_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OSPECReadS[0], "Read", "Read PEC to FILE****", ISS_OFF);
-    IUFillSwitch(&OSPECReadS[1], "Write", "Write PEC from FILE***", ISS_OFF);
-    //    IUFillSwitch(&OSPECReadS[2], "Write to EEPROM", "Write to EEPROM", ISS_OFF);
-    IUFillSwitchVector(&OSPECReadSP, OSPECReadS, 2, getDeviceName(), "PEC File", "PEC File", PEC_TAB, IP_RW, ISR_ATMOST1, 0,
+    OSPECReadSP[0].fill("Read", "Read PEC to FILE****", ISS_OFF);
+    OSPECReadSP[1].fill("Write", "Write PEC from FILE***", ISS_OFF);
+    //    OSPECReadSP[2].fill("Write to EEPROM", "Write to EEPROM", ISS_OFF);
+    OSPECReadSP.fill(getDeviceName(), "PEC File", "PEC File", PEC_TAB, IP_RW, ISR_ATMOST1, 0,
                        IPS_IDLE);
     // ============== New ALIGN_TAB
     // Only supports Alpha versions currently (July 2018) Now Beta (Dec 2018)
-    IUFillSwitch(&OSNAlignStarsS[0], "1", "1 Star", ISS_OFF);
-    IUFillSwitch(&OSNAlignStarsS[1], "2", "2 Stars", ISS_OFF);
-    IUFillSwitch(&OSNAlignStarsS[2], "3", "3 Stars", ISS_ON);
-    IUFillSwitch(&OSNAlignStarsS[3], "4", "4 Stars", ISS_OFF);
-    IUFillSwitch(&OSNAlignStarsS[4], "5", "5 Stars", ISS_OFF);
-    IUFillSwitch(&OSNAlignStarsS[5], "6", "6 Stars", ISS_OFF);
-    IUFillSwitch(&OSNAlignStarsS[6], "7", "7 Stars", ISS_OFF);
-    IUFillSwitch(&OSNAlignStarsS[7], "8", "8 Stars", ISS_OFF);
-    IUFillSwitch(&OSNAlignStarsS[8], "9", "9 Stars", ISS_OFF);
-    IUFillSwitchVector(&OSNAlignStarsSP, OSNAlignStarsS, 9, getDeviceName(), "AlignStars", "Align using some stars, Alpha only",
+    OSNAlignStarsSP[0].fill("1", "1 Star", ISS_OFF);
+    OSNAlignStarsSP[1].fill("2", "2 Stars", ISS_OFF);
+    OSNAlignStarsSP[2].fill("3", "3 Stars", ISS_ON);
+    OSNAlignStarsSP[3].fill("4", "4 Stars", ISS_OFF);
+    OSNAlignStarsSP[4].fill("5", "5 Stars", ISS_OFF);
+    OSNAlignStarsSP[5].fill("6", "6 Stars", ISS_OFF);
+    OSNAlignStarsSP[6].fill("7", "7 Stars", ISS_OFF);
+    OSNAlignStarsSP[7].fill("8", "8 Stars", ISS_OFF);
+    OSNAlignStarsSP[8].fill("9", "9 Stars", ISS_OFF);
+    OSNAlignStarsSP.fill(getDeviceName(), "AlignStars", "Align using some stars, Alpha only",
                        ALIGN_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OSNAlignS[0], "0", "Start Align", ISS_OFF);
-    IUFillSwitch(&OSNAlignS[1], "1", "Issue Align", ISS_OFF);
-    IUFillSwitch(&OSNAlignS[2], "3", "Write Align", ISS_OFF);
-    IUFillSwitchVector(&OSNAlignSP, OSNAlignS, 2, getDeviceName(), "NewAlignStar", "Align using up to 6 stars, Alpha only",
+    OSNAlignSP[0].fill("0", "Start Align", ISS_OFF);
+    OSNAlignSP[1].fill("1", "Issue Align", ISS_OFF);
+    OSNAlignSP[2].fill("3", "Write Align", ISS_OFF);
+    OSNAlignSP.fill(getDeviceName(), "NewAlignStar", "Align using up to 6 stars, Alpha only",
                        ALIGN_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OSNAlignWriteS[0], "0", "Write Align to NVRAM/Flash", ISS_OFF);
-    IUFillSwitchVector(&OSNAlignWriteSP, OSNAlignWriteS, 1, getDeviceName(), "NewAlignStar2", "NVRAM", ALIGN_TAB, IP_RW,
+    OSNAlignWriteSP[0].fill("0", "Write Align to NVRAM/Flash", ISS_OFF);
+    OSNAlignWriteSP.fill(getDeviceName(), "NewAlignStar2", "NVRAM", ALIGN_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
-    IUFillSwitch(&OSNAlignPolarRealignS[0], "0", "Instructions", ISS_OFF);
-    IUFillSwitch(&OSNAlignPolarRealignS[1], "1", "Refine Polar Align (manually)", ISS_OFF);
-    IUFillSwitchVector(&OSNAlignPolarRealignSP, OSNAlignPolarRealignS, 2, getDeviceName(), "AlignMP",
+    OSNAlignPolarRealignSP[0].fill("0", "Instructions", ISS_OFF);
+    OSNAlignPolarRealignSP[1].fill("1", "Refine Polar Align (manually)", ISS_OFF);
+    OSNAlignPolarRealignSP.fill(getDeviceName(), "AlignMP",
                        "Polar Correction, See info box", ALIGN_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillText(&OSNAlignT[0], "0", "Align Process Status", "Align not started");
-    IUFillText(&OSNAlignT[1], "1", "1. Manual Process", "Point towards the NCP");
-    IUFillText(&OSNAlignT[2], "2", "2. Plate Solver Process", "Point towards the NCP");
-    IUFillText(&OSNAlignT[3], "3", "Manual Action after 1", "Press 'Start Align'");
-    IUFillText(&OSNAlignT[4], "4", "Current Status", "Not Updated");
-    IUFillText(&OSNAlignT[5], "5", "Max Stars", "Not Updated");
-    IUFillText(&OSNAlignT[6], "6", "Current Star", "Not Updated");
-    IUFillText(&OSNAlignT[7], "7", "# of Align Stars", "Not Updated");
-    IUFillTextVector(&OSNAlignTP, OSNAlignT, 8, getDeviceName(), "NAlign Process", "", ALIGN_TAB, IP_RO, 0, IPS_IDLE);
+    OSNAlignTP[0].fill("0", "Align Process Status", "Align not started");
+    OSNAlignTP[1].fill("1", "1. Manual Process", "Point towards the NCP");
+    OSNAlignTP[2].fill("2", "2. Plate Solver Process", "Point towards the NCP");
+    OSNAlignTP[3].fill("3", "Manual Action after 1", "Press 'Start Align'");
+    OSNAlignTP[4].fill("4", "Current Status", "Not Updated");
+    OSNAlignTP[5].fill("5", "Max Stars", "Not Updated");
+    OSNAlignTP[6].fill("6", "Current Star", "Not Updated");
+    OSNAlignTP[7].fill("7", "# of Align Stars", "Not Updated");
+    OSNAlignTP.fill(getDeviceName(), "NAlign Process", "", ALIGN_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillText(&OSNAlignErrT[0], "0", "EQ Polar Error Alt", "Available once Aligned");
-    IUFillText(&OSNAlignErrT[1], "1", "EQ Polar Error Az", "Available once Aligned");
-    //     IUFillText(&OSNAlignErrT[2], "2", "2. Plate Solver Process", "Point towards the NCP");
-    //     IUFillText(&OSNAlignErrT[3], "3", "After 1 or 2", "Press 'Start Align'");
-    //     IUFillText(&OSNAlignErrT[4], "4", "Current Status", "Not Updated");
-    //     IUFillText(&OSNAlignErrT[5], "5", "Max Stars", "Not Updated");
-    //     IUFillText(&OSNAlignErrT[6], "6", "Current Star", "Not Updated");
-    //     IUFillText(&OSNAlignErrT[7], "7", "# of Align Stars", "Not Updated");
-    IUFillTextVector(&OSNAlignErrTP, OSNAlignErrT, 2, getDeviceName(), "ErrAlign Process", "", ALIGN_TAB, IP_RO, 0, IPS_IDLE);
+    OSNAlignErrTP[0].fill("0", "EQ Polar Error Alt", "Available once Aligned");
+    OSNAlignErrTP[1].fill("1", "EQ Polar Error Az", "Available once Aligned");
+    //     OSNAlignErrTP[2].fill("2", "2. Plate Solver Process", "Point towards the NCP");
+    //     OSNAlignErrTP[3].fill("3", "After 1 or 2", "Press 'Start Align'");
+    //     OSNAlignErrTP[4].fill("4", "Current Status", "Not Updated");
+    //     OSNAlignErrTP[5].fill("5", "Max Stars", "Not Updated");
+    //     OSNAlignErrTP[6].fill("6", "Current Star", "Not Updated");
+    //     OSNAlignErrTP[7].fill("7", "# of Align Stars", "Not Updated");
+    OSNAlignErrTP.fill(getDeviceName(), "ErrAlign Process", "", ALIGN_TAB, IP_RO, 0, IPS_IDLE);
 
 #ifdef ONSTEP_NOTDONE
     // =============== OUTPUT_TAB
     // ===============
-    IUFillSwitch(&OSOutput1S[0], "0", "OFF", ISS_ON);
-    IUFillSwitch(&OSOutput1S[1], "1", "ON", ISS_OFF);
-    IUFillSwitchVector(&OSOutput1SP, OSOutput1S, 2, getDeviceName(), "Output 1", "Output 1", OUTPUT_TAB, IP_RW, ISR_ATMOST1, 60,
+    OSOutput1SP[0].fill("0", "OFF", ISS_ON);
+    OSOutput1SP[1].fill("1", "ON", ISS_OFF);
+    OSOutput1SP.fill(getDeviceName(), "Output 1", "Output 1", OUTPUT_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_ALERT);
 
-    IUFillSwitch(&OSOutput2S[0], "0", "OFF", ISS_ON);
-    IUFillSwitch(&OSOutput2S[1], "1", "ON", ISS_OFF);
-    IUFillSwitchVector(&OSOutput2SP, OSOutput2S, 2, getDeviceName(), "Output 2", "Output 2", OUTPUT_TAB, IP_RW, ISR_ATMOST1, 60,
+    OSOutput2SP[0].fill("0", "OFF", ISS_ON);
+    OSOutput2SP[1].fill("1", "ON", ISS_OFF);
+    OSOutput2SP.fill(getDeviceName(), "Output 2", "Output 2", OUTPUT_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_ALERT);
 #endif
 
@@ -343,20 +343,20 @@ bool LX200_OnStep::initProperties()
 
     // ============== WEATHER TAB
     // Uses OnStep's defaults for this
-    IUFillNumber(&OSSetTemperatureN[0], "Set Temperature (C)", "C", "%4.2f", -100, 100, 1, 10);//-274, 999, 1, 10);
-    IUFillNumberVector(&OSSetTemperatureNP, OSSetTemperatureN, 1, getDeviceName(), "Set Temperature (C)", "", ENVIRONMENT_TAB,
+    OSSetTemperatureNP[0].fill("Set Temperature (C)", "C", "%4.2f", -100, 100, 1, 10);//-274, 999, 1, 10);
+    OSSetTemperatureNP.fill(getDeviceName(), "Set Temperature (C)", "", ENVIRONMENT_TAB,
                        IP_RW, 0, IPS_IDLE);
-    IUFillNumber(&OSSetHumidityN[0], "Set Relative Humidity (%)", "%", "%5.2f", 0, 100, 1, 70);
-    IUFillNumberVector(&OSSetHumidityNP, OSSetHumidityN, 1, getDeviceName(), "Set Relative Humidity (%)", "", ENVIRONMENT_TAB,
+    OSSetHumidityNP[0].fill("Set Relative Humidity (%)", "%", "%5.2f", 0, 100, 1, 70);
+    OSSetHumidityNP.fill(getDeviceName(), "Set Relative Humidity (%)", "", ENVIRONMENT_TAB,
                        IP_RW, 0, IPS_IDLE);
-    IUFillNumber(&OSSetPressureN[0], "Set Pressure (hPa)", "hPa", "%4f", 500, 1500, 1, 1010);
-    IUFillNumberVector(&OSSetPressureNP, OSSetPressureN, 1, getDeviceName(), "Set Pressure (hPa)", "", ENVIRONMENT_TAB, IP_RW,
+    OSSetPressureNP[0].fill("Set Pressure (hPa)", "hPa", "%4f", 500, 1500, 1, 1010);
+    OSSetPressureNP.fill(getDeviceName(), "Set Pressure (hPa)", "", ENVIRONMENT_TAB, IP_RW,
                        0, IPS_IDLE);
 
     //Will eventually pull from the elevation in site settings
     //TODO: Pull from elevation in site settings
-    IUFillNumber(&OSSetAltitudeN[0], "Set Altitude (m)", "m", "%4f", 0, 20000, 1, 110);
-    IUFillNumberVector(&OSSetAltitudeNP, OSSetAltitudeN, 1, getDeviceName(), "Set Altitude (m)", "", ENVIRONMENT_TAB, IP_RW, 0,
+    OSSetAltitudeNP[0].fill("Set Altitude (m)", "m", "%4f", 0, 20000, 1, 110);
+    OSSetAltitudeNP.fill(getDeviceName(), "Set Altitude (m)", "", ENVIRONMENT_TAB, IP_RW, 0,
                        IPS_IDLE);
 
 
@@ -391,9 +391,9 @@ bool LX200_OnStep::updateProperties()
         // Firstinitialize some variables
         // keep sorted by TABs is easier
         // Main Control
-        defineProperty(&ReticSP);
-        defineProperty(&ElevationLimitNP);
-        defineProperty(&ObjectInfoTP);
+        defineProperty(ReticSP);
+        defineProperty(ElevationLimitNP);
+        defineProperty(ObjectInfoTP);
         // Connection
 
         // Options
@@ -402,20 +402,20 @@ bool LX200_OnStep::updateProperties()
         defineProperty(&OnstepStatTP);
 
         // Motion Control
-        defineProperty(&MaxSlewRateNP);
-        defineProperty(&TrackCompSP);
-        defineProperty(&TrackAxisSP);
-        defineProperty(&BacklashNP);
-        defineProperty(&GuideRateNP);
-        defineProperty(&AutoFlipSP);
-        defineProperty(&HomePauseSP);
-        defineProperty(&FrequencyAdjustSP);
-        defineProperty(&PreferredPierSideSP);
-        defineProperty(&minutesPastMeridianNP);
+        defineProperty(MaxSlewRateNP);
+        defineProperty(TrackCompSP);
+        defineProperty(TrackAxisSP);
+        defineProperty(BacklashNP);
+        defineProperty(GuideRateNP);
+        defineProperty(AutoFlipSP);
+        defineProperty(HomePauseSP);
+        defineProperty(FrequencyAdjustSP);
+        defineProperty(PreferredPierSideSP);
+        defineProperty(minutesPastMeridianNP);
 
         // Site Management
-        defineProperty(&ParkOptionSP);
-        defineProperty(&SetHomeSP);
+        defineProperty(ParkOptionSP);
+        defineProperty(SetHomeSP);
 
         // Guide
 
@@ -426,66 +426,66 @@ bool LX200_OnStep::updateProperties()
         if (!sendOnStepCommand(":FA#"))  // do we have a Focuser 1
         {
             OSFocuser1 = true;
-            defineProperty(&OSFocus1InitializeSP);
+            defineProperty(OSFocus1InitializeSP);
         }
         // Focuser 2
         if (!sendOnStepCommand(":fA#"))  // Do we have a Focuser 2
         {
             OSFocuser2 = true;
             //defineProperty(&OSFocus2SelSP);
-            defineProperty(&OSFocus2MotionSP);
-            defineProperty(&OSFocus2RateSP);
-            defineProperty(&OSFocus2TargNP);
+            defineProperty(OSFocus2MotionSP);
+            defineProperty(OSFocus2RateSP);
+            defineProperty(OSFocus2TargNP);
         }
 
         // Firmware Data
         defineProperty(&VersionTP);
 
         //PEC
-        defineProperty(&OSPECStatusSP);
-        defineProperty(&OSPECIndexSP);
-        defineProperty(&OSPECRecordSP);
-        defineProperty(&OSPECReadSP);
-        defineProperty(&OSPECCurrentIndexNP);
-        defineProperty(&OSPECRWValuesNP);
+        defineProperty(OSPECStatusSP);
+        defineProperty(OSPECIndexSP);
+        defineProperty(OSPECRecordSP);
+        defineProperty(OSPECReadSP);
+        defineProperty(OSPECCurrentIndexNP);
+        defineProperty(OSPECRWValuesNP);
 
         //New Align
-        defineProperty(&OSNAlignStarsSP);
-        defineProperty(&OSNAlignSP);
-        defineProperty(&OSNAlignWriteSP);
-        defineProperty(&OSNAlignTP);
-        defineProperty(&OSNAlignErrTP);
-        defineProperty(&OSNAlignPolarRealignSP);
+        defineProperty(OSNAlignStarsSP);
+        defineProperty(OSNAlignSP);
+        defineProperty(OSNAlignWriteSP);
+        defineProperty(OSNAlignTP);
+        defineProperty(OSNAlignErrTP);
+        defineProperty(OSNAlignPolarRealignSP);
 
 #ifdef ONSTEP_NOTDONE
         //Outputs
-        defineProperty(&OSOutput1SP);
-        defineProperty(&OSOutput2SP);
+        defineProperty(OSOutput1SP);
+        defineProperty(OSOutput2SP);
 #endif
 
         defineProperty(&OutputPorts_NP);
 
         //Weather
-        defineProperty(&OSSetTemperatureNP);
-        defineProperty(&OSSetPressureNP);
-        defineProperty(&OSSetHumidityNP);
-        defineProperty(&OSSetAltitudeNP);
+        defineProperty(OSSetTemperatureNP);
+        defineProperty(OSSetPressureNP);
+        defineProperty(OSSetHumidityNP);
+        defineProperty(OSSetAltitudeNP);
 
 
         if (InitPark())
         {
             // If loading parking data is successful, we just set the default parking values.
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
         else
         {
             // Otherwise, we set all parking data to default in case no parking data is found.
-            SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value);
 
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
 
         double longitude = -1000, latitude = -1000;
@@ -501,63 +501,63 @@ bool LX200_OnStep::updateProperties()
     {
         // keep sorted by TABs is easier
         // Main Control
-        deleteProperty(ReticSP.name);
-        deleteProperty(ElevationLimitNP.name);
+        deleteProperty(ReticSP.getName());
+        deleteProperty(ElevationLimitNP.getName());
         // Connection
 
         // Options
 
         // Motion Control
-        deleteProperty(MaxSlewRateNP.name);
-        deleteProperty(TrackCompSP.name);
-        deleteProperty(TrackAxisSP.name);
-        deleteProperty(BacklashNP.name);
-        deleteProperty(GuideRateNP.name);
-        deleteProperty(AutoFlipSP.name);
-        deleteProperty(HomePauseSP.name);
-        deleteProperty(FrequencyAdjustSP.name);
-        deleteProperty(PreferredPierSideSP.name);
-        deleteProperty(minutesPastMeridianNP.name);
+        deleteProperty(MaxSlewRateNP.getName());
+        deleteProperty(TrackCompSP.getName());
+        deleteProperty(TrackAxisSP.getName());
+        deleteProperty(BacklashNP.getName());
+        deleteProperty(GuideRateNP.getName());
+        deleteProperty(AutoFlipSP.getName());
+        deleteProperty(HomePauseSP.getName());
+        deleteProperty(FrequencyAdjustSP.getName());
+        deleteProperty(PreferredPierSideSP.getName());
+        deleteProperty(minutesPastMeridianNP.getName());
 
         // Site Management
-        deleteProperty(ParkOptionSP.name);
-        deleteProperty(SetHomeSP.name);
+        deleteProperty(ParkOptionSP.getName());
+        deleteProperty(SetHomeSP.getName());
         // Guide
 
         // Focuser
         // Focuser 1
-        deleteProperty(OSFocus1InitializeSP.name);
+        deleteProperty(OSFocus1InitializeSP.getName());
 
         // Focuser 2
         //deleteProperty(OSFocus2SelSP.name);
-        deleteProperty(OSFocus2MotionSP.name);
-        deleteProperty(OSFocus2RateSP.name);
-        deleteProperty(OSFocus2TargNP.name);
+        deleteProperty(OSFocus2MotionSP.getName());
+        deleteProperty(OSFocus2RateSP.getName());
+        deleteProperty(OSFocus2TargNP.getName());
 
         // Firmware Data
         deleteProperty(VersionTP.name);
 
 
         //PEC
-        deleteProperty(OSPECStatusSP.name);
-        deleteProperty(OSPECIndexSP.name);
-        deleteProperty(OSPECRecordSP.name);
-        deleteProperty(OSPECReadSP.name);
-        deleteProperty(OSPECCurrentIndexNP.name);
-        deleteProperty(OSPECRWValuesNP.name);
+        deleteProperty(OSPECStatusSP.getName());
+        deleteProperty(OSPECIndexSP.getName());
+        deleteProperty(OSPECRecordSP.getName());
+        deleteProperty(OSPECReadSP.getName());
+        deleteProperty(OSPECCurrentIndexNP.getName());
+        deleteProperty(OSPECRWValuesNP.getName());
 
         //New Align
-        deleteProperty(OSNAlignStarsSP.name);
-        deleteProperty(OSNAlignSP.name);
-        deleteProperty(OSNAlignWriteSP.name);
-        deleteProperty(OSNAlignTP.name);
-        deleteProperty(OSNAlignErrTP.name);
-        deleteProperty(OSNAlignPolarRealignSP.name);
+        deleteProperty(OSNAlignStarsSP.getName());
+        deleteProperty(OSNAlignSP.getName());
+        deleteProperty(OSNAlignWriteSP.getName());
+        deleteProperty(OSNAlignTP.getName());
+        deleteProperty(OSNAlignErrTP.getName());
+        deleteProperty(OSNAlignPolarRealignSP.getName());
 
 #ifdef ONSTEP_NOTDONE
         //Outputs
-        deleteProperty(OSOutput1SP.name);
-        deleteProperty(OSOutput2SP.name);
+        deleteProperty(OSOutput1SP.getName());
+        deleteProperty(OSOutput2SP.getName());
 #endif
 
         deleteProperty(OutputPorts_NP.name);
@@ -567,10 +567,10 @@ bool LX200_OnStep::updateProperties()
 
 
         //Weather
-        deleteProperty(OSSetTemperatureNP.name);
-        deleteProperty(OSSetPressureNP.name);
-        deleteProperty(OSSetHumidityNP.name);
-        deleteProperty(OSSetAltitudeNP.name);
+        deleteProperty(OSSetTemperatureNP.getName());
+        deleteProperty(OSSetPressureNP.getName());
+        deleteProperty(OSSetHumidityNP.getName());
+        deleteProperty(OSSetAltitudeNP.getName());
 
     }
     return true;
@@ -582,54 +582,54 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
     {
         if (strstr(name, "FOCUS_"))
             return FI::processNumber(dev, name, values, names, n);
-        if (!strcmp(name, ObjectNoNP.name))
+        if (ObjectNoNP.isNameMatch(name))
         {
             char object_name[256];
 
             if (selectCatalogObject(PortFD, currentCatalog, (int)values[0]) < 0)
             {
-                ObjectNoNP.s = IPS_ALERT;
-                IDSetNumber(&ObjectNoNP, "Failed to select catalog object.");
+                ObjectNoNP.setState(IPS_ALERT);
+                ObjectNoNP.apply("Failed to select catalog object.");
                 return false;
             }
 
             getLX200RA(PortFD, &targetRA);
             getLX200DEC(PortFD, &targetDEC);
 
-            ObjectNoNP.s = IPS_OK;
-            IDSetNumber(&ObjectNoNP, "Object updated.");
+            ObjectNoNP.setState(IPS_OK);
+            ObjectNoNP.apply("Object updated.");
 
             if (getObjectInfo(PortFD, object_name) < 0)
                 IDMessage(getDeviceName(), "Getting object info failed.");
             else
             {
-                IUSaveText(&ObjectInfoTP.tp[0], object_name);
-                IDSetText(&ObjectInfoTP, nullptr);
+                IUSaveText(&ObjectInfoTP[0], object_name);
+                ObjectInfoTP.apply();
             }
             Goto(targetRA, targetDEC);
             return true;
         }
 
-        if (!strcmp(name, MaxSlewRateNP.name))
+        if (MaxSlewRateNP.isNameMatch(name))
         {
             int ret;
             char cmd[5];
             snprintf(cmd, 5, ":R%d#", (int)values[0]);
             ret = sendOnStepCommandBlind(cmd);
 
-            //if (setMaxSlewRate(PortFD, (int)values[0]) < 0) //(int) MaxSlewRateN[0].value
+            //if (setMaxSlewRate(PortFD, (int)values[0]) < 0) //(int) MaxSlewRateNP[0].value
             if (ret == -1)
             {
                 LOGF_DEBUG("Pas OK Return value =%d", ret);
                 LOGF_DEBUG("Setting Max Slew Rate to %f\n", values[0]);
-                MaxSlewRateNP.s = IPS_ALERT;
-                IDSetNumber(&MaxSlewRateNP, "Setting Max Slew Rate Failed");
+                MaxSlewRateNP.setState(IPS_ALERT);
+                MaxSlewRateNP.apply("Setting Max Slew Rate Failed");
                 return false;
             }
             LOGF_DEBUG("OK Return value =%d", ret);
-            MaxSlewRateNP.s           = IPS_OK;
-            MaxSlewRateNP.np[0].value = values[0];
-            IDSetNumber(&MaxSlewRateNP, "Slewrate set to %04.1f", values[0]);
+            MaxSlewRateNP.setState(IPS_OK);
+            MaxSlewRateNP[0].setValue(values[0]);
+            MaxSlewRateNP.apply("Slewrate set to %04.1f", values[0]);
             IUResetSwitch(&SlewRateSP);
             SlewRateS[int(values[0])].s = ISS_ON;
             SlewRateSP.s = IPS_OK;
@@ -637,7 +637,7 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
             return true;
         }
 
-        if (!strcmp(name, BacklashNP.name))
+        if (BacklashNP.isNameMatch(name))
         {
             char cmd[9];
             int i, nset;
@@ -645,14 +645,14 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
 
             for (nset = i = 0; i < n; i++)
             {
-                INumber *bktp = IUFindNumber(&BacklashNP, names[i]);
-                if (bktp == &BacklashN[0])
+                INumber *bktp = BacklashNP.findWidgetByName(names[i]);
+                if (bktp == &BacklashNP[0])
                 {
                     bklshdec = values[i];
                     LOGF_DEBUG("===CMD==> Backlash DEC= %f", bklshdec);
                     nset += bklshdec >= 0 && bklshdec <= 999;  //range 0 to 999
                 }
-                else if (bktp == &BacklashN[1])
+                else if (bktp == &BacklashNP[1])
                 {
                     bklshra = values[i];
                     LOGF_DEBUG("===CMD==> Backlash RA= %f", bklshra);
@@ -664,33 +664,33 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
                 snprintf(cmd, 9, ":$BD%d#", (int)bklshdec);
                 if (sendOnStepCommand(cmd))
                 {
-                    BacklashNP.s = IPS_ALERT;
-                    IDSetNumber(&BacklashNP, "Error Backlash DEC limit.");
+                    BacklashNP.setState(IPS_ALERT);
+                    BacklashNP.apply("Error Backlash DEC limit.");
                 }
                 const struct timespec timeout = {0, 100000000L};
                 nanosleep(&timeout, nullptr); // time for OnStep to respond to previous cmd
                 snprintf(cmd, 9, ":$BR%d#", (int)bklshra);
                 if (sendOnStepCommand(cmd))
                 {
-                    BacklashNP.s = IPS_ALERT;
-                    IDSetNumber(&BacklashNP, "Error Backlash RA limit.");
+                    BacklashNP.setState(IPS_ALERT);
+                    BacklashNP.apply("Error Backlash RA limit.");
                 }
 
-                BacklashNP.np[0].value = bklshdec;
-                BacklashNP.np[1].value = bklshra;
-                BacklashNP.s           = IPS_OK;
-                IDSetNumber(&BacklashNP, nullptr);
+                BacklashNP[0].setValue(bklshdec);
+                BacklashNP[1].setValue(bklshra);
+                BacklashNP.setState(IPS_OK);
+                BacklashNP.apply();
                 return true;
             }
             else
             {
-                BacklashNP.s = IPS_ALERT;
-                IDSetNumber(&BacklashNP, "Backlash invalid.");
+                BacklashNP.setState(IPS_ALERT);
+                BacklashNP.apply("Backlash invalid.");
                 return false;
             }
         }
 
-        if (!strcmp(name, ElevationLimitNP.name))
+        if (ElevationLimitNP.isNameMatch(name))
         {
             // new elevation limits
             double minAlt = 0, maxAlt = 0;
@@ -698,13 +698,13 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
 
             for (nset = i = 0; i < n; i++)
             {
-                INumber *altp = IUFindNumber(&ElevationLimitNP, names[i]);
-                if (altp == &ElevationLimitN[0])
+                INumber *altp = ElevationLimitNP.findWidgetByName(names[i]);
+                if (altp == &ElevationLimitNP[0])
                 {
                     minAlt = values[i];
                     nset += minAlt >= -30.0 && minAlt <= 30.0;  //range -30 to 30
                 }
-                else if (altp == &ElevationLimitN[1])
+                else if (altp == &ElevationLimitNP[1])
                 {
                     maxAlt = values[i];
                     nset += maxAlt >= 60.0 && maxAlt <= 90.0;   //range 60 to 90
@@ -714,32 +714,32 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
             {
                 if (setMinElevationLimit(PortFD, (int)minAlt) < 0)
                 {
-                    ElevationLimitNP.s = IPS_ALERT;
-                    IDSetNumber(&ElevationLimitNP, "Error setting min elevation limit.");
+                    ElevationLimitNP.setState(IPS_ALERT);
+                    ElevationLimitNP.apply("Error setting min elevation limit.");
                 }
 
                 if (setMaxElevationLimit(PortFD, (int)maxAlt) < 0)
                 {
-                    ElevationLimitNP.s = IPS_ALERT;
-                    IDSetNumber(&ElevationLimitNP, "Error setting max elevation limit.");
+                    ElevationLimitNP.setState(IPS_ALERT);
+                    ElevationLimitNP.apply("Error setting max elevation limit.");
                     return false;
                 }
-                ElevationLimitNP.np[0].value = minAlt;
-                ElevationLimitNP.np[1].value = maxAlt;
-                ElevationLimitNP.s           = IPS_OK;
-                IDSetNumber(&ElevationLimitNP, nullptr);
+                ElevationLimitNP[0].setValue(minAlt);
+                ElevationLimitNP[1].setValue(maxAlt);
+                ElevationLimitNP.setState(IPS_OK);
+                ElevationLimitNP.apply();
                 return true;
             }
             else
             {
-                ElevationLimitNP.s = IPS_IDLE;
-                IDSetNumber(&ElevationLimitNP, "elevation limit missing or invalid.");
+                ElevationLimitNP.setState(IPS_IDLE);
+                ElevationLimitNP.apply("elevation limit missing or invalid.");
                 return false;
             }
         }
     }
 
-    if (!strcmp(name, minutesPastMeridianNP.name))
+    if (minutesPastMeridianNP.isNameMatch(name))
     {
         char cmd[20];
         int i, nset;
@@ -747,17 +747,17 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
 
         for (nset = i = 0; i < n; i++)
         {
-            INumber *bktp = IUFindNumber(&minutesPastMeridianNP, names[i]);
-            if (bktp == &minutesPastMeridianN[0])
+            INumber *bktp = minutesPastMeridianNP.findWidgetByName(names[i]);
+            if (bktp == &minutesPastMeridianNP[0])
             {
                 minPMEast = values[i];
-                LOGF_DEBUG("===CMD==> minutesPastMeridianN[0]/East = %f", minPMEast);
+                LOGF_DEBUG("===CMD==> minutesPastMeridianNP[0]/East = %f", minPMEast);
                 nset += minPMEast >= 0 && minPMEast <= 180;  //range 0 to 180
             }
-            else if (bktp == &minutesPastMeridianN[1])
+            else if (bktp == &minutesPastMeridianNP[1])
             {
                 minPMWest = values[i];
-                LOGF_DEBUG("===CMD==> minutesPastMeridianN[1]/West= %f", minPMWest);
+                LOGF_DEBUG("===CMD==> minutesPastMeridianNP[1]/West= %f", minPMWest);
                 nset += minPMWest >= 0 && minPMWest <= 180;   //range 0 to 180
             }
         }
@@ -766,28 +766,28 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
             snprintf(cmd, 20, ":SXE9,%d#", (int) minPMEast);
             if (sendOnStepCommand(cmd))
             {
-                minutesPastMeridianNP.s = IPS_ALERT;
-                IDSetNumber(&minutesPastMeridianNP, "Error Backlash DEC limit.");
+                minutesPastMeridianNP.setState(IPS_ALERT);
+                minutesPastMeridianNP.apply("Error Backlash DEC limit.");
             }
             const struct timespec timeout = {0, 100000000L};
             nanosleep(&timeout, nullptr); // time for OnStep to respond to previous cmd
             snprintf(cmd, 20, ":SXEA,%d#", (int) minPMWest);
             if (sendOnStepCommand(cmd))
             {
-                minutesPastMeridianNP.s = IPS_ALERT;
-                IDSetNumber(&minutesPastMeridianNP, "Error Backlash RA limit.");
+                minutesPastMeridianNP.setState(IPS_ALERT);
+                minutesPastMeridianNP.apply("Error Backlash RA limit.");
             }
 
-            minutesPastMeridianNP.np[0].value = minPMEast;
-            minutesPastMeridianNP.np[1].value = minPMWest;
-            minutesPastMeridianNP.s           = IPS_OK;
-            IDSetNumber(&minutesPastMeridianNP, nullptr);
+            minutesPastMeridianNP[0].setValue(minPMEast);
+            minutesPastMeridianNP[1].setValue(minPMWest);
+            minutesPastMeridianNP.setState(IPS_OK);
+            minutesPastMeridianNP.apply();
             return true;
         }
         else
         {
-            minutesPastMeridianNP.s = IPS_ALERT;
-            IDSetNumber(&minutesPastMeridianNP, "minutesPastMeridian invalid.");
+            minutesPastMeridianNP.setState(IPS_ALERT);
+            minutesPastMeridianNP.apply("minutesPastMeridian invalid.");
             return false;
         }
     }
@@ -795,7 +795,7 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
     // Focuser 1 Now handled by Focusr Interface
 
     // Focuser 2 Target
-    if (!strcmp(name, OSFocus2TargNP.name))
+    if (OSFocus2TargNP.isNameMatch(name))
     {
         char cmd[32];
 
@@ -803,14 +803,14 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
         {
             snprintf(cmd, 15, ":fR%d#", (int)values[0]);
             sendOnStepCommandBlind(cmd);
-            OSFocus2TargNP.s           = IPS_OK;
-            IDSetNumber(&OSFocus2TargNP, "Focuser 2 position (relative) moved by %d", (int)values[0]);
+            OSFocus2TargNP.setState(IPS_OK);
+            OSFocus2TargNP.apply("Focuser 2 position (relative) moved by %d", (int)values[0]);
             OSUpdateFocuser();
         }
         else
         {
-            OSFocus2TargNP.s = IPS_ALERT;
-            IDSetNumber(&OSFocus2TargNP, "Setting Max Slew Rate Failed");
+            OSFocus2TargNP.setState(IPS_ALERT);
+            OSFocus2TargNP.apply("Setting Max Slew Rate Failed");
         }
         return true;
     }
@@ -850,7 +850,7 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
     }
     //Weather not handled by Weather Interface
 
-    if (!strcmp(name, OSSetTemperatureNP.name))
+    if (OSSetTemperatureNP.isNameMatch(name))
     {
         char cmd[32];
 
@@ -858,18 +858,18 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
         {
             snprintf(cmd, 15, ":SX9A,%d#", (int)values[0]);
             sendOnStepCommandBlind(cmd);
-            OSSetTemperatureNP.s           = IPS_OK;
-            IDSetNumber(&OSSetTemperatureNP, "Temperature set to %d", (int)values[0]);
+            OSSetTemperatureNP.setState(IPS_OK);
+            OSSetTemperatureNP.apply("Temperature set to %d", (int)values[0]);
         }
         else
         {
-            OSSetTemperatureNP.s = IPS_ALERT;
-            IDSetNumber(&OSSetTemperatureNP, "Setting Temperature Failed");
+            OSSetTemperatureNP.setState(IPS_ALERT);
+            OSSetTemperatureNP.apply("Setting Temperature Failed");
         }
         return true;
     }
 
-    if (!strcmp(name, OSSetHumidityNP.name))
+    if (OSSetHumidityNP.isNameMatch(name))
     {
         char cmd[32];
 
@@ -877,18 +877,18 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
         {
             snprintf(cmd, 15, ":SX9C,%d#", (int)values[0]);
             sendOnStepCommandBlind(cmd);
-            OSSetHumidityNP.s           = IPS_OK;
-            IDSetNumber(&OSSetHumidityNP, "Humidity set to %d", (int)values[0]);
+            OSSetHumidityNP.setState(IPS_OK);
+            OSSetHumidityNP.apply("Humidity set to %d", (int)values[0]);
         }
         else
         {
-            OSSetHumidityNP.s = IPS_ALERT;
-            IDSetNumber(&OSSetHumidityNP, "Setting Humidity Failed");
+            OSSetHumidityNP.setState(IPS_ALERT);
+            OSSetHumidityNP.apply("Setting Humidity Failed");
         }
         return true;
     }
 
-    if (!strcmp(name, OSSetPressureNP.name))
+    if (OSSetPressureNP.isNameMatch(name))
     {
         char cmd[32];
 
@@ -896,13 +896,13 @@ bool LX200_OnStep::ISNewNumber(const char *dev, const char *name, double values[
         {
             snprintf(cmd, 15, ":SX9B,%d#", (int)values[0]);
             sendOnStepCommandBlind(cmd);
-            OSSetPressureNP.s           = IPS_OK;
-            IDSetNumber(&OSSetPressureNP, "Pressure set to %d", (int)values[0]);
+            OSSetPressureNP.setState(IPS_OK);
+            OSSetPressureNP.apply("Pressure set to %d", (int)values[0]);
         }
         else
         {
-            OSSetPressureNP.s = IPS_ALERT;
-            IDSetNumber(&OSSetPressureNP, "Setting Pressure Failed");
+            OSSetPressureNP.setState(IPS_ALERT);
+            OSSetPressureNP.apply("Setting Pressure Failed");
         }
         return true;
     }
@@ -926,28 +926,28 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Reticlue +/- Buttons
-        if (!strcmp(name, ReticSP.name))
+        if (ReticSP.isNameMatch(name))
         {
             long ret = 0;
 
-            IUUpdateSwitch(&ReticSP, states, names, n);
-            ReticSP.s = IPS_OK;
+            ReticSP.update(states, names, n);
+            ReticSP.setState(IPS_OK);
 
-            if (ReticS[0].s == ISS_ON)
+            if (ReticSP[0].getState() == ISS_ON)
             {
                 ret = ReticPlus(PortFD);
-                ReticS[0].s = ISS_OFF;
-                IDSetSwitch(&ReticSP, "Bright");
+                ReticSP[0].setState(ISS_OFF);
+                ReticSP.apply("Bright");
             }
             else
             {
                 ret = ReticMoins(PortFD);
-                ReticS[1].s = ISS_OFF;
-                IDSetSwitch(&ReticSP, "Dark");
+                ReticSP[1].setState(ISS_OFF);
+                ReticSP.apply("Dark");
             }
 
-            IUResetSwitch(&ReticSP);
-            IDSetSwitch(&ReticSP, nullptr);
+            ReticSP.reset();
+            ReticSP.apply();
             return true;
         }
         //Move to more standard controls
@@ -960,7 +960,7 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
             snprintf(cmd, 5, ":R%d#", index);
             ret = sendOnStepCommandBlind(cmd);
 
-            //if (setMaxSlewRate(PortFD, (int)values[0]) < 0) //(int) MaxSlewRateN[0].value
+            //if (setMaxSlewRate(PortFD, (int)values[0]) < 0) //(int) MaxSlewRateNP[0].value
             if (ret == -1)
             {
                 LOGF_DEBUG("Pas OK Return value =%d", ret);
@@ -971,9 +971,9 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
             }
             LOGF_INFO("Setting Max Slew Rate to %u\n", index);
             LOGF_DEBUG("OK Return value =%d", ret);
-            MaxSlewRateNP.s           = IPS_OK;
-            MaxSlewRateNP.np[0].value = index;
-            IDSetNumber(&MaxSlewRateNP, "Slewrate set to %d", index);
+            MaxSlewRateNP.setState(IPS_OK);
+            MaxSlewRateNP[0].setValue(index);
+            MaxSlewRateNP.apply("Slewrate set to %d", index);
             IUResetSwitch(&SlewRateSP);
             SlewRateS[index].s = ISS_ON;
             SlewRateSP.s = IPS_OK;
@@ -981,298 +981,298 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
             return true;
         }
         // Homing, Cold and Warm Init
-        if (!strcmp(name, SetHomeSP.name))
+        if (SetHomeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SetHomeSP, states, names, n);
-            SetHomeSP.s = IPS_OK;
+            SetHomeSP.update(states, names, n);
+            SetHomeSP.setState(IPS_OK);
 
-            if (SetHomeS[0].s == ISS_ON)
+            if (SetHomeSP[0].getState() == ISS_ON)
             {
                 if(!sendOnStepCommandBlind(":hC#"))
                     return false;
-                IDSetSwitch(&SetHomeSP, "Return Home");
-                SetHomeS[0].s = ISS_OFF;
+                SetHomeSP.apply("Return Home");
+                SetHomeSP[0].setState(ISS_OFF);
             }
             else
             {
                 if(!sendOnStepCommandBlind(":hF#"))
                     return false;
-                IDSetSwitch(&SetHomeSP, "At Home (Reset)");
-                SetHomeS[1].s = ISS_OFF;
+                SetHomeSP.apply("At Home (Reset)");
+                SetHomeSP[1].setState(ISS_OFF);
             }
-            IUResetSwitch(&ReticSP);
-            SetHomeSP.s = IPS_IDLE;
-            IDSetSwitch(&SetHomeSP, nullptr);
+            ReticSP.reset();
+            SetHomeSP.setState(IPS_IDLE);
+            SetHomeSP.apply();
             return true;
         }
 
         // Tracking Compensation selection
-        if (!strcmp(name, TrackCompSP.name))
+        if (TrackCompSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&TrackCompSP, states, names, n);
-            TrackCompSP.s = IPS_BUSY;
+            TrackCompSP.update(states, names, n);
+            TrackCompSP.setState(IPS_BUSY);
 
-            if (TrackCompS[0].s == ISS_ON)
+            if (TrackCompSP[0].getState() == ISS_ON)
             {
                 if (!sendOnStepCommand(":To#"))
                 {
-                    IDSetSwitch(&TrackCompSP, "Full Compensated Tracking On");
-                    TrackCompSP.s = IPS_OK;
-                    IDSetSwitch(&TrackCompSP, nullptr);
+                    TrackCompSP.apply("Full Compensated Tracking On");
+                    TrackCompSP.setState(IPS_OK);
+                    TrackCompSP.apply();
                     return true;
                 }
             }
-            if (TrackCompS[1].s == ISS_ON)
+            if (TrackCompSP[1].getState() == ISS_ON)
             {
                 if (!sendOnStepCommand(":Tr#"))
                 {
-                    IDSetSwitch(&TrackCompSP, "Refraction Tracking On");
-                    TrackCompSP.s = IPS_OK;
-                    IDSetSwitch(&TrackCompSP, nullptr);
+                    TrackCompSP.apply("Refraction Tracking On");
+                    TrackCompSP.setState(IPS_OK);
+                    TrackCompSP.apply();
                     return true;
                 }
             }
-            if (TrackCompS[2].s == ISS_ON)
+            if (TrackCompSP[2].getState() == ISS_ON)
             {
                 if (!sendOnStepCommand(":Tn#"))
                 {
-                    IDSetSwitch(&TrackCompSP, "Refraction Tracking Disabled");
-                    TrackCompSP.s = IPS_OK;
-                    IDSetSwitch(&TrackCompSP, nullptr);
+                    TrackCompSP.apply("Refraction Tracking Disabled");
+                    TrackCompSP.setState(IPS_OK);
+                    TrackCompSP.apply();
                     return true;
                 }
             }
-            IUResetSwitch(&TrackCompSP);
-            TrackCompSP.s = IPS_IDLE;
-            IDSetSwitch(&TrackCompSP, nullptr);
+            TrackCompSP.reset();
+            TrackCompSP.setState(IPS_IDLE);
+            TrackCompSP.apply();
             return true;
         }
 
-        if (!strcmp(name, TrackAxisSP.name))
+        if (TrackAxisSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&TrackAxisSP, states, names, n);
-            TrackAxisSP.s = IPS_BUSY;
+            TrackAxisSP.update(states, names, n);
+            TrackAxisSP.setState(IPS_BUSY);
 
-            if (TrackAxisS[0].s == ISS_ON)
+            if (TrackAxisSP[0].getState() == ISS_ON)
             {
                 if (!sendOnStepCommand(":T1#"))
                 {
-                    IDSetSwitch(&TrackAxisSP, "Single Tracking On");
-                    TrackAxisSP.s = IPS_OK;
-                    IDSetSwitch(&TrackAxisSP, nullptr);
+                    TrackAxisSP.apply("Single Tracking On");
+                    TrackAxisSP.setState(IPS_OK);
+                    TrackAxisSP.apply();
                     return true;
                 }
             }
-            if (TrackAxisS[1].s == ISS_ON)
+            if (TrackAxisSP[1].getState() == ISS_ON)
             {
                 if (!sendOnStepCommand(":T2#"))
                 {
-                    IDSetSwitch(&TrackAxisSP, "Dual Axis Tracking On");
-                    TrackAxisSP.s = IPS_OK;
-                    IDSetSwitch(&TrackAxisSP, nullptr);
+                    TrackAxisSP.apply("Dual Axis Tracking On");
+                    TrackAxisSP.setState(IPS_OK);
+                    TrackAxisSP.apply();
                     return true;
                 }
             }
-            IUResetSwitch(&TrackAxisSP);
-            TrackAxisSP.s = IPS_IDLE;
-            IDSetSwitch(&TrackAxisSP, nullptr);
+            TrackAxisSP.reset();
+            TrackAxisSP.setState(IPS_IDLE);
+            TrackAxisSP.apply();
             return true;
         }
 
-        if (!strcmp(name, AutoFlipSP.name))
+        if (AutoFlipSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&AutoFlipSP, states, names, n);
-            AutoFlipSP.s = IPS_BUSY;
+            AutoFlipSP.update(states, names, n);
+            AutoFlipSP.setState(IPS_BUSY);
 
-            if (AutoFlipS[0].s == ISS_ON)
+            if (AutoFlipSP[0].getState() == ISS_ON)
             {
                 if (sendOnStepCommand(":SX95,0#"))
                 {
-                    AutoFlipSP.s = IPS_OK;
-                    IDSetSwitch(&AutoFlipSP, "Auto Meridian Flip OFF");
+                    AutoFlipSP.setState(IPS_OK);
+                    AutoFlipSP.apply("Auto Meridian Flip OFF");
                     return true;
                 }
             }
-            if (AutoFlipS[1].s == ISS_ON)
+            if (AutoFlipSP[1].getState() == ISS_ON)
             {
                 if (sendOnStepCommand(":SX95,1#"))
                 {
-                    AutoFlipSP.s = IPS_OK;
-                    IDSetSwitch(&AutoFlipSP, "Auto Meridian Flip ON");
+                    AutoFlipSP.setState(IPS_OK);
+                    AutoFlipSP.apply("Auto Meridian Flip ON");
                     return true;
                 }
             }
-            IUResetSwitch(&AutoFlipSP);
-            //AutoFlipSP.s = IPS_IDLE;
-            IDSetSwitch(&AutoFlipSP, nullptr);
+            AutoFlipSP.reset();
+            //AutoFlipSP.setState(IPS_IDLE);
+            AutoFlipSP.apply();
             return true;
         }
 
-        if (!strcmp(name, HomePauseSP.name))
+        if (HomePauseSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&HomePauseSP, states, names, n);
-            HomePauseSP.s = IPS_BUSY;
+            HomePauseSP.update(states, names, n);
+            HomePauseSP.setState(IPS_BUSY);
 
-            if (HomePauseS[0].s == ISS_ON)
+            if (HomePauseSP[0].getState() == ISS_ON)
             {
                 if (sendOnStepCommand(":SX98,0#"))
                 {
-                    HomePauseSP.s = IPS_OK;
-                    IDSetSwitch(&HomePauseSP, "Home Pause OFF");
+                    HomePauseSP.setState(IPS_OK);
+                    HomePauseSP.apply("Home Pause OFF");
                     return true;
                 }
             }
-            if (HomePauseS[1].s == ISS_ON)
+            if (HomePauseSP[1].getState() == ISS_ON)
             {
                 if (sendOnStepCommand(":SX98,1#"))
                 {
-                    HomePauseSP.s = IPS_OK;
-                    IDSetSwitch(&HomePauseSP, "Home Pause ON");
+                    HomePauseSP.setState(IPS_OK);
+                    HomePauseSP.apply("Home Pause ON");
                     return true;
                 }
             }
-            if (HomePauseS[2].s == ISS_ON)
+            if (HomePauseSP[2].getState() == ISS_ON)
             {
                 if (sendOnStepCommand(":SX99,1#"))
                 {
-                    IUResetSwitch(&HomePauseSP);
-                    HomePauseSP.s = IPS_OK;
-                    IDSetSwitch(&HomePauseSP, "Home Pause: Continue");
+                    HomePauseSP.reset();
+                    HomePauseSP.setState(IPS_OK);
+                    HomePauseSP.apply("Home Pause: Continue");
                     return true;
                 }
             }
-            IUResetSwitch(&HomePauseSP);
-            HomePauseSP.s = IPS_IDLE;
-            IDSetSwitch(&HomePauseSP, nullptr);
+            HomePauseSP.reset();
+            HomePauseSP.setState(IPS_IDLE);
+            HomePauseSP.apply();
             return true;
         }
 
-        if (!strcmp(name, FrequencyAdjustSP.name))      //
+        if (FrequencyAdjustSP.isNameMatch(name))      //
 
             //
         {
-            IUUpdateSwitch(&FrequencyAdjustSP, states, names, n);
-            FrequencyAdjustSP.s = IPS_OK;
+            FrequencyAdjustSP.update(states, names, n);
+            FrequencyAdjustSP.setState(IPS_OK);
 
-            if (FrequencyAdjustS[0].s == ISS_ON)
+            if (FrequencyAdjustSP[0].getState() == ISS_ON)
             {
                 if (!sendOnStepCommandBlind(":T-#"))
                 {
-                    IDSetSwitch(&FrequencyAdjustSP, "Frequency decreased");
+                    FrequencyAdjustSP.apply("Frequency decreased");
                     return true;
                 }
             }
-            if (FrequencyAdjustS[1].s == ISS_ON)
+            if (FrequencyAdjustSP[1].getState() == ISS_ON)
             {
                 if (!sendOnStepCommandBlind(":T+#"))
                 {
-                    IDSetSwitch(&FrequencyAdjustSP, "Frequency increased");
+                    FrequencyAdjustSP.apply("Frequency increased");
                     return true;
                 }
             }
-            if (FrequencyAdjustS[2].s == ISS_ON)
+            if (FrequencyAdjustSP[2].getState() == ISS_ON)
             {
                 if (!sendOnStepCommandBlind(":TR#"))
                 {
-                    IDSetSwitch(&FrequencyAdjustSP, "Frequency Reset (TO saved EEPROM)");
+                    FrequencyAdjustSP.apply("Frequency Reset (TO saved EEPROM)");
                     return true;
                 }
             }
-            IUResetSwitch(&FrequencyAdjustSP);
-            FrequencyAdjustSP.s = IPS_IDLE;
-            IDSetSwitch(&FrequencyAdjustSP, nullptr);
+            FrequencyAdjustSP.reset();
+            FrequencyAdjustSP.setState(IPS_IDLE);
+            FrequencyAdjustSP.apply();
             return true;
         }
 
         //Pier Side
-        if (!strcmp(name, PreferredPierSideSP.name))
+        if (PreferredPierSideSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PreferredPierSideSP, states, names, n);
-            PreferredPierSideSP.s = IPS_BUSY;
+            PreferredPierSideSP.update(states, names, n);
+            PreferredPierSideSP.setState(IPS_BUSY);
 
-            if (PreferredPierSideS[0].s == ISS_ON) //West
+            if (PreferredPierSideSP[0].getState() == ISS_ON) //West
             {
                 if (sendOnStepCommand(":SX96,W#"))
                 {
-                    PreferredPierSideSP.s = IPS_OK;
-                    IDSetSwitch(&PreferredPierSideSP, "Preferred Pier Side: West");
+                    PreferredPierSideSP.setState(IPS_OK);
+                    PreferredPierSideSP.apply("Preferred Pier Side: West");
                     return true;
                 }
             }
-            if (PreferredPierSideS[1].s == ISS_ON) //East
+            if (PreferredPierSideSP[1].getState() == ISS_ON) //East
             {
                 if (sendOnStepCommand(":SX96,E#"))
                 {
-                    PreferredPierSideSP.s = IPS_OK;
-                    IDSetSwitch(&PreferredPierSideSP, "Preferred Pier Side: East");
+                    PreferredPierSideSP.setState(IPS_OK);
+                    PreferredPierSideSP.apply("Preferred Pier Side: East");
                     return true;
                 }
             }
-            if (PreferredPierSideS[2].s == ISS_ON) //Best
+            if (PreferredPierSideSP[2].getState() == ISS_ON) //Best
             {
                 if (sendOnStepCommand(":SX96,B#"))
                 {
-                    PreferredPierSideSP.s = IPS_OK;
-                    IDSetSwitch(&PreferredPierSideSP, "Preferred Pier Side: Best");
+                    PreferredPierSideSP.setState(IPS_OK);
+                    PreferredPierSideSP.apply("Preferred Pier Side: Best");
                     return true;
                 }
             }
-            IUResetSwitch(&PreferredPierSideSP);
-            IDSetSwitch(&PreferredPierSideSP, nullptr);
+            PreferredPierSideSP.reset();
+            PreferredPierSideSP.apply();
             return true;
         }
 
 
         // Focuser
         // Focuser 1 Rates
-        if (!strcmp(name, OSFocus1InitializeSP.name))
+        if (OSFocus1InitializeSP.isNameMatch(name))
         {
             char cmd[32];
-            if (IUUpdateSwitch(&OSFocus1InitializeSP, states, names, n) < 0)
+            if (!OSFocus1InitializeSP.update(states, names, n))
                 return false;
-            index = IUFindOnSwitchIndex(&OSFocus1InitializeSP);
+            index = OSFocus1InitializeSP.findOnSwitchIndex();
             if (index == 0)
             {
                 snprintf(cmd, 5, ":FZ#");
                 sendOnStepCommandBlind(cmd);
-                OSFocus1InitializeS[index].s = ISS_OFF;
-                OSFocus1InitializeSP.s = IPS_OK;
-                IDSetSwitch(&OSFocus1InitializeSP, nullptr);
+                OSFocus1InitializeSP[index].setState(ISS_OFF);
+                OSFocus1InitializeSP.setState(IPS_OK);
+                OSFocus1InitializeSP.apply();
             }
             if (index == 1)
             {
                 snprintf(cmd, 5, ":FH#");
                 sendOnStepCommandBlind(cmd);
-                OSFocus1InitializeS[index].s = ISS_OFF;
-                OSFocus1InitializeSP.s = IPS_OK;
-                IDSetSwitch(&OSFocus1InitializeSP, nullptr);
+                OSFocus1InitializeSP[index].setState(ISS_OFF);
+                OSFocus1InitializeSP.setState(IPS_OK);
+                OSFocus1InitializeSP.apply();
             }
         }
 
         // Focuser 2 Rates
-        if (!strcmp(name, OSFocus2RateSP.name))
+        if (OSFocus2RateSP.isNameMatch(name))
         {
             char cmd[32];
 
-            if (IUUpdateSwitch(&OSFocus2RateSP, states, names, n) < 0)
+            if (!OSFocus2RateSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&OSFocus2RateSP);
+            index = OSFocus2RateSP.findOnSwitchIndex();
             snprintf(cmd, 5, ":F%d#", index + 1);
             sendOnStepCommandBlind(cmd);
-            OSFocus2RateS[index].s = ISS_OFF;
-            OSFocus2RateSP.s = IPS_OK;
-            IDSetSwitch(&OSFocus2RateSP, nullptr);
+            OSFocus2RateSP[index].setState(ISS_OFF);
+            OSFocus2RateSP.setState(IPS_OK);
+            OSFocus2RateSP.apply();
         }
         // Focuser 2 Motion
-        if (!strcmp(name, OSFocus2MotionSP.name))
+        if (OSFocus2MotionSP.isNameMatch(name))
         {
             char cmd[32];
 
-            if (IUUpdateSwitch(&OSFocus2MotionSP, states, names, n) < 0)
+            if (!OSFocus2MotionSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&OSFocus2MotionSP);
+            index = OSFocus2MotionSP.findOnSwitchIndex();
             if (index == 0)
             {
                 strcpy(cmd, ":f+#");
@@ -1292,207 +1292,207 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
             {
                 sendOnStepCommandBlind(":fQ#");
             }
-            OSFocus2MotionS[index].s = ISS_OFF;
-            OSFocus2MotionSP.s = IPS_OK;
-            IDSetSwitch(&OSFocus2MotionSP, nullptr);
+            OSFocus2MotionSP[index].setState(ISS_OFF);
+            OSFocus2MotionSP.setState(IPS_OK);
+            OSFocus2MotionSP.apply();
         }
 
         // PEC
-        if (!strcmp(name, OSPECRecordSP.name))
+        if (OSPECRecordSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&OSPECRecordSP, states, names, n);
-            OSPECRecordSP.s = IPS_OK;
+            OSPECRecordSP.update(states, names, n);
+            OSPECRecordSP.setState(IPS_OK);
 
-            if (OSPECRecordS[0].s == ISS_ON)
+            if (OSPECRecordSP[0].getState() == ISS_ON)
             {
                 OSPECEnabled = true;
                 ClearPECBuffer(0);
-                OSPECRecordS[0].s = ISS_OFF;
+                OSPECRecordSP[0].setState(ISS_OFF);
             }
-            if (OSPECRecordS[1].s == ISS_ON)
+            if (OSPECRecordSP[1].getState() == ISS_ON)
             {
                 OSPECEnabled = true;
                 StartPECRecord(0);
-                OSPECRecordS[1].s = ISS_OFF;
+                OSPECRecordSP[1].setState(ISS_OFF);
             }
-            if (OSPECRecordS[2].s == ISS_ON)
+            if (OSPECRecordSP[2].getState() == ISS_ON)
             {
                 OSPECEnabled = true;
                 SavePECBuffer(0);
-                OSPECRecordS[2].s = ISS_OFF;
+                OSPECRecordSP[2].setState(ISS_OFF);
             }
-            IDSetSwitch(&OSPECRecordSP, nullptr);
+            OSPECRecordSP.apply();
         }
-        if (!strcmp(name, OSPECReadSP.name))
+        if (OSPECReadSP.isNameMatch(name))
         {
-            if (OSPECReadS[0].s == ISS_ON)
+            if (OSPECReadSP[0].getState() == ISS_ON)
             {
                 OSPECEnabled = true;
                 ReadPECBuffer(0);
-                OSPECReadS[0].s = ISS_OFF;
+                OSPECReadSP[0].setState(ISS_OFF);
             }
-            if (OSPECReadS[1].s == ISS_ON)
+            if (OSPECReadSP[1].getState() == ISS_ON)
             {
                 OSPECEnabled = true;
                 WritePECBuffer(0);
-                OSPECReadS[1].s = ISS_OFF;
+                OSPECReadSP[1].setState(ISS_OFF);
             }
-            IDSetSwitch(&OSPECReadSP, nullptr);
+            OSPECReadSP.apply();
         }
-        if (!strcmp(name, PECStateSP.name))
+        if (PECStateSP.isNameMatch(name))
         {
-            index = IUFindOnSwitchIndex(&PECStateSP);
+            index = PECStateSP.findOnSwitchIndex();
             if (index == 0)
             {
                 OSPECEnabled = true;
                 StopPECPlayback(0); //Status will set OSPECEnabled to false if that's set by the controller
-                PECStateS[0].s = ISS_ON;
-                PECStateS[1].s = ISS_OFF;
-                IDSetSwitch(&PECStateSP, nullptr);
+                PECStateSP[0].setState(ISS_ON);
+                PECStateSP[1].setState(ISS_OFF);
+                PECStateSP.apply();
             }
             else if (index == 1)
             {
                 OSPECEnabled = true;
                 StartPECPlayback(0);
-                PECStateS[0].s = ISS_OFF;
-                PECStateS[1].s = ISS_ON;
-                IDSetSwitch(&PECStateSP, nullptr);
+                PECStateSP[0].setState(ISS_OFF);
+                PECStateSP[1].setState(ISS_ON);
+                PECStateSP.apply();
             }
 
         }
 
         // Align Buttons
-        if (!strcmp(name, OSNAlignStarsSP.name))
+        if (OSNAlignStarsSP.isNameMatch(name))
         {
-            IUResetSwitch(&OSNAlignStarsSP);
-            IUUpdateSwitch(&OSNAlignStarsSP, states, names, n);
-            index = IUFindOnSwitchIndex(&OSNAlignStarsSP);
+            OSNAlignStarsSP.reset();
+            OSNAlignStarsSP.update(states, names, n);
+            index = OSNAlignStarsSP.findOnSwitchIndex();
 
             return true;
         }
 
         // Alignment
-        if (!strcmp(name, OSNAlignSP.name))
+        if (OSNAlignSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&OSNAlignSP, states, names, n) < 0)
+            if (!OSNAlignSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&OSNAlignSP);
+            index = OSNAlignSP.findOnSwitchIndex();
             //NewGeometricAlignment
             //End NewGeometricAlignment
-            OSNAlignSP.s = IPS_BUSY;
+            OSNAlignSP.setState(IPS_BUSY);
             if (index == 0)
             {
 
                 /* Index is 0-8 and represents index+1*/
 
-                int index_stars = IUFindOnSwitchIndex(&OSNAlignStarsSP);
+                int index_stars = OSNAlignStarsSP.findOnSwitchIndex();
                 if ((index_stars <= 8) && (index_stars >= 0))
                 {
                     int stars = index_stars + 1;
-                    OSNAlignS[0].s = ISS_OFF;
+                    OSNAlignSP[0].setState(ISS_OFF);
                     LOGF_INFO("Align index: %d, stars: %d", index_stars, stars);
                     AlignStartGeometric(stars);
                 }
             }
             if (index == 1)
             {
-                OSNAlignS[1].s = ISS_OFF;
-                OSNAlignSP.s = AlignAddStar();
+                OSNAlignSP[1].setState(ISS_OFF);
+                OSNAlignSP.setState(AlignAddStar());
             }
             //Write to EEPROM moved to new line/variable
-            IDSetSwitch(&OSNAlignSP, nullptr);
+            OSNAlignSP.apply();
             UpdateAlignStatus();
         }
 
-        if (!strcmp(name, OSNAlignWriteSP.name))
+        if (OSNAlignWriteSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&OSNAlignWriteSP, states, names, n) < 0)
+            if (!OSNAlignWriteSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&OSNAlignWriteSP);
+            index = OSNAlignWriteSP.findOnSwitchIndex();
 
-            OSNAlignWriteSP.s = IPS_BUSY;
+            OSNAlignWriteSP.setState(IPS_BUSY);
             if (index == 0)
             {
-                OSNAlignWriteS[0].s = ISS_OFF;
-                OSNAlignWriteSP.s = AlignWrite();
+                OSNAlignWriteSP[0].setState(ISS_OFF);
+                OSNAlignWriteSP.setState(AlignWrite());
             }
-            IDSetSwitch(&OSNAlignWriteSP, nullptr);
+            OSNAlignWriteSP.apply();
             UpdateAlignStatus();
         }
 
-        if (!strcmp(name, OSNAlignPolarRealignSP.name))
+        if (OSNAlignPolarRealignSP.isNameMatch(name))
         {
             char cmd[10];
-            if (IUUpdateSwitch(&OSNAlignPolarRealignSP, states, names, n) < 0)
+            if (!OSNAlignPolarRealignSP.update(states, names, n))
                 return false;
 
 
-            OSNAlignPolarRealignSP.s = IPS_BUSY;
-            if (OSNAlignPolarRealignS[0].s == ISS_ON) //INFO
+            OSNAlignPolarRealignSP.setState(IPS_BUSY);
+            if (OSNAlignPolarRealignSP[0].getState() == ISS_ON) //INFO
             {
-                OSNAlignPolarRealignS[0].s = ISS_OFF;
+                OSNAlignPolarRealignSP[0].setState(ISS_OFF);
                 LOG_INFO("Step 1: Goto a bright star between 50 and 80 degrees N/S from the pole. Preferably on the Meridian.");
                 LOG_INFO("Step 2: Make sure it is centered.");
                 LOG_INFO("Step 3: Press Refine Polar Alignment.");
                 LOG_INFO("Step 4: Using the mount's Alt and Az screws manually recenter the star. (Video mode if your camera supports it will be helpful.)");
                 LOG_INFO("Optional: Start a new alignment.");
-                IDSetSwitch(&OSNAlignPolarRealignSP, nullptr);
+                OSNAlignPolarRealignSP.apply();
                 UpdateAlignStatus();
                 return true;
             }
-            if (OSNAlignPolarRealignS[1].s == ISS_ON) //Command
+            if (OSNAlignPolarRealignSP[1].getState() == ISS_ON) //Command
             {
-                OSNAlignPolarRealignS[1].s = ISS_OFF;
+                OSNAlignPolarRealignSP[1].setState(ISS_OFF);
                 // int returncode=sendOnStepCommand("
                 snprintf(cmd, 5, ":MP#");
                 sendOnStepCommandBlind(cmd);
                 if (!sendOnStepCommandBlind(":MP#"))
                 {
-                    IDSetSwitch(&OSNAlignPolarRealignSP, "Command for Refine Polar Alignment successful");
+                    OSNAlignPolarRealignSP.apply("Command for Refine Polar Alignment successful");
                     UpdateAlignStatus();
-                    OSNAlignPolarRealignSP.s = IPS_OK;
+                    OSNAlignPolarRealignSP.setState(IPS_OK);
                     return true;
                 }
                 else
                 {
-                    IDSetSwitch(&OSNAlignPolarRealignSP, "Command for Refine Polar Alignment FAILED");
+                    OSNAlignPolarRealignSP.apply("Command for Refine Polar Alignment FAILED");
                     UpdateAlignStatus();
-                    OSNAlignPolarRealignSP.s = IPS_ALERT;
+                    OSNAlignPolarRealignSP.setState(IPS_ALERT);
                     return false;
                 }
             }
         }
 
 #ifdef ONSTEP_NOTDONE
-        if (!strcmp(name, OSOutput1SP.name))      //
+        if (OSOutput1SP.isNameMatch(name))      //
         {
-            if (OSOutput1S[0].s == ISS_ON)
+            if (OSOutput1SP[0].getState() == ISS_ON)
             {
                 OSDisableOutput(1);
-                //PECStateS[0].s == ISS_OFF;
+                //PECStateSP[0].getState() == ISS_OFF;
             }
-            else if (OSOutput1S[1].s == ISS_ON)
+            else if (OSOutput1SP[1].getState() == ISS_ON)
             {
                 OSEnableOutput(1);
-                //PECStateS[1].s == ISS_OFF;
+                //PECStateSP[1].getState() == ISS_OFF;
             }
-            IDSetSwitch(&OSOutput1SP, nullptr);
+            OSOutput1SP.apply();
         }
-        if (!strcmp(name, OSOutput2SP.name))      //
+        if (OSOutput2SP.isNameMatch(name))      //
         {
-            if (OSOutput2S[0].s == ISS_ON)
+            if (OSOutput2SP[0].getState() == ISS_ON)
             {
                 OSDisableOutput(2);
-                //PECStateS[0].s == ISS_OFF;
+                //PECStateSP[0].getState() == ISS_OFF;
             }
-            else if (OSOutput2S[1].s == ISS_ON)
+            else if (OSOutput2SP[1].getState() == ISS_ON)
             {
                 OSEnableOutput(2);
-                //PECStateS[1].s == ISS_OFF;
+                //PECStateSP[1].getState() == ISS_OFF;
             }
-            IDSetSwitch(&OSOutput2SP, nullptr);
+            OSOutput2SP.apply();
         }
 #endif
 
@@ -1584,39 +1584,39 @@ bool LX200_OnStep::Park()
     if (!isSimulation())
     {
         // If scope is moving, let's stop it first.
-        if (EqNP.s == IPS_BUSY)
+        if (EqNP.getState() == IPS_BUSY)
         {
             if (!isSimulation() && abortSlew(PortFD) < 0)
             {
-                Telescope::AbortSP.s = IPS_ALERT;
+                Telescope::AbortSP.setState(IPS_ALERT);
                 IDSetSwitch(&(Telescope::AbortSP), "Abort slew failed.");
                 return false;
             }
-            Telescope::AbortSP.s = IPS_OK;
-            EqNP.s    = IPS_IDLE;
+            Telescope::AbortSP.setState(IPS_OK);
+            EqNP.setState(IPS_IDLE);
             IDSetSwitch(&(Telescope::AbortSP), "Slew aborted.");
-            IDSetNumber(&EqNP, nullptr);
+            EqNP.apply();
 
-            if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+            if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
             {
-                MovementNSSP.s = IPS_IDLE;
-                MovementWESP.s = IPS_IDLE;
-                EqNP.s = IPS_IDLE;
-                IUResetSwitch(&MovementNSSP);
-                IUResetSwitch(&MovementWESP);
+                MovementNSSP.setState(IPS_IDLE);
+                MovementWESP.setState(IPS_IDLE);
+                EqNP.setState(IPS_IDLE);
+                MovementNSSP.reset();
+                MovementWESP.reset();
 
-                IDSetSwitch(&MovementNSSP, nullptr);
-                IDSetSwitch(&MovementWESP, nullptr);
+                MovementNSSP.apply();
+                MovementWESP.apply();
             }
         }
         if (!isSimulation() && slewToPark(PortFD) < 0)
         {
-            ParkSP.s = IPS_ALERT;
-            IDSetSwitch(&ParkSP, "Parking Failed.");
+            ParkSP.setState(IPS_ALERT);
+            ParkSP.apply("Parking Failed.");
             return false;
         }
     }
-    ParkSP.s   = IPS_BUSY;
+    ParkSP.setState(IPS_BUSY);
     return true;
 }
 
@@ -1638,8 +1638,8 @@ bool LX200_OnStep::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0) // Update actual position
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -1788,15 +1788,15 @@ bool LX200_OnStep::ReadScopeStatus()
             //AutoPauseAtHome
             if (strstr(OSStat, "u"))  //  pa[u]se at home enabled?
             {
-                HomePauseS[1].s = ISS_ON;
-                HomePauseSP.s = IPS_OK;
-                IDSetSwitch(&HomePauseSP, "Pause at Home Enabled");
+                HomePauseSP[1].setState(ISS_ON);
+                HomePauseSP.setState(IPS_OK);
+                HomePauseSP.apply("Pause at Home Enabled");
             }
             else
             {
-                HomePauseS[0].s = ISS_ON;
-                HomePauseSP.s = IPS_OK;
-                IDSetSwitch(&HomePauseSP, nullptr);
+                HomePauseSP[0].setState(ISS_ON);
+                HomePauseSP.setState(IPS_OK);
+                HomePauseSP.apply();
             }
 
             if (strstr(OSStat, "w"))
@@ -1953,15 +1953,15 @@ bool LX200_OnStep::ReadScopeStatus()
         {
             // Pause at home enabled?
             //AutoPauseAtHome
-            HomePauseS[1].s = ISS_ON;
-            HomePauseSP.s = IPS_OK;
-            IDSetSwitch(&HomePauseSP, "Pause at Home Enabled");
+            HomePauseSP[1].setState(ISS_ON);
+            HomePauseSP.setState(IPS_OK);
+            HomePauseSP.apply("Pause at Home Enabled");
         }
         else
         {
-            HomePauseS[0].s = ISS_ON;
-            HomePauseSP.s = IPS_OK;
-            IDSetSwitch(&HomePauseSP, nullptr);
+            HomePauseSP[0].setState(ISS_ON);
+            HomePauseSP.setState(IPS_OK);
+            HomePauseSP.apply();
         }
         if (OSStat[2] & 0b10001000 == 0b10001000)
         {
@@ -1970,15 +1970,15 @@ bool LX200_OnStep::ReadScopeStatus()
         if (OSStat[2] & 0b10010000 == 0b10010000)
         {
             // Auto meridian flip
-            AutoFlipS[1].s = ISS_ON;
-            AutoFlipSP.s = IPS_OK;
-            IDSetSwitch(&AutoFlipSP, nullptr);
+            AutoFlipSP[1].setState(ISS_ON);
+            AutoFlipSP.setState(IPS_OK);
+            AutoFlipSP.apply();
         }
         else
         {
-            AutoFlipS[0].s = ISS_ON;
-            AutoFlipSP.s = IPS_OK;
-            IDSetSwitch(&AutoFlipSP, nullptr);
+            AutoFlipSP[0].setState(ISS_ON);
+            AutoFlipSP.setState(IPS_OK);
+            AutoFlipSP.apply();
         }
         if (OSStat[2] & 0b10100000 == 0b10100000)
         {
@@ -2159,18 +2159,18 @@ bool LX200_OnStep::ReadScopeStatus()
     //========== Get actual Backlash values
     getCommandString(PortFD, OSbacklashDEC, ":%BD#");
     getCommandString(PortFD, OSbacklashRA, ":%BR#");
-    BacklashNP.np[0].value = atof(OSbacklashDEC);
-    BacklashNP.np[1].value = atof(OSbacklashRA);
-    IDSetNumber(&BacklashNP, nullptr);
+    BacklashNP[0].setValue(atof(OSbacklashDEC));
+    BacklashNP[1].setValue(atof(OSbacklashRA));
+    BacklashNP.apply();
 
     double pulseguiderate;
     getCommandString(PortFD, GuideValue, ":GX90#");
     //     LOGF_DEBUG("Guide Rate String: %s", GuideValue);
     pulseguiderate = atof(GuideValue);
     LOGF_DEBUG("Guide Rate: %f", pulseguiderate);
-    GuideRateNP.np[0].value = pulseguiderate;
-    GuideRateNP.np[1].value = pulseguiderate;
-    IDSetNumber(&GuideRateNP, nullptr);
+    GuideRateNP[0].setValue(pulseguiderate);
+    GuideRateNP[1].setValue(pulseguiderate);
+    GuideRateNP.apply();
 
 
 #ifndef OnStep_Alpha
@@ -2180,15 +2180,15 @@ bool LX200_OnStep::ReadScopeStatus()
         getCommandString(PortFD, TempValue, ":GX95#");
         if (atoi(TempValue))
         {
-            AutoFlipS[1].s = ISS_ON;
-            AutoFlipSP.s = IPS_OK;
-            IDSetSwitch(&AutoFlipSP, nullptr);
+            AutoFlipSP[1].setState(ISS_ON);
+            AutoFlipSP.setState(IPS_OK);
+            AutoFlipSP.apply();
         }
         else
         {
-            AutoFlipS[0].s = ISS_ON;
-            AutoFlipSP.s = IPS_OK;
-            IDSetSwitch(&AutoFlipSP, nullptr);
+            AutoFlipSP[0].setState(ISS_ON);
+            AutoFlipSP.setState(IPS_OK);
+            AutoFlipSP.apply();
         }
     }
 #endif
@@ -2199,34 +2199,34 @@ bool LX200_OnStep::ReadScopeStatus()
         getCommandString(PortFD, TempValue, ":GX96#");
         if (strstr(TempValue, "W"))
         {
-            PreferredPierSideS[0].s = ISS_ON;
-            PreferredPierSideSP.s = IPS_OK;
-            IDSetSwitch(&PreferredPierSideSP, nullptr);
+            PreferredPierSideSP[0].setState(ISS_ON);
+            PreferredPierSideSP.setState(IPS_OK);
+            PreferredPierSideSP.apply();
         }
         else if (strstr(TempValue, "E"))
         {
-            PreferredPierSideS[1].s = ISS_ON;
-            PreferredPierSideSP.s = IPS_OK;
-            IDSetSwitch(&PreferredPierSideSP, nullptr);
+            PreferredPierSideSP[1].setState(ISS_ON);
+            PreferredPierSideSP.setState(IPS_OK);
+            PreferredPierSideSP.apply();
         }
         else if (strstr(TempValue, "B"))
         {
-            PreferredPierSideS[2].s = ISS_ON;
-            PreferredPierSideSP.s = IPS_OK;
-            IDSetSwitch(&PreferredPierSideSP, nullptr);
+            PreferredPierSideSP[2].setState(ISS_ON);
+            PreferredPierSideSP.setState(IPS_OK);
+            PreferredPierSideSP.apply();
         }
         else
         {
-            IUResetSwitch(&PreferredPierSideSP);
-            PreferredPierSideSP.s = IPS_BUSY;
-            IDSetSwitch(&PreferredPierSideSP, nullptr);
+            PreferredPierSideSP.reset();
+            PreferredPierSideSP.setState(IPS_BUSY);
+            PreferredPierSideSP.apply();
         }
 
         getCommandString(PortFD, TempValue, ":GXE9#"); // E
         getCommandString(PortFD, TempValue2, ":GXEA#"); // W
-        minutesPastMeridianNP.np[0].value = atof(TempValue); // E
-        minutesPastMeridianNP.np[1].value = atof(TempValue2); //W
-        IDSetNumber(&minutesPastMeridianNP, nullptr);
+        minutesPastMeridianNP[0].setValue(atof(TempValue)); // E
+        minutesPastMeridianNP[1].setValue(atof(TempValue2)); //W
+        minutesPastMeridianNP.apply();
 
     }
 
@@ -2450,7 +2450,7 @@ IPState LX200_OnStep::MoveAbsFocuser (uint32_t targetTicks)
 {
     //  :FSsnnn#  Set focuser target position (in microns)
     //            Returns: Nothing
-    if (FocusAbsPosN[0].max >= int(targetTicks) && FocusAbsPosN[0].min <= int(targetTicks))
+    if (FocusAbsPosNP[0].max >= int(targetTicks) && FocusAbsPosNP[0].min <= int(targetTicks))
     {
         char read_buffer[32];
         snprintf(read_buffer, sizeof(read_buffer), ":FS%06d#", int(targetTicks));
@@ -2495,57 +2495,57 @@ void LX200_OnStep::OSUpdateFocuser()
         // Alternate option:
         //if (!sendOnStepCommand(":FA#")) {
         getCommandString(PortFD, value, ":FG#");
-        FocusAbsPosN[0].value =  atoi(value);
-        current = FocusAbsPosN[0].value;
-        IDSetNumber(&FocusAbsPosNP, nullptr);
-        LOGF_DEBUG("Current focuser: %d, %d", atoi(value), FocusAbsPosN[0].value);
+        FocusAbsPosNP[0].setValue(atoi(value));
+        current = FocusAbsPosNP[0].getValue();
+        FocusAbsPosNP.apply();
+        LOGF_DEBUG("Current focuser: %d, %d", atoi(value), FocusAbsPosNP[0].getValue());
         //  :FT#  get status
         //         Returns: M# (for moving) or S# (for stopped)
         getCommandString(PortFD, value, ":FT#");
         if (value[0] == 'S')
         {
-            FocusRelPosNP.s = IPS_OK;
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            FocusAbsPosNP.s = IPS_OK;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusRelPosNP.apply();
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusAbsPosNP.apply();
         }
         else if (value[0] == 'M')
         {
-            FocusRelPosNP.s = IPS_BUSY;
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            FocusAbsPosNP.s = IPS_BUSY;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusRelPosNP.setState(IPS_BUSY);
+            FocusRelPosNP.apply();
+            FocusAbsPosNP.setState(IPS_BUSY);
+            FocusAbsPosNP.apply();
         }
         else
         {
             //INVALID REPLY
-            FocusRelPosNP.s = IPS_ALERT;
-            IDSetNumber(&FocusRelPosNP, nullptr);
-            FocusAbsPosNP.s = IPS_ALERT;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusRelPosNP.setState(IPS_ALERT);
+            FocusRelPosNP.apply();
+            FocusAbsPosNP.setState(IPS_ALERT);
+            FocusAbsPosNP.apply();
         }
         //  :FM#  Get max position (in microns)
         //         Returns: n#
         getCommandString(PortFD, value, ":FM#");
-        FocusAbsPosN[0].max   = atoi(value);
-        IUUpdateMinMax(&FocusAbsPosNP);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setMax(atoi(value));
+        FocusAbsPosNP.updateMinMax();
+        FocusAbsPosNP.apply();
         //  :FI#  Get full in position (in microns)
         //         Returns: n#
         getCommandString(PortFD, value, ":FI#");
-        FocusAbsPosN[0].min =  atoi(value);
-        IUUpdateMinMax(&FocusAbsPosNP);
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP[0].setMin(atoi(value));
+        FocusAbsPosNP.updateMinMax();
+        FocusAbsPosNP.apply();
         FI::updateProperties();
-        LOGF_DEBUG("After update properties: FocusAbsPosN min: %f max: %f", FocusAbsPosN[0].min, FocusAbsPosN[0].max);
+        LOGF_DEBUG("After update properties: FocusAbsPosN min: %f max: %f", FocusAbsPosNP[0].min, FocusAbsPosNP[0].max);
     }
 
 
     if(OSFocuser2)
     {
         getCommandString(PortFD, value, ":fG#");
-        OSFocus2TargNP.np[0].value = atoi(value);
-        IDSetNumber(&OSFocus2TargNP, nullptr);
+        OSFocus2TargNP[0].setValue(atoi(value));
+        OSFocus2TargNP.apply();
     }
 }
 
@@ -2679,74 +2679,74 @@ IPState LX200_OnStep::PECStatus (int axis)
         //  :$QZ?  Get PEC status
         //         Returns: S#
         // Returns status (pecSense) In the form: Status is one of "IpPrR" (I)gnore, get ready to (p)lay, (P)laying, get ready to (r)ecord, (R)ecording.  Or an optional (.) to indicate an index detect.
-        // IUFillSwitch(&OSPECStatusS[0], "OFF", "OFF", ISS_ON);
-        // IUFillSwitch(&OSPECStatusS[1], "Playing", "Playing", ISS_OFF);
-        // IUFillSwitch(&OSPECStatusS[2], "Recording", "Recording", ISS_OFF);
-        // IUFillSwitch(&OSPECStatusS[3], "Will Play", "Will Play", ISS_OFF);
-        // IUFillSwitch(&OSPECStatusS[4], "Will Record", "Will Record", ISS_OFF);
+        // OSPECStatusSP[0].fill("OFF", "OFF", ISS_ON);
+        // OSPECStatusSP[1].fill("Playing", "Playing", ISS_OFF);
+        // OSPECStatusSP[2].fill("Recording", "Recording", ISS_OFF);
+        // OSPECStatusSP[3].fill("Will Play", "Will Play", ISS_OFF);
+        // OSPECStatusSP[4].fill("Will Record", "Will Record", ISS_OFF);
         char value[RB_MAX_LEN] = "  ";
-        OSPECStatusSP.s = IPS_BUSY;
+        OSPECStatusSP.setState(IPS_BUSY);
         getCommandString(PortFD, value, ":$QZ?#");
         // LOGF_INFO("Response %s", value);
         // LOGF_INFO("Response %d", value[0]);
         // LOGF_INFO("Response %d", value[1]);
-        OSPECStatusS[0].s = ISS_OFF ;
-        OSPECStatusS[1].s = ISS_OFF ;
-        OSPECStatusS[2].s = ISS_OFF ;
-        OSPECStatusS[3].s = ISS_OFF ;
-        OSPECStatusS[4].s = ISS_OFF ;
+        OSPECStatusSP[0].setState(ISS_OFF );
+        OSPECStatusSP[1].setState(ISS_OFF );
+        OSPECStatusSP[2].setState(ISS_OFF );
+        OSPECStatusSP[3].setState(ISS_OFF );
+        OSPECStatusSP[4].setState(ISS_OFF );
         if (value[0] == 'I') //Ignore
         {
-            OSPECStatusSP.s = IPS_OK;
-            OSPECStatusS[0].s = ISS_ON ;
-            OSPECRecordSP.s = IPS_IDLE;
+            OSPECStatusSP.setState(IPS_OK);
+            OSPECStatusSP[0].setState(ISS_ON );
+            OSPECRecordSP.setState(IPS_IDLE);
             OSPECEnabled = false;
             LOG_INFO("Controller reports PEC Ignored and not supported");
             LOG_INFO("No Further PEC Commands will be processed, unless status changed");
         }
         else if (value[0] == 'R') //Active Recording
         {
-            OSPECStatusSP.s = IPS_OK;
-            OSPECStatusS[2].s = ISS_ON ;
-            OSPECRecordSP.s = IPS_BUSY;
+            OSPECStatusSP.setState(IPS_OK);
+            OSPECStatusSP[2].setState(ISS_ON );
+            OSPECRecordSP.setState(IPS_BUSY);
         }
         else if (value[0] == 'r')  //Waiting for index before recording
         {
-            OSPECStatusSP.s = IPS_OK;
-            OSPECStatusS[4].s = ISS_ON ;
-            OSPECRecordSP.s = IPS_BUSY;
+            OSPECStatusSP.setState(IPS_OK);
+            OSPECStatusSP[4].setState(ISS_ON );
+            OSPECRecordSP.setState(IPS_BUSY);
         }
         else if (value[0] == 'P') //Active Playing
         {
-            OSPECStatusSP.s = IPS_BUSY;
-            OSPECStatusS[1].s = ISS_ON ;
-            OSPECRecordSP.s = IPS_IDLE;
+            OSPECStatusSP.setState(IPS_BUSY);
+            OSPECStatusSP[1].setState(ISS_ON );
+            OSPECRecordSP.setState(IPS_IDLE);
         }
         else if (value[0] == 'p') //Waiting for index before playing
         {
-            OSPECStatusSP.s = IPS_BUSY;
-            OSPECStatusS[3].s = ISS_ON ;
-            OSPECRecordSP.s = IPS_IDLE;
+            OSPECStatusSP.setState(IPS_BUSY);
+            OSPECStatusSP[3].setState(ISS_ON );
+            OSPECRecordSP.setState(IPS_IDLE);
         }
         else //INVALID REPLY
         {
-            OSPECStatusSP.s = IPS_ALERT;
-            OSPECRecordSP.s = IPS_ALERT;
+            OSPECStatusSP.setState(IPS_ALERT);
+            OSPECRecordSP.setState(IPS_ALERT);
         }
         if (value[1] == '.')
         {
-            OSPECIndexSP.s = IPS_OK;
-            OSPECIndexS[0].s = ISS_OFF;
-            OSPECIndexS[1].s = ISS_ON;
+            OSPECIndexSP.setState(IPS_OK);
+            OSPECIndexSP[0].setState(ISS_OFF);
+            OSPECIndexSP[1].setState(ISS_ON);
         }
         else
         {
-            OSPECIndexS[1].s = ISS_OFF;
-            OSPECIndexS[0].s = ISS_ON;
+            OSPECIndexSP[1].setState(ISS_OFF);
+            OSPECIndexSP[0].setState(ISS_ON);
         }
-        IDSetSwitch(&OSPECStatusSP, nullptr);
-        IDSetSwitch(&OSPECRecordSP, nullptr);
-        IDSetSwitch(&OSPECIndexSP, nullptr);
+        OSPECStatusSP.apply();
+        OSPECRecordSP.apply();
+        OSPECIndexSP.apply();
         return IPS_OK;
     }
     else
@@ -2796,11 +2796,11 @@ IPState LX200_OnStep::AlignStartGeometric (int stars)
     char cmd[8];
 
     LOG_INFO("Sending Command to Start Alignment");
-    IUSaveText(&OSNAlignT[0], "Align STARTED");
-    IUSaveText(&OSNAlignT[1], "GOTO a star, center it");
-    IUSaveText(&OSNAlignT[2], "GOTO a star, Solve and Sync");
-    IUSaveText(&OSNAlignT[3], "Press 'Issue Align' if not solving");
-    IDSetText(&OSNAlignTP, "==>Align Started");
+    OSNAlignTP[0].setText("Align STARTED");
+    OSNAlignTP[1].setText("GOTO a star, center it");
+    OSNAlignTP[2].setText("GOTO a star, Solve and Sync");
+    OSNAlignTP[3].setText("Press 'Issue Align' if not solving");
+    OSNAlignTP.apply("==>Align Started");
     // Check for max number of stars and gracefully fall back to max, if more are requested.
     char read_buffer[RB_MAX_LEN];
     if(getCommandString(PortFD, read_buffer, ":A?#"))
@@ -2865,11 +2865,11 @@ bool LX200_OnStep::UpdateAlignStatus ()
     current_star = read_buffer[1] - '0';
     align_stars = read_buffer[2] - '0';
     snprintf(stars, sizeof(stars), "%d", max_stars);
-    IUSaveText(&OSNAlignT[5], stars);
+    OSNAlignTP[5].setText(stars);
     snprintf(stars, sizeof(stars), "%d", current_star);
-    IUSaveText(&OSNAlignT[6], stars);
+    OSNAlignTP[6].setText(stars);
     snprintf(stars, sizeof(stars), "%d", align_stars);
-    IUSaveText(&OSNAlignT[7], stars);
+    OSNAlignTP[7].setText(stars);
     LOGF_DEBUG("Align: max_stars: %i current star: %u, align_stars %u", max_stars, current_star, align_stars);
 
     /* if (align_stars > max_stars) {
@@ -2880,17 +2880,17 @@ bool LX200_OnStep::UpdateAlignStatus ()
     if (current_star <= align_stars)
     {
         snprintf(msg, sizeof(msg), "%s Manual Align: Star %d/%d", read_buffer, current_star, align_stars );
-        IUSaveText(&OSNAlignT[4], msg);
+        OSNAlignTP[4].setText(msg);
     }
     if (current_star > align_stars && max_stars > 1)
     {
         LOGF_DEBUG("Align: current star: %u, align_stars %u", int(current_star), int(align_stars));
         snprintf(msg, sizeof(msg), "Manual Align: Completed");
         AlignDone();
-        IUSaveText(&OSNAlignT[4], msg);
+        OSNAlignTP[4].setText(msg);
         UpdateAlignErr();
     }
-    IDSetText(&OSNAlignTP, nullptr);
+    OSNAlignTP.apply();
     return true;
 }
 
@@ -2919,10 +2919,10 @@ bool LX200_OnStep::UpdateAlignErr()
 
     char read_buffer[RB_MAX_LEN];
     char polar_error[40], sexabuf[20];
-    //  IUFillText(&OSNAlignT[4], "4", "Current Status", "Not Updated");
-    //  IUFillText(&OSNAlignT[5], "5", "Max Stars", "Not Updated");
-    //  IUFillText(&OSNAlignT[6], "6", "Current Star", "Not Updated");
-    //  IUFillText(&OSNAlignT[7], "7", "# of Align Stars", "Not Updated");
+    //  OSNAlignTP[4].fill("4", "Current Status", "Not Updated");
+    //  OSNAlignTP[5].fill("5", "Max Stars", "Not Updated");
+    //  OSNAlignTP[6].fill("6", "Current Star", "Not Updated");
+    //  OSNAlignTP[7].fill("7", "# of Align Stars", "Not Updated");
 
     // LOG_INFO("Getting Align Error Status");
     if(getCommandString(PortFD, read_buffer, ":GX02#"))
@@ -2943,11 +2943,11 @@ bool LX200_OnStep::UpdateAlignErr()
     long azmCor = strtold(read_buffer, nullptr);
     fs_sexa(sexabuf, (double)azmCor / 3600, 4, 3600);
     snprintf(polar_error, sizeof(polar_error), "%ld'' /%s", azmCor, sexabuf);
-    IUSaveText(&OSNAlignErrT[1], polar_error);
+    OSNAlignErrTP[1].setText(polar_error);
     fs_sexa(sexabuf, (double)altCor / 3600, 4, 3600);
     snprintf(polar_error, sizeof(polar_error), "%ld'' /%s", altCor, sexabuf);
-    IUSaveText(&OSNAlignErrT[0], polar_error);
-    IDSetText(&OSNAlignErrTP, nullptr);
+    OSNAlignErrTP[0].setText(polar_error);
+    OSNAlignErrTP.apply();
 
 
     return true;
@@ -2960,11 +2960,11 @@ IPState LX200_OnStep::AlignDone()
     {
         OSAlignCompleted = true;
         LOG_INFO("Alignment Done - May still be calculating");
-        IUSaveText(&OSNAlignT[0], "Align FINISHED");
-        IUSaveText(&OSNAlignT[1], "------");
-        IUSaveText(&OSNAlignT[2], "Optionally press:");
-        IUSaveText(&OSNAlignT[3], "Write Align to NVRAM/Flash ");
-        IDSetText(&OSNAlignTP, nullptr);
+        OSNAlignTP[0].setText("Align FINISHED");
+        OSNAlignTP[1].setText("------");
+        OSNAlignTP[2].setText("Optionally press:");
+        OSNAlignTP[3].setText("Write Align to NVRAM/Flash ");
+        OSNAlignTP.apply();
         return IPS_OK;
     }
     return IPS_BUSY;
@@ -2976,17 +2976,17 @@ IPState LX200_OnStep::AlignWrite()
     char cmd[8];
     LOG_INFO("Sending Command to Finish Alignment and write");
     strcpy(cmd, ":AW#");
-    IUSaveText(&OSNAlignT[0], "Align FINISHED");
-    IUSaveText(&OSNAlignT[1], "------");
-    IUSaveText(&OSNAlignT[2], "And Written to EEPROM");
-    IUSaveText(&OSNAlignT[3], "------");
-    IDSetText(&OSNAlignTP, nullptr);
+    OSNAlignTP[0].setText("Align FINISHED");
+    OSNAlignTP[1].setText("------");
+    OSNAlignTP[2].setText("And Written to EEPROM");
+    OSNAlignTP[3].setText("------");
+    OSNAlignTP.apply();
     if (sendOnStepCommandBlind(cmd))
     {
         return IPS_OK;
     }
-    IUSaveText(&OSNAlignT[0], "Align WRITE FAILED");
-    IDSetText(&OSNAlignTP, nullptr);
+    OSNAlignTP[0].setText("Align WRITE FAILED");
+    OSNAlignTP.apply();
     return IPS_ALERT;
 
 }
@@ -3085,15 +3085,15 @@ bool LX200_OnStep::OSGetOutputState(int output)
     getCommandString(PortFD, value, command);
     if (value[0] == 0)
     {
-        OSOutput1S[0].s = ISS_ON;
-        OSOutput1S[1].s = ISS_OFF;
+        OSOutput1SP[0].setState(ISS_ON);
+        OSOutput1SP[1].setState(ISS_OFF);
     }
     else
     {
-        OSOutput1S[0].s = ISS_OFF;
-        OSOutput1S[1].s = ISS_ON;
+        OSOutput1SP[0].setState(ISS_OFF);
+        OSOutput1SP[1].setState(ISS_ON);
     }
-    IDSetSwitch(&OSOutput1SP, nullptr);
+    OSOutput1SP.apply();
     return true;
 }
 
@@ -3163,8 +3163,8 @@ void LX200_OnStep::slewError(int slewCode)
         default:
             LOG_ERROR("OnStep slew/syncError: Not in range of values that should be returned! INVALID, Something went wrong!");
     }
-    EqNP.s = IPS_ALERT;
-    IDSetNumber(&EqNP, nullptr);
+    EqNP.setState(IPS_ALERT);
+    EqNP.apply();
 }
 
 
@@ -3179,8 +3179,8 @@ bool LX200_OnStep::Sync(double ra, double dec)
     {
         if (setObjectRA(PortFD, ra) < 0 || (setObjectDEC(PortFD, dec)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC. Unable to Sync.");
             return false;
         }
         LOG_DEBUG("CMD <:CM#>");
@@ -3191,8 +3191,8 @@ bool LX200_OnStep::Sync(double ra, double dec)
             error_code = read_buffer[1] - '0';
             LOGF_DEBUG("Sync failed with response: %s, Error code: %i", read_buffer, error_code);
             slewError(error_code);
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Synchronization failed.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Synchronization failed.");
             return false;
         }
     }
@@ -3202,7 +3202,7 @@ bool LX200_OnStep::Sync(double ra, double dec)
 
     LOG_INFO("OnStep: Synchronization successful.");
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 

--- a/drivers/telescope/lx200_OnStep.h
+++ b/drivers/telescope/lx200_OnStep.h
@@ -92,6 +92,11 @@
 #include <termios.h>
 #include <stdlib.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 #define RB_MAX_LEN 64
 
 #define setParkOnStep(fd)  write(fd, "#:hQ#", 5)
@@ -198,30 +203,14 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface
         bool sendOnStepCommandBlind(const char *cmd);
         int  setMaxElevationLimit(int fd, int max);
         void OSUpdateFocuser();
-
-        ITextVectorProperty ObjectInfoTP;
-        IText ObjectInfoT[1] {};
-
-        ISwitchVectorProperty StarCatalogSP;
-        ISwitch StarCatalogS[3];
-
-        ISwitchVectorProperty DeepSkyCatalogSP;
-        ISwitch DeepSkyCatalogS[7];
-
-        ISwitchVectorProperty SolarSP;
-        ISwitch SolarS[10];
-
-        INumberVectorProperty ObjectNoNP;
-        INumber ObjectNoN[1];
-
-        INumberVectorProperty MaxSlewRateNP;
-        INumber MaxSlewRateN[2];
-
-        INumberVectorProperty BacklashNP;    //test
-        INumber BacklashN[2];    //Test
-
-        INumberVectorProperty ElevationLimitNP;
-        INumber ElevationLimitN[2];
+        INDI::PropertyText ObjectInfoTP {1};
+        INDI::PropertySwitch StarCatalogSP {3};
+        INDI::PropertySwitch DeepSkyCatalogSP {7};
+        INDI::PropertySwitch SolarSP {10};
+        INDI::PropertyNumber ObjectNoNP {1};
+        INDI::PropertyNumber MaxSlewRateNP {2};    //test
+        INDI::PropertyNumber BacklashNP {2};    //Test
+        INDI::PropertyNumber ElevationLimitNP {2};
 
         ITextVectorProperty VersionTP;
         IText VersionT[5] {};
@@ -233,94 +222,53 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface
         // Focuser controls
         // Focuser 1
         bool OSFocuser1 = false;
-        ISwitchVectorProperty OSFocus1InitializeSP;
-        ISwitch OSFocus1InitializeS[4];
+        INDI::PropertySwitch OSFocus1InitializeSP {4};
 
         // Focuser 2
         //ISwitchVectorProperty OSFocus2SelSP;
         //ISwitch OSFocus2SelS[2];
         bool OSFocuser2 = false;
-        ISwitchVectorProperty OSFocus2RateSP;
-        ISwitch OSFocus2RateS[4];
-
-        ISwitchVectorProperty OSFocus2MotionSP;
-        ISwitch OSFocus2MotionS[3];
-
-        INumberVectorProperty OSFocus2TargNP;
-        INumber OSFocus2TargN[1];
+        INDI::PropertySwitch OSFocus2RateSP {4};
+        INDI::PropertySwitch OSFocus2MotionSP {3};
+        INDI::PropertyNumber OSFocus2TargNP {1};
 
 
         int IsTracking = 0;
 
         // Reticle +/- Buttons
-        ISwitchVectorProperty ReticSP;
-        ISwitch ReticS[2];
+        INDI::PropertySwitch ReticSP {2};
 
         // Align Buttons
-        ISwitchVectorProperty TrackCompSP;
-        ISwitch TrackCompS[3];
-
-        ISwitchVectorProperty TrackAxisSP;
-        ISwitch TrackAxisS[3];
-
-        ISwitchVectorProperty FrequencyAdjustSP;
-        ISwitch FrequencyAdjustS[3];
-
-        ISwitchVectorProperty AutoFlipSP;
-        ISwitch AutoFlipS[2];
-
-        ISwitchVectorProperty HomePauseSP;
-        ISwitch HomePauseS[3];
-
-        ISwitchVectorProperty SetHomeSP;
-        ISwitch SetHomeS[2];
-
-        ISwitchVectorProperty PreferredPierSideSP;
-        ISwitch PreferredPierSideS[3];
-
-        INumberVectorProperty minutesPastMeridianNP;
-        INumber minutesPastMeridianN[2];
-
-        ISwitchVectorProperty OSPECStatusSP;
-        ISwitch OSPECStatusS[5];
-        ISwitchVectorProperty OSPECIndexSP;
-        ISwitch OSPECIndexS[2];
-        ISwitchVectorProperty OSPECRecordSP;
-        ISwitch OSPECRecordS[3];
-        ISwitchVectorProperty OSPECReadSP;
-        ISwitch OSPECReadS[2];
-        INumberVectorProperty OSPECCurrentIndexNP;
-        INumber OSPECCurrentIndexN[2];
-        INumberVectorProperty OSPECUserIndexNP;
-        INumber OSPECUserIndexN[2];
-        INumberVectorProperty OSPECRWValuesNP;
-        INumber OSPECRWValuesN[2]; //Current Index  and User Index
-
-        ISwitchVectorProperty OSNAlignStarsSP;
-        ISwitch OSNAlignStarsS[9];
-        ISwitchVectorProperty OSNAlignSP;
-        ISwitch OSNAlignS[4];
-        ISwitchVectorProperty OSNAlignWriteSP;
-        ISwitch OSNAlignWriteS[1];
-        ISwitchVectorProperty OSNAlignPolarRealignSP;
-        ISwitch OSNAlignPolarRealignS[2];
-        IText OSNAlignT[8] {};
-        ITextVectorProperty OSNAlignTP;
-        IText OSNAlignErrT[4] {};
-        ITextVectorProperty OSNAlignErrTP;
+        INDI::PropertySwitch TrackCompSP {3};
+        INDI::PropertySwitch TrackAxisSP {3};
+        INDI::PropertySwitch FrequencyAdjustSP {3};
+        INDI::PropertySwitch AutoFlipSP {2};
+        INDI::PropertySwitch HomePauseSP {3};
+        INDI::PropertySwitch SetHomeSP {2};
+        INDI::PropertySwitch PreferredPierSideSP {3};
+        INDI::PropertyNumber minutesPastMeridianNP {2};
+        INDI::PropertySwitch OSPECStatusSP {5};
+        INDI::PropertySwitch OSPECIndexSP {2};
+        INDI::PropertySwitch OSPECRecordSP {3};
+        INDI::PropertySwitch OSPECReadSP {2};
+        INDI::PropertyNumber OSPECCurrentIndexNP {2};
+        INDI::PropertyNumber OSPECUserIndexNP {2};
+        INDI::PropertyNumber OSPECRWValuesNP {2}; //Current Index  and User Index
+        INDI::PropertySwitch OSNAlignStarsSP {9};
+        INDI::PropertySwitch OSNAlignSP {4};
+        INDI::PropertySwitch OSNAlignWriteSP {1};
+        INDI::PropertySwitch OSNAlignPolarRealignSP {2};
+        INDI::PropertyText OSNAlignTP {8};
+        INDI::PropertyText OSNAlignErrTP {4};
         char OSNAlignStat[RB_MAX_LEN];
-
-        ISwitchVectorProperty OSOutput1SP;
-        ISwitch OSOutput1S[2];
-        ISwitchVectorProperty OSOutput2SP;
-        ISwitch OSOutput2S[2];
+        INDI::PropertySwitch OSOutput1SP {2};
+        INDI::PropertySwitch OSOutput2SP {2};
 
 
         INumber OutputPorts[PORTS_COUNT];
         INumberVectorProperty OutputPorts_NP;
 
-        INumber GuideRateN[2];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};
 
         char OSStat[RB_MAX_LEN];
         char OldOSStat[RB_MAX_LEN];
@@ -337,17 +285,11 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface
         // Weather support
         // NOTE: Much is handled by WeatherInterface, these controls are mainly for setting values which are not detected
         // As of right now, if there is a sensor the values will be overwritten on the next update
-
-
-        INumberVectorProperty OSSetTemperatureNP;
-        INumber OSSetTemperatureN[1];
-        INumberVectorProperty OSSetHumidityNP;
-        INumber OSSetHumidityN[1];
-        INumberVectorProperty OSSetPressureNP;
-        INumber OSSetPressureN[1];
+        INDI::PropertyNumber OSSetTemperatureNP {1};
+        INDI::PropertyNumber OSSetHumidityNP {1};
+        INDI::PropertyNumber OSSetPressureNP {1};
         //Not sure why this would be used, but will feed to it from site settings
-        INumberVectorProperty OSSetAltitudeNP;
-        INumber OSSetAltitudeN[1];
+        INDI::PropertyNumber OSSetAltitudeNP {1};
 
 
         //This is updated via other commands, as such I'm going to ignore it like some others do.

--- a/drivers/telescope/lx200_TeenAstro.cpp
+++ b/drivers/telescope/lx200_TeenAstro.cpp
@@ -135,8 +135,8 @@ bool LX200_TeenAstro::initProperties()
      AddTrackMode("TRACK_LUNAR", "Lunar");
 
     // Error Status
-    IUFillText(&ErrorStatusT[0], "Error code", "", "");
-    IUFillTextVector(&ErrorStatusTP, ErrorStatusT, 1, getDeviceName(), "Mount Status", "", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    ErrorStatusTP[0].fill("Error code", "", "");
+    ErrorStatusTP.fill(getDeviceName(), "Mount Status", "", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
 
     // ============== MOTION_TAB
@@ -151,25 +151,25 @@ bool LX200_TeenAstro::initProperties()
 
     // ============== GUIDE_TAB
     // Motion speed of axis when guiding
-    IUFillSwitch(&GuideRateS[0], "25", "0.25x", ISS_OFF);
-    IUFillSwitch(&GuideRateS[1], "50", "0.5x", ISS_ON);
-    IUFillSwitch(&GuideRateS[2], "100", "1.0x", ISS_OFF);
-    IUFillSwitchVector(&GuideRateSP, GuideRateS, 3, getDeviceName(), "TELESCOPE_GUIDE_RATE", "Guide Rate", GUIDE_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    GuideRateSP[0].fill("25", "0.25x", ISS_OFF);
+    GuideRateSP[1].fill("50", "0.5x", ISS_ON);
+    GuideRateSP[2].fill("100", "1.0x", ISS_OFF);
+    GuideRateSP.fill(getDeviceName(), "TELESCOPE_GUIDE_RATE", "Guide Rate", GUIDE_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
     initGuiderProperties(getDeviceName(), GUIDE_TAB);
 
     // ============== OPTIONS_TAB
     // Slew threshold
-    IUFillNumber(&SlewAccuracyN[0], "SlewRA", "RA (arcmin)", "%10.6m", 0., 60., 1., 3.0);   // min,max,step,current
-    IUFillNumber(&SlewAccuracyN[1], "SlewDEC", "Dec (arcmin)", "%10.6m", 0., 60., 1., 3.0);
-    IUFillNumberVector(&SlewAccuracyNP, SlewAccuracyN, NARRAY(SlewAccuracyN), getDeviceName(), "Slew Accuracy", "",
+    SlewAccuracyNP[0].fill("SlewRA", "RA (arcmin)", "%10.6m", 0., 60., 1., 3.0);   // min,max,step,current
+    SlewAccuracyNP[1].fill("SlewDEC", "Dec (arcmin)", "%10.6m", 0., 60., 1., 3.0);
+    SlewAccuracyNP.fill(getDeviceName(), "Slew Accuracy", "",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     // ============== SITE_TAB
-    IUFillSwitch(&SiteS[0], "Site 1", "", ISS_OFF);
-    IUFillSwitch(&SiteS[1], "Site 2", "", ISS_OFF);
-    IUFillSwitch(&SiteS[2], "Site 3", "", ISS_OFF);
-    IUFillSwitch(&SiteS[3], "Site 4", "", ISS_OFF);
-    IUFillSwitchVector(&SiteSP, SiteS, 4, getDeviceName(), "Sites", "", SITE_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    SiteSP[0].fill("Site 1", "", ISS_OFF);
+    SiteSP[1].fill("Site 2", "", ISS_OFF);
+    SiteSP[2].fill("Site 3", "", ISS_OFF);
+    SiteSP[3].fill("Site 4", "", ISS_OFF);
+    SiteSP.fill(getDeviceName(), "Sites", "", SITE_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     IUFillText(&SiteNameT[0], "Name", "", "");
     IUFillTextVector(&SiteNameTP, SiteNameT, 1, getDeviceName(), "Site Name", "", SITE_TAB, IP_RO, 0, IPS_IDLE);
@@ -217,19 +217,19 @@ bool LX200_TeenAstro::updateProperties()
         deleteProperty("DOME_POLICY");
         deleteProperty("TELESCOPE_HAS_TRACK_RATE");
         // Main Control
-        defineProperty(&SlewAccuracyNP);
-        defineProperty(&ErrorStatusTP);
+        defineProperty(SlewAccuracyNP);
+        defineProperty(ErrorStatusTP);
         // Connection
         // Options
         // Motion Control
         defineProperty(&SlewRateSP);
-        defineProperty(&GuideRateSP);
+        defineProperty(GuideRateSP);
 
         // Site Management
-        defineProperty(&ParkOptionSP);
-        defineProperty(&SetHomeSP);
+        defineProperty(ParkOptionSP);
+        defineProperty(SetHomeSP);
 
-        defineProperty(&SiteSP);
+        defineProperty(SiteSP);
         defineProperty(&SiteNameTP);
 
         // Guide
@@ -243,19 +243,19 @@ bool LX200_TeenAstro::updateProperties()
     else
     {
         // Main Control
-        deleteProperty(SlewAccuracyNP.name);
-        deleteProperty(ErrorStatusTP.name);
+        deleteProperty(SlewAccuracyNP.getName());
+        deleteProperty(ErrorStatusTP.getName());
       // Connection
         // Options
         // Motion Control
         deleteProperty(SlewRateSP.name);
-        deleteProperty(GuideRateSP.name);
-        deleteProperty(SiteSP.name);
+        deleteProperty(GuideRateSP.getName());
+        deleteProperty(SiteSP.getName());
         deleteProperty(SiteNameTP.name);
 
         // Site Management
-        deleteProperty(ParkOptionSP.name);
-        deleteProperty(SetHomeSP.name);
+        deleteProperty(ParkOptionSP.getName());
+        deleteProperty(SetHomeSP.getName());
         // Guide
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
@@ -299,7 +299,7 @@ bool LX200_TeenAstro::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
+        EqNP.setState(IPS_ALERT);
         return false;
     }
 
@@ -400,15 +400,15 @@ void LX200_TeenAstro::updateMountStatus(char status)
     }
     if (status == '0')
     {
-        ErrorStatusTP.s = IPS_OK;
+        ErrorStatusTP.setState(IPS_OK);
     }
     else
     {
-        ErrorStatusTP.s = IPS_ALERT;
+        ErrorStatusTP.setState(IPS_ALERT);
         TrackState = SCOPE_IDLE;     // Tell Ekos mount is not tracking anymore            
     }
-    IUSaveText(&ErrorStatusT[0], errCodes[status-'0']);
-    IDSetText(&ErrorStatusTP, nullptr);        
+    ErrorStatusTP[0].setText(errCodes[status-'0']);
+    ErrorStatusTP.apply();        
 }
 
 /*
@@ -426,19 +426,19 @@ bool LX200_TeenAstro::Goto(double r, double d)
     fs_sexa(DecStr, targetDEC, 2, 3600);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
         // sleep for 100 mseconds
         usleep(100000);
@@ -448,8 +448,8 @@ bool LX200_TeenAstro::Goto(double r, double d)
     {
         if (setObjectRA(PortFD, targetRA) < 0 || (setObjectDEC(PortFD, targetDEC)) < 0)  // standard LX200 command
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
@@ -458,15 +458,15 @@ bool LX200_TeenAstro::Goto(double r, double d)
         /* Slew reads the '0', that is not the end of the slew */
         if ((err = Slew(PortFD)))
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
             slewError(err);
             return false;
         }
     }
 
     TrackState = SCOPE_SLEWING;
-    EqNP.s     = IPS_BUSY;
+    EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
     return true;
@@ -476,7 +476,7 @@ bool LX200_TeenAstro::isSlewComplete()
 {
     const double dx = targetRA - currentRA;
     const double dy = targetDEC - currentDEC;
-    return fabs(dx) <= (SlewAccuracyN[0].value / (900.0)) && fabs(dy) <= (SlewAccuracyN[1].value / 60.0);
+    return fabs(dx) <= (SlewAccuracyNP[0].value / (900.0)) && fabs(dy) <= (SlewAccuracyNP[1].value / 60.0);
 }
 
 bool LX200_TeenAstro::SetTrackMode(uint8_t mode)
@@ -499,16 +499,16 @@ bool LX200_TeenAstro::Sync(double ra, double dec)
     // goto target
     if (!isSimulation() && (setObjectRA(PortFD, ra) < 0 || (setObjectDEC(PortFD, dec)) < 0))
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error setting RA/DEC. Unable to Sync.");
         return false;
     }
 
     // Use the parent Sync() function (lx200driver.cpp)
     if (!isSimulation() && ::Sync(PortFD, syncString) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Synchronization failed.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Synchronization failed.");
         return false;
     }
 
@@ -516,7 +516,7 @@ bool LX200_TeenAstro::Sync(double ra, double dec)
     currentDEC = dec;
 
     LOG_INFO("Synchronization successful.");
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
     NewRaDec(currentRA, currentDEC);
 
     return true;
@@ -554,7 +554,7 @@ bool LX200_TeenAstro::UnPark()
     {
         LOG_DEBUG("UnPark: CMD <:hR>");
         TrackState = SCOPE_IDLE;
-        EqNP.s    = IPS_OK;
+        EqNP.setState(IPS_OK);
         return true;
     }
     if (getCommandString(PortFD, response, ":hR#") < 0)
@@ -572,43 +572,43 @@ bool LX200_TeenAstro::Park()
     {
         LOG_DEBUG("SlewToPark: CMD <:hP>");
         TrackState = SCOPE_PARKED;
-        EqNP.s    = IPS_OK;
+        EqNP.setState(IPS_OK);
         return true;
     }
 
     // If scope is moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (abortSlew(PortFD) < 0)
         {
-            Telescope::AbortSP.s = IPS_ALERT;
+            Telescope::AbortSP.setState(IPS_ALERT);
             IDSetSwitch(&(Telescope::AbortSP), "Abort slew failed.");
             return false;
         }
-        Telescope::AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
+        Telescope::AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
         IDSetSwitch(&(Telescope::AbortSP), "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        EqNP.apply();
 
-        if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
         {
-            MovementNSSP.s = IPS_IDLE;
-            MovementWESP.s = IPS_IDLE;
-            EqNP.s = IPS_IDLE;
-            IUResetSwitch(&MovementNSSP);
-            IUResetSwitch(&MovementWESP);
+            MovementNSSP.setState(IPS_IDLE);
+            MovementWESP.setState(IPS_IDLE);
+            EqNP.setState(IPS_IDLE);
+            MovementNSSP.reset();
+            MovementWESP.reset();
 
-            IDSetSwitch(&MovementNSSP, nullptr);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementNSSP.apply();
+            MovementWESP.apply();
         }
     }
     if (slewToPark(PortFD) < 0)  // slewToPark is a macro (lx200driver.h)
     {
-        ParkSP.s = IPS_ALERT;
-        IDSetSwitch(&ParkSP, "Parking Failed.");
+        ParkSP.setState(IPS_ALERT);
+        ParkSP.apply("Parking Failed.");
         return false;
     }
-    ParkSP.s   = IPS_BUSY;
+    ParkSP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking is in progress...");
 
@@ -656,14 +656,14 @@ void LX200_TeenAstro::getBasicData()
 
         if (getSiteIndex(&currentSiteIndex))
         {
-            SiteS[currentSiteIndex].s = ISS_ON;
+            SiteSP[currentSiteIndex].setState(ISS_ON);
             currentSiteNum = currentSiteIndex + 1;
             LOGF_INFO("Site number %d", currentSiteNum);
             getSiteName(PortFD, SiteNameTP.tp[0].text, currentSiteNum);
             SiteNameTP.s = IPS_OK;
-            SiteSP.s = IPS_OK;
+            SiteSP.setState(IPS_OK);
             IDSetText(&SiteNameTP, nullptr);
-            IDSetSwitch(&SiteSP, nullptr);
+            SiteSP.apply();
             getLocation();                  // read site from TeenAstro
         }
         else
@@ -721,17 +721,17 @@ bool LX200_TeenAstro::ISNewNumber(const char *dev, const char *name, double valu
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, SlewAccuracyNP.name))
+        if (SlewAccuracyNP.isNameMatch(name))
         {
-            if (IUUpdateNumber(&SlewAccuracyNP, values, names, n) < 0)
+            if (!SlewAccuracyNP.update(values, names, n))
                 return false;
 
-            SlewAccuracyNP.s = IPS_OK;
+            SlewAccuracyNP.setState(IPS_OK);
 
-            if (SlewAccuracyN[0].value < 3 || SlewAccuracyN[1].value < 3)
-                IDSetNumber(&SlewAccuracyNP, "Warning: Setting the slew accuracy too low may result in a dead lock");
+            if (SlewAccuracyNP[0].value < 3 || SlewAccuracyNP[1].getValue() < 3)
+                SlewAccuracyNP.apply("Warning: Setting the slew accuracy too low may result in a dead lock");
 
-            IDSetNumber(&SlewAccuracyNP, nullptr);
+            SlewAccuracyNP.apply();
             return true;
         }
 
@@ -772,26 +772,26 @@ bool LX200_TeenAstro::ISNewSwitch(const char *dev, const char *name, ISState *st
             return true;
         }
 
-        if (!strcmp(name, GuideRateSP.name))
+        if (GuideRateSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&GuideRateSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&GuideRateSP);
-            GuideRateSP.s = IPS_OK;
+            GuideRateSP.update(states, names, n);
+            int index = GuideRateSP.findOnSwitchIndex();
+            GuideRateSP.setState(IPS_OK);
             SetGuideRate(index);
-            IDSetSwitch(&GuideRateSP, nullptr);
+            GuideRateSP.apply();
         }
          // Sites
-        if (!strcmp(name, SiteSP.name))
+        if (SiteSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&SiteSP, states, names, n) < 0)
+            if (!SiteSP.update(states, names, n))
                 return false;
 
-            currentSiteNum = IUFindOnSwitchIndex(&SiteSP) + 1;
+            currentSiteNum = SiteSP.findOnSwitchIndex() + 1;
             LOGF_DEBUG("currentSiteNum: %d", currentSiteNum);
             if (!isSimulation() && (!setSite(currentSiteNum)))
             {
-                SiteSP.s = IPS_ALERT;
-                IDSetSwitch(&SiteSP, "Error selecting sites.");
+                SiteSP.setState(IPS_ALERT);
+                SiteSP.apply("Error selecting sites.");
                 return false;
             }
 
@@ -807,12 +807,12 @@ bool LX200_TeenAstro::ISNewSwitch(const char *dev, const char *name, ISState *st
             getLocation();
 
             LOGF_INFO("Setting site number %d", currentSiteNum);
-            SiteS[currentSiteNum-1].s = ISS_ON;
+            SiteSP[currentSiteNum-1].setState(ISS_ON);
             SiteNameTP.s = IPS_OK;
-            SiteSP.s = IPS_OK;
+            SiteSP.setState(IPS_OK);
 
             IDSetText(&SiteNameTP, nullptr);
-            IDSetSwitch(&SiteSP, nullptr);
+            SiteSP.apply();
 
             return false;
         }
@@ -920,7 +920,7 @@ bool LX200_TeenAstro::sendScopeTime()
     {
         char utcStr[8] = {0};
         snprintf(utcStr, sizeof(utcStr), "%.2f", offset);
-        IUSaveText(&TimeT[1], utcStr);
+        TimeTP[1].setText(utcStr);
     }
     else
     {
@@ -962,14 +962,14 @@ bool LX200_TeenAstro::sendScopeTime()
 
     // Format it into the final UTC ISO 8601
     strftime(cdate, MAXINDINAME, "%Y-%m-%dT%H:%M:%S", &utm);
-    IUSaveText(&TimeT[0], cdate);
+    TimeTP[0].setText(cdate);
 
-    LOGF_DEBUG("Mount controller UTC Time: %s", TimeT[0].text);
-    LOGF_DEBUG("Mount controller UTC Offset: %s", TimeT[1].text);
+    LOGF_DEBUG("Mount controller UTC Time: %s", TimeTP[0].getText());
+    LOGF_DEBUG("Mount controller UTC Offset: %s", TimeTP[1].getText());
 
     // Let's send everything to the client
-    TimeTP.s = IPS_OK;
-    IDSetText(&TimeTP, nullptr);
+    TimeTP.setState(IPS_OK);
+    TimeTP.apply();
 
     return true;
 }
@@ -987,11 +987,11 @@ bool LX200_TeenAstro::sendScopeLocation()
 
     if (isSimulation())
     {
-        LocationNP.np[LOCATION_LATITUDE].value = 29.5;  // Kuwait - Jasem's home!
-        LocationNP.np[LOCATION_LONGITUDE].value = 48.0;
-        LocationNP.np[LOCATION_ELEVATION].value = 10;
-        LocationNP.s           = IPS_OK;
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP[LOCATION_LATITUDE].setValue(29.5);  // Kuwait - Jasem's home!
+        LocationNP[LOCATION_LONGITUDE].setValue(48.0);
+        LocationNP[LOCATION_ELEVATION].setValue(10);
+        LocationNP.setState(IPS_OK);
+        LocationNP.apply();
         return true;
     }
 
@@ -1003,9 +1003,9 @@ bool LX200_TeenAstro::sendScopeLocation()
     else
     {
         if (dd > 0)
-            LocationNP.np[LOCATION_LATITUDE].value = dd + mm / 60.0;
+            LocationNP[LOCATION_LATITUDE].setValue(dd + mm / 60.0);
         else
-            LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0;
+            LocationNP[LOCATION_LATITUDE].setValue(dd - mm / 60.0);
     }
     if (getSiteLongitude(PortFD, &dd, &mm, &ssf) < 0)
     {
@@ -1015,21 +1015,21 @@ bool LX200_TeenAstro::sendScopeLocation()
     else
     {
         if (dd > 0)
-            LocationNP.np[LOCATION_LONGITUDE].value = 360.0 - (dd + mm / 60.0);
+            LocationNP[LOCATION_LONGITUDE].setValue(360.0 - (dd + mm / 60.0));
         else
-            LocationNP.np[LOCATION_LONGITUDE].value = (dd - mm / 60.0) * -1.0;
+            LocationNP[LOCATION_LONGITUDE].setValue((dd - mm / 60.0) * -1.0);
     }
-    LOGF_DEBUG("Mount Controller Latitude: %g Longitude: %g", LocationN[LOCATION_LATITUDE].value, LocationN[LOCATION_LONGITUDE].value);
+    LOGF_DEBUG("Mount Controller Latitude: %g Longitude: %g", LocationNP[LOCATION_LATITUDE].getValue(), LocationNP[LOCATION_LONGITUDE].getValue());
 
     if (getSiteElevation(&elev))
     {
-        LocationNP.np[LOCATION_ELEVATION].value = elev;
+        LocationNP[LOCATION_ELEVATION].setValue(elev);
     }
     else
     {
         LOG_ERROR("Error getting site elevation");
     }
-    IDSetNumber(&LocationNP, nullptr);
+    LocationNP.apply();
     saveConfig(true, "GEOGRAPHIC_COORD");
 
     return true;
@@ -1108,9 +1108,9 @@ bool LX200_TeenAstro::getLocation()
     else
     {
         if (dd > 0)
-            LocationNP.np[LOCATION_LATITUDE].value = dd + mm / 60.0;
+            LocationNP[LOCATION_LATITUDE].setValue(dd + mm / 60.0);
         else
-            LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0;
+            LocationNP[LOCATION_LATITUDE].setValue(dd - mm / 60.0);
     }
 
     if (getSiteLongitude(PortFD, &dd, &mm, &ssf) < 0)
@@ -1121,20 +1121,20 @@ bool LX200_TeenAstro::getLocation()
     else
     {
         if (dd > 0)
-            LocationNP.np[LOCATION_LONGITUDE].value = 360.0 - (dd + mm / 60.0);
+            LocationNP[LOCATION_LONGITUDE].setValue(360.0 - (dd + mm / 60.0));
         else
-            LocationNP.np[LOCATION_LONGITUDE].value = (dd - mm / 60.0) * -1.0;
+            LocationNP[LOCATION_LONGITUDE].setValue((dd - mm / 60.0) * -1.0);
     }
     if (getSiteElevation(&elev))
     {
-        LocationNP.np[LOCATION_ELEVATION].value = elev;
+        LocationNP[LOCATION_ELEVATION].setValue(elev);
     }
     else
     {
         LOG_ERROR("Error getting site elevation");
     }
 
-    IDSetNumber(&LocationNP, nullptr);
+    LocationNP.apply();
     return true;
 }
 
@@ -1145,7 +1145,7 @@ bool LX200_TeenAstro::SetGuideRate(int index)
 {
     char cmdString[20];
 
-    snprintf (cmdString, sizeof(cmdString), guideSpeedCommand, GuideRateS[index].name);  // GuideRateS is {25,50,100}
+    snprintf (cmdString, sizeof(cmdString), guideSpeedCommand, GuideRateSP[index].getName());  // GuideRateS is {25,50,100}
     sendCommand(cmdString);
 
     return true;
@@ -1196,9 +1196,9 @@ bool LX200_TeenAstro::Abort()
         return false;
     }
 
-    EqNP.s     = IPS_IDLE;
+    EqNP.setState(IPS_IDLE);
     TrackState = SCOPE_IDLE;
-    IDSetNumber(&EqNP, nullptr);
+    EqNP.apply();
 
     LOG_INFO("Slew aborted.");
     return true;
@@ -1241,7 +1241,7 @@ bool LX200_TeenAstro::Move(TDirection dir, TelescopeMotionCommand cmd)
 bool LX200_TeenAstro::saveConfigItems(FILE *fp)
 {
     IUSaveConfigSwitch(fp, &SlewRateSP);
-    IUSaveConfigSwitch(fp, &GuideRateSP);
+    GuideRateSP.save(fp);
 
     return INDI::Telescope::saveConfigItems(fp);
 }
@@ -1318,14 +1318,14 @@ void LX200_TeenAstro::mountSim()
 
 void LX200_TeenAstro::slewError(int slewCode)
 {
-    EqNP.s = IPS_ALERT;
+    EqNP.setState(IPS_ALERT);
 
     if (slewCode == 1)
-        IDSetNumber(&EqNP, "Object below horizon.");
+        EqNP.apply("Object below horizon.");
     else if (slewCode == 2)
-        IDSetNumber(&EqNP, "Object below the minimum elevation limit.");
+        EqNP.apply("Object below the minimum elevation limit.");
     else
-        IDSetNumber(&EqNP, "Slew failed.");
+        EqNP.apply("Slew failed.");
 }
 /*
  *  Enable or disable sidereal tracking (events handled by inditelescope) 

--- a/drivers/telescope/lx200_TeenAstro.h
+++ b/drivers/telescope/lx200_TeenAstro.h
@@ -29,6 +29,11 @@
 #include "lx200driver.h"
 #include "indicom.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 #define RB_MAX_LEN 64
 
 class LX200_TeenAstro : public INDI::Telescope, public INDI::GuiderInterface
@@ -108,14 +113,9 @@ class LX200_TeenAstro : public INDI::Telescope, public INDI::GuiderInterface
 
         // User interface
 
-        INumber SlewAccuracyN[2];
-        INumberVectorProperty SlewAccuracyNP;
-
-        ISwitchVectorProperty HomePauseSP;
-        ISwitch HomePauseS[3];    
-        
-        ISwitchVectorProperty SetHomeSP;
-        ISwitch SetHomeS[2];
+        INDI::PropertyNumber SlewAccuracyNP {2};
+        INDI::PropertySwitch HomePauseSP {3};
+        INDI::PropertySwitch SetHomeSP {2};
 
         ITextVectorProperty VersionTP;
         IText VersionT[5] {};
@@ -123,15 +123,12 @@ class LX200_TeenAstro : public INDI::Telescope, public INDI::GuiderInterface
         ISwitch SlewRateS[5];
         ISwitchVectorProperty SlewRateSP;
 
-        ISwitch GuideRateS[3];
-        ISwitchVectorProperty GuideRateSP;
+        INDI::PropertySwitch GuideRateSP {3};
 
-        ISwitch TATrackModeS[3];
-        ISwitchVectorProperty TATrackModeSP;
+        INDI::PropertySwitch TATrackModeSP {3};
 
-        // Site Management 
-        ISwitchVectorProperty SiteSP;
-        ISwitch SiteS[4];
+        // Site Management
+        INDI::PropertySwitch SiteSP {4};
         int currentSiteNum {0}; // on TeenAstro, sites are numbered 0 to 3, not 1 to 4 like on the Meade standard
 
         // Site Name
@@ -139,8 +136,7 @@ class LX200_TeenAstro : public INDI::Telescope, public INDI::GuiderInterface
         IText SiteNameT[1] {};
 
         // Error Status
-        ITextVectorProperty ErrorStatusTP;
-        IText ErrorStatusT[1] {};
+        INDI::PropertyText ErrorStatusTP {1};
 
         double targetRA = 0, targetDEC = 0;
         double currentRA = 0, currentDEC = 0;

--- a/drivers/telescope/lx200ap.cpp
+++ b/drivers/telescope/lx200ap.cpp
@@ -57,28 +57,28 @@ bool LX200AstroPhysics::initProperties()
 
     timeFormat = LX200_24;
 
-    IUFillSwitch(&StartUpS[0], "COLD", "Cold", ISS_OFF);
-    IUFillSwitch(&StartUpS[1], "WARM", "Warm", ISS_OFF);
-    IUFillSwitchVector(&StartUpSP, StartUpS, 2, getDeviceName(), "STARTUP", "Mount init.", MAIN_CONTROL_TAB, IP_RW,
+    StartUpSP[0].fill("COLD", "Cold", ISS_OFF);
+    StartUpSP[1].fill("WARM", "Warm", ISS_OFF);
+    StartUpSP.fill(getDeviceName(), "STARTUP", "Mount init.", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&HourangleCoordsN[0], "HA", "HA H:M:S", "%10.6m", 0., 24., 0., 0.);
-    IUFillNumber(&HourangleCoordsN[1], "DEC", "Dec D:M:S", "%10.6m", -90.0, 90.0, 0., 0.);
-    IUFillNumberVector(&HourangleCoordsNP, HourangleCoordsN, 2, getDeviceName(), "HOURANGLE_COORD", "Hourangle Coords",
+    HourangleCoordsNP[0].fill("HA", "HA H:M:S", "%10.6m", 0., 24., 0., 0.);
+    HourangleCoordsNP[1].fill("DEC", "Dec D:M:S", "%10.6m", -90.0, 90.0, 0., 0.);
+    HourangleCoordsNP.fill(getDeviceName(), "HOURANGLE_COORD", "Hourangle Coords",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillNumber(&HorizontalCoordsN[0], "AZ", "Az D:M:S", "%10.6m", 0., 360., 0., 0.);
-    IUFillNumber(&HorizontalCoordsN[1], "ALT", "Alt D:M:S", "%10.6m", -90., 90., 0., 0.);
-    IUFillNumberVector(&HorizontalCoordsNP, HorizontalCoordsN, 2, getDeviceName(), "HORIZONTAL_COORD",
+    HorizontalCoordsNP[0].fill("AZ", "Az D:M:S", "%10.6m", 0., 360., 0., 0.);
+    HorizontalCoordsNP[1].fill("ALT", "Alt D:M:S", "%10.6m", -90., 90., 0., 0.);
+    HorizontalCoordsNP.fill(getDeviceName(), "HORIZONTAL_COORD",
                        "Horizontal Coords", MAIN_CONTROL_TAB, IP_RW, 120, IPS_IDLE);
 
 
     // Max rate is 999.99999X for the GTOCP4.
     // Using :RR998.9999#  just to be safe. 15.041067*998.99999 = 15026.02578
-    TrackRateN[AXIS_RA].min = -15026.0258;
-    TrackRateN[AXIS_RA].max = 15026.0258;
-    TrackRateN[AXIS_DE].min = -998.9999;
-    TrackRateN[AXIS_DE].max = 998.9999;
+    TrackRateNP[AXIS_RA].setMin(-15026.0258);
+    TrackRateNP[AXIS_RA].setMax(15026.0258);
+    TrackRateNP[AXIS_DE].setMin(-998.9999);
+    TrackRateNP[AXIS_DE].setMax(998.9999);
 
     // Motion speed of axis when pressing NSWE buttons
     IUFillSwitch(&SlewRateS[0], "12", "12x", ISS_OFF);
@@ -89,40 +89,40 @@ bool LX200AstroPhysics::initProperties()
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Slew speed when performing regular GOTO
-    IUFillSwitch(&APSlewSpeedS[0], "600", "600x", ISS_ON);
-    IUFillSwitch(&APSlewSpeedS[1], "900", "900x", ISS_OFF);
-    IUFillSwitch(&APSlewSpeedS[2], "1200", "1200x", ISS_OFF);
-    IUFillSwitchVector(&APSlewSpeedSP, APSlewSpeedS, 3, getDeviceName(), "GOTO Rate", "", MOTION_TAB, IP_RW, ISR_1OFMANY,
+    APSlewSpeedSP[0].fill("600", "600x", ISS_ON);
+    APSlewSpeedSP[1].fill("900", "900x", ISS_OFF);
+    APSlewSpeedSP[2].fill("1200", "1200x", ISS_OFF);
+    APSlewSpeedSP.fill(getDeviceName(), "GOTO Rate", "", MOTION_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
-    IUFillSwitch(&SwapS[0], "NS", "North/South", ISS_OFF);
-    IUFillSwitch(&SwapS[1], "EW", "East/West", ISS_OFF);
-    IUFillSwitchVector(&SwapSP, SwapS, 2, getDeviceName(), "SWAP", "Swap buttons", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SwapSP[0].fill("NS", "North/South", ISS_OFF);
+    SwapSP[1].fill("EW", "East/West", ISS_OFF);
+    SwapSP.fill(getDeviceName(), "SWAP", "Swap buttons", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], ":CM#", ":CM#", ISS_OFF);
-    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], ":CMR#", ":CMR#", ISS_ON);
-    IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SyncCMRSP[USE_REGULAR_SYNC].fill(":CM#", ":CM#", ISS_OFF);
+    SyncCMRSP[USE_CMR_SYNC].fill(":CMR#", ":CMR#", ISS_ON);
+    SyncCMRSP.fill(getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // guide speed
-    IUFillSwitch(&APGuideSpeedS[0], "0.25", "0.25x", ISS_OFF);
-    IUFillSwitch(&APGuideSpeedS[1], "0.5", "0.50x", ISS_OFF);
-    IUFillSwitch(&APGuideSpeedS[2], "1.0", "1.0x", ISS_ON);
-    IUFillSwitchVector(&APGuideSpeedSP, APGuideSpeedS, 3, getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
+    APGuideSpeedSP[0].fill("0.25", "0.25x", ISS_OFF);
+    APGuideSpeedSP[1].fill("0.5", "0.50x", ISS_OFF);
+    APGuideSpeedSP[2].fill("1.0", "1.0x", ISS_ON);
+    APGuideSpeedSP.fill(getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
     IUFillText(&VersionT[0], "Number", "", nullptr);
     IUFillTextVector(&VersionTP, VersionT, 1, getDeviceName(), "Firmware Info", "", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillText(&DeclinationAxisT[0], "RELHA", "rel. to HA", "undefined");
-    IUFillTextVector(&DeclinationAxisTP, DeclinationAxisT, 1, getDeviceName(), "DECLINATIONAXIS", "Declination axis",
+    DeclinationAxisTP[0].fill("RELHA", "rel. to HA", "undefined");
+    DeclinationAxisTP.fill(getDeviceName(), "DECLINATIONAXIS", "Declination axis",
                      MOUNT_TAB, IP_RO, 0, IPS_IDLE);
 
     // Slew threshold
-    IUFillNumber(&SlewAccuracyN[0], "SlewRA", "RA (arcmin)", "%10.6m", 0., 60., 1., 3.0);
-    IUFillNumber(&SlewAccuracyN[1], "SlewDEC", "Dec (arcmin)", "%10.6m", 0., 60., 1., 3.0);
-    IUFillNumberVector(&SlewAccuracyNP, SlewAccuracyN, 2, getDeviceName(), "Slew Accuracy", "", MOUNT_TAB, IP_RW, 0,
+    SlewAccuracyNP[0].fill("SlewRA", "RA (arcmin)", "%10.6m", 0., 60., 1., 3.0);
+    SlewAccuracyNP[1].fill("SlewDEC", "Dec (arcmin)", "%10.6m", 0., 60., 1., 3.0);
+    SlewAccuracyNP.fill(getDeviceName(), "Slew Accuracy", "", MOUNT_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     SetParkDataType(PARK_AZ_ALT);
@@ -137,17 +137,17 @@ void LX200AstroPhysics::ISGetProperties(const char *dev)
     /*
     if (isConnected())
     {
-        defineProperty(&StartUpSP);
+        defineProperty(StartUpSP);
         defineProperty(&VersionTP);
 
-        //defineProperty(&DeclinationAxisTP);
+        //defineProperty(DeclinationAxisTP);
 
         // Motion group
-        defineProperty(&APSlewSpeedSP);
-        defineProperty(&SwapSP);
-        defineProperty(&SyncCMRSP);
-        defineProperty(&APGuideSpeedSP);
-        defineProperty(&SlewAccuracyNP);
+        defineProperty(APSlewSpeedSP);
+        defineProperty(SwapSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(APGuideSpeedSP);
+        defineProperty(SlewAccuracyNP);
 
         LOG_INFO("Please initialize the mount before issuing any command.");
     }
@@ -160,30 +160,30 @@ bool LX200AstroPhysics::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&StartUpSP);
+        defineProperty(StartUpSP);
         defineProperty(&VersionTP);
 
-        //defineProperty(&DeclinationAxisTP);
+        //defineProperty(DeclinationAxisTP);
 
         /* Motion group */
-        defineProperty(&APSlewSpeedSP);
-        defineProperty(&SwapSP);
-        defineProperty(&SyncCMRSP);
-        defineProperty(&APGuideSpeedSP);
-        defineProperty(&SlewAccuracyNP);
+        defineProperty(APSlewSpeedSP);
+        defineProperty(SwapSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(APGuideSpeedSP);
+        defineProperty(SlewAccuracyNP);
 
         LOG_INFO("Please initialize the mount before issuing any command.");
     }
     else
     {
-        deleteProperty(StartUpSP.name);
+        deleteProperty(StartUpSP.getName());
         deleteProperty(VersionTP.name);
-        //deleteProperty(DeclinationAxisTP.name);
-        deleteProperty(APSlewSpeedSP.name);
-        deleteProperty(SwapSP.name);
-        deleteProperty(SyncCMRSP.name);
-        deleteProperty(APGuideSpeedSP.name);
-        deleteProperty(SlewAccuracyNP.name);
+        //deleteProperty(DeclinationAxisTP.getName());
+        deleteProperty(APSlewSpeedSP.getName());
+        deleteProperty(SwapSP.getName());
+        deleteProperty(SyncCMRSP.getName());
+        deleteProperty(APGuideSpeedSP.getName());
+        deleteProperty(SlewAccuracyNP.getName());
     }
 
     return true;
@@ -200,28 +200,28 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
     // ============================================================
     // Satisfy AP mount initialization, see AP key pad manual p. 76
     // ============================================================
-    if (!strcmp(name, StartUpSP.name))
+    if (StartUpSP.isNameMatch(name))
     {
         int switch_nr;
 
-        IUUpdateSwitch(&StartUpSP, states, names, n);
+        StartUpSP.update(states, names, n);
 
         if (initStatus == MOUNTNOTINITIALIZED)
         {
             if (timeUpdated == false || locationUpdated == false)
             {
-                StartUpSP.s = IPS_ALERT;
+                StartUpSP.setState(IPS_ALERT);
                 LOG_ERROR("Time and location must be set before mount initialization is invoked.");
-                IDSetSwitch(&StartUpSP, nullptr);
+                StartUpSP.apply();
                 return false;
             }
 
-            if (StartUpSP.sp[0].s == ISS_ON) // do it only in case a power on (cold start)
+            if (StartUpSP[0].s == ISS_ON) // do it only in case a power on (cold start)
             {
                 if (setBasicDataPart1() == false)
                 {
-                    StartUpSP.s = IPS_ALERT;
-                    IDSetSwitch(&StartUpSP, "Cold mount initialization failed.");
+                    StartUpSP.setState(IPS_ALERT);
+                    StartUpSP.apply("Cold mount initialization failed.");
                     return false;
                 }
             }
@@ -233,15 +233,15 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
                 SlewRateSP.s = IPS_OK;
                 IDSetSwitch(&SlewRateSP, nullptr);
 
-                APSlewSpeedSP.s = IPS_OK;
-                IDSetSwitch(&APSlewSpeedSP, nullptr);
+                APSlewSpeedSP.setState(IPS_OK);
+                APSlewSpeedSP.apply();
 
                 IUSaveText(&VersionT[0], "1.0");
                 VersionTP.s = IPS_OK;
                 IDSetText(&VersionTP, nullptr);
 
-                StartUpSP.s = IPS_OK;
-                IDSetSwitch(&StartUpSP, "Mount initialized.");
+                StartUpSP.setState(IPS_OK);
+                StartUpSP.apply("Mount initialized.");
 
                 //currentRA  = 0;
                 //currentDEC = 90;
@@ -275,14 +275,14 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
                 IDSetSwitch(&SlewRateSP, nullptr);
 
                 // APSlewSpeedsS defines the Slew (GOTO) speeds valid on the AP mounts
-                switch_nr = IUFindOnSwitchIndex(&APSlewSpeedSP);
+                switch_nr = APSlewSpeedSP.findOnSwitchIndex();
                 if ( (err = selectAPSlewRate(PortFD, switch_nr)) < 0)
                 {
                     LOGF_ERROR("StartUpSP: Error setting slew to rate (%d).", err);
                     return false;
                 }
-                APSlewSpeedSP.s = IPS_OK;
-                IDSetSwitch(&APSlewSpeedSP, nullptr);
+                APSlewSpeedSP.setState(IPS_OK);
+                APSlewSpeedSP.apply();
 
                 getLX200RA(PortFD, &currentRA);
                 getLX200DEC(PortFD, &currentDEC);
@@ -304,15 +304,15 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
                 INDI_UNUSED(servoType);
                 //controllerType = ...;
 
-                StartUpSP.s = IPS_OK;
-                IDSetSwitch(&StartUpSP, "Mount initialized.");
+                StartUpSP.setState(IPS_OK);
+                StartUpSP.apply("Mount initialized.");
 
             }
         }
         else
         {
-            StartUpSP.s = IPS_OK;
-            IDSetSwitch(&StartUpSP, "Mount is already initialized.");
+            StartUpSP.setState(IPS_OK);
+            StartUpSP.apply("Mount is already initialized.");
         }
         return true;
     }
@@ -320,13 +320,13 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
     // =======================================
     // Swap Buttons
     // =======================================
-    if (!strcmp(name, SwapSP.name))
+    if (SwapSP.isNameMatch(name))
     {
         int currentSwap;
 
-        IUResetSwitch(&SwapSP);
-        IUUpdateSwitch(&SwapSP, states, names, n);
-        currentSwap = IUFindOnSwitchIndex(&SwapSP);
+        SwapSP.reset();
+        SwapSP.update(states, names, n);
+        currentSwap = SwapSP.findOnSwitchIndex();
 
         if ((!isSimulation() && (err = swapAPButtons(PortFD, currentSwap)) < 0))
         {
@@ -334,20 +334,20 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
             return false;
         }
 
-        SwapS[0].s = ISS_OFF;
-        SwapS[1].s = ISS_OFF;
-        SwapSP.s   = IPS_OK;
-        IDSetSwitch(&SwapSP, nullptr);
+        SwapSP[0].setState(ISS_OFF);
+        SwapSP[1].setState(ISS_OFF);
+        SwapSP.setState(IPS_OK);
+        SwapSP.apply();
         return true;
     }
 
     // ===========================================================
     // GOTO ("slew") Speed.
     // ===========================================================
-    if (!strcmp(name, APSlewSpeedSP.name))
+    if (APSlewSpeedSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&APSlewSpeedSP, states, names, n);
-        int slewRate = IUFindOnSwitchIndex(&APSlewSpeedSP);
+        APSlewSpeedSP.update(states, names, n);
+        int slewRate = APSlewSpeedSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPSlewRate(PortFD, slewRate) < 0))
         {
@@ -355,18 +355,18 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
             return false;
         }
 
-        APSlewSpeedSP.s = IPS_OK;
-        IDSetSwitch(&APSlewSpeedSP, nullptr);
+        APSlewSpeedSP.setState(IPS_OK);
+        APSlewSpeedSP.apply();
         return true;
     }
 
     // ===========================================================
     // Guide Speed.
     // ===========================================================
-    if (!strcmp(name, APGuideSpeedSP.name))
+    if (APGuideSpeedSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&APGuideSpeedSP, states, names, n);
-        int guideRate = IUFindOnSwitchIndex(&APGuideSpeedSP);
+        APGuideSpeedSP.update(states, names, n);
+        int guideRate = APGuideSpeedSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPGuideRate(PortFD, guideRate) < 0))
         {
@@ -374,34 +374,34 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
             return false;
         }
 
-        APGuideSpeedSP.s = IPS_OK;
-        IDSetSwitch(&APGuideSpeedSP, nullptr);
+        APGuideSpeedSP.setState(IPS_OK);
+        APGuideSpeedSP.apply();
         return true;
     }
 
     // =======================================
     // Choose the appropriate sync command
     // =======================================
-    if (!strcmp(name, SyncCMRSP.name))
+    if (SyncCMRSP.isNameMatch(name))
     {
-        IUResetSwitch(&SyncCMRSP);
-        IUUpdateSwitch(&SyncCMRSP, states, names, n);
-        IUFindOnSwitchIndex(&SyncCMRSP);
-        SyncCMRSP.s = IPS_OK;
-        IDSetSwitch(&SyncCMRSP, nullptr);
+        SyncCMRSP.reset();
+        SyncCMRSP.update(states, names, n);
+        SyncCMRSP.findOnSwitchIndex();
+        SyncCMRSP.setState(IPS_OK);
+        SyncCMRSP.apply();
         return true;
     }
 
     // =======================================
     // Choose the PEC playback mode
     // =======================================
-    if (!strcmp(name, PECStateSP.name))
+    if (PECStateSP.isNameMatch(name))
     {
-        IUResetSwitch(&PECStateSP);
-        IUUpdateSwitch(&PECStateSP, states, names, n);
-        IUFindOnSwitchIndex(&PECStateSP);
+        PECStateSP.reset();
+        PECStateSP.update(states, names, n);
+        PECStateSP.findOnSwitchIndex();
 
-        int pecstate = IUFindOnSwitchIndex(&PECStateSP);
+        int pecstate = PECStateSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPPECState(PortFD, pecstate) < 0))
         {
@@ -409,8 +409,8 @@ bool LX200AstroPhysics::ISNewSwitch(const char *dev, const char *name, ISState *
             return false;
         }
 
-        PECStateSP.s = IPS_OK;
-        IDSetSwitch(&PECStateSP, nullptr);
+        PECStateSP.setState(IPS_OK);
+        PECStateSP.apply();
 
         return true;
     }
@@ -427,17 +427,17 @@ bool LX200AstroPhysics::ISNewNumber(const char *dev, const char *name, double va
         return false;
 
     // Update slew precision limit
-    if (!strcmp(name, SlewAccuracyNP.name))
+    if (SlewAccuracyNP.isNameMatch(name))
     {
-        if (IUUpdateNumber(&SlewAccuracyNP, values, names, n) < 0)
+        if (!SlewAccuracyNP.update(values, names, n))
             return false;
 
-        SlewAccuracyNP.s = IPS_OK;
+        SlewAccuracyNP.setState(IPS_OK);
 
-        if (SlewAccuracyN[0].value < 3 || SlewAccuracyN[1].value < 3)
-            IDSetNumber(&SlewAccuracyNP, "Warning: Setting the slew accuracy too low may result in a dead lock");
+        if (SlewAccuracyNP[0].value < 3 || SlewAccuracyNP[1].getValue() < 3)
+            SlewAccuracyNP.apply("Warning: Setting the slew accuracy too low may result in a dead lock");
 
-        IDSetNumber(&SlewAccuracyNP, nullptr);
+        SlewAccuracyNP.apply();
         return true;
     }
 
@@ -446,7 +446,7 @@ bool LX200AstroPhysics::ISNewNumber(const char *dev, const char *name, double va
 
 bool LX200AstroPhysics::isMountInit()
 {
-    return (StartUpSP.s != IPS_IDLE);
+    return (StartUpSP.getState() != IPS_IDLE);
 }
 
 bool LX200AstroPhysics::ReadScopeStatus()
@@ -462,8 +462,8 @@ bool LX200AstroPhysics::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -473,7 +473,7 @@ bool LX200AstroPhysics::ReadScopeStatus()
         double dy = targetDEC - currentDEC;
 
         // Wait until acknowledged or within threshold
-        if (fabs(dx) <= (SlewAccuracyN[0].value / (900.0)) && fabs(dy) <= (SlewAccuracyN[1].value / 60.0))
+        if (fabs(dx) <= (SlewAccuracyNP[0].value / (900.0)) && fabs(dy) <= (SlewAccuracyNP[1].value / 60.0))
         {
             TrackState = SCOPE_TRACKING;
             LOG_INFO("Slew is complete. Tracking...");
@@ -484,8 +484,8 @@ bool LX200AstroPhysics::ReadScopeStatus()
         double currentAlt, currentAz;
         if (getLX200Az(PortFD, &currentAz) < 0 || getLX200Alt(PortFD, &currentAlt) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error reading Az/Alt.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error reading Az/Alt.");
             return false;
         }
 
@@ -495,7 +495,7 @@ bool LX200AstroPhysics::ReadScopeStatus()
         LOGF_DEBUG("Parking... targetAz: %g currentAz: %g dx: %g targetAlt: %g currentAlt: %g dy: %g", GetAxis1Park(),
                    currentAz, dx, GetAxis2Park(), currentAlt, dy);
 
-        if (fabs(dx) <= (SlewAccuracyN[0].value / (60.0)) && fabs(dy) <= (SlewAccuracyN[1].value / 60.0))
+        if (fabs(dx) <= (SlewAccuracyNP[0].value / (60.0)) && fabs(dy) <= (SlewAccuracyNP[1].value / 60.0))
         {
             LOG_DEBUG("Parking slew is complete. Asking astrophysics mount to park...");
 
@@ -563,17 +563,17 @@ bool LX200AstroPhysics::setBasicDataPart1()
     if (InitPark())
     {
         // If loading parking data is successful, we just set the default parking values.
-        SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+        SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
     }
     else
     {
         // Otherwise, we set all parking data to default in case no parking data is found.
-        SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value);
+        SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value);
 
-        SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-        SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+        SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+        SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
     }
 
     // Unpark
@@ -604,29 +604,29 @@ bool LX200AstroPhysics::Goto(double r, double d)
     fs_sexa(DecStr, targetDEC, 2, 3600);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
-        if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
         {
-            MovementNSSP.s = IPS_IDLE;
-            MovementWESP.s = IPS_IDLE;
-            EqNP.s = IPS_IDLE;
-            IUResetSwitch(&MovementNSSP);
-            IUResetSwitch(&MovementWESP);
-            IDSetSwitch(&MovementNSSP, nullptr);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementNSSP.setState(IPS_IDLE);
+            MovementWESP.setState(IPS_IDLE);
+            EqNP.setState(IPS_IDLE);
+            MovementNSSP.reset();
+            MovementWESP.reset();
+            MovementNSSP.apply();
+            MovementWESP.apply();
         }
 
         // sleep for 100 mseconds
@@ -637,8 +637,8 @@ bool LX200AstroPhysics::Goto(double r, double d)
     {
         if (setAPObjectRA(PortFD, targetRA) < 0 || (setAPObjectDEC(PortFD, targetDEC)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
@@ -647,15 +647,15 @@ bool LX200AstroPhysics::Goto(double r, double d)
         /* Slew reads the '0', that is not the end of the slew */
         if ((err = Slew(PortFD)))
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
             slewError(err);
             return false;
         }
     }
 
     TrackState = SCOPE_SLEWING;
-    //EqNP.s     = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
     return true;
@@ -685,14 +685,14 @@ bool LX200AstroPhysics::Sync(double ra, double dec)
 {
     char syncString[256];
 
-    int syncType = IUFindOnSwitchIndex(&SyncCMRSP);
+    int syncType = SyncCMRSP.findOnSwitchIndex();
 
     if (!isSimulation())
     {
         if (setAPObjectRA(PortFD, ra) < 0 || setAPObjectDEC(PortFD, dec) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC. Unable to Sync.");
             return false;
         }
 
@@ -716,8 +716,8 @@ bool LX200AstroPhysics::Sync(double ra, double dec)
 
         if (syncOK == false)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Synchronization failed.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Synchronization failed.");
             return false;
         }
 
@@ -729,7 +729,7 @@ bool LX200AstroPhysics::Sync(double ra, double dec)
     LOGF_DEBUG("%s Synchronization successful %s", (syncType == USE_REGULAR_SYNC ? "CM" : "CMR"), syncString);
     LOG_INFO("Synchronization successful.");
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -862,8 +862,8 @@ bool LX200AstroPhysics::Park()
     if (isSimulation())
     {
         ln_lnlat_posn observer;
-        observer.lat = LocationN[LOCATION_LATITUDE].value;
-        observer.lng = LocationN[LOCATION_LONGITUDE].value;
+        observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+        observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
         if (observer.lng > 180)
             observer.lng -= 360;
 
@@ -898,7 +898,7 @@ bool LX200AstroPhysics::Park()
         }
     }
 
-    EqNP.s     = IPS_BUSY;
+    EqNP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking is in progress...");
 
@@ -929,8 +929,8 @@ bool LX200AstroPhysics::UnPark()
     if (isSimulation())
     {
         ln_lnlat_posn observer;
-        observer.lat = LocationN[LOCATION_LATITUDE].value;
-        observer.lng = LocationN[LOCATION_LONGITUDE].value;
+        observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+        observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
         if (observer.lng > 180)
             observer.lng -= 360;
 
@@ -973,8 +973,8 @@ bool LX200AstroPhysics::SetCurrentPark()
     // Libnova south = 0, west = 90, north = 180, east = 270
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -1001,10 +1001,10 @@ bool LX200AstroPhysics::SetCurrentPark()
 bool LX200AstroPhysics::SetDefaultPark()
 {
     // Az = 0 for North hemisphere
-    SetAxis1Park(LocationN[LOCATION_LATITUDE].value > 0 ? 0 : 180);
+    SetAxis1Park(LocationNP[LOCATION_LATITUDE].value > 0 ? 0 : 180);
 
     // Alt = Latitude
-    SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+    SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
 
     return true;
 }
@@ -1056,9 +1056,9 @@ bool LX200AstroPhysics::saveConfigItems(FILE *fp)
 {
     LX200Generic::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &SyncCMRSP);
-    IUSaveConfigSwitch(fp, &APSlewSpeedSP);
-    IUSaveConfigSwitch(fp, &APGuideSpeedSP);
+    SyncCMRSP.save(fp);
+    APSlewSpeedSP.save(fp);
+    APGuideSpeedSP.save(fp);
 
     return true;
 }
@@ -1075,7 +1075,7 @@ bool LX200AstroPhysics::SetTrackMode(uint8_t mode)
             return false;
         }
 
-        return SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+        return SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
     }
 
     if (!isSimulation() && (err = selectAPTrackingMode(PortFD, mode)) < 0)

--- a/drivers/telescope/lx200ap.h
+++ b/drivers/telescope/lx200ap.h
@@ -24,6 +24,11 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 #define SYNCCM  0
 #define SYNCCMR 1
 
@@ -79,36 +84,27 @@ class LX200AstroPhysics : public LX200Generic
 
     virtual void debugTriggered(bool enable) override;
 
-    ISwitch StartUpS[2];
-    ISwitchVectorProperty StartUpSP;
+    INDI::PropertySwitch StartUpSP {2};
 
-    INumber HourangleCoordsN[2];
-    INumberVectorProperty HourangleCoordsNP;
+    INDI::PropertyNumber HourangleCoordsNP {2};
 
-    INumber HorizontalCoordsN[2];
-    INumberVectorProperty HorizontalCoordsNP;
+    INDI::PropertyNumber HorizontalCoordsNP {2};
 
-    ISwitch APSlewSpeedS[3];
-    ISwitchVectorProperty APSlewSpeedSP;
+    INDI::PropertySwitch APSlewSpeedSP {3};
 
-    ISwitch SwapS[2];
-    ISwitchVectorProperty SwapSP;
+    INDI::PropertySwitch SwapSP {2};
 
-    ISwitch SyncCMRS[2];
-    ISwitchVectorProperty SyncCMRSP;
+    INDI::PropertySwitch SyncCMRSP {2};
     enum { USE_REGULAR_SYNC, USE_CMR_SYNC };
 
-    ISwitch APGuideSpeedS[3];
-    ISwitchVectorProperty APGuideSpeedSP;
+    INDI::PropertySwitch APGuideSpeedSP {3};
 
     IText VersionT[1] {};
     ITextVectorProperty VersionTP;
 
-    IText DeclinationAxisT[1] {};
-    ITextVectorProperty DeclinationAxisTP;
+    INDI::PropertyText DeclinationAxisTP {1};
 
-    INumber SlewAccuracyN[2];
-    INumberVectorProperty SlewAccuracyNP;
+    INDI::PropertyNumber SlewAccuracyNP {2};
 
   private:
     bool isMountInit();

--- a/drivers/telescope/lx200ap_experimental.cpp
+++ b/drivers/telescope/lx200ap_experimental.cpp
@@ -97,27 +97,27 @@ bool LX200AstroPhysicsExperimental::initProperties()
 
     timeFormat = LX200_24;
 
-    IUFillSwitch(&StartUpS[0], "COLD", "Cold", ISS_OFF);
-    IUFillSwitch(&StartUpS[1], "WARM", "Warm", ISS_OFF);
-    IUFillSwitchVector(&StartUpSP, StartUpS, 2, getDeviceName(), "STARTUP", "Startup", MAIN_CONTROL_TAB, IP_RW,
+    StartUpSP[0].fill("COLD", "Cold", ISS_OFF);
+    StartUpSP[1].fill("WARM", "Warm", ISS_OFF);
+    StartUpSP.fill(getDeviceName(), "STARTUP", "Startup", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&HourangleCoordsN[0], "HA", "HA H:M:S", "%10.6m", -24., 24., 0., 0.);
-    IUFillNumber(&HourangleCoordsN[1], "DEC", "Dec D:M:S", "%10.6m", -90.0, 90.0, 0., 0.);
-    IUFillNumberVector(&HourangleCoordsNP, HourangleCoordsN, 2, getDeviceName(), "HOURANGLE_COORD", "Hourangle Coords",
+    HourangleCoordsNP[0].fill("HA", "HA H:M:S", "%10.6m", -24., 24., 0., 0.);
+    HourangleCoordsNP[1].fill("DEC", "Dec D:M:S", "%10.6m", -90.0, 90.0, 0., 0.);
+    HourangleCoordsNP.fill(getDeviceName(), "HOURANGLE_COORD", "Hourangle Coords",
                        MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillNumber(&HorizontalCoordsN[0], "AZ", "Az D:M:S", "%10.6m", 0., 360., 0., 0.);
-    IUFillNumber(&HorizontalCoordsN[1], "ALT", "Alt D:M:S", "%10.6m", -90., 90., 0., 0.);
-    IUFillNumberVector(&HorizontalCoordsNP, HorizontalCoordsN, 2, getDeviceName(), "HORIZONTAL_COORD",
+    HorizontalCoordsNP[0].fill("AZ", "Az D:M:S", "%10.6m", 0., 360., 0., 0.);
+    HorizontalCoordsNP[1].fill("ALT", "Alt D:M:S", "%10.6m", -90., 90., 0., 0.);
+    HorizontalCoordsNP.fill(getDeviceName(), "HORIZONTAL_COORD",
                        "Horizontal Coords", MAIN_CONTROL_TAB, IP_RW, 120, IPS_IDLE);
 
     // Max rate is 999.99999X for the GTOCP4.
     // Using :RR998.9999#  just to be safe. 15.041067*998.99999 = 15026.02578
-    TrackRateN[AXIS_RA].min = -15026.0258;
-    TrackRateN[AXIS_RA].max = 15026.0258;
-    TrackRateN[AXIS_DE].min = -998.9999;
-    TrackRateN[AXIS_DE].max = 998.9999;
+    TrackRateNP[AXIS_RA].setMin(-15026.0258);
+    TrackRateNP[AXIS_RA].setMax(15026.0258);
+    TrackRateNP[AXIS_DE].setMin(-998.9999);
+    TrackRateNP[AXIS_DE].setMax(998.9999);
 
     // Motion speed of axis when pressing NSWE buttons
     IUFillSwitch(&SlewRateS[0], "1", "Guide", ISS_OFF);
@@ -129,58 +129,58 @@ bool LX200AstroPhysicsExperimental::initProperties()
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Slew speed when performing regular GOTO
-    IUFillSwitch(&APSlewSpeedS[0], "600", "600x", ISS_ON);
-    IUFillSwitch(&APSlewSpeedS[1], "900", "900x", ISS_OFF);
-    IUFillSwitch(&APSlewSpeedS[2], "1200", "1200x", ISS_OFF);
-    IUFillSwitchVector(&APSlewSpeedSP, APSlewSpeedS, 3, getDeviceName(), "GOTO Rate", "", MOTION_TAB, IP_RW, ISR_1OFMANY,
+    APSlewSpeedSP[0].fill("600", "600x", ISS_ON);
+    APSlewSpeedSP[1].fill("900", "900x", ISS_OFF);
+    APSlewSpeedSP[2].fill("1200", "1200x", ISS_OFF);
+    APSlewSpeedSP.fill(getDeviceName(), "GOTO Rate", "", MOTION_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
-    IUFillSwitch(&SwapS[0], "NS", "North/South", ISS_OFF);
-    IUFillSwitch(&SwapS[1], "EW", "East/West", ISS_OFF);
-    IUFillSwitchVector(&SwapSP, SwapS, 2, getDeviceName(), "SWAP", "Swap buttons", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SwapSP[0].fill("NS", "North/South", ISS_OFF);
+    SwapSP[1].fill("EW", "East/West", ISS_OFF);
+    SwapSP.fill(getDeviceName(), "SWAP", "Swap buttons", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     //2020-06-02, wildi, I'm not fond of this CMR sync
-    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], ":CM#", ":CM#", ISS_ON);
-    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], ":CMR#", ":CMR#", ISS_OFF);
-    IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SyncCMRSP[USE_REGULAR_SYNC].fill(":CM#", ":CM#", ISS_ON);
+    SyncCMRSP[USE_CMR_SYNC].fill(":CMR#", ":CMR#", ISS_OFF);
+    SyncCMRSP.fill(getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // guide speed
-    IUFillSwitch(&APGuideSpeedS[0], "0.25", "0.25x", ISS_OFF);
-    IUFillSwitch(&APGuideSpeedS[1], "0.5", "0.50x", ISS_OFF);
-    IUFillSwitch(&APGuideSpeedS[2], "1.0", "1.0x", ISS_ON);
-    IUFillSwitchVector(&APGuideSpeedSP, APGuideSpeedS, 3, getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
+    APGuideSpeedSP[0].fill("0.25", "0.25x", ISS_OFF);
+    APGuideSpeedSP[1].fill("0.5", "0.50x", ISS_OFF);
+    APGuideSpeedSP[2].fill("1.0", "1.0x", ISS_ON);
+    APGuideSpeedSP.fill(getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
     // Unpark from?
-    IUFillSwitch(&UnparkFromS[0], "Last", "Last Parked", ISS_OFF);
-    IUFillSwitch(&UnparkFromS[1], "Park1", "Park1", ISS_OFF);
-    IUFillSwitch(&UnparkFromS[2], "Park2", "Park2", ISS_ON);
-    IUFillSwitch(&UnparkFromS[3], "Park3", "Park3", ISS_OFF);
-    IUFillSwitch(&UnparkFromS[4], "Park4", "Park4", ISS_OFF);
-    IUFillSwitchVector(&UnparkFromSP, UnparkFromS, 5, getDeviceName(), "UNPARK_FROM", "Unpark From?", MAIN_CONTROL_TAB, IP_RW,
+    UnparkFromSP[0].fill("Last", "Last Parked", ISS_OFF);
+    UnparkFromSP[1].fill("Park1", "Park1", ISS_OFF);
+    UnparkFromSP[2].fill("Park2", "Park2", ISS_ON);
+    UnparkFromSP[3].fill("Park3", "Park3", ISS_OFF);
+    UnparkFromSP[4].fill("Park4", "Park4", ISS_OFF);
+    UnparkFromSP.fill(getDeviceName(), "UNPARK_FROM", "Unpark From?", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // park presets
-    IUFillSwitch(&ParkToS[0], "Custom", "Custom", ISS_OFF);
-    IUFillSwitch(&ParkToS[1], "Park1", "Park1", ISS_OFF);
-    IUFillSwitch(&ParkToS[2], "Park2", "Park2", ISS_ON);
-    IUFillSwitch(&ParkToS[3], "Park3", "Park3", ISS_OFF);
-    IUFillSwitch(&ParkToS[4], "Park4", "Park4", ISS_OFF);
-    IUFillSwitchVector(&ParkToSP, ParkToS, 5, getDeviceName(), "PARK_TO", "Park To?", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
+    ParkToSP[0].fill("Custom", "Custom", ISS_OFF);
+    ParkToSP[1].fill("Park1", "Park1", ISS_OFF);
+    ParkToSP[2].fill("Park2", "Park2", ISS_ON);
+    ParkToSP[3].fill("Park3", "Park3", ISS_OFF);
+    ParkToSP[4].fill("Park4", "Park4", ISS_OFF);
+    ParkToSP.fill(getDeviceName(), "PARK_TO", "Park To?", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     IUFillText(&VersionT[0], "Version", "Version", "");
     IUFillTextVector(&VersionTP, VersionT, 1, getDeviceName(), "Firmware", "Firmware", SITE_TAB, IP_RO, 0, IPS_IDLE);
 
     // UTC offset
-    IUFillNumber(&APUTCOffsetN[0], "APUTC_OFFSET", "AP UTC offset", "%8.5f", 0.0, 24.0, 0.0, 0.);
-    IUFillNumberVector(&APUTCOffsetNP, APUTCOffsetN, 1, getDeviceName(), "APUTC_OFFSET", "AP UTC offset", SITE_TAB,
+    APUTCOffsetNP[0].fill("APUTC_OFFSET", "AP UTC offset", "%8.5f", 0.0, 24.0, 0.0, 0.);
+    APUTCOffsetNP.fill(getDeviceName(), "APUTC_OFFSET", "AP UTC offset", SITE_TAB,
                        IP_RW, 60, IPS_OK);
     // sidereal time, ToDO move define where it belongs to
-    IUFillNumber(&APSiderealTimeN[0], "AP_SIDEREAL_TIME", "AP sidereal time", "%10.6m", 0.0, 24.0, 0.0, 0.0);
-    IUFillNumberVector(&APSiderealTimeNP, APSiderealTimeN, 1, getDeviceName(), "AP_SIDEREAL_TIME", "ap sidereal time", SITE_TAB,
+    APSiderealTimeNP[0].fill("AP_SIDEREAL_TIME", "AP sidereal time", "%10.6m", 0.0, 24.0, 0.0, 0.0);
+    APSiderealTimeNP.fill(getDeviceName(), "AP_SIDEREAL_TIME", "ap sidereal time", SITE_TAB,
                        IP_RO, 60, IPS_OK);
 
     SetParkDataType(PARK_AZ_ALT);
@@ -192,7 +192,7 @@ void LX200AstroPhysicsExperimental::ISGetProperties(const char *dev)
 {
     LX200Generic::ISGetProperties(dev);
 
-    defineProperty(&StartUpSP);
+    defineProperty(StartUpSP);
 
     // MSF 2018/04/10 - disable this behavior for now - we want to have
     //                  UnparkFromSP to always start out as "Last Parked" for safety
@@ -200,18 +200,18 @@ void LX200AstroPhysicsExperimental::ISGetProperties(const char *dev)
     //if (!isConnected())
     //{
     //    LOG_DEBUG("Loading unpark from location from config file");
-    //    loadConfig(true, UnparkFromSP.name);
+    //    loadConfig(true, UnparkFromSP.getName());
     //}
 
     if (isConnected())
     {
-        defineProperty(&UnparkFromSP);
-        defineProperty(&ParkToSP);
+        defineProperty(UnparkFromSP);
+        defineProperty(ParkToSP);
         defineProperty(&VersionTP);
-        defineProperty(&APSlewSpeedSP);
-        defineProperty(&SwapSP);
-        defineProperty(&SyncCMRSP);
-        defineProperty(&APGuideSpeedSP);
+        defineProperty(APSlewSpeedSP);
+        defineProperty(SwapSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(APGuideSpeedSP);
     }
 }
 
@@ -219,27 +219,27 @@ bool LX200AstroPhysicsExperimental::updateProperties()
 {
     LX200Generic::updateProperties();
 
-    defineProperty(&StartUpSP);
+    defineProperty(StartUpSP);
 
     if (isConnected())
     {
         deleteProperty("TELESCOPE_PIER_SIDE");
         if (firmwareVersion < MCV_G)
         {
-            deleteProperty(UsePulseCmdSP.name);
-            deleteProperty(TrackRateNP.name);
+            deleteProperty(UsePulseCmdSP.getName());
+            deleteProperty(TrackRateNP.getName());
         }
         defineProperty(&VersionTP);
-        defineProperty(&UnparkFromSP);
+        defineProperty(UnparkFromSP);
         /* Motion group */
-        defineProperty(&APSlewSpeedSP);
-        defineProperty(&SwapSP);
-        defineProperty(&SyncCMRSP);
-        defineProperty(&APGuideSpeedSP);
-        defineProperty(&ParkToSP);
-        defineProperty(&APSiderealTimeNP);
-        defineProperty(&HourangleCoordsNP);
-        defineProperty(&APUTCOffsetNP);
+        defineProperty(APSlewSpeedSP);
+        defineProperty(SwapSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(APGuideSpeedSP);
+        defineProperty(ParkToSP);
+        defineProperty(APSiderealTimeNP);
+        defineProperty(HourangleCoordsNP);
+        defineProperty(APUTCOffsetNP);
 
 #ifdef no
         if(!InitPark())
@@ -249,8 +249,8 @@ bool LX200AstroPhysicsExperimental::updateProperties()
         else
         {
             // wildi: too early, no time, site information
-            //loadConfig(true, ParkToSP.name);
-            //loadConfig(true, UnparkFromSP.name);
+            //loadConfig(true, ParkToSP.getName());
+            //loadConfig(true, UnparkFromSP.getName());
             SetParked(true);
         }
 
@@ -259,8 +259,8 @@ bool LX200AstroPhysicsExperimental::updateProperties()
         // The RA/Dec values are 0,90 at startup and should not be
         // displayed until they are set in UnPark()
         // load in config value for park to and initialize park position
-        loadConfig(true, ParkToSP.name);
-        ParkPosition parkPos = static_cast<ParkPosition>(IUFindOnSwitchIndex(&ParkToSP));
+        loadConfig(true, ParkToSP.getName());
+        ParkPosition parkPos = static_cast<ParkPosition>(ParkToSP.findOnSwitchIndex());
         LOGF_DEBUG("park position = %d", parkPos);
 
         // setup location
@@ -275,17 +275,17 @@ bool LX200AstroPhysicsExperimental::updateProperties()
         // initialize park position
         if (InitPark())
         {
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
         else
         {
             // Otherwise, we set all parking data to default in case no parking data is found.
-            SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value);
 
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
 
         // override with predefined position if selected
@@ -307,16 +307,16 @@ bool LX200AstroPhysicsExperimental::updateProperties()
     }
     else
     {
-        deleteProperty(UnparkFromSP.name);
+        deleteProperty(UnparkFromSP.getName());
         deleteProperty(VersionTP.name);
-        deleteProperty(APSlewSpeedSP.name);
-        deleteProperty(SwapSP.name);
-        deleteProperty(SyncCMRSP.name);
-        deleteProperty(APGuideSpeedSP.name);
-        deleteProperty(ParkToSP.name);
-        deleteProperty(APUTCOffsetNP.name);
-        deleteProperty(APSiderealTimeNP.name);
-        deleteProperty(HourangleCoordsNP.name);
+        deleteProperty(APSlewSpeedSP.getName());
+        deleteProperty(SwapSP.getName());
+        deleteProperty(SyncCMRSP.getName());
+        deleteProperty(APGuideSpeedSP.getName());
+        deleteProperty(ParkToSP.getName());
+        deleteProperty(APUTCOffsetNP.getName());
+        deleteProperty(APSiderealTimeNP.getName());
+        deleteProperty(HourangleCoordsNP.getName());
     }
 
     return true;
@@ -442,14 +442,14 @@ bool LX200AstroPhysicsExperimental::initMount()
     IDSetSwitch(&SlewRateSP, nullptr);
 
     // APSlewSpeedsS defines the Slew (GOTO) speeds valid on the AP mounts
-    if (!isSimulation() && (err = selectAPSlewRate(PortFD, IUFindOnSwitchIndex(&APSlewSpeedSP))) < 0)
+    if (!isSimulation() && (err = selectAPSlewRate(PortFD, APSlewSpeedSP.findOnSwitchIndex())) < 0)
     {
         LOGF_ERROR("Error setting slew to rate (%d).", err);
         return false;
     }
 
-    APSlewSpeedSP.s = IPS_OK;
-    IDSetSwitch(&APSlewSpeedSP, nullptr);
+    APSlewSpeedSP.setState(IPS_OK);
+    APSlewSpeedSP.apply();
 
     return true;
 }
@@ -463,15 +463,15 @@ bool LX200AstroPhysicsExperimental::ISNewNumber(const char *dev, const char *nam
     if (strcmp(getDeviceName(), dev))
         return false;
 
-    if (!strcmp(name, APUTCOffsetNP.name))
+    if (APUTCOffsetNP.isNameMatch(name))
     {
-        if (IUUpdateNumber(&APUTCOffsetNP, values, names, n) < 0)
+        if (!APUTCOffsetNP.update(values, names, n))
             return false;
 
         float mdelay;
         int err;
 
-        mdelay = APUTCOffsetN[0].value;
+        mdelay = APUTCOffsetNP[0].getValue();
 
         if (!isSimulation() && (err = setAPUTCOffset(PortFD, mdelay) < 0))
         {
@@ -479,23 +479,23 @@ bool LX200AstroPhysicsExperimental::ISNewNumber(const char *dev, const char *nam
             return false;
         }
 
-        APUTCOffsetNP.s  = IPS_OK;
-        IDSetNumber(&APUTCOffsetNP, nullptr);
+        APUTCOffsetNP.setState(IPS_OK);
+        APUTCOffsetNP.apply();
 
         return true;
     }
-    if (!strcmp(name, HourangleCoordsNP.name))
+    if (HourangleCoordsNP.isNameMatch(name))
     {
 
-        if (IUUpdateNumber(&HourangleCoordsNP, values, names, n) < 0)
+        if (!HourangleCoordsNP.update(values, names, n))
             return false;
 
-        double lng = LocationN[LOCATION_LONGITUDE].value;
+        double lng = LocationNP[LOCATION_LONGITUDE].getValue();
         double lst = get_local_sidereal_time(lng);
-        double ra = lst - HourangleCoordsN[0].value;
-        double dec = HourangleCoordsN[1].value;
+        double ra = lst - HourangleCoordsNP[0].getValue();
+        double dec = HourangleCoordsNP[1].getValue();
         bool success = false;
-        if ((ISS_ON == IUFindSwitch(&CoordSP, "TRACK")->s) || (ISS_ON == IUFindSwitch(&CoordSP, "SLEW")->s))
+        if ((ISS_ON == CoordSP.findWidgetByName("TRACK")->s) || (ISS_ON == CoordSP.findWidgetByName("SLEW")->s))
         {
             success = Goto(ra, dec);
         }
@@ -505,13 +505,13 @@ bool LX200AstroPhysicsExperimental::ISNewNumber(const char *dev, const char *nam
         }
         if (success)
         {
-            HourangleCoordsNP.s = IPS_OK;
+            HourangleCoordsNP.setState(IPS_OK);
         }
         else
         {
-            HourangleCoordsNP.s = IPS_ALERT;
+            HourangleCoordsNP.setState(IPS_ALERT);
         }
-        IDSetNumber(&HourangleCoordsNP,  nullptr);
+        HourangleCoordsNP.apply();
         return true;
     }
 
@@ -529,33 +529,33 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
     // Reintroduce cold/warm start from lx200ap.cpp in order to check if a valid park position is available.
     // AP's startup sequence is not mandatory with the exception of :PO.
     // Button Startup is defined outside "connected" state only to make it more visible to the user.
-    if (!strcmp(name, StartUpSP.name))
+    if (StartUpSP.isNameMatch(name))
     {
         if (!isConnected())
         {
-            StartUpSP.s = IPS_ALERT;
+            StartUpSP.setState(IPS_ALERT);
             LOG_ERROR("Connect first before reading mount's park configuration");
-            IDSetSwitch(&StartUpSP, nullptr);
+            StartUpSP.apply();
             return false;
         }
         int switch_nr;
 
-        IUUpdateSwitch(&StartUpSP, states, names, n);
+        StartUpSP.update(states, names, n);
 
-        if (StartUpSP.s == IPS_OK)
+        if (StartUpSP.getState() == IPS_OK)
         {
             LOG_INFO("Mount's park configuration already read");
-            StartUpSP.s = IPS_OK;
-            IDSetSwitch(&StartUpSP, nullptr);
+            StartUpSP.setState(IPS_OK);
+            StartUpSP.apply();
             return true;
         }
         // rely on INDI's logic
-        if (!(TimeTP.s == IPS_OK && LocationNP.s == IPS_OK))
+        if (!(TimeTP.getState() == IPS_OK && LocationNP.getState() == IPS_OK))
         {
-            StartUpSP.s = IPS_ALERT;
+            StartUpSP.setState(IPS_ALERT);
             LOGF_ERROR("Time is %s ok and location is %s ok must be set before mount initialization is invoked.",
-                       TimeTP.s == IPS_OK ? "" : "not ", LocationNP.s == IPS_OK ? "" : "not " );
-            IDSetSwitch(&StartUpSP, nullptr);
+                       TimeTP.getState() == IPS_OK ? "" : "not ", LocationNP.getState() == IPS_OK ? "" : "not " );
+            StartUpSP.apply();
             return false;
         }
 
@@ -563,16 +563,16 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
         bool parkDataValid = (LoadParkData() == nullptr);
         if (parkDataValid && isParked())
         {
-            if (!loadConfig(true, UnparkFromSP.name))
+            if (!loadConfig(true, UnparkFromSP.getName()))
             {
-                LOG_DEBUG("could not load config data for UnparkFromSP.name");
+                LOG_DEBUG("could not load config data for UnparkFromSP.getName()");
             }
-            if (!loadConfig(true, ParkToSP.name))
+            if (!loadConfig(true, ParkToSP.getName()))
             {
                 LOG_DEBUG("could not load config data for ParkTo.name");
             }
 
-            if(UnparkFromS[PARK_LAST].s == ISS_ON)
+            if(UnparkFromSP[PARK_LAST].getState() == ISS_ON)
             {
                 LOGF_INFO("Driver's config 'Unpark From ?' is set to 'Last Parked': will unpark from  Alt=%f Az=%f", GetAxis2Park(),
                           GetAxis1Park());
@@ -582,19 +582,19 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
         }
         else
         {
-            if (StartUpSP.sp[0].s == ISS_ON)
+            if (StartUpSP[0].s == ISS_ON)
             {
                 LOG_WARN("Set 'Park To' and 'Unpark From ?' manually and save dirver's config and park data");
                 SetParked(true);
 
-                StartUpSP.s = IPS_OK;
-                IDSetSwitch(&StartUpSP, nullptr);
+                StartUpSP.setState(IPS_OK);
+                StartUpSP.apply();
             }
             else
             {
                 LOG_WARN("No ParkData.xml or parkstatus is false, do a cold start");
-                StartUpSP.s = IPS_ALERT;
-                IDSetSwitch(&StartUpSP, nullptr);
+                StartUpSP.setState(IPS_ALERT);
+                StartUpSP.apply();
             }
             return false;
         }
@@ -604,15 +604,15 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
             SlewRateSP.s = IPS_OK;
             IDSetSwitch(&SlewRateSP, nullptr);
 
-            APSlewSpeedSP.s = IPS_OK;
-            IDSetSwitch(&APSlewSpeedSP, nullptr);
+            APSlewSpeedSP.setState(IPS_OK);
+            APSlewSpeedSP.apply();
 
             IUSaveText(&VersionT[0], "1.0");
             VersionTP.s = IPS_OK;
             IDSetText(&VersionTP, nullptr);
 
-            StartUpSP.s = IPS_OK;
-            IDSetSwitch(&StartUpSP, "Mount initialized.");
+            StartUpSP.setState(IPS_OK);
+            StartUpSP.apply("Mount initialized.");
 
             return true;
 
@@ -644,14 +644,14 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
         IDSetSwitch(&SlewRateSP, nullptr);
 
         // APSlewSpeedsS defines the Slew (GOTO) speeds valid on the AP mounts
-        switch_nr = IUFindOnSwitchIndex(&APSlewSpeedSP);
+        switch_nr = APSlewSpeedSP.findOnSwitchIndex();
         if ( (err = selectAPSlewRate(PortFD, switch_nr)) < 0)
         {
             LOGF_ERROR("StartUpSP: Error setting slew to rate (%d).", err);
             return false;
         }
-        APSlewSpeedSP.s = IPS_OK;
-        IDSetSwitch(&APSlewSpeedSP, nullptr);
+        APSlewSpeedSP.setState(IPS_OK);
+        APSlewSpeedSP.apply();
 
         getLX200RA(PortFD, &currentRA);
         getLX200DEC(PortFD, &currentDEC);
@@ -668,8 +668,8 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
         IUSaveText(&VersionT[0], versionString);
         IDSetText(&VersionTP, nullptr);
 
-        StartUpSP.s = IPS_OK;
-        IDSetSwitch(&StartUpSP, "Mount initialized.");
+        StartUpSP.setState(IPS_OK);
+        StartUpSP.apply("Mount initialized.");
 
         return true;
     }
@@ -677,13 +677,13 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
     // =======================================
     // Swap Buttons
     // =======================================
-    if (!strcmp(name, SwapSP.name))
+    if (SwapSP.isNameMatch(name))
     {
         int currentSwap;
 
-        IUResetSwitch(&SwapSP);
-        IUUpdateSwitch(&SwapSP, states, names, n);
-        currentSwap = IUFindOnSwitchIndex(&SwapSP);
+        SwapSP.reset();
+        SwapSP.update(states, names, n);
+        currentSwap = SwapSP.findOnSwitchIndex();
 
         if ((!isSimulation() && (err = swapAPButtons(PortFD, currentSwap)) < 0))
         {
@@ -691,20 +691,20 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
             return false;
         }
 
-        SwapS[0].s = ISS_OFF;
-        SwapS[1].s = ISS_OFF;
-        SwapSP.s   = IPS_OK;
-        IDSetSwitch(&SwapSP, nullptr);
+        SwapSP[0].setState(ISS_OFF);
+        SwapSP[1].setState(ISS_OFF);
+        SwapSP.setState(IPS_OK);
+        SwapSP.apply();
         return true;
     }
 
     // ===========================================================
     // GOTO ("slew") Speed.
     // ===========================================================
-    if (!strcmp(name, APSlewSpeedSP.name))
+    if (APSlewSpeedSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&APSlewSpeedSP, states, names, n);
-        int slewRate = IUFindOnSwitchIndex(&APSlewSpeedSP);
+        APSlewSpeedSP.update(states, names, n);
+        int slewRate = APSlewSpeedSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPSlewRate(PortFD, slewRate) < 0))
         {
@@ -712,18 +712,18 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
             return false;
         }
 
-        APSlewSpeedSP.s = IPS_OK;
-        IDSetSwitch(&APSlewSpeedSP, nullptr);
+        APSlewSpeedSP.setState(IPS_OK);
+        APSlewSpeedSP.apply();
         return true;
     }
 
     // ===========================================================
     // Guide Speed.
     // ===========================================================
-    if (!strcmp(name, APGuideSpeedSP.name))
+    if (APGuideSpeedSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&APGuideSpeedSP, states, names, n);
-        int guideRate = IUFindOnSwitchIndex(&APGuideSpeedSP);
+        APGuideSpeedSP.update(states, names, n);
+        int guideRate = APGuideSpeedSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPGuideRate(PortFD, guideRate) < 0))
         {
@@ -731,34 +731,34 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
             return false;
         }
 
-        APGuideSpeedSP.s = IPS_OK;
-        IDSetSwitch(&APGuideSpeedSP, nullptr);
+        APGuideSpeedSP.setState(IPS_OK);
+        APGuideSpeedSP.apply();
         return true;
     }
 
     // =======================================
     // Choose the appropriate sync command
     // =======================================
-    if (!strcmp(name, SyncCMRSP.name))
+    if (SyncCMRSP.isNameMatch(name))
     {
-        IUResetSwitch(&SyncCMRSP);
-        IUUpdateSwitch(&SyncCMRSP, states, names, n);
-        IUFindOnSwitchIndex(&SyncCMRSP);
-        SyncCMRSP.s = IPS_OK;
-        IDSetSwitch(&SyncCMRSP, nullptr);
+        SyncCMRSP.reset();
+        SyncCMRSP.update(states, names, n);
+        SyncCMRSP.findOnSwitchIndex();
+        SyncCMRSP.setState(IPS_OK);
+        SyncCMRSP.apply();
         return true;
     }
 
     // =======================================
     // Choose the PEC playback mode
     // =======================================
-    if (!strcmp(name, PECStateSP.name))
+    if (PECStateSP.isNameMatch(name))
     {
-        IUResetSwitch(&PECStateSP);
-        IUUpdateSwitch(&PECStateSP, states, names, n);
-        IUFindOnSwitchIndex(&PECStateSP);
+        PECStateSP.reset();
+        PECStateSP.update(states, names, n);
+        PECStateSP.findOnSwitchIndex();
 
-        int pecstate = IUFindOnSwitchIndex(&PECStateSP);
+        int pecstate = PECStateSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPPECState(PortFD, pecstate) < 0))
         {
@@ -766,8 +766,8 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
             return false;
         }
 
-        PECStateSP.s = IPS_OK;
-        IDSetSwitch(&PECStateSP, nullptr);
+        PECStateSP.setState(IPS_OK);
+        PECStateSP.apply();
 
         return true;
     }
@@ -775,19 +775,19 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
     // ===========================================================
     // Unpark from positions
     // ===========================================================
-    if (!strcmp(name, UnparkFromSP.name))
+    if (UnparkFromSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&UnparkFromSP, states, names, n);
-        ParkPosition unparkPos = static_cast<ParkPosition>(IUFindOnSwitchIndex(&UnparkFromSP));
+        UnparkFromSP.update(states, names, n);
+        ParkPosition unparkPos = static_cast<ParkPosition>(UnparkFromSP.findOnSwitchIndex());
 
-        UnparkFromSP.s = IPS_OK;
+        UnparkFromSP.setState(IPS_OK);
         if( unparkPos != PARK_LAST)
         {
             double unparkAlt, unparkAz;
             if (!calcParkPosition(unparkPos, &unparkAlt, &unparkAz))
             {
                 LOG_WARN("Error calculating unpark position!");
-                UnparkFromSP.s = IPS_ALERT;
+                UnparkFromSP.setState(IPS_ALERT);
             }
             else
             {
@@ -797,7 +797,7 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
                 saveConfig(true);
             }
         }
-        IDSetSwitch(&UnparkFromSP, nullptr);
+        UnparkFromSP.apply();
         return true;
     }
 
@@ -805,9 +805,9 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
     // Switch Park(ed), Unpark(ed)
     // ===========================================================
 
-    if (!strcmp(name, ParkSP.name))
+    if (ParkSP.isNameMatch(name))
     {
-        if (StartUpSP.s != IPS_OK)
+        if (StartUpSP.getState() != IPS_OK)
         {
             LOG_ERROR("Read driver's config first");
             return false;
@@ -816,21 +816,21 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
     // ===========================================================
     // Park To positions
     // ===========================================================
-    if (!strcmp(name, ParkToSP.name))
+    if (ParkToSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&ParkToSP, states, names, n);
-        ParkPosition parkPos = static_cast<ParkPosition>(IUFindOnSwitchIndex(&ParkToSP));
+        ParkToSP.update(states, names, n);
+        ParkPosition parkPos = static_cast<ParkPosition>(ParkToSP.findOnSwitchIndex());
 
         // override with predefined position if selected
         if (parkPos != PARK_CUSTOM)
         {
             double parkAz, parkAlt;
-            if (!(TimeTP.s == IPS_OK && LocationNP.s == IPS_OK))
+            if (!(TimeTP.getState() == IPS_OK && LocationNP.getState() == IPS_OK))
             {
                 LOG_WARN("ParkTo can not calculate park position, latitude, longitude not yet available");
-                IUResetSwitch(&ParkToSP);
-                ParkToSP.s = IPS_ALERT;
-                IDSetSwitch(&ParkToSP, nullptr);
+                ParkToSP.reset();
+                ParkToSP.setState(IPS_ALERT);
+                ParkToSP.apply();
                 return false;
             }
             if (calcParkPosition(parkPos, &parkAlt, &parkAz))
@@ -847,15 +847,15 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
         else
         {
             LOG_WARN("ISNewSwitch: park custom not yet supported");
-            IUResetSwitch(&ParkToSP);
-            ParkToSP.s = IPS_ALERT;
-            IDSetSwitch(&ParkToSP, nullptr);
+            ParkToSP.reset();
+            ParkToSP.setState(IPS_ALERT);
+            ParkToSP.apply();
             return false;
         }
-        IUResetSwitch(&ParkToSP);
-        ParkToS[(int)parkPos].s = ISS_ON;
-        ParkToSP.s = IPS_OK;
-        IDSetSwitch(&ParkToSP, nullptr);
+        ParkToSP.reset();
+        ParkToSP[(int)parkPos].setState(ISS_ON);
+        ParkToSP.setState(IPS_OK);
+        ParkToSP.apply();
         return true;
     }
 
@@ -864,7 +864,7 @@ bool LX200AstroPhysicsExperimental::ISNewSwitch(const char *dev, const char *nam
 
 bool LX200AstroPhysicsExperimental::ReadScopeStatus()
 {
-    double lng = LocationN[LOCATION_LONGITUDE].value;
+    double lng = LocationNP[LOCATION_LONGITUDE].getValue();
     double lst = get_local_sidereal_time(lng);
     // 2020-06-02, wildi, isParked is reserved for the state in ParkData.xml
     // see method isParked()
@@ -875,14 +875,14 @@ bool LX200AstroPhysicsExperimental::ReadScopeStatus()
         double ha = get_local_hour_angle(lst, currentRA);
 
         // No need to spam log until we have some actual changes.
-        if (std::fabs(HourangleCoordsN[0].value - ha) > 0.0001 ||
-                std::fabs(HourangleCoordsN[1].value - currentDEC) > 0.0001)
+        if (std::fabs(HourangleCoordsNP[0].value - ha) > 0.0001 ||
+                std::fabs(HourangleCoordsNP[1].value - currentDEC) > 0.0001)
         {
             // in case of simulation, the coordinates are set on parking
-            HourangleCoordsN[0].value = ha;
-            HourangleCoordsN[1].value = currentDEC;
-            HourangleCoordsNP.s = IPS_OK;
-            IDSetNumber(&HourangleCoordsNP, nullptr );
+            HourangleCoordsNP[0].setValue(ha);
+            HourangleCoordsNP[1].setValue(currentDEC);
+            HourangleCoordsNP.setState(IPS_OK);
+            HourangleCoordsNP.apply(nullptr );
         }
     }
     double val;
@@ -895,9 +895,9 @@ bool LX200AstroPhysicsExperimental::ReadScopeStatus()
     {
         val = lst;
     }
-    APSiderealTimeNP.np[0].value = val;
-    APSiderealTimeNP.s           = IPS_IDLE;
-    IDSetNumber(&APSiderealTimeNP, nullptr);
+    APSiderealTimeNP[0].setValue(val);
+    APSiderealTimeNP.setState(IPS_IDLE);
+    APSiderealTimeNP.apply();
 
     if (isSimulation())
     {
@@ -941,8 +941,8 @@ bool LX200AstroPhysicsExperimental::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -987,8 +987,8 @@ bool LX200AstroPhysicsExperimental::ReadScopeStatus()
         // old way
         if (getLX200Az(PortFD, &currentAz) < 0 || getLX200Alt(PortFD, &currentAlt) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error reading Az/Alt.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error reading Az/Alt.");
             return false;
         }
 
@@ -1054,8 +1054,8 @@ bool LX200AstroPhysicsExperimental::IsMountInitialized(bool *initialized)
 
     if (isSimulation())
     {
-        ra = get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value);
-        dec = LocationN[LOCATION_LATITUDE].value > 0 ? 90 : -90;
+        ra = get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].value);
+        dec = LocationNP[LOCATION_LATITUDE].getValue() > 0 ? 90 : -90;
     }
     else if (getLX200RA(PortFD, &ra) || getLX200DEC(PortFD, &dec))
     {
@@ -1099,7 +1099,7 @@ bool LX200AstroPhysicsExperimental::IsMountParked(bool *isAPParked)
     if (isSimulation())
     {
         // 2030-05-30, if Unparked is selected, this condition is not met
-        *isAPParked = (ParkS[0].s == ISS_ON);
+        *isAPParked = (ParkSP[0].getState() == ISS_ON);
         return true;
     }
     // check for newer
@@ -1165,29 +1165,29 @@ bool LX200AstroPhysicsExperimental::Goto(double r, double d)
     fs_sexa(DecStr, targetDEC, 2, 3600);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
-        if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
         {
-            MovementNSSP.s = IPS_IDLE;
-            MovementWESP.s = IPS_IDLE;
-            EqNP.s = IPS_IDLE;
-            IUResetSwitch(&MovementNSSP);
-            IUResetSwitch(&MovementWESP);
-            IDSetSwitch(&MovementNSSP, nullptr);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementNSSP.setState(IPS_IDLE);
+            MovementWESP.setState(IPS_IDLE);
+            EqNP.setState(IPS_IDLE);
+            MovementNSSP.reset();
+            MovementWESP.reset();
+            MovementNSSP.apply();
+            MovementWESP.apply();
         }
 
         // sleep for 100 mseconds
@@ -1198,8 +1198,8 @@ bool LX200AstroPhysicsExperimental::Goto(double r, double d)
     {
         if (setAPObjectRA(PortFD, targetRA) < 0 || (setAPObjectDEC(PortFD, targetDEC)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
@@ -1208,8 +1208,8 @@ bool LX200AstroPhysicsExperimental::Goto(double r, double d)
         /* Slew reads the '0', that is not the end of the slew */
         if ((err = Slew(PortFD)))
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
             slewError(err);
             return false;
         }
@@ -1221,7 +1221,7 @@ bool LX200AstroPhysicsExperimental::Goto(double r, double d)
     }
 
     TrackState = SCOPE_SLEWING;
-    //EqNP.s     = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
     return true;
@@ -1257,7 +1257,7 @@ bool LX200AstroPhysicsExperimental::updateAPSlewRate(int index)
 IPState LX200AstroPhysicsExperimental::GuideNorth(uint32_t ms)
 {
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1289,8 +1289,8 @@ IPState LX200AstroPhysicsExperimental::GuideNorth(uint32_t ms)
         GuideNSTID = 1;
 
         ISState states[] = { ISS_ON, ISS_OFF };
-        const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
-        ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementNSSP[DIRECTION_NORTH].getName(), MovementNSSP[DIRECTION_SOUTH].getName()};
+        ISNewSwitch(MovementNSSP.getDeviceName(), MovementNSSP.getName(), states, const_cast<char **>(names), 2);
         GuideNSTID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperNS, this);
     }
 
@@ -1300,7 +1300,7 @@ IPState LX200AstroPhysicsExperimental::GuideNorth(uint32_t ms)
 IPState LX200AstroPhysicsExperimental::GuideSouth(uint32_t ms)
 {
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1331,8 +1331,8 @@ IPState LX200AstroPhysicsExperimental::GuideSouth(uint32_t ms)
         GuideNSTID = 1;
 
         ISState states[] = { ISS_OFF, ISS_ON };
-        const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
-        ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementNSSP[DIRECTION_NORTH].getName(), MovementNSSP[DIRECTION_SOUTH].getName()};
+        ISNewSwitch(MovementNSSP.getDeviceName(), MovementNSSP.getName(), states, const_cast<char **>(names), 2);
         GuideNSTID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperNS, this);
     }
 
@@ -1342,7 +1342,7 @@ IPState LX200AstroPhysicsExperimental::GuideSouth(uint32_t ms)
 IPState LX200AstroPhysicsExperimental::GuideEast(uint32_t ms)
 {
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1373,8 +1373,8 @@ IPState LX200AstroPhysicsExperimental::GuideEast(uint32_t ms)
         GuideWETID = 1;
 
         ISState states[] = { ISS_OFF, ISS_ON };
-        const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
-        ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementWESP[DIRECTION_WEST].getName(), MovementWESP[DIRECTION_EAST].getName()};
+        ISNewSwitch(MovementWESP.getDeviceName(), MovementWESP.getName(), states, const_cast<char **>(names), 2);
         GuideWETID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperWE, this);
     }
 
@@ -1384,7 +1384,7 @@ IPState LX200AstroPhysicsExperimental::GuideEast(uint32_t ms)
 IPState LX200AstroPhysicsExperimental::GuideWest(uint32_t ms)
 {
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1415,8 +1415,8 @@ IPState LX200AstroPhysicsExperimental::GuideWest(uint32_t ms)
         GuideWETID = 1;
 
         ISState states[] = { ISS_ON, ISS_OFF };
-        const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
-        ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementWESP[DIRECTION_WEST].getName(), MovementWESP[DIRECTION_EAST].getName()};
+        ISNewSwitch(MovementWESP.getDeviceName(), MovementWESP.getName(), states, const_cast<char **>(names), 2);
         GuideWETID      = IEAddTimer(static_cast<int>(ms), simulGuideTimeoutHelperWE, this);
     }
 
@@ -1450,8 +1450,8 @@ void LX200AstroPhysicsExperimental::AstroPhysicsGuideTimeoutWE(bool simul)
     if (simul == true)
     {
         ISState states[] = { ISS_OFF, ISS_OFF };
-        const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
-        ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementWESP[DIRECTION_WEST].getName(), MovementWESP[DIRECTION_EAST].getName()};
+        ISNewSwitch(MovementWESP.getDeviceName(), MovementWESP.getName(), states, const_cast<char **>(names), 2);
     }
 
     GuideWENP.np[DIRECTION_WEST].value = 0;
@@ -1468,8 +1468,8 @@ void LX200AstroPhysicsExperimental::AstroPhysicsGuideTimeoutNS(bool simul)
     if (simul == true)
     {
         ISState states[] = { ISS_OFF, ISS_OFF };
-        const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
-        ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementNSSP[DIRECTION_NORTH].getName(), MovementNSSP[DIRECTION_SOUTH].getName()};
+        ISNewSwitch(MovementNSSP.getDeviceName(), MovementNSSP.getName(), states, const_cast<char **>(names), 2);
     }
 
     GuideNSNP.np[0].value = 0;
@@ -1568,10 +1568,10 @@ bool LX200AstroPhysicsExperimental::Disconnect()
     locationUpdated = false;
     mountInitialized = false;
 #endif
-    IUResetSwitch(&StartUpSP);
-    StartUpS[0].s = ISS_OFF;
-    StartUpSP.s = IPS_IDLE;
-    IDSetSwitch(&StartUpSP, nullptr);
+    StartUpSP.reset();
+    StartUpSP[0].setState(ISS_OFF);
+    StartUpSP.setState(IPS_IDLE);
+    StartUpSP.apply();
 
     return LX200Generic::Disconnect();
 }
@@ -1579,13 +1579,13 @@ bool LX200AstroPhysicsExperimental::Sync(double ra, double dec)
 {
     char syncString[256] = ""; // simulation needs UTF-8
 
-    int syncType = IUFindOnSwitchIndex(&SyncCMRSP);
+    int syncType = SyncCMRSP.findOnSwitchIndex();
     if (!isSimulation())
     {
         if (setAPObjectRA(PortFD, ra) < 0 || setAPObjectDEC(PortFD, dec) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC. Unable to Sync.");
             return false;
         }
         bool syncOK = true;
@@ -1609,8 +1609,8 @@ bool LX200AstroPhysicsExperimental::Sync(double ra, double dec)
 
         if (!syncOK)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Synchronization failed.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Synchronization failed.");
             return false;
         }
 
@@ -1620,7 +1620,7 @@ bool LX200AstroPhysicsExperimental::Sync(double ra, double dec)
     currentDEC = dec;
     LOGF_DEBUG("%s Synchronization successful %s", (syncType == USE_REGULAR_SYNC ? "CM" : "CMR"), syncString);
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -1673,9 +1673,9 @@ bool LX200AstroPhysicsExperimental::updateTime(ln_date *utc, double utc_offset)
         LOG_ERROR("Error setting UTC Offset.");
         return false;
     }
-    APUTCOffsetN[0].value = ap_utc_offset ;
-    APUTCOffsetNP.s  = IPS_OK;
-    IDSetNumber(&APUTCOffsetNP, nullptr);
+    APUTCOffsetNP[0].setValue(ap_utc_offset );
+    APUTCOffsetNP.setState(IPS_OK);
+    APUTCOffsetNP.apply();
 
     LOGF_DEBUG("Set UTC Offset %g as AP UTC Offset %g is successful.", utc_offset, ap_utc_offset);
 
@@ -1762,7 +1762,7 @@ bool LX200AstroPhysicsExperimental::Park()
 {
     LOG_DEBUG("Park entry");
 
-    ParkPosition parkPos = static_cast<ParkPosition>(IUFindOnSwitchIndex(&ParkToSP));
+    ParkPosition parkPos = static_cast<ParkPosition>(ParkToSP.findOnSwitchIndex());
     double parkAz, parkAlt;
     if (calcParkPosition(parkPos, &parkAlt, &parkAz))
     {
@@ -1781,8 +1781,8 @@ bool LX200AstroPhysicsExperimental::Park()
     LOGF_INFO("Parking to Az (%s) Alt (%s)...", AzStr, AltStr);
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -1796,10 +1796,10 @@ bool LX200AstroPhysicsExperimental::Park()
     double lst = get_local_sidereal_time(observer.lng);
     double ha = get_local_hour_angle(lst, equatorialPos.ra / 15.);
 
-    HourangleCoordsNP.s = IPS_OK;
-    HourangleCoordsN[0].value = ha;
-    HourangleCoordsN[1].value = equatorialPos.dec;
-    IDSetNumber(&HourangleCoordsNP, nullptr);
+    HourangleCoordsNP.setState(IPS_OK);
+    HourangleCoordsNP[0].setValue(ha);
+    HourangleCoordsNP[1].setValue(equatorialPos.dec);
+    HourangleCoordsNP.apply();
 
     if (isSimulation())
     {
@@ -1829,7 +1829,7 @@ bool LX200AstroPhysicsExperimental::Park()
         lastAL = parkAlt;
     }
 
-    EqNP.s     = IPS_BUSY;
+    EqNP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking is in progress...");
 
@@ -1852,7 +1852,7 @@ bool LX200AstroPhysicsExperimental::calcParkPosition(ParkPosition pos, double *p
         case 1:
             LOG_INFO("Computing PARK1 position...");
             *parkAlt = 0;
-            *parkAz = LocationN[LOCATION_LATITUDE].value > 0 ? 359.1 : 180.1;
+            *parkAz = LocationNP[LOCATION_LATITUDE].getValue() > 0 ? 359.1 : 180.1;
             break;
 
         // Park 2
@@ -1870,8 +1870,8 @@ bool LX200AstroPhysicsExperimental::calcParkPosition(ParkPosition pos, double *p
         // wildi: the hour angle is undefined if AZ = 0,180 and ALT=LAT is chosen, adding .1 to Az sets PARK3
         //        as close as possible to to HA = -6 hours (CW down), valid for both hemispheres.
         case 3:
-            *parkAlt = fabs(LocationN[LOCATION_LATITUDE].value);
-            *parkAz = LocationN[LOCATION_LATITUDE].value > 0 ? 0.1 : 179.9;
+            *parkAlt = fabs(LocationNP[LOCATION_LATITUDE].value);
+            *parkAz = LocationNP[LOCATION_LATITUDE].getValue() > 0 ? 0.1 : 179.9;
             LOG_INFO("Computing PARK3 position");
             break;
 
@@ -1881,7 +1881,7 @@ bool LX200AstroPhysicsExperimental::calcParkPosition(ParkPosition pos, double *p
         case 4:
             LOG_INFO("Computing PARK4 position...");
             *parkAlt = 0;
-            *parkAz = LocationN[LOCATION_LATITUDE].value > 0 ? 180.1 : 359.1;
+            *parkAz = LocationNP[LOCATION_LATITUDE].getValue() > 0 ? 180.1 : 359.1;
             break;
 
         default:
@@ -1899,12 +1899,12 @@ bool LX200AstroPhysicsExperimental::calcParkPosition(ParkPosition pos, double *p
 bool LX200AstroPhysicsExperimental::UnPark()
 {
     // 2020-05-30, wildi, NO: if (!(locationUpdated && timeUpdated)) {
-    if (!(TimeTP.s == IPS_OK && LocationNP.s == IPS_OK))
+    if (!(TimeTP.getState() == IPS_OK && LocationNP.getState() == IPS_OK))
     {
         LOG_WARN("UnPark: can not unpark, either missing location or time data");
-        //wildi IUResetSwitch(&UnparkFromSP);
-        UnparkFromSP.s = IPS_ALERT;
-        IDSetSwitch(&UnparkFromSP, nullptr);
+        //wildi UnparkFromSP.reset();
+        UnparkFromSP.setState(IPS_ALERT);
+        UnparkFromSP.apply();
         return false;
     }
     bool parkDataValid = InitPark() ;
@@ -1912,7 +1912,7 @@ bool LX200AstroPhysicsExperimental::UnPark()
     bool parkDataValid_and_parked = (parkDataValid && isParked());
     bool unpark_from_last_config = false;
 
-    unpark_from_last_config = (PARK_LAST == IUFindOnSwitchIndex(&UnparkFromSP));
+    unpark_from_last_config = (PARK_LAST == UnparkFromSP.findOnSwitchIndex());
     double unparkAlt, unparkAz;
     if (parkDataValid_and_parked && unpark_from_last_config)
     {
@@ -1923,13 +1923,13 @@ bool LX200AstroPhysicsExperimental::UnPark()
     }
     else if(!unpark_from_last_config)
     {
-        ParkPosition unparkfromPos = static_cast<ParkPosition>(IUFindOnSwitchIndex(&UnparkFromSP));
+        ParkPosition unparkfromPos = static_cast<ParkPosition>(UnparkFromSP.findOnSwitchIndex());
         LOGF_DEBUG("UnPark: park position = %d from current driver", unparkfromPos);
         if (!calcParkPosition(unparkfromPos, &unparkAlt, &unparkAz))
         {
             LOG_ERROR("UnPark: Error calculating unpark position!");
-            UnparkFromSP.s = IPS_ALERT;
-            IDSetSwitch(&UnparkFromSP, nullptr);
+            UnparkFromSP.setState(IPS_ALERT);
+            UnparkFromSP.apply();
             return false;
         }
         LOGF_DEBUG("UnPark: parkPos=%d parkAlt=%f parkAz=%f", unparkfromPos, unparkAlt, unparkAz);
@@ -1956,26 +1956,26 @@ bool LX200AstroPhysicsExperimental::UnPark()
             if (!IsMountParked(&isAPParked))
             {
                 LOG_WARN("UnPark:could not determine AP park status");
-                UnparkFromSP.s = IPS_ALERT;
-                IDSetSwitch(&UnparkFromSP, nullptr);
+                UnparkFromSP.setState(IPS_ALERT);
+                UnparkFromSP.apply();
                 return false;
             }
         }
         if(!isAPParked)
         {
             LOG_WARN("UnPark: AP mount status: unparked, park first");
-            UnparkFromSP.s = IPS_ALERT;
-            IDSetSwitch(&UnparkFromSP, nullptr);
+            UnparkFromSP.setState(IPS_ALERT);
+            UnparkFromSP.apply();
             return false;
         }
         // The AP :PO# should only be used during initilization and not here as indicated by email from Preston on 2017-12-12
         // 2020-05-27, wildi, ToDo taking care of above comment later
         if (APUnParkMount(PortFD) < 0)
         {
-            IUResetSwitch(&ParkSP);
-            ParkS[0].s = ISS_ON;
-            ParkSP.s = IPS_ALERT;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.reset();
+            ParkSP[0].setState(ISS_ON);
+            ParkSP.setState(IPS_ALERT);
+            ParkSP.apply();
             LOG_ERROR("UnParking AP mount failed.");
             return false;
         }
@@ -1984,10 +1984,10 @@ bool LX200AstroPhysicsExperimental::UnPark()
         // Stop :Q#
         if ( abortSlew(PortFD) < 0)
         {
-            IUResetSwitch(&ParkSP);
-            ParkS[0].s = ISS_ON;
-            ParkSP.s = IPS_ALERT;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.reset();
+            ParkSP[0].setState(ISS_ON);
+            ParkSP.setState(IPS_ALERT);
+            ParkSP.apply();
             LOG_WARN("Abort motion Failed");
             return false;
         }
@@ -2004,8 +2004,8 @@ bool LX200AstroPhysicsExperimental::UnPark()
     }
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -2030,10 +2030,10 @@ bool LX200AstroPhysicsExperimental::UnPark()
     LOGF_INFO("UnPark: Current parking position Az (%s) Alt (%s), HA (%s) RA (%s) Dec (%s)", AzStr, AltStr, HaStr,
               RaStr, DecStr);
 
-    HourangleCoordsNP.s = IPS_OK;
-    HourangleCoordsN[0].value = ha;
-    HourangleCoordsN[1].value = equatorialPos.dec;
-    IDSetNumber(&HourangleCoordsNP, nullptr);
+    HourangleCoordsNP.setState(IPS_OK);
+    HourangleCoordsNP[0].setValue(ha);
+    HourangleCoordsNP[1].setValue(equatorialPos.dec);
+    HourangleCoordsNP.apply();
 
     bool success = Sync(equatorialPos.ra / 15.0, equatorialPos.dec);
     if(!success)
@@ -2065,15 +2065,15 @@ bool LX200AstroPhysicsExperimental::UnPark()
     }
 #endif
 
-    if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+    if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
     {
-        MovementNSSP.s = IPS_IDLE;
-        MovementWESP.s = IPS_IDLE;
-        EqNP.s = IPS_IDLE;
-        IUResetSwitch(&MovementNSSP);
-        IUResetSwitch(&MovementWESP);
-        IDSetSwitch(&MovementNSSP, nullptr);
-        IDSetSwitch(&MovementWESP, nullptr);
+        MovementNSSP.setState(IPS_IDLE);
+        MovementWESP.setState(IPS_IDLE);
+        EqNP.setState(IPS_IDLE);
+        MovementNSSP.reset();
+        MovementWESP.reset();
+        MovementNSSP.apply();
+        MovementWESP.apply();
     }
     //
 #ifdef no
@@ -2085,8 +2085,8 @@ bool LX200AstroPhysicsExperimental::UnPark()
         return false;
     }
 #endif
-    UnparkFromSP.s = IPS_OK;
-    IDSetSwitch(&UnparkFromSP, nullptr);
+    UnparkFromSP.setState(IPS_OK);
+    UnparkFromSP.apply();
     // SlewRateS is used as the MoveTo speed
     int err;
     if (!isSimulation() && (err = selectAPCenterRate(PortFD, IUFindOnSwitchIndex(&SlewRateSP))) < 0)
@@ -2099,14 +2099,14 @@ bool LX200AstroPhysicsExperimental::UnPark()
     IDSetSwitch(&SlewRateSP, nullptr);
 
     // APSlewSpeedsS defines the Slew (GOTO) speeds valid on the AP mounts
-    if (!isSimulation() && (err = selectAPSlewRate(PortFD, IUFindOnSwitchIndex(&APSlewSpeedSP))) < 0)
+    if (!isSimulation() && (err = selectAPSlewRate(PortFD, APSlewSpeedSP.findOnSwitchIndex())) < 0)
     {
         LOGF_ERROR("Error setting slew to rate (%d).", err);
         return false;
     }
 
-    APSlewSpeedSP.s = IPS_OK;
-    IDSetSwitch(&APSlewSpeedSP, nullptr);
+    APSlewSpeedSP.setState(IPS_OK);
+    APSlewSpeedSP.apply();
 
     LOG_DEBUG("UnPark: Mount unparked successfully");
     return true;
@@ -2118,8 +2118,8 @@ bool LX200AstroPhysicsExperimental::SetCurrentPark()
     // Libnova south = 0, west = 90, north = 180, east = 270
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -2145,10 +2145,10 @@ bool LX200AstroPhysicsExperimental::SetCurrentPark()
 bool LX200AstroPhysicsExperimental::SetDefaultPark()
 {
     // Az = 0 for North hemisphere, Az = 180 for South
-    SetAxis1Park(LocationN[LOCATION_LATITUDE].value > 0.1 ? 0 : 179.1);
+    SetAxis1Park(LocationNP[LOCATION_LATITUDE].value > 0.1 ? 0 : 179.1);
 
     // Alt = Latitude
-    SetAxis2Park(fabs(LocationN[LOCATION_LATITUDE].value));
+    SetAxis2Park(fabs(LocationNP[LOCATION_LATITUDE].value));
 
     return true;
 }
@@ -2199,12 +2199,12 @@ bool LX200AstroPhysicsExperimental::saveConfigItems(FILE *fp)
 {
     LX200Generic::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &SyncCMRSP);
-    IUSaveConfigSwitch(fp, &APSlewSpeedSP);
-    IUSaveConfigSwitch(fp, &APGuideSpeedSP);
-    IUSaveConfigSwitch(fp, &ParkToSP);
-    IUSaveConfigSwitch(fp, &UnparkFromSP);
-    IUSaveConfigSwitch(fp, &TrackStateSP);
+    SyncCMRSP.save(fp);
+    APSlewSpeedSP.save(fp);
+    APGuideSpeedSP.save(fp);
+    ParkToSP.save(fp);
+    UnparkFromSP.save(fp);
+    TrackStateSP.save(fp);
 
     return true;
 }
@@ -2223,7 +2223,7 @@ bool LX200AstroPhysicsExperimental::SetTrackMode(uint8_t mode)
             return false;
         }
 
-        return SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+        return SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
     }
 
     if (!isSimulation() && (err = selectAPTrackingMode(PortFD, mode)) < 0)
@@ -2328,7 +2328,7 @@ bool LX200AstroPhysicsExperimental::MoveWE(INDI_DIR_WE dir, TelescopeMotionComma
 bool LX200AstroPhysicsExperimental::GuideNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
 {
     // restore guide rate
-    selectAPGuideRate(PortFD, IUFindOnSwitchIndex(&APGuideSpeedSP));
+    selectAPGuideRate(PortFD, APGuideSpeedSP.findOnSwitchIndex());
 
     bool rc = LX200Generic::MoveNS(dir, command);
 #ifdef no
@@ -2341,7 +2341,7 @@ bool LX200AstroPhysicsExperimental::GuideNS(INDI_DIR_NS dir, TelescopeMotionComm
 bool LX200AstroPhysicsExperimental::GuideWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
 {
     // restore guide rate
-    selectAPGuideRate(PortFD, IUFindOnSwitchIndex(&APGuideSpeedSP));
+    selectAPGuideRate(PortFD, APGuideSpeedSP.findOnSwitchIndex());
 
     bool rc = LX200Generic::MoveWE(dir, command);
 #ifdef no

--- a/drivers/telescope/lx200ap_experimental.h
+++ b/drivers/telescope/lx200ap_experimental.h
@@ -23,6 +23,10 @@
 #pragma once
 
 #include "lx200generic.h"
+
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
 #define MOUNTNOTINITIALIZED 0
 #define MOUNTINITIALIZED    1
 
@@ -99,38 +103,26 @@ class LX200AstroPhysicsExperimental : public LX200Generic
 
         void handleGTOCP2MotionBug();
 
-        ISwitch StartUpS[2];
-        ISwitchVectorProperty StartUpSP;
+        INDI::PropertySwitch StartUpSP {2};
 
-        INumber HourangleCoordsN[2];
-        INumberVectorProperty HourangleCoordsNP;
-        INumber APSiderealTimeN[1];
-        INumberVectorProperty APSiderealTimeNP;
+        INDI::PropertyNumber HourangleCoordsNP {2};
+        INDI::PropertyNumber APSiderealTimeNP {1};
 
-        INumber HorizontalCoordsN[2];
-        INumberVectorProperty HorizontalCoordsNP;
+        INDI::PropertyNumber HorizontalCoordsNP {2};
 
-        ISwitch APSlewSpeedS[3];
-        ISwitchVectorProperty APSlewSpeedSP;
+        INDI::PropertySwitch APSlewSpeedSP {3};
 
-        ISwitch SwapS[2];
-        ISwitchVectorProperty SwapSP;
+        INDI::PropertySwitch SwapSP {2};
 
-        ISwitch SyncCMRS[2];
-        ISwitchVectorProperty SyncCMRSP;
+        INDI::PropertySwitch SyncCMRSP {2};
         enum { USE_REGULAR_SYNC, USE_CMR_SYNC };
 
-        ISwitch APGuideSpeedS[3];
-        ISwitchVectorProperty APGuideSpeedSP;
+        INDI::PropertySwitch APGuideSpeedSP {3};
 
-        ISwitch UnparkFromS[5];
-        ISwitchVectorProperty UnparkFromSP;
+        INDI::PropertySwitch UnparkFromSP {5};
 
-        ISwitch ParkToS[5];
-        ISwitchVectorProperty ParkToSP;
-
-        INumberVectorProperty APUTCOffsetNP;
-        INumber APUTCOffsetN[1];
+        INDI::PropertySwitch ParkToSP {5};
+        INDI::PropertyNumber APUTCOffsetNP {1};
 
         IText VersionT[1] {};
         ITextVectorProperty VersionTP;

--- a/drivers/telescope/lx200ap_gtocp2.cpp
+++ b/drivers/telescope/lx200ap_gtocp2.cpp
@@ -55,23 +55,23 @@ bool LX200AstroPhysicsGTOCP2::initProperties()
 
     timeFormat = LX200_24;
 
-    IUFillNumber(&HourangleCoordsN[0], "HA", "HA H:M:S", "%10.6m", 0., 24., 0., 0.);
-    IUFillNumber(&HourangleCoordsN[1], "DEC", "Dec D:M:S", "%10.6m", -90.0, 90.0, 0., 0.);
-    IUFillNumberVector(&HourangleCoordsNP, HourangleCoordsN, 2, getDeviceName(), "HOURANGLE_COORD", "Hourangle Coords",
+    HourangleCoordsNP[0].fill("HA", "HA H:M:S", "%10.6m", 0., 24., 0., 0.);
+    HourangleCoordsNP[1].fill("DEC", "Dec D:M:S", "%10.6m", -90.0, 90.0, 0., 0.);
+    HourangleCoordsNP.fill(getDeviceName(), "HOURANGLE_COORD", "Hourangle Coords",
                        MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
-    IUFillNumber(&HorizontalCoordsN[0], "AZ", "Az D:M:S", "%10.6m", 0., 360., 0., 0.);
-    IUFillNumber(&HorizontalCoordsN[1], "ALT", "Alt D:M:S", "%10.6m", -90., 90., 0., 0.);
-    IUFillNumberVector(&HorizontalCoordsNP, HorizontalCoordsN, 2, getDeviceName(), "HORIZONTAL_COORD",
+    HorizontalCoordsNP[0].fill("AZ", "Az D:M:S", "%10.6m", 0., 360., 0., 0.);
+    HorizontalCoordsNP[1].fill("ALT", "Alt D:M:S", "%10.6m", -90., 90., 0., 0.);
+    HorizontalCoordsNP.fill(getDeviceName(), "HORIZONTAL_COORD",
                        "Horizontal Coords", MAIN_CONTROL_TAB, IP_RW, 120, IPS_IDLE);
 
 
     // Max rate is 999.99999X for the GTOCP4.
     // Using :RR998.9999#  just to be safe. 15.041067*998.99999 = 15026.02578
-    TrackRateN[AXIS_RA].min = -15026.0258;
-    TrackRateN[AXIS_RA].max = 15026.0258;
-    TrackRateN[AXIS_DE].min = -998.9999;
-    TrackRateN[AXIS_DE].max = 998.9999;
+    TrackRateNP[AXIS_RA].setMin(-15026.0258);
+    TrackRateNP[AXIS_RA].setMax(15026.0258);
+    TrackRateNP[AXIS_DE].setMin(-998.9999);
+    TrackRateNP[AXIS_DE].setMax(998.9999);
 
     // Motion speed of axis when pressing NSWE buttons
     IUFillSwitch(&SlewRateS[0], "12", "12x", ISS_OFF);
@@ -82,27 +82,27 @@ bool LX200AstroPhysicsGTOCP2::initProperties()
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     // Slew speed when performing regular GOTO
-    IUFillSwitch(&APSlewSpeedS[0], "600", "600x", ISS_ON);
-    IUFillSwitch(&APSlewSpeedS[1], "900", "900x", ISS_OFF);
-    IUFillSwitch(&APSlewSpeedS[2], "1200", "1200x", ISS_OFF);
-    IUFillSwitchVector(&APSlewSpeedSP, APSlewSpeedS, 3, getDeviceName(), "GOTO Rate", "", MOTION_TAB, IP_RW, ISR_1OFMANY,
+    APSlewSpeedSP[0].fill("600", "600x", ISS_ON);
+    APSlewSpeedSP[1].fill("900", "900x", ISS_OFF);
+    APSlewSpeedSP[2].fill("1200", "1200x", ISS_OFF);
+    APSlewSpeedSP.fill(getDeviceName(), "GOTO Rate", "", MOTION_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
-    IUFillSwitch(&SwapS[0], "NS", "North/South", ISS_OFF);
-    IUFillSwitch(&SwapS[1], "EW", "East/West", ISS_OFF);
-    IUFillSwitchVector(&SwapSP, SwapS, 2, getDeviceName(), "SWAP", "Swap buttons", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SwapSP[0].fill("NS", "North/South", ISS_OFF);
+    SwapSP[1].fill("EW", "East/West", ISS_OFF);
+    SwapSP.fill(getDeviceName(), "SWAP", "Swap buttons", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], ":CM#", ":CM#", ISS_ON);
-    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], ":CMR#", ":CMR#", ISS_OFF);
-    IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SyncCMRSP[USE_REGULAR_SYNC].fill(":CM#", ":CM#", ISS_ON);
+    SyncCMRSP[USE_CMR_SYNC].fill(":CMR#", ":CMR#", ISS_OFF);
+    SyncCMRSP.fill(getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // guide speed
-    IUFillSwitch(&APGuideSpeedS[0], "0.25", "0.25x", ISS_OFF);
-    IUFillSwitch(&APGuideSpeedS[1], "0.5", "0.50x", ISS_ON);
-    IUFillSwitch(&APGuideSpeedS[2], "1.0", "1.0x", ISS_OFF);
-    IUFillSwitchVector(&APGuideSpeedSP, APGuideSpeedS, 3, getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
+    APGuideSpeedSP[0].fill("0.25", "0.25x", ISS_OFF);
+    APGuideSpeedSP[1].fill("0.5", "0.50x", ISS_ON);
+    APGuideSpeedSP[2].fill("1.0", "1.0x", ISS_OFF);
+    APGuideSpeedSP.fill(getDeviceName(), "Guide Rate", "", GUIDE_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
     IUFillText(&VersionT[0], "Version", "Version", "");
@@ -122,10 +122,10 @@ void LX200AstroPhysicsGTOCP2::ISGetProperties(const char *dev)
         defineProperty(&VersionTP);
 
         /* Motion group */
-        defineProperty(&APSlewSpeedSP);
-        defineProperty(&SwapSP);
-        defineProperty(&SyncCMRSP);
-        defineProperty(&APGuideSpeedSP);
+        defineProperty(APSlewSpeedSP);
+        defineProperty(SwapSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(APGuideSpeedSP);
     }
 }
 
@@ -138,25 +138,25 @@ bool LX200AstroPhysicsGTOCP2::updateProperties()
         defineProperty(&VersionTP);
 
         /* Motion group */
-        defineProperty(&APSlewSpeedSP);
-        defineProperty(&SwapSP);
-        defineProperty(&SyncCMRSP);
-        defineProperty(&APGuideSpeedSP);
+        defineProperty(APSlewSpeedSP);
+        defineProperty(SwapSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(APGuideSpeedSP);
 
         if (InitPark())
         {
             // If loading parking data is successful, we just set the default parking values.
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
         else
         {
             // Otherwise, we set all parking data to default in case no parking data is found.
-            SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value);
 
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
 
         double longitude = -1000, latitude = -1000;
@@ -169,10 +169,10 @@ bool LX200AstroPhysicsGTOCP2::updateProperties()
     else
     {
         deleteProperty(VersionTP.name);
-        deleteProperty(APSlewSpeedSP.name);
-        deleteProperty(SwapSP.name);
-        deleteProperty(SyncCMRSP.name);
-        deleteProperty(APGuideSpeedSP.name);
+        deleteProperty(APSlewSpeedSP.getName());
+        deleteProperty(SwapSP.getName());
+        deleteProperty(SyncCMRSP.getName());
+        deleteProperty(APGuideSpeedSP.getName());
     }
 
     return true;
@@ -239,14 +239,14 @@ bool LX200AstroPhysicsGTOCP2::initMount()
     IDSetSwitch(&SlewRateSP, nullptr);
 
     // APSlewSpeedsS defines the Slew (GOTO) speeds valid on the AP mounts
-    if (isSimulation() == false && (err = selectAPSlewRate(PortFD, IUFindOnSwitchIndex(&APSlewSpeedSP))) < 0)
+    if (isSimulation() == false && (err = selectAPSlewRate(PortFD, APSlewSpeedSP.findOnSwitchIndex())) < 0)
     {
         LOGF_ERROR("Error setting slew to rate (%d).", err);
         return false;
     }
 
-    APSlewSpeedSP.s = IPS_OK;
-    IDSetSwitch(&APSlewSpeedSP, nullptr);
+    APSlewSpeedSP.setState(IPS_OK);
+    APSlewSpeedSP.apply();
 
     char versionString[128];
     if (isSimulation())
@@ -291,13 +291,13 @@ bool LX200AstroPhysicsGTOCP2::ISNewSwitch(const char *dev, const char *name, ISS
     // =======================================
     // Swap Buttons
     // =======================================
-    if (!strcmp(name, SwapSP.name))
+    if (SwapSP.isNameMatch(name))
     {
         int currentSwap;
 
-        IUResetSwitch(&SwapSP);
-        IUUpdateSwitch(&SwapSP, states, names, n);
-        currentSwap = IUFindOnSwitchIndex(&SwapSP);
+        SwapSP.reset();
+        SwapSP.update(states, names, n);
+        currentSwap = SwapSP.findOnSwitchIndex();
 
         if ((!isSimulation() && (err = swapAPButtons(PortFD, currentSwap)) < 0))
         {
@@ -305,20 +305,20 @@ bool LX200AstroPhysicsGTOCP2::ISNewSwitch(const char *dev, const char *name, ISS
             return false;
         }
 
-        SwapS[0].s = ISS_OFF;
-        SwapS[1].s = ISS_OFF;
-        SwapSP.s   = IPS_OK;
-        IDSetSwitch(&SwapSP, nullptr);
+        SwapSP[0].setState(ISS_OFF);
+        SwapSP[1].setState(ISS_OFF);
+        SwapSP.setState(IPS_OK);
+        SwapSP.apply();
         return true;
     }
 
     // ===========================================================
     // GOTO ("slew") Speed.
     // ===========================================================
-    if (!strcmp(name, APSlewSpeedSP.name))
+    if (APSlewSpeedSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&APSlewSpeedSP, states, names, n);
-        int slewRate = IUFindOnSwitchIndex(&APSlewSpeedSP);
+        APSlewSpeedSP.update(states, names, n);
+        int slewRate = APSlewSpeedSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPSlewRate(PortFD, slewRate) < 0))
         {
@@ -326,18 +326,18 @@ bool LX200AstroPhysicsGTOCP2::ISNewSwitch(const char *dev, const char *name, ISS
             return false;
         }
 
-        APSlewSpeedSP.s = IPS_OK;
-        IDSetSwitch(&APSlewSpeedSP, nullptr);
+        APSlewSpeedSP.setState(IPS_OK);
+        APSlewSpeedSP.apply();
         return true;
     }
 
     // ===========================================================
     // Guide Speed.
     // ===========================================================
-    if (!strcmp(name, APGuideSpeedSP.name))
+    if (APGuideSpeedSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&APGuideSpeedSP, states, names, n);
-        int guideRate = IUFindOnSwitchIndex(&APGuideSpeedSP);
+        APGuideSpeedSP.update(states, names, n);
+        int guideRate = APGuideSpeedSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPGuideRate(PortFD, guideRate) < 0))
         {
@@ -345,34 +345,34 @@ bool LX200AstroPhysicsGTOCP2::ISNewSwitch(const char *dev, const char *name, ISS
             return false;
         }
 
-        APGuideSpeedSP.s = IPS_OK;
-        IDSetSwitch(&APGuideSpeedSP, nullptr);
+        APGuideSpeedSP.setState(IPS_OK);
+        APGuideSpeedSP.apply();
         return true;
     }
 
     // =======================================
     // Choose the appropriate sync command
     // =======================================
-    if (!strcmp(name, SyncCMRSP.name))
+    if (SyncCMRSP.isNameMatch(name))
     {
-        IUResetSwitch(&SyncCMRSP);
-        IUUpdateSwitch(&SyncCMRSP, states, names, n);
-        IUFindOnSwitchIndex(&SyncCMRSP);
-        SyncCMRSP.s = IPS_OK;
-        IDSetSwitch(&SyncCMRSP, nullptr);
+        SyncCMRSP.reset();
+        SyncCMRSP.update(states, names, n);
+        SyncCMRSP.findOnSwitchIndex();
+        SyncCMRSP.setState(IPS_OK);
+        SyncCMRSP.apply();
         return true;
     }
 
     // =======================================
     // Choose the PEC playback mode
     // =======================================
-    if (!strcmp(name, PECStateSP.name))
+    if (PECStateSP.isNameMatch(name))
     {
-        IUResetSwitch(&PECStateSP);
-        IUUpdateSwitch(&PECStateSP, states, names, n);
-        IUFindOnSwitchIndex(&PECStateSP);
+        PECStateSP.reset();
+        PECStateSP.update(states, names, n);
+        PECStateSP.findOnSwitchIndex();
 
-        int pecstate = IUFindOnSwitchIndex(&PECStateSP);
+        int pecstate = PECStateSP.findOnSwitchIndex();
 
         if (!isSimulation() && (err = selectAPPECState(PortFD, pecstate) < 0))
         {
@@ -380,8 +380,8 @@ bool LX200AstroPhysicsGTOCP2::ISNewSwitch(const char *dev, const char *name, ISS
             return false;
         }
 
-        PECStateSP.s = IPS_OK;
-        IDSetSwitch(&PECStateSP, nullptr);
+        PECStateSP.setState(IPS_OK);
+        PECStateSP.apply();
 
         return true;
     }
@@ -399,8 +399,8 @@ bool LX200AstroPhysicsGTOCP2::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -426,8 +426,8 @@ bool LX200AstroPhysicsGTOCP2::ReadScopeStatus()
     {
         if (getLX200Az(PortFD, &currentAz) < 0 || getLX200Alt(PortFD, &currentAlt) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error reading Az/Alt.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error reading Az/Alt.");
             return false;
         }
 
@@ -477,29 +477,29 @@ bool LX200AstroPhysicsGTOCP2::Goto(double r, double d)
     fs_sexa(DecStr, targetDEC, 2, 3600);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
-        if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
         {
-            MovementNSSP.s = IPS_IDLE;
-            MovementWESP.s = IPS_IDLE;
-            EqNP.s = IPS_IDLE;
-            IUResetSwitch(&MovementNSSP);
-            IUResetSwitch(&MovementWESP);
-            IDSetSwitch(&MovementNSSP, nullptr);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementNSSP.setState(IPS_IDLE);
+            MovementWESP.setState(IPS_IDLE);
+            EqNP.setState(IPS_IDLE);
+            MovementNSSP.reset();
+            MovementWESP.reset();
+            MovementNSSP.apply();
+            MovementWESP.apply();
         }
 
         // sleep for 100 mseconds
@@ -510,8 +510,8 @@ bool LX200AstroPhysicsGTOCP2::Goto(double r, double d)
     {
         if (setAPObjectRA(PortFD, targetRA) < 0 || (setAPObjectDEC(PortFD, targetDEC)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
@@ -520,8 +520,8 @@ bool LX200AstroPhysicsGTOCP2::Goto(double r, double d)
         /* Slew reads the '0', that is not the end of the slew */
         if ((err = Slew(PortFD)))
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
             slewError(err);
             return false;
         }
@@ -532,7 +532,7 @@ bool LX200AstroPhysicsGTOCP2::Goto(double r, double d)
     }
 
     TrackState = SCOPE_SLEWING;
-    //EqNP.s     = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
     return true;
@@ -590,14 +590,14 @@ bool LX200AstroPhysicsGTOCP2::Sync(double ra, double dec)
 {
     char syncString[256];
 
-    int syncType = IUFindOnSwitchIndex(&SyncCMRSP);
+    int syncType = SyncCMRSP.findOnSwitchIndex();
 
     if (!isSimulation())
     {
         if (setAPObjectRA(PortFD, ra) < 0 || setAPObjectDEC(PortFD, dec) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC. Unable to Sync.");
             return false;
         }
 
@@ -621,8 +621,8 @@ bool LX200AstroPhysicsGTOCP2::Sync(double ra, double dec)
 
         if (syncOK == false)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Synchronization failed.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Synchronization failed.");
             return false;
         }
 
@@ -634,7 +634,7 @@ bool LX200AstroPhysicsGTOCP2::Sync(double ra, double dec)
     LOGF_DEBUG("%s Synchronization successful %s", (syncType == USE_REGULAR_SYNC ? "CM" : "CMR"), syncString);
     LOG_INFO("Synchronization successful.");
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -753,8 +753,8 @@ bool LX200AstroPhysicsGTOCP2::Park()
     if (isSimulation())
     {
         ln_lnlat_posn observer;
-        observer.lat = LocationN[LOCATION_LATITUDE].value;
-        observer.lng = LocationN[LOCATION_LONGITUDE].value;
+        observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+        observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
         if (observer.lng > 180)
             observer.lng -= 360;
 
@@ -793,7 +793,7 @@ bool LX200AstroPhysicsGTOCP2::Park()
         lastAL = parkAlt;
     }
 
-    EqNP.s     = IPS_BUSY;
+    EqNP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking is in progress...");
 
@@ -818,8 +818,8 @@ bool LX200AstroPhysicsGTOCP2::SetCurrentPark()
     // Libnova south = 0, west = 90, north = 180, east = 270
 
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -845,10 +845,10 @@ bool LX200AstroPhysicsGTOCP2::SetCurrentPark()
 bool LX200AstroPhysicsGTOCP2::SetDefaultPark()
 {
     // Az = 0 for North hemisphere
-    SetAxis1Park(LocationN[LOCATION_LATITUDE].value > 0 ? 0 : 180);
+    SetAxis1Park(LocationNP[LOCATION_LATITUDE].value > 0 ? 0 : 180);
 
     // Alt = Latitude
-    SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+    SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
 
     return true;
 }
@@ -900,9 +900,9 @@ bool LX200AstroPhysicsGTOCP2::saveConfigItems(FILE *fp)
 {
     LX200Generic::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &SyncCMRSP);
-    IUSaveConfigSwitch(fp, &APSlewSpeedSP);
-    IUSaveConfigSwitch(fp, &APGuideSpeedSP);
+    SyncCMRSP.save(fp);
+    APSlewSpeedSP.save(fp);
+    APGuideSpeedSP.save(fp);
 
     return true;
 }
@@ -919,7 +919,7 @@ bool LX200AstroPhysicsGTOCP2::SetTrackMode(uint8_t mode)
             return false;
         }
 
-        return SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+        return SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
     }
 
     if (!isSimulation() && (err = selectAPTrackingMode(PortFD, mode)) < 0)
@@ -996,8 +996,8 @@ void LX200AstroPhysicsGTOCP2::handleGTOCP2MotionBug()
     // So it must be reset to the user setting in order for guiding to work properly.
     if (motionCommanded)
     {
-        LOGF_DEBUG("%s: Issuing select guide rate index: %d", __FUNCTION__, IUFindOnSwitchIndex(&APGuideSpeedSP));
-        selectAPGuideRate(PortFD, IUFindOnSwitchIndex(&APGuideSpeedSP));
+        LOGF_DEBUG("%s: Issuing select guide rate index: %d", __FUNCTION__, APGuideSpeedSP.findOnSwitchIndex());
+        selectAPGuideRate(PortFD, APGuideSpeedSP.findOnSwitchIndex());
         motionCommanded = false;
     }
 }

--- a/drivers/telescope/lx200ap_gtocp2.h
+++ b/drivers/telescope/lx200ap_gtocp2.h
@@ -24,6 +24,10 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200AstroPhysicsGTOCP2 : public LX200Generic
 {
   public:
@@ -75,24 +79,18 @@ class LX200AstroPhysicsGTOCP2 : public LX200Generic
 
     void handleGTOCP2MotionBug();
 
-    INumber HourangleCoordsN[2];
-    INumberVectorProperty HourangleCoordsNP;
+    INDI::PropertyNumber HourangleCoordsNP {2};
 
-    INumber HorizontalCoordsN[2];
-    INumberVectorProperty HorizontalCoordsNP;
+    INDI::PropertyNumber HorizontalCoordsNP {2};
 
-    ISwitch APSlewSpeedS[3];
-    ISwitchVectorProperty APSlewSpeedSP;
+    INDI::PropertySwitch APSlewSpeedSP {3};
 
-    ISwitch SwapS[2];
-    ISwitchVectorProperty SwapSP;
+    INDI::PropertySwitch SwapSP {2};
 
-    ISwitch SyncCMRS[2];
-    ISwitchVectorProperty SyncCMRSP;
+    INDI::PropertySwitch SyncCMRSP {2};
     enum { USE_REGULAR_SYNC, USE_CMR_SYNC };
 
-    ISwitch APGuideSpeedS[3];
-    ISwitchVectorProperty APGuideSpeedSP;
+    INDI::PropertySwitch APGuideSpeedSP {3};
 
     IText VersionT[1] {};
     ITextVectorProperty VersionTP;

--- a/drivers/telescope/lx200autostar.cpp
+++ b/drivers/telescope/lx200autostar.cpp
@@ -51,13 +51,13 @@ bool LX200Autostar::initProperties()
     IUFillText(&VersionT[4], "Name", "", "");
     IUFillTextVector(&VersionTP, VersionT, 5, getDeviceName(), "Firmware Info", "", FIRMWARE_TAB, IP_RO, 0, IPS_IDLE);
 
-    //    IUFillNumber(&FocusSpeedN[0], "SPEED", "Speed", "%0.f", 0, 4.0, 1.0, 0);
-    //    IUFillNumberVector(&FocusSpeedNP, FocusSpeedN, 1, getDeviceName(), "FOCUS_SPEED", "Speed", FOCUS_TAB, IP_RW, 0,
+    //    FocusSpeedNP[0].fill("SPEED", "Speed", "%0.f", 0, 4.0, 1.0, 0);
+    //    FocusSpeedNP.fill(getDeviceName(), "FOCUS_SPEED", "Speed", FOCUS_TAB, IP_RW, 0,
     //                       IPS_IDLE);
 
-    FocusSpeedN[0].min = 1;
-    FocusSpeedN[0].max = 4;
-    FocusSpeedN[0].value = 1;
+    FocusSpeedNP[0].setMin(1);
+    FocusSpeedNP[0].setMax(4);
+    FocusSpeedNP[0].setValue(1);
 
     return true;
 }
@@ -73,11 +73,11 @@ bool LX200Autostar::initProperties()
 //    if (isConnected())
 //    {
 //        defineProperty(&VersionTP);
-//        defineProperty(&FocusSpeedNP);
+//        defineProperty(FocusSpeedNP);
 
 //        // For Autostar, we have a different focus speed method
 //        // Therefore, we don't need the classical one
-//        deleteProperty(FocusModeSP.name);
+//        deleteProperty(FocusModeSP.getName());
 //    }
 //    */
 //}
@@ -89,17 +89,17 @@ bool LX200Autostar::updateProperties()
     if (isConnected())
     {
         defineProperty(&VersionTP);
-        //defineProperty(&FocusSpeedNP);
+        //defineProperty(FocusSpeedNP);
 
         // For Autostar, we have a different focus speed method
         // Therefore, we don't need the classical one
-        //deleteProperty(FocusModeSP.name);
+        //deleteProperty(FocusModeSP.getName());
         return true;
     }
     else
     {
         deleteProperty(VersionTP.name);
-        //deleteProperty(FocusSpeedNP.name);
+        //deleteProperty(FocusSpeedNP.getName());
         return true;
     }
 }
@@ -109,15 +109,15 @@ bool LX200Autostar::updateProperties()
 //    if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
 //    {
 //        // Focus speed
-//        if (!strcmp(name, FocusSpeedNP.name))
+//        if (FocusSpeedNP.isNameMatch(name))
 //        {
-//            if (IUUpdateNumber(&FocusSpeedNP, values, names, n) < 0)
+//            if (!FocusSpeedNP.update(values, names, n))
 //                return false;
 
 //            if (!isSimulation())
-//                setGPSFocuserSpeed(PortFD, ((int)FocusSpeedN[0].value));
-//            FocusSpeedNP.s = IPS_OK;
-//            IDSetNumber(&FocusSpeedNP, nullptr);
+//                setGPSFocuserSpeed(PortFD, ((int)FocusSpeedNP[0].getValue()));
+//            FocusSpeedNP.setState(IPS_OK);
+//            FocusSpeedNP.apply();
 //            return true;
 //        }
 //    }
@@ -132,53 +132,53 @@ bool LX200Autostar::updateProperties()
 //    if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
 //    {
 //        // Focus Motion
-//        if (!strcmp(name, FocusMotionSP.name))
+//        if (FocusMotionSP.isNameMatch(name))
 //        {
 //            // If speed is "halt"
-//            if (FocusSpeedN[0].value == 0)
+//            if (FocusSpeedNP[0].value == 0)
 //            {
-//                FocusMotionSP.s = IPS_IDLE;
-//                IDSetSwitch(&FocusMotionSP, nullptr);
+//                FocusMotionSP.setState(IPS_IDLE);
+//                FocusMotionSP.apply();
 //                return false;
 //            }
 
-//            int last_motion = IUFindOnSwitchIndex(&FocusMotionSP);
+//            int last_motion = FocusMotionSP.findOnSwitchIndex();
 
-//            if (IUUpdateSwitch(&FocusMotionSP, states, names, n) < 0)
+//            if (!FocusMotionSP.update(states, names, n))
 //                return false;
 
-//            index = IUFindOnSwitchIndex(&FocusMotionSP);
+//            index = FocusMotionSP.findOnSwitchIndex();
 
 //            // If same direction and we're busy, stop
-//            if (last_motion == index && FocusMotionSP.s == IPS_BUSY)
+//            if (last_motion == index && FocusMotionSP.getState() == IPS_BUSY)
 //            {
-//                IUResetSwitch(&FocusMotionSP);
-//                FocusMotionSP.s = IPS_IDLE;
+//                FocusMotionSP.reset();
+//                FocusMotionSP.setState(IPS_IDLE);
 //                setFocuserSpeedMode(PortFD, 0);
-//                IDSetSwitch(&FocusMotionSP, nullptr);
+//                FocusMotionSP.apply();
 //                return true;
 //            }
 
 //            if (!isSimulation() && setFocuserMotion(PortFD, index) < 0)
 //            {
-//                FocusMotionSP.s = IPS_ALERT;
-//                IDSetSwitch(&FocusMotionSP, "Error setting focuser speed.");
+//                FocusMotionSP.setState(IPS_ALERT);
+//                FocusMotionSP.apply("Error setting focuser speed.");
 //                return false;
 //            }
 
-//            FocusMotionSP.s = IPS_BUSY;
+//            FocusMotionSP.setState(IPS_BUSY);
 
 //            // with a timer
-//            if (FocusTimerNP.np[0].value > 0)
+//            if (FocusTimerNP[0].value > 0)
 //            {
-//                FocusTimerNP.s = IPS_BUSY;
+//                FocusTimerNP.setState(IPS_BUSY);
 //                if (isDebug())
 //                    IDLog("Starting Focus Timer BUSY\n");
 
 //                IEAddTimer(50, LX200Generic::updateFocusHelper, this);
 //            }
 
-//            IDSetSwitch(&FocusMotionSP, nullptr);
+//            FocusMotionSP.apply();
 //            return true;
 //        }
 //    }

--- a/drivers/telescope/lx200autostar.h
+++ b/drivers/telescope/lx200autostar.h
@@ -22,6 +22,9 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class LX200Autostar : public LX200Generic
 {
     public:
@@ -42,6 +45,6 @@ class LX200Autostar : public LX200Generic
         ITextVectorProperty VersionTP;
         IText VersionT[5] {};
 
-        //        INumberVectorProperty FocusSpeedNP;
-        //        INumber FocusSpeedN[1];
+        //
+        //        INDI::PropertyNumber FocusSpeedNP {1};
 };

--- a/drivers/telescope/lx200basic.cpp
+++ b/drivers/telescope/lx200basic.cpp
@@ -147,9 +147,9 @@ bool LX200Basic::initProperties()
     INDI::Telescope::initProperties();
 
     // Slew threshold
-    IUFillNumber(&SlewAccuracyN[0], "SlewRA", "RA (arcmin)", "%10.6m", 0., 60., 1., 3.0);
-    IUFillNumber(&SlewAccuracyN[1], "SlewDEC", "Dec (arcmin)", "%10.6m", 0., 60., 1., 3.0);
-    IUFillNumberVector(&SlewAccuracyNP, SlewAccuracyN, NARRAY(SlewAccuracyN), getDeviceName(), "Slew Accuracy", "",
+    SlewAccuracyNP[0].fill("SlewRA", "RA (arcmin)", "%10.6m", 0., 60., 1., 3.0);
+    SlewAccuracyNP[1].fill("SlewDEC", "Dec (arcmin)", "%10.6m", 0., 60., 1., 3.0);
+    SlewAccuracyNP.fill(getDeviceName(), "Slew Accuracy", "",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     addAuxControls();
@@ -166,17 +166,17 @@ bool LX200Basic::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&SlewAccuracyNP);
+        defineProperty(SlewAccuracyNP);
 
         // We don't support NSWE controls
-        deleteProperty(MovementNSSP.name);
-        deleteProperty(MovementWESP.name);
+        deleteProperty(MovementNSSP.getName());
+        deleteProperty(MovementWESP.getName());
 
         getBasicData();
     }
     else
     {
-        deleteProperty(SlewAccuracyNP.name);
+        deleteProperty(SlewAccuracyNP.getName());
     }
 
     return true;
@@ -203,7 +203,7 @@ bool LX200Basic::isSlewComplete()
 {
     const double dx = targetRA - currentRA;
     const double dy = targetDEC - currentDEC;
-    return fabs(dx) <= (SlewAccuracyN[0].value / (900.0)) && fabs(dy) <= (SlewAccuracyN[1].value / 60.0);
+    return fabs(dx) <= (SlewAccuracyNP[0].value / (900.0)) && fabs(dy) <= (SlewAccuracyNP[1].value / 60.0);
 }
 
 /**************************************************************************************
@@ -222,8 +222,8 @@ bool LX200Basic::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -255,19 +255,19 @@ bool LX200Basic::Goto(double r, double d)
     fs_sexa(DecStr, targetDEC, 2, 3600);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
         // sleep for 100 mseconds
         usleep(100000);
@@ -277,8 +277,8 @@ bool LX200Basic::Goto(double r, double d)
     {
         if (setObjectRA(PortFD, targetRA) < 0 || (setObjectDEC(PortFD, targetDEC)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
@@ -287,15 +287,15 @@ bool LX200Basic::Goto(double r, double d)
         /* Slew reads the '0', that is not the end of the slew */
         if ((err = Slew(PortFD)))
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
             slewError(err);
             return false;
         }
     }
 
     TrackState = SCOPE_SLEWING;
-    //EqNP.s     = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
     return true;
@@ -310,15 +310,15 @@ bool LX200Basic::Sync(double ra, double dec)
 
     if (!isSimulation() && (setObjectRA(PortFD, ra) < 0 || (setObjectDEC(PortFD, dec)) < 0))
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error setting RA/DEC. Unable to Sync.");
         return false;
     }
 
     if (!isSimulation() && ::Sync(PortFD, syncString) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Synchronization failed.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Synchronization failed.");
         return false;
     }
 
@@ -327,7 +327,7 @@ bool LX200Basic::Sync(double ra, double dec)
 
     LOG_INFO("Synchronization successful.");
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -341,17 +341,17 @@ bool LX200Basic::ISNewNumber(const char *dev, const char *name, double values[],
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, SlewAccuracyNP.name))
+        if (SlewAccuracyNP.isNameMatch(name))
         {
-            if (IUUpdateNumber(&SlewAccuracyNP, values, names, n) < 0)
+            if (!SlewAccuracyNP.update(values, names, n))
                 return false;
 
-            SlewAccuracyNP.s = IPS_OK;
+            SlewAccuracyNP.setState(IPS_OK);
 
-            if (SlewAccuracyN[0].value < 3 || SlewAccuracyN[1].value < 3)
-                IDSetNumber(&SlewAccuracyNP, "Warning: Setting the slew accuracy too low may result in a dead lock");
+            if (SlewAccuracyNP[0].value < 3 || SlewAccuracyNP[1].getValue() < 3)
+                SlewAccuracyNP.apply("Warning: Setting the slew accuracy too low may result in a dead lock");
 
-            IDSetNumber(&SlewAccuracyNP, nullptr);
+            SlewAccuracyNP.apply();
             return true;
         }
     }
@@ -370,9 +370,9 @@ bool LX200Basic::Abort()
         return false;
     }
 
-    EqNP.s     = IPS_IDLE;
+    EqNP.setState(IPS_IDLE);
     TrackState = SCOPE_IDLE;
-    IDSetNumber(&EqNP, nullptr);
+    EqNP.apply();
 
     LOG_INFO("Slew aborted.");
     return true;
@@ -390,7 +390,7 @@ void LX200Basic::getBasicData()
     getLX200RA(PortFD, &currentRA);
     getLX200DEC(PortFD, &currentDEC);
 
-    IDSetNumber(&EqNP, nullptr);
+    EqNP.apply();
 }
 
 /**************************************************************************************
@@ -467,14 +467,14 @@ void LX200Basic::mountSim()
 ***************************************************************************************/
 void LX200Basic::slewError(int slewCode)
 {
-    EqNP.s = IPS_ALERT;
+    EqNP.setState(IPS_ALERT);
 
     if (slewCode == 1)
-        IDSetNumber(&EqNP, "Object below horizon.");
+        EqNP.apply("Object below horizon.");
     else if (slewCode == 2)
-        IDSetNumber(&EqNP, "Object below the minimum elevation limit.");
+        EqNP.apply("Object below the minimum elevation limit.");
     else
-        IDSetNumber(&EqNP, "Slew failed.");
+        EqNP.apply("Slew failed.");
 }
 
 /**************************************************************************************
@@ -483,6 +483,6 @@ void LX200Basic::slewError(int slewCode)
 bool LX200Basic::saveConfigItems(FILE *fp)
 {
     INDI::Telescope::saveConfigItems(fp);
-    IUSaveConfigNumber(fp, &SlewAccuracyNP);
+    SlewAccuracyNP.save(fp);
     return true;
 }

--- a/drivers/telescope/lx200basic.h
+++ b/drivers/telescope/lx200basic.h
@@ -22,6 +22,9 @@
 
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class LX200Basic : public INDI::Telescope
 {
     public:
@@ -50,8 +53,7 @@ class LX200Basic : public INDI::Telescope
         void slewError(int slewCode);
         void mountSim();
 
-        INumber SlewAccuracyN[2];
-        INumberVectorProperty SlewAccuracyNP;
+        INDI::PropertyNumber SlewAccuracyNP {2};
 
         double targetRA = 0, targetDEC = 0;
         double currentRA = 0, currentDEC = 0;

--- a/drivers/telescope/lx200classic.cpp
+++ b/drivers/telescope/lx200classic.cpp
@@ -45,56 +45,56 @@ bool LX200Classic::initProperties()
     LX200Generic::initProperties();
     SetParkDataType(PARK_AZ_ALT);
 
-    IUFillText(&ObjectInfoT[0], "Info", "", "");
-    IUFillTextVector(&ObjectInfoTP, ObjectInfoT, 1, getDeviceName(), "Object Info", "", MAIN_CONTROL_TAB, IP_RO, 0,
+    ObjectInfoTP[0].fill("Info", "", "");
+    ObjectInfoTP.fill(getDeviceName(), "Object Info", "", MAIN_CONTROL_TAB, IP_RO, 0,
                      IPS_IDLE);
 
-    IUFillSwitch(&StarCatalogS[0], "Star", "", ISS_ON);
-    IUFillSwitch(&StarCatalogS[1], "SAO", "", ISS_OFF);
-    IUFillSwitch(&StarCatalogS[2], "GCVS", "", ISS_OFF);
-    IUFillSwitchVector(&StarCatalogSP, StarCatalogS, 3, getDeviceName(), "Star Catalogs", "", LIBRARY_TAB, IP_RW,
+    StarCatalogSP[0].fill("Star", "", ISS_ON);
+    StarCatalogSP[1].fill("SAO", "", ISS_OFF);
+    StarCatalogSP[2].fill("GCVS", "", ISS_OFF);
+    StarCatalogSP.fill(getDeviceName(), "Star Catalogs", "", LIBRARY_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&DeepSkyCatalogS[0], "NGC", "", ISS_ON);
-    IUFillSwitch(&DeepSkyCatalogS[1], "IC", "", ISS_OFF);
-    IUFillSwitch(&DeepSkyCatalogS[2], "UGC", "", ISS_OFF);
-    IUFillSwitch(&DeepSkyCatalogS[3], "Caldwell", "", ISS_OFF);
-    IUFillSwitch(&DeepSkyCatalogS[4], "Arp", "", ISS_OFF);
-    IUFillSwitch(&DeepSkyCatalogS[5], "Abell", "", ISS_OFF);
-    IUFillSwitch(&DeepSkyCatalogS[6], "Messier", "", ISS_OFF);
-    IUFillSwitchVector(&DeepSkyCatalogSP, DeepSkyCatalogS, 7, getDeviceName(), "Deep Sky Catalogs", "", LIBRARY_TAB,
+    DeepSkyCatalogSP[0].fill("NGC", "", ISS_ON);
+    DeepSkyCatalogSP[1].fill("IC", "", ISS_OFF);
+    DeepSkyCatalogSP[2].fill("UGC", "", ISS_OFF);
+    DeepSkyCatalogSP[3].fill("Caldwell", "", ISS_OFF);
+    DeepSkyCatalogSP[4].fill("Arp", "", ISS_OFF);
+    DeepSkyCatalogSP[5].fill("Abell", "", ISS_OFF);
+    DeepSkyCatalogSP[6].fill("Messier", "", ISS_OFF);
+    DeepSkyCatalogSP.fill(getDeviceName(), "Deep Sky Catalogs", "", LIBRARY_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&SolarS[0], "Select", "Select item", ISS_ON);
-    IUFillSwitch(&SolarS[1], "1", "Mercury", ISS_OFF);
-    IUFillSwitch(&SolarS[2], "2", "Venus", ISS_OFF);
-    IUFillSwitch(&SolarS[3], "3", "Moon", ISS_OFF);
-    IUFillSwitch(&SolarS[4], "4", "Mars", ISS_OFF);
-    IUFillSwitch(&SolarS[5], "5", "Jupiter", ISS_OFF);
-    IUFillSwitch(&SolarS[6], "6", "Saturn", ISS_OFF);
-    IUFillSwitch(&SolarS[7], "7", "Uranus", ISS_OFF);
-    IUFillSwitch(&SolarS[8], "8", "Neptune", ISS_OFF);
-    IUFillSwitch(&SolarS[9], "9", "Pluto", ISS_OFF);
-    IUFillSwitchVector(&SolarSP, SolarS, 10, getDeviceName(), "SOLAR_SYSTEM", "Solar System", LIBRARY_TAB, IP_RW,
+    SolarSP[0].fill("Select", "Select item", ISS_ON);
+    SolarSP[1].fill("1", "Mercury", ISS_OFF);
+    SolarSP[2].fill("2", "Venus", ISS_OFF);
+    SolarSP[3].fill("3", "Moon", ISS_OFF);
+    SolarSP[4].fill("4", "Mars", ISS_OFF);
+    SolarSP[5].fill("5", "Jupiter", ISS_OFF);
+    SolarSP[6].fill("6", "Saturn", ISS_OFF);
+    SolarSP[7].fill("7", "Uranus", ISS_OFF);
+    SolarSP[8].fill("8", "Neptune", ISS_OFF);
+    SolarSP[9].fill("9", "Pluto", ISS_OFF);
+    SolarSP.fill(getDeviceName(), "SOLAR_SYSTEM", "Solar System", LIBRARY_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&ObjectNoN[0], "ObjectN", "Number", "%+03f", 1.0, 1000.0, 1.0, 0);
-    IUFillNumberVector(&ObjectNoNP, ObjectNoN, 1, getDeviceName(), "Object Number", "", LIBRARY_TAB, IP_RW, 0,
+    ObjectNoNP[0].fill("ObjectN", "Number", "%+03f", 1.0, 1000.0, 1.0, 0);
+    ObjectNoNP.fill(getDeviceName(), "Object Number", "", LIBRARY_TAB, IP_RW, 0,
                        IPS_IDLE);
 
-    IUFillNumber(&MaxSlewRateN[0], "RATE", "Rate", "%.2f", 2.0, 9.0, 1.0, 9.0);
-    IUFillNumberVector(&MaxSlewRateNP, MaxSlewRateN, 1, getDeviceName(), "TELESCOPE_MAX_SLEW_RATE", "Slew Rate", MOTION_TAB,
+    MaxSlewRateNP[0].fill("RATE", "Rate", "%.2f", 2.0, 9.0, 1.0, 9.0);
+    MaxSlewRateNP.fill(getDeviceName(), "TELESCOPE_MAX_SLEW_RATE", "Slew Rate", MOTION_TAB,
                        IP_RW, 0, IPS_IDLE);
 
-    IUFillNumber(&ElevationLimitN[0], "MIN_ALT", "Min Alt.", "%+.2f", -90.0, 90.0, 0.0, 0.0);
-    IUFillNumber(&ElevationLimitN[1], "MAX_ALT", "Max Alt", "%+.2f", -90.0, 90.0, 0.0, 0.0);
-    IUFillNumberVector(&ElevationLimitNP, ElevationLimitN, 2, getDeviceName(), "TELESCOPE_ELEVATION_SLEW_LIMIT",
+    ElevationLimitNP[0].fill("MIN_ALT", "Min Alt.", "%+.2f", -90.0, 90.0, 0.0, 0.0);
+    ElevationLimitNP[1].fill("MAX_ALT", "Max Alt", "%+.2f", -90.0, 90.0, 0.0, 0.0);
+    ElevationLimitNP.fill(getDeviceName(), "TELESCOPE_ELEVATION_SLEW_LIMIT",
                        "Slew elevation Limit", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillSwitch(&UnparkAlignmentS[0], "Polar", "", ISS_ON);
-    IUFillSwitch(&UnparkAlignmentS[1], "AltAz", "", ISS_OFF);
-    IUFillSwitch(&UnparkAlignmentS[2], "Land", "", ISS_OFF);
-    IUFillSwitchVector(&UnparkAlignmentSP, UnparkAlignmentS, 3, getDeviceName(), "Unpark Mode", "", SITE_TAB, IP_RW,
+    UnparkAlignmentSP[0].fill("Polar", "", ISS_ON);
+    UnparkAlignmentSP[1].fill("AltAz", "", ISS_OFF);
+    UnparkAlignmentSP[2].fill("Land", "", ISS_OFF);
+    UnparkAlignmentSP.fill(getDeviceName(), "Unpark Mode", "", SITE_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     return true;
@@ -106,44 +106,44 @@ bool LX200Classic::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&ElevationLimitNP);
-        defineProperty(&ObjectInfoTP);
-        defineProperty(&SolarSP);
-        defineProperty(&StarCatalogSP);
-        defineProperty(&DeepSkyCatalogSP);
-        defineProperty(&ObjectNoNP);
-        defineProperty(&MaxSlewRateNP);
-        defineProperty(&UnparkAlignmentSP);
+        defineProperty(ElevationLimitNP);
+        defineProperty(ObjectInfoTP);
+        defineProperty(SolarSP);
+        defineProperty(StarCatalogSP);
+        defineProperty(DeepSkyCatalogSP);
+        defineProperty(ObjectNoNP);
+        defineProperty(MaxSlewRateNP);
+        defineProperty(UnparkAlignmentSP);
 
         if (InitPark())
         {
             // If loading parking data is successful, we just set the default parking values.
             // Default values are poinitng to North or South Pole in AltAz coordinates.
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
         else
         {
             // Otherwise, we set all parking data to default in case no parking data is found.
-            SetAxis1Park(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1Park(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
 
-            SetAxis1ParkDefault(LocationN[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
-            SetAxis2ParkDefault(LocationN[LOCATION_LATITUDE].value);
+            SetAxis1ParkDefault(LocationNP[LOCATION_LATITUDE].value >= 0 ? 0 : 180);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].value);
         }
 
         return true;
     }
     else
     {
-        deleteProperty(ElevationLimitNP.name);
-        deleteProperty(ObjectInfoTP.name);
-        deleteProperty(SolarSP.name);
-        deleteProperty(StarCatalogSP.name);
-        deleteProperty(DeepSkyCatalogSP.name);
-        deleteProperty(ObjectNoNP.name);
-        deleteProperty(MaxSlewRateNP.name);
-        deleteProperty(UnparkAlignmentSP.name);
+        deleteProperty(ElevationLimitNP.getName());
+        deleteProperty(ObjectInfoTP.getName());
+        deleteProperty(SolarSP.getName());
+        deleteProperty(StarCatalogSP.getName());
+        deleteProperty(DeepSkyCatalogSP.getName());
+        deleteProperty(ObjectNoNP.getName());
+        deleteProperty(MaxSlewRateNP.getName());
+        deleteProperty(UnparkAlignmentSP.getName());
 
         return true;
     }
@@ -153,51 +153,51 @@ bool LX200Classic::ISNewNumber(const char *dev, const char *name, double values[
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, ObjectNoNP.name))
+        if (ObjectNoNP.isNameMatch(name))
         {
             char object_name[256] = {0};
 
             if (selectCatalogObject(PortFD, currentCatalog, (int)values[0]) < 0)
             {
-                ObjectNoNP.s = IPS_ALERT;
-                IDSetNumber(&ObjectNoNP, "Failed to select catalog object.");
+                ObjectNoNP.setState(IPS_ALERT);
+                ObjectNoNP.apply("Failed to select catalog object.");
                 return false;
             }
 
             getLX200RA(PortFD, &targetRA);
             getLX200DEC(PortFD, &targetDEC);
 
-            ObjectNoNP.s = IPS_OK;
-            IDSetNumber(&ObjectNoNP, "Object updated.");
+            ObjectNoNP.setState(IPS_OK);
+            ObjectNoNP.apply("Object updated.");
 
             if (getObjectInfo(PortFD, object_name) < 0)
                 IDMessage(getDeviceName(), "Getting object info failed.");
             else
             {
-                IUSaveText(&ObjectInfoTP.tp[0], object_name);
-                IDSetText(&ObjectInfoTP, nullptr);
+                IUSaveText(&ObjectInfoTP[0], object_name);
+                ObjectInfoTP.apply();
             }
 
             Goto(targetRA, targetDEC);
             return true;
         }
 
-        if (!strcmp(name, MaxSlewRateNP.name))
+        if (MaxSlewRateNP.isNameMatch(name))
         {
             if (setMaxSlewRate(PortFD, (int)values[0]) < 0)
             {
-                MaxSlewRateNP.s = IPS_ALERT;
-                IDSetNumber(&MaxSlewRateNP, "Error setting maximum slew rate.");
+                MaxSlewRateNP.setState(IPS_ALERT);
+                MaxSlewRateNP.apply("Error setting maximum slew rate.");
                 return false;
             }
 
-            MaxSlewRateNP.s           = IPS_OK;
-            MaxSlewRateNP.np[0].value = values[0];
-            IDSetNumber(&MaxSlewRateNP, nullptr);
+            MaxSlewRateNP.setState(IPS_OK);
+            MaxSlewRateNP[0].setValue(values[0]);
+            MaxSlewRateNP.apply();
             return true;
         }
 
-        if (!strcmp(name, ElevationLimitNP.name))
+        if (ElevationLimitNP.isNameMatch(name))
         {
             // new elevation limits
             double minAlt = 0, maxAlt = 0;
@@ -205,13 +205,13 @@ bool LX200Classic::ISNewNumber(const char *dev, const char *name, double values[
 
             for (nset = i = 0; i < n; i++)
             {
-                INumber *altp = IUFindNumber(&ElevationLimitNP, names[i]);
-                if (altp == &ElevationLimitN[0])
+                INumber *altp = ElevationLimitNP.findWidgetByName(names[i]);
+                if (altp == &ElevationLimitNP[0])
                 {
                     minAlt = values[i];
                     nset += minAlt >= -90.0 && minAlt <= 90.0;
                 }
-                else if (altp == &ElevationLimitN[1])
+                else if (altp == &ElevationLimitNP[1])
                 {
                     maxAlt = values[i];
                     nset += maxAlt >= -90.0 && maxAlt <= 90.0;
@@ -221,22 +221,22 @@ bool LX200Classic::ISNewNumber(const char *dev, const char *name, double values[
             {
                 if (setMinElevationLimit(PortFD, (int)minAlt) < 0)
                 {
-                    ElevationLimitNP.s = IPS_ALERT;
-                    IDSetNumber(&ElevationLimitNP, "Error setting elevation limit.");
+                    ElevationLimitNP.setState(IPS_ALERT);
+                    ElevationLimitNP.apply("Error setting elevation limit.");
                     return false;
                 }
 
                 setMaxElevationLimit(PortFD, (int)maxAlt);
-                ElevationLimitNP.np[0].value = minAlt;
-                ElevationLimitNP.np[1].value = maxAlt;
-                ElevationLimitNP.s           = IPS_OK;
-                IDSetNumber(&ElevationLimitNP, nullptr);
+                ElevationLimitNP[0].setValue(minAlt);
+                ElevationLimitNP[1].setValue(maxAlt);
+                ElevationLimitNP.setState(IPS_OK);
+                ElevationLimitNP.apply();
                 return true;
             }
             else
             {
-                ElevationLimitNP.s = IPS_IDLE;
-                IDSetNumber(&ElevationLimitNP, "elevation limit missing or invalid.");
+                ElevationLimitNP.setState(IPS_IDLE);
+                ElevationLimitNP.apply("elevation limit missing or invalid.");
                 return false;
             }
         }
@@ -252,41 +252,41 @@ bool LX200Classic::ISNewSwitch(const char *dev, const char *name, ISState *state
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Star Catalog
-        if (!strcmp(name, StarCatalogSP.name))
+        if (StarCatalogSP.isNameMatch(name))
         {
-            IUResetSwitch(&StarCatalogSP);
-            IUUpdateSwitch(&StarCatalogSP, states, names, n);
-            index = IUFindOnSwitchIndex(&StarCatalogSP);
+            StarCatalogSP.reset();
+            StarCatalogSP.update(states, names, n);
+            index = StarCatalogSP.findOnSwitchIndex();
 
             currentCatalog = LX200_STAR_C;
 
             if (selectSubCatalog(PortFD, currentCatalog, index))
             {
                 currentSubCatalog = index;
-                StarCatalogSP.s   = IPS_OK;
-                IDSetSwitch(&StarCatalogSP, nullptr);
+                StarCatalogSP.setState(IPS_OK);
+                StarCatalogSP.apply();
                 return true;
             }
             else
             {
-                StarCatalogSP.s = IPS_IDLE;
-                IDSetSwitch(&StarCatalogSP, "Catalog unavailable.");
+                StarCatalogSP.setState(IPS_IDLE);
+                StarCatalogSP.apply("Catalog unavailable.");
                 return false;
             }
         }
 
         // Deep sky catalog
-        if (!strcmp(name, DeepSkyCatalogSP.name))
+        if (DeepSkyCatalogSP.isNameMatch(name))
         {
-            IUResetSwitch(&DeepSkyCatalogSP);
-            IUUpdateSwitch(&DeepSkyCatalogSP, states, names, n);
-            index = IUFindOnSwitchIndex(&DeepSkyCatalogSP);
+            DeepSkyCatalogSP.reset();
+            DeepSkyCatalogSP.update(states, names, n);
+            index = DeepSkyCatalogSP.findOnSwitchIndex();
 
             if (index == LX200_MESSIER_C)
             {
                 currentCatalog     = index;
-                DeepSkyCatalogSP.s = IPS_OK;
-                IDSetSwitch(&DeepSkyCatalogSP, nullptr);
+                DeepSkyCatalogSP.setState(IPS_OK);
+                DeepSkyCatalogSP.apply();
             }
             else
                 currentCatalog = LX200_DEEPSKY_C;
@@ -294,13 +294,13 @@ bool LX200Classic::ISNewSwitch(const char *dev, const char *name, ISState *state
             if (selectSubCatalog(PortFD, currentCatalog, index))
             {
                 currentSubCatalog  = index;
-                DeepSkyCatalogSP.s = IPS_OK;
-                IDSetSwitch(&DeepSkyCatalogSP, nullptr);
+                DeepSkyCatalogSP.setState(IPS_OK);
+                DeepSkyCatalogSP.apply();
             }
             else
             {
-                DeepSkyCatalogSP.s = IPS_IDLE;
-                IDSetSwitch(&DeepSkyCatalogSP, "Catalog unavailable");
+                DeepSkyCatalogSP.setState(IPS_IDLE);
+                DeepSkyCatalogSP.apply("Catalog unavailable");
                 return false;
             }
 
@@ -308,30 +308,30 @@ bool LX200Classic::ISNewSwitch(const char *dev, const char *name, ISState *state
         }
 
         // Solar system
-        if (!strcmp(name, SolarSP.name))
+        if (SolarSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&SolarSP, states, names, n) < 0)
+            if (!SolarSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&SolarSP);
+            index = SolarSP.findOnSwitchIndex();
 
             // We ignore the first option : "Select item"
             if (index == 0)
             {
-                SolarSP.s = IPS_IDLE;
-                IDSetSwitch(&SolarSP, nullptr);
+                SolarSP.setState(IPS_IDLE);
+                SolarSP.apply();
                 return true;
             }
 
             selectSubCatalog(PortFD, LX200_STAR_C, LX200_STAR);
             selectCatalogObject(PortFD, LX200_STAR_C, index + 900);
 
-            ObjectNoNP.s = IPS_OK;
-            SolarSP.s    = IPS_OK;
+            ObjectNoNP.setState(IPS_OK);
+            SolarSP.setState(IPS_OK);
 
-            getObjectInfo(PortFD, ObjectInfoTP.tp[0].text);
-            IDSetNumber(&ObjectNoNP, "Object updated.");
-            IDSetSwitch(&SolarSP, nullptr);
+            getObjectInfo(PortFD, ObjectInfoTP[0].text);
+            ObjectNoNP.apply("Object updated.");
+            SolarSP.apply();
 
             if (currentCatalog == LX200_STAR_C || currentCatalog == LX200_DEEPSKY_C)
                 selectSubCatalog(PortFD, currentCatalog, currentSubCatalog);
@@ -345,11 +345,11 @@ bool LX200Classic::ISNewSwitch(const char *dev, const char *name, ISState *state
         }
 
         // Unpark Alignment Mode
-        if (!strcmp(name, UnparkAlignmentSP.name))
+        if (UnparkAlignmentSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&UnparkAlignmentSP, states, names, n);
-            UnparkAlignmentSP.s = IPS_OK;
-            IDSetSwitch(&UnparkAlignmentSP, nullptr);
+            UnparkAlignmentSP.update(states, names, n);
+            UnparkAlignmentSP.setState(IPS_OK);
+            UnparkAlignmentSP.apply();
 
             return true;
         }
@@ -363,10 +363,10 @@ bool LX200Classic::saveConfigItems(FILE *fp)
 {
     LX200Generic::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &MaxSlewRateNP);
-    IUSaveConfigNumber(fp, &ElevationLimitNP);
+    MaxSlewRateNP.save(fp);
+    ElevationLimitNP.save(fp);
 
-    IUSaveConfigSwitch(fp, &UnparkAlignmentSP);
+    UnparkAlignmentSP.save(fp);
 
     return true;
 }
@@ -389,21 +389,21 @@ bool LX200Classic::Park()
 
     //save the current AlignmentMode to UnparkAlignment
     LX200Generic::getAlignment();
-    int curAlignment = IUFindOnSwitchIndex(&AlignmentSP);
-    IUResetSwitch(&UnparkAlignmentSP);
-    UnparkAlignmentS[curAlignment].s = ISS_ON;
-    UnparkAlignmentSP.s = IPS_OK;
-    IDSetSwitch(&UnparkAlignmentSP, nullptr);
-    saveConfig(true, UnparkAlignmentSP.name);
+    int curAlignment = AlignmentSP.findOnSwitchIndex();
+    UnparkAlignmentSP.reset();
+    UnparkAlignmentSP[curAlignment].setState(ISS_ON);
+    UnparkAlignmentSP.setState(IPS_OK);
+    UnparkAlignmentSP.apply();
+    saveConfig(true, UnparkAlignmentSP.getName());
 
     if (!Goto(parkRA, parkDEC))
     {
-        ParkSP.s = IPS_ALERT;
-        IDSetSwitch(&ParkSP, "Parking Failed.");
+        ParkSP.setState(IPS_ALERT);
+        ParkSP.apply("Parking Failed.");
         return false;
     }
 
-    EqNP.s     = IPS_BUSY;
+    EqNP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking is in progress...");
 
@@ -415,11 +415,11 @@ bool LX200Classic::UnPark()
     if (isSimulation() == false)
     {
         // Parked in Land alignment. Restore previous mode.
-        if (setAlignmentMode(PortFD, IUFindOnSwitchIndex(&UnparkAlignmentSP)) < 0)
+        if (setAlignmentMode(PortFD, UnparkAlignmentSP.findOnSwitchIndex()) < 0)
         {
             LOG_ERROR("UnParking Failed.");
-            AlignmentSP.s = IPS_ALERT;
-            IDSetSwitch(&AlignmentSP, "Error setting alignment mode.");
+            AlignmentSP.setState(IPS_ALERT);
+            AlignmentSP.apply("Error setting alignment mode.");
             return false;
         }
         //Update the UI
@@ -484,10 +484,10 @@ bool LX200Classic::SetCurrentPark()
 bool LX200Classic::SetDefaultPark()
 {
     // Az = 0 for North hemisphere
-    SetAxis1Park(LocationN[LOCATION_LATITUDE].value > 0 ? 0 : 180);
+    SetAxis1Park(LocationNP[LOCATION_LATITUDE].value > 0 ? 0 : 180);
 
     // Alt = Latitude
-    SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+    SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
 
     return true;
 }
@@ -505,8 +505,8 @@ bool LX200Classic::ReadScopeStatus()
         if (setAlignmentMode(PortFD, LX200_ALIGN_LAND) < 0)
         {
             LOG_ERROR("Parking Failed.");
-            AlignmentSP.s = IPS_ALERT;
-            IDSetSwitch(&AlignmentSP, "Error setting alignment mode.");
+            AlignmentSP.setState(IPS_ALERT);
+            AlignmentSP.apply("Error setting alignment mode.");
             return false;
         }
         //Update the UI
@@ -532,8 +532,8 @@ bool LX200Classic::ReadScopeStatus()
 void LX200Classic::azAltToRaDecNow(double az, double alt, double &ra, double &dec)
 {
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 
@@ -556,8 +556,8 @@ void LX200Classic::azAltToRaDecNow(double az, double alt, double &ra, double &de
 void LX200Classic::raDecToAzAltNow(double ra, double dec, double &az, double &alt)
 {
     ln_lnlat_posn observer;
-    observer.lat = LocationN[LOCATION_LATITUDE].value;
-    observer.lng = LocationN[LOCATION_LONGITUDE].value;
+    observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     if (observer.lng > 180)
         observer.lng -= 360;
 

--- a/drivers/telescope/lx200classic.h
+++ b/drivers/telescope/lx200classic.h
@@ -22,6 +22,11 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200Classic : public LX200Generic
 {
     public:
@@ -46,30 +51,14 @@ class LX200Classic : public LX200Generic
         virtual bool ReadScopeStatus() override;
 
     private:
-
-        ITextVectorProperty ObjectInfoTP;
-        IText ObjectInfoT[1] {};
-
-        ISwitchVectorProperty StarCatalogSP;
-        ISwitch StarCatalogS[3];
-
-        ISwitchVectorProperty DeepSkyCatalogSP;
-        ISwitch DeepSkyCatalogS[7];
-
-        ISwitchVectorProperty SolarSP;
-        ISwitch SolarS[10];
-
-        INumberVectorProperty ObjectNoNP;
-        INumber ObjectNoN[1];
-
-        INumberVectorProperty MaxSlewRateNP;
-        INumber MaxSlewRateN[1];
-
-        INumberVectorProperty ElevationLimitNP;
-        INumber ElevationLimitN[2];
-        
-        ISwitchVectorProperty UnparkAlignmentSP;
-        ISwitch UnparkAlignmentS[3];
+        INDI::PropertyText ObjectInfoTP {1};
+        INDI::PropertySwitch StarCatalogSP {3};
+        INDI::PropertySwitch DeepSkyCatalogSP {7};
+        INDI::PropertySwitch SolarSP {10};
+        INDI::PropertyNumber ObjectNoNP {1};
+        INDI::PropertyNumber MaxSlewRateNP {1};
+        INDI::PropertyNumber ElevationLimitNP {2};
+        INDI::PropertySwitch UnparkAlignmentSP {3};
 
     private:
         int currentCatalog {0};

--- a/drivers/telescope/lx200fs2.h
+++ b/drivers/telescope/lx200fs2.h
@@ -22,6 +22,10 @@
 #include "lx200generic.h"
 #include "alignment/AlignmentSubsystemForDrivers.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200FS2 : public LX200Generic
 {
     public:
@@ -56,11 +60,8 @@ class LX200FS2 : public LX200Generic
         // Fake Location
         virtual bool updateLocation(double latitude, double longitude, double elevation) override;
 
-        INumber SlewAccuracyN[2];
-        INumberVectorProperty SlewAccuracyNP;
-
-        ISwitchVectorProperty StopAfterParkSP;
-        ISwitch StopAfterParkS[2];
+        INDI::PropertyNumber SlewAccuracyNP {2};
+        INDI::PropertySwitch StopAfterParkSP {2};
         bool MotorsParked;
         enum TelescopeSlewRate savedSlewRateIndex {SLEW_MAX};
         enum TelescopeParkedStatus

--- a/drivers/telescope/lx200gemini.cpp
+++ b/drivers/telescope/lx200gemini.cpp
@@ -83,11 +83,11 @@ void LX200Gemini::ISGetProperties(const char *dev)
 
     // Read config from file
     int index = 0;
-    if (IUGetConfigOnSwitch(&StartupModeSP, &index) == 0)
+    if (IUGetConfigOnSwitch(StartupModeSP.getSwitch(), &index) == 0) // #PS: refactor needed
     {
-        IUResetSwitch(&StartupModeSP);
-        StartupModeSP.sp[index].s = ISS_ON;
-        defineProperty(&StartupModeSP);
+        StartupModeSP.reset();
+        StartupModeSP[index].setState(ISS_ON);
+        defineProperty(StartupModeSP);
     }
 }
 
@@ -96,36 +96,36 @@ bool LX200Gemini::initProperties()
     LX200Generic::initProperties();
 
     // Park Option
-    IUFillSwitch(&ParkSettingsS[PARK_HOME], "HOME", "Home", ISS_ON);
-    IUFillSwitch(&ParkSettingsS[PARK_STARTUP], "STARTUP", "Startup", ISS_OFF);
-    IUFillSwitch(&ParkSettingsS[PARK_ZENITH], "ZENITH", "Zenith", ISS_OFF);
-    IUFillSwitchVector(&ParkSettingsSP, ParkSettingsS, 3, getDeviceName(), "PARK_SETTINGS", "Park Settings",
+    ParkSettingsSP[PARK_HOME].fill("HOME", "Home", ISS_ON);
+    ParkSettingsSP[PARK_STARTUP].fill("STARTUP", "Startup", ISS_OFF);
+    ParkSettingsSP[PARK_ZENITH].fill("ZENITH", "Zenith", ISS_OFF);
+    ParkSettingsSP.fill(getDeviceName(), "PARK_SETTINGS", "Park Settings",
                        MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
-    IUFillSwitch(&StartupModeS[COLD_START], "COLD_START", "Cold", ISS_ON);
-    IUFillSwitch(&StartupModeS[PARK_STARTUP], "WARM_START", "Warm", ISS_OFF);
-    IUFillSwitch(&StartupModeS[PARK_ZENITH], "WARM_RESTART", "Restart", ISS_OFF);
-    IUFillSwitchVector(&StartupModeSP, StartupModeS, 3, getDeviceName(), "STARTUP_MODE", "Startup Mode",
+    StartupModeSP[COLD_START].fill("COLD_START", "Cold", ISS_ON);
+    StartupModeSP[PARK_STARTUP].fill("WARM_START", "Warm", ISS_OFF);
+    StartupModeSP[PARK_ZENITH].fill("WARM_RESTART", "Restart", ISS_OFF);
+    StartupModeSP.fill(getDeviceName(), "STARTUP_MODE", "Startup Mode",
                        MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&ManualSlewingSpeedN[0], "MANUAL_SLEWING_SPEED", "Manual Slewing Speed", "%g", 20, 2000., 10., 800);
-    IUFillNumberVector(&ManualSlewingSpeedNP, ManualSlewingSpeedN, 1, getDeviceName(), "MANUAL_SLEWING_SPEED",
+    ManualSlewingSpeedNP[0].fill("MANUAL_SLEWING_SPEED", "Manual Slewing Speed", "%g", 20, 2000., 10., 800);
+    ManualSlewingSpeedNP.fill(getDeviceName(), "MANUAL_SLEWING_SPEED",
                        "Manual Slewing Speed", MOTION_TAB, IP_RW,  0, IPS_IDLE);
 
-    IUFillNumber(&GotoSlewingSpeedN[0], "GOTO_SLEWING_SPEED", "Goto Slewing Speed", "%g", 20, 2000., 10., 800);
-    IUFillNumberVector(&GotoSlewingSpeedNP, GotoSlewingSpeedN, 1, getDeviceName(), "GOTO_SLEWING_SPEED", "Goto Slewing Speed",
+    GotoSlewingSpeedNP[0].fill("GOTO_SLEWING_SPEED", "Goto Slewing Speed", "%g", 20, 2000., 10., 800);
+    GotoSlewingSpeedNP.fill(getDeviceName(), "GOTO_SLEWING_SPEED", "Goto Slewing Speed",
                        MOTION_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillNumber(&MoveSpeedN[0], "MOVE_SPEED", "Move Speed", "%g", 20, 2000., 10., 10);
-    IUFillNumberVector(&MoveSpeedNP, MoveSpeedN, 1, getDeviceName(), "MOVE_SLEWING_SPEED", "Move Slewing Speed", MOTION_TAB,
+    MoveSpeedNP[0].fill("MOVE_SPEED", "Move Speed", "%g", 20, 2000., 10., 10);
+    MoveSpeedNP.fill(getDeviceName(), "MOVE_SLEWING_SPEED", "Move Slewing Speed", MOTION_TAB,
                        IP_RW, 0, IPS_IDLE);
 
-    IUFillNumber(&GuidingSpeedN[0], "GUIDING_SPEED", "Guiding Speed", "%g", 0.2, 0.8, 0.1, 0.5);
-    IUFillNumberVector(&GuidingSpeedNP, GuidingSpeedN, 1, getDeviceName(), "GUIDING_SLEWING_SPEED", "Guiding Slewing Speed",
+    GuidingSpeedNP[0].fill("GUIDING_SPEED", "Guiding Speed", "%g", 0.2, 0.8, 0.1, 0.5);
+    GuidingSpeedNP.fill(getDeviceName(), "GUIDING_SLEWING_SPEED", "Guiding Slewing Speed",
                        GUIDE_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillNumber(&CenteringSpeedN[0], "CENTERING_SPEED", "Centering Speed", "%g", 20, 2000., 10., 10);
-    IUFillNumberVector(&CenteringSpeedNP, CenteringSpeedN, 1, getDeviceName(), "CENTERING_SLEWING_SPEED",
+    CenteringSpeedNP[0].fill("CENTERING_SPEED", "Centering Speed", "%g", 20, 2000., 10., 10);
+    CenteringSpeedNP.fill(getDeviceName(), "CENTERING_SLEWING_SPEED",
                        "Centering Slewing Speed", MOTION_TAB, IP_RW, 0, IPS_IDLE);
 
     IUFillSwitch(&TrackModeS[GEMINI_TRACK_SIDEREAL], "TRACK_SIDEREAL", "Sidereal", ISS_ON);
@@ -145,38 +145,38 @@ bool LX200Gemini::updateProperties()
     {
         uint32_t speed = 0;
         char value[MAX_VALUE_LENGTH] = {0};
-        defineProperty(&ParkSettingsSP);
+        defineProperty(ParkSettingsSP);
 
         if (getGeminiProperty(MANUAL_SLEWING_SPEED_ID, value))
         {
             sscanf(value, "%u", &speed);
-            ManualSlewingSpeedN[0].value = speed;
-            defineProperty(&ManualSlewingSpeedNP);
+            ManualSlewingSpeedNP[0].setValue(speed);
+            defineProperty(ManualSlewingSpeedNP);
         }
         if (getGeminiProperty(GOTO_SLEWING_SPEED_ID, value))
         {
             sscanf(value, "%u", &speed);
-            GotoSlewingSpeedN[0].value = speed;
-            defineProperty(&GotoSlewingSpeedNP);
+            GotoSlewingSpeedNP[0].setValue(speed);
+            defineProperty(GotoSlewingSpeedNP);
         }
         if (getGeminiProperty(MOVE_SPEED_ID, value))
         {
             sscanf(value, "%u", &speed);
-            MoveSpeedN[0].value = speed;
-            defineProperty(&MoveSpeedNP);
+            MoveSpeedNP[0].setValue(speed);
+            defineProperty(MoveSpeedNP);
         }
         if (getGeminiProperty(GUIDING_SPEED_ID, value))
         {
             float guidingSpeed = 0.0;
             sscanf(value, "%f", &guidingSpeed);
-            GuidingSpeedN[0].value = guidingSpeed;
-            defineProperty(&GuidingSpeedNP);
+            GuidingSpeedNP[0].setValue(guidingSpeed);
+            defineProperty(GuidingSpeedNP);
         }
         if (getGeminiProperty(CENTERING_SPEED_ID, value))
         {
             sscanf(value, "%u", &speed);
-            CenteringSpeedN[0].value = speed;
-            defineProperty(&CenteringSpeedNP);
+            CenteringSpeedNP[0].setValue(speed);
+            defineProperty(CenteringSpeedNP);
         }
 
         updateParkingState();
@@ -184,12 +184,12 @@ bool LX200Gemini::updateProperties()
     }
     else
     {
-        deleteProperty(ParkSettingsSP.name);
-        deleteProperty(ManualSlewingSpeedNP.name);
-        deleteProperty(GotoSlewingSpeedNP.name);
-        deleteProperty(MoveSpeedNP.name);
-        deleteProperty(GuidingSpeedNP.name);
-        deleteProperty(CenteringSpeedNP.name);
+        deleteProperty(ParkSettingsSP.getName());
+        deleteProperty(ManualSlewingSpeedNP.getName());
+        deleteProperty(GotoSlewingSpeedNP.getName());
+        deleteProperty(MoveSpeedNP.getName());
+        deleteProperty(GuidingSpeedNP.getName());
+        deleteProperty(CenteringSpeedNP.getName());
     }
 
     return true;
@@ -199,21 +199,21 @@ bool LX200Gemini::ISNewSwitch(const char *dev, const char *name, ISState *states
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, StartupModeSP.name))
+        if (StartupModeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&StartupModeSP, states, names, n);
-            StartupModeSP.s = IPS_OK;
+            StartupModeSP.update(states, names, n);
+            StartupModeSP.setState(IPS_OK);
             if (isConnected())
                 LOG_INFO("Startup mode will take effect on future connections.");
-            IDSetSwitch(&StartupModeSP, nullptr);
+            StartupModeSP.apply();
             return true;
         }
 
-        if (!strcmp(name, ParkSettingsSP.name))
+        if (ParkSettingsSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ParkSettingsSP, states, names, n);
-            ParkSettingsSP.s = IPS_OK;
-            IDSetSwitch(&ParkSettingsSP, nullptr);
+            ParkSettingsSP.update(states, names, n);
+            ParkSettingsSP.setState(IPS_OK);
+            ParkSettingsSP.apply();
             return true;
         }
     }
@@ -228,58 +228,58 @@ bool LX200Gemini::ISNewNumber(const char *dev, const char *name, double values[]
         char valueString[16] = {0};
         snprintf(valueString, 16, "%2.0f", values[0]);
 
-        if (!strcmp(name, ManualSlewingSpeedNP.name))
+        if (ManualSlewingSpeedNP.isNameMatch(name))
         {
             LOGF_DEBUG("Trying to set manual slewing speed of: %f", values[0]);
 
             if (!isSimulation() && !setGeminiProperty(MANUAL_SLEWING_SPEED_ID, valueString))
             {
-                ManualSlewingSpeedNP.s = IPS_ALERT;
-                IDSetNumber(&ManualSlewingSpeedNP, "Error setting manual slewing speed");
+                ManualSlewingSpeedNP.setState(IPS_ALERT);
+                ManualSlewingSpeedNP.apply("Error setting manual slewing speed");
                 return false;
             }
 
-            ManualSlewingSpeedNP.s    = IPS_OK;
-            ManualSlewingSpeedN[0].value = values[0];
-            IDSetNumber(&ManualSlewingSpeedNP, "Manual slewing speed set to %f", values[0]);
+            ManualSlewingSpeedNP.setState(IPS_OK);
+            ManualSlewingSpeedNP[0].setValue(values[0]);
+            ManualSlewingSpeedNP.apply("Manual slewing speed set to %f", values[0]);
 
             return true;
         }
-        if (!strcmp(name, GotoSlewingSpeedNP.name))
+        if (GotoSlewingSpeedNP.isNameMatch(name))
         {
             LOGF_DEBUG("Trying to set goto slewing speed of: %f", values[0]);
 
             if (!isSimulation() && !setGeminiProperty(GOTO_SLEWING_SPEED_ID, valueString))
             {
-                GotoSlewingSpeedNP.s = IPS_ALERT;
-                IDSetNumber(&GotoSlewingSpeedNP, "Error setting goto slewing speed");
+                GotoSlewingSpeedNP.setState(IPS_ALERT);
+                GotoSlewingSpeedNP.apply("Error setting goto slewing speed");
                 return false;
             }
 
-            GotoSlewingSpeedNP.s       = IPS_OK;
-            GotoSlewingSpeedN[0].value = values[0];
-            IDSetNumber(&GotoSlewingSpeedNP, "Goto slewing speed set to %f", values[0]);
+            GotoSlewingSpeedNP.setState(IPS_OK);
+            GotoSlewingSpeedNP[0].setValue(values[0]);
+            GotoSlewingSpeedNP.apply("Goto slewing speed set to %f", values[0]);
 
             return true;
         }
-        if (!strcmp(name, MoveSpeedNP.name))
+        if (MoveSpeedNP.isNameMatch(name))
         {
             LOGF_DEBUG("Trying to set move speed of: %f", values[0]);
 
             if (!isSimulation() && !setGeminiProperty(MOVE_SPEED_ID, valueString))
             {
-                MoveSpeedNP.s = IPS_ALERT;
-                IDSetNumber(&MoveSpeedNP, "Error setting move speed");
+                MoveSpeedNP.setState(IPS_ALERT);
+                MoveSpeedNP.apply("Error setting move speed");
                 return false;
             }
 
-            MoveSpeedNP.s       = IPS_OK;
-            MoveSpeedN[0].value = values[0];
-            IDSetNumber(&MoveSpeedNP, "Move speed set to %f", values[0]);
+            MoveSpeedNP.setState(IPS_OK);
+            MoveSpeedNP[0].setValue(values[0]);
+            MoveSpeedNP.apply("Move speed set to %f", values[0]);
 
             return true;
         }
-        if (!strcmp(name, GuidingSpeedNP.name))
+        if (GuidingSpeedNP.isNameMatch(name))
         {
             LOGF_DEBUG("Trying to set guiding speed of: %f", values[0]);
 
@@ -288,31 +288,31 @@ bool LX200Gemini::ISNewNumber(const char *dev, const char *name, double values[]
 
             if (!isSimulation() && !setGeminiProperty(GUIDING_SPEED_ID, valueString))
             {
-                GuidingSpeedNP.s = IPS_ALERT;
-                IDSetNumber(&GuidingSpeedNP, "Error setting guiding speed");
+                GuidingSpeedNP.setState(IPS_ALERT);
+                GuidingSpeedNP.apply("Error setting guiding speed");
                 return false;
             }
 
-            GuidingSpeedNP.s       = IPS_OK;
-            GuidingSpeedN[0].value = values[0];
-            IDSetNumber(&GuidingSpeedNP, "Guiding speed set to %f", values[0]);
+            GuidingSpeedNP.setState(IPS_OK);
+            GuidingSpeedNP[0].setValue(values[0]);
+            GuidingSpeedNP.apply("Guiding speed set to %f", values[0]);
 
             return true;
         }
-        if (!strcmp(name, CenteringSpeedNP.name))
+        if (CenteringSpeedNP.isNameMatch(name))
         {
             LOGF_DEBUG("Trying to set centering speed of: %f", values[0]);
 
             if (!isSimulation() && !setGeminiProperty(CENTERING_SPEED_ID, valueString))
             {
-                CenteringSpeedNP.s = IPS_ALERT;
-                IDSetNumber(&CenteringSpeedNP, "Error setting centering speed");
+                CenteringSpeedNP.setState(IPS_ALERT);
+                CenteringSpeedNP.apply("Error setting centering speed");
                 return false;
             }
 
-            CenteringSpeedNP.s       = IPS_OK;
-            CenteringSpeedN[0].value = values[0];
-            IDSetNumber(&CenteringSpeedNP, "Centering speed set to %f", values[0]);
+            CenteringSpeedNP.setState(IPS_OK);
+            CenteringSpeedNP[0].setValue(values[0]);
+            CenteringSpeedNP.apply("Centering speed set to %f", values[0]);
 
             return true;
         }
@@ -365,7 +365,7 @@ bool LX200Gemini::checkConnection()
     {
         LOG_DEBUG("Mount is waiting for selection of the startup mode.");
         char cmd[4]     = "bC#";
-        int startupMode = IUFindOnSwitchIndex(&StartupModeSP);
+        int startupMode = StartupModeSP.findOnSwitchIndex();
         if (startupMode == WARM_START)
             strncpy(cmd, "bW#", 4);
         else if (startupMode == WARM_RESTART)
@@ -437,8 +437,8 @@ bool LX200Gemini::ReadScopeStatus()
     {
         updateMovementState();
 
-        EqNP.s = IPS_BUSY;
-        IDSetNumber(&EqNP, NULL);
+        EqNP.setState(IPS_BUSY);
+        EqNP.apply(NULL);
 
         // Check if LX200 is done slewing
         if (isSlewComplete())
@@ -448,8 +448,8 @@ bool LX200Gemini::ReadScopeStatus()
             SlewRateS[SLEW_CENTERING].s = ISS_ON;
             IDSetSwitch(&SlewRateSP, nullptr);
 
-            EqNP.s = IPS_OK;
-            IDSetNumber(&EqNP, NULL);
+            EqNP.setState(IPS_OK);
+            EqNP.apply(NULL);
 
             LOG_INFO("Slew is complete. Tracking...");
         }
@@ -464,8 +464,8 @@ bool LX200Gemini::ReadScopeStatus()
             SetParked(true);
             sleepMount();
 
-            EqNP.s = IPS_IDLE;
-            IDSetNumber(&EqNP, NULL);
+            EqNP.setState(IPS_IDLE);
+            EqNP.apply(NULL);
 
             return true;
         }
@@ -522,7 +522,7 @@ void LX200Gemini::syncSideOfPier()
     // see https://www.indilib.org/forum/general/6785-side-of-pier-problem-bug.html?start=12#52492
     // for a description of the problem and the proposed fix
     //
-    auto lst = get_local_sidereal_time(this->LocationN[LOCATION_LONGITUDE].value);
+    auto lst = get_local_sidereal_time(this->LocationNP[LOCATION_LONGITUDE].getValue());
     auto ha = rangeHA(lst - currentRA);
     auto pointingState = PIER_UNKNOWN;
 
@@ -552,7 +552,7 @@ bool LX200Gemini::Park()
 {
     char cmd[6] = ":hP#";
 
-    int parkSetting = IUFindOnSwitchIndex(&ParkSettingsSP);
+    int parkSetting = ParkSettingsSP.findOnSwitchIndex();
 
     if (parkSetting == PARK_STARTUP)
         strncpy(cmd, ":hC#", 5);
@@ -576,7 +576,7 @@ bool LX200Gemini::Park()
 
     tcflush(PortFD, TCIOFLUSH);
 
-    ParkSP.s   = IPS_BUSY;
+    ParkSP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
 
     updateParkingState();
@@ -804,8 +804,8 @@ bool LX200Gemini::saveConfigItems(FILE *fp)
 {
     LX200Generic::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &StartupModeSP);
-    IUSaveConfigSwitch(fp, &ParkSettingsSP);
+    StartupModeSP.save(fp);
+    ParkSettingsSP.save(fp);
 
     return true;
 }

--- a/drivers/telescope/lx200gemini.h
+++ b/drivers/telescope/lx200gemini.h
@@ -28,6 +28,10 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200Gemini : public LX200Generic
 {
     public:
@@ -70,23 +74,17 @@ class LX200Gemini : public LX200Generic
         // Checksum for private commands
         uint8_t calculateChecksum(char *cmd);
 
-        INumber ManualSlewingSpeedN[1];
-        INumberVectorProperty ManualSlewingSpeedNP;
+        INDI::PropertyNumber ManualSlewingSpeedNP {1};
 
-        INumber GotoSlewingSpeedN[1];
-        INumberVectorProperty GotoSlewingSpeedNP;
+        INDI::PropertyNumber GotoSlewingSpeedNP {1};
 
-        INumber MoveSpeedN[1];
-        INumberVectorProperty MoveSpeedNP;
+        INDI::PropertyNumber MoveSpeedNP {1};
 
-        INumber GuidingSpeedN[1];
-        INumberVectorProperty GuidingSpeedNP;
+        INDI::PropertyNumber GuidingSpeedNP {1};
 
-        INumber CenteringSpeedN[1];
-        INumberVectorProperty CenteringSpeedNP;
+        INDI::PropertyNumber CenteringSpeedNP {1};
 
-        ISwitch ParkSettingsS[3];
-        ISwitchVectorProperty ParkSettingsSP;
+        INDI::PropertySwitch ParkSettingsSP {3};
         enum
         {
             PARK_HOME,
@@ -94,8 +92,7 @@ class LX200Gemini : public LX200Generic
             PARK_ZENITH
         };
 
-        ISwitch StartupModeS[3];
-        ISwitchVectorProperty StartupModeSP;
+        INDI::PropertySwitch StartupModeSP {3};
         enum
         {
             COLD_START,

--- a/drivers/telescope/lx200gotonova.cpp
+++ b/drivers/telescope/lx200gotonova.cpp
@@ -58,26 +58,26 @@ bool LX200GotoNova::initProperties()
     strcpy(SlewRateS[3].label, "512x");
 
     // Sync Type
-    IUFillSwitch(&SyncCMRS[USE_REGULAR_SYNC], ":CM#", ":CM#", ISS_ON);
-    IUFillSwitch(&SyncCMRS[USE_CMR_SYNC], ":CMR#", ":CMR#", ISS_OFF);
-    IUFillSwitchVector(&SyncCMRSP, SyncCMRS, 2, getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    SyncCMRSP[USE_REGULAR_SYNC].fill(":CM#", ":CM#", ISS_ON);
+    SyncCMRSP[USE_CMR_SYNC].fill(":CMR#", ":CMR#", ISS_OFF);
+    SyncCMRSP.fill(getDeviceName(), "SYNCCMR", "Sync", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Park Position
-    IUFillSwitch(&ParkPositionS[PS_NORTH_POLE], "North Pole", "", ISS_ON);
-    IUFillSwitch(&ParkPositionS[PS_LEFT_VERTICAL], "Left and Vertical", "", ISS_OFF);
-    IUFillSwitch(&ParkPositionS[PS_LEFT_HORIZON], "Left and Horizon", "", ISS_OFF);
-    IUFillSwitch(&ParkPositionS[PS_RIGHT_VERTICAL], "Right and Vertical", "", ISS_OFF);
-    IUFillSwitch(&ParkPositionS[PS_RIGHT_HORIZON], "Right and Horizon", "", ISS_OFF);
-    IUFillSwitchVector(&ParkPositionSP, ParkPositionS, 5, getDeviceName(), "PARKING_POSITION", "Parking Position", SITE_TAB, IP_RW, ISR_1OFMANY, 0,
+    ParkPositionSP[PS_NORTH_POLE].fill("North Pole", "", ISS_ON);
+    ParkPositionSP[PS_LEFT_VERTICAL].fill("Left and Vertical", "", ISS_OFF);
+    ParkPositionSP[PS_LEFT_HORIZON].fill("Left and Horizon", "", ISS_OFF);
+    ParkPositionSP[PS_RIGHT_VERTICAL].fill("Right and Vertical", "", ISS_OFF);
+    ParkPositionSP[PS_RIGHT_HORIZON].fill("Right and Horizon", "", ISS_OFF);
+    ParkPositionSP.fill(getDeviceName(), "PARKING_POSITION", "Parking Position", SITE_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Guide Rate
-    IUFillSwitch(&GuideRateS[0], "1.0x", "", ISS_ON);
-    IUFillSwitch(&GuideRateS[1], "0.8x", "", ISS_OFF);
-    IUFillSwitch(&GuideRateS[2], "0.6x", "", ISS_OFF);
-    IUFillSwitch(&GuideRateS[3], "0.4x", "", ISS_OFF);
-    IUFillSwitchVector(&GuideRateSP, GuideRateS, 4, getDeviceName(), "GUIDE_RATE", "Guide Rate", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    GuideRateSP[0].fill("1.0x", "", ISS_ON);
+    GuideRateSP[1].fill("0.8x", "", ISS_OFF);
+    GuideRateSP[2].fill("0.6x", "", ISS_OFF);
+    GuideRateSP[3].fill("0.4x", "", ISS_OFF);
+    GuideRateSP.fill(getDeviceName(), "GUIDE_RATE", "Guide Rate", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Track Mode -- We do not support Custom so let's just define the first 3 properties
@@ -92,15 +92,15 @@ bool LX200GotoNova::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&SyncCMRSP);
-        defineProperty(&ParkPositionSP);
-        defineProperty(&GuideRateSP);
+        defineProperty(SyncCMRSP);
+        defineProperty(ParkPositionSP);
+        defineProperty(GuideRateSP);
     }
     else
     {
-        deleteProperty(SyncCMRSP.name);
-        deleteProperty(ParkPositionSP.name);
-        deleteProperty(GuideRateSP.name);
+        deleteProperty(SyncCMRSP.getName());
+        deleteProperty(ParkPositionSP.getName());
+        deleteProperty(GuideRateSP.getName());
     }
 
     return true;
@@ -164,49 +164,49 @@ bool LX200GotoNova::ISNewSwitch(const char *dev, const char *name, ISState *stat
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Park Position
-        if (!strcmp(ParkPositionSP.name, name))
+        if (ParkPositionSP.isNameMatch(name))
         {
-            int currentSwitch = IUFindOnSwitchIndex(&ParkPositionSP);
-            IUUpdateSwitch(&ParkPositionSP, states, names, n);
-            if (setGotoNovaParkPosition(IUFindOnSwitchIndex(&ParkPositionSP)) == TTY_OK)
-                ParkPositionSP.s = IPS_OK;
+            int currentSwitch = ParkPositionSP.findOnSwitchIndex();
+            ParkPositionSP.update(states, names, n);
+            if (setGotoNovaParkPosition(ParkPositionSP.findOnSwitchIndex()) == TTY_OK)
+                ParkPositionSP.setState(IPS_OK);
             else
             {
-                IUResetSwitch(&ParkPositionSP);
-                ParkPositionS[currentSwitch].s = ISS_ON;
-                ParkPositionSP.s = IPS_ALERT;
+                ParkPositionSP.reset();
+                ParkPositionSP[currentSwitch].setState(ISS_ON);
+                ParkPositionSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&ParkPositionSP, nullptr);
+            ParkPositionSP.apply();
             return true;
         }
 
         // Guide Rate
-        if (!strcmp(GuideRateSP.name, name))
+        if (GuideRateSP.isNameMatch(name))
         {
-            int currentSwitch = IUFindOnSwitchIndex(&ParkPositionSP);
-            IUUpdateSwitch(&GuideRateSP, states, names, n);
-            if (setGotoNovaGuideRate(IUFindOnSwitchIndex(&GuideRateSP)) == TTY_OK)
-                GuideRateSP.s = IPS_OK;
+            int currentSwitch = ParkPositionSP.findOnSwitchIndex();
+            GuideRateSP.update(states, names, n);
+            if (setGotoNovaGuideRate(GuideRateSP.findOnSwitchIndex()) == TTY_OK)
+                GuideRateSP.setState(IPS_OK);
             else
             {
-                IUResetSwitch(&GuideRateSP);
-                GuideRateS[currentSwitch].s = ISS_ON;
-                GuideRateSP.s = IPS_ALERT;
+                GuideRateSP.reset();
+                GuideRateSP[currentSwitch].setState(ISS_ON);
+                GuideRateSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&GuideRateSP, nullptr);
+            GuideRateSP.apply();
             return true;
         }
 
         // Sync type
-        if (!strcmp(name, SyncCMRSP.name))
+        if (SyncCMRSP.isNameMatch(name))
         {
-            IUResetSwitch(&SyncCMRSP);
-            IUUpdateSwitch(&SyncCMRSP, states, names, n);
-            IUFindOnSwitchIndex(&SyncCMRSP);
-            SyncCMRSP.s = IPS_OK;
-            IDSetSwitch(&SyncCMRSP, nullptr);
+            SyncCMRSP.reset();
+            SyncCMRSP.update(states, names, n);
+            SyncCMRSP.findOnSwitchIndex();
+            SyncCMRSP.setState(IPS_OK);
+            SyncCMRSP.apply();
             return true;
         }
     }
@@ -263,10 +263,10 @@ void LX200GotoNova::getBasicData()
     int rc = getGotoNovaGuideRate(&guideRate);
     if (rc == TTY_OK)
     {
-        IUResetSwitch(&GuideRateSP);
-        GuideRateS[guideRate].s = ISS_ON;
-        GuideRateSP.s = IPS_OK;
-        IDSetSwitch(&GuideRateSP, nullptr);
+        GuideRateSP.reset();
+        GuideRateSP[guideRate].setState(ISS_ON);
+        GuideRateSP.setState(IPS_OK);
+        GuideRateSP.apply();
     }
 }
 
@@ -282,29 +282,29 @@ bool LX200GotoNova::Goto(double r, double d)
     fs_sexa(DecStr, targetDEC, 2, 3600);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
-        if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
         {
-            MovementNSSP.s = IPS_IDLE;
-            MovementWESP.s = IPS_IDLE;
-            EqNP.s = IPS_IDLE;
-            IUResetSwitch(&MovementNSSP);
-            IUResetSwitch(&MovementWESP);
-            IDSetSwitch(&MovementNSSP, nullptr);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementNSSP.setState(IPS_IDLE);
+            MovementWESP.setState(IPS_IDLE);
+            EqNP.setState(IPS_IDLE);
+            MovementNSSP.reset();
+            MovementWESP.reset();
+            MovementNSSP.apply();
+            MovementWESP.apply();
         }
 
         // sleep for 100 mseconds
@@ -315,22 +315,22 @@ bool LX200GotoNova::Goto(double r, double d)
     {
         if (setObjectRA(PortFD, targetRA) < 0 || (setObjectDEC(PortFD, targetDEC)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
         if (slewGotoNova() == 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error Slewing to JNow RA %s - DEC %s\n", RAStr, DecStr);
             slewError(1);
             return false;
         }
     }
 
     TrackState = SCOPE_SLEWING;
-    EqNP.s     = IPS_BUSY;
+    EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
     return true;
@@ -340,14 +340,14 @@ bool LX200GotoNova::Sync(double ra, double dec)
 {
     char syncString[256];
 
-    int syncType = IUFindOnSwitchIndex(&SyncCMRSP);
+    int syncType = SyncCMRSP.findOnSwitchIndex();
 
     if (!isSimulation())
     {
         if (setObjectRA(PortFD, ra) < 0 || setObjectDEC(PortFD, dec) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC. Unable to Sync.");
             return false;
         }
 
@@ -371,8 +371,8 @@ bool LX200GotoNova::Sync(double ra, double dec)
 
         if (syncOK == false)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Synchronization failed.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Synchronization failed.");
             return false;
         }
 
@@ -384,7 +384,7 @@ bool LX200GotoNova::Sync(double ra, double dec)
     LOGF_DEBUG("%s Synchronization successful %s", (syncType == USE_REGULAR_SYNC ? "CM" : "CMR"), syncString);
     LOG_INFO("Synchronization successful.");
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -702,7 +702,7 @@ bool LX200GotoNova::Park()
 
     tcflush(PortFD, TCIFLUSH);
 
-    EqNP.s     = IPS_BUSY;
+    EqNP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking is in progress...");
 
@@ -745,8 +745,8 @@ bool LX200GotoNova::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -840,7 +840,7 @@ int LX200GotoNova::getGotoNovaGuideRate(int *rate)
 
     if (isSimulation())
     {
-        snprintf(response, 8, "%d#", IUFindOnSwitchIndex(&GuideRateSP));
+        snprintf(response, 8, "%d#", GuideRateSP.findOnSwitchIndex());
         nbytes_read = strlen(response);
     }
     else
@@ -958,8 +958,8 @@ bool LX200GotoNova::saveConfigItems(FILE *fp)
 {
     LX200Generic::saveConfigItems(fp);
 
-    IUSaveConfigSwitch(fp, &SyncCMRSP);
-    IUSaveConfigSwitch(fp, &ParkPositionSP);
+    SyncCMRSP.save(fp);
+    ParkPositionSP.save(fp);
 
     return true;
 }

--- a/drivers/telescope/lx200gotonova.h
+++ b/drivers/telescope/lx200gotonova.h
@@ -22,6 +22,9 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertyswitch.h"
+
 class LX200GotoNova : public LX200Generic
 {
   public:
@@ -86,19 +89,16 @@ class LX200GotoNova : public LX200Generic
     void mountSim();
 
     // Custom Parking Position
-    ISwitch ParkPositionS[5];
-    ISwitchVectorProperty ParkPositionSP;
+    INDI::PropertySwitch ParkPositionSP {5};
     enum { PS_NORTH_POLE, PS_LEFT_VERTICAL, PS_LEFT_HORIZON, PS_RIGHT_VERTICAL, PS_RIGHT_HORIZON };
 
     // Sync type
-    ISwitch SyncCMRS[2];
-    ISwitchVectorProperty SyncCMRSP;
+    INDI::PropertySwitch SyncCMRSP {2};
     enum { USE_REGULAR_SYNC, USE_CMR_SYNC };
 
 
     /* Guide Rate */
-    ISwitch GuideRateS[4];
-    ISwitchVectorProperty GuideRateSP;
+    INDI::PropertySwitch GuideRateSP {4};
 
     bool isGuiding=false;
 };

--- a/drivers/telescope/lx200gps.cpp
+++ b/drivers/telescope/lx200gps.cpp
@@ -41,50 +41,50 @@ bool LX200GPS::initProperties()
 {
     LX200Autostar::initProperties();
 
-    IUFillSwitch(&GPSPowerS[0], "On", "", ISS_OFF);
-    IUFillSwitch(&GPSPowerS[1], "Off", "", ISS_OFF);
-    IUFillSwitchVector(&GPSPowerSP, GPSPowerS, 2, getDeviceName(), "GPS Power", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
+    GPSPowerSP[0].fill("On", "", ISS_OFF);
+    GPSPowerSP[1].fill("Off", "", ISS_OFF);
+    GPSPowerSP.fill(getDeviceName(), "GPS Power", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&GPSStatusS[0], "Sleep", "", ISS_OFF);
-    IUFillSwitch(&GPSStatusS[1], "Wake Up", "", ISS_OFF);
-    IUFillSwitch(&GPSStatusS[2], "Restart", "", ISS_OFF);
-    IUFillSwitchVector(&GPSStatusSP, GPSStatusS, 3, getDeviceName(), "GPS Status", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
+    GPSStatusSP[0].fill("Sleep", "", ISS_OFF);
+    GPSStatusSP[1].fill("Wake Up", "", ISS_OFF);
+    GPSStatusSP[2].fill("Restart", "", ISS_OFF);
+    GPSStatusSP.fill(getDeviceName(), "GPS Status", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&GPSUpdateS[0], "Update GPS", "", ISS_OFF);
-    IUFillSwitch(&GPSUpdateS[1], "Update Client", "", ISS_OFF);
-    IUFillSwitchVector(&GPSUpdateSP, GPSUpdateS, 2, getDeviceName(), "GPS System", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
+    GPSUpdateSP[0].fill("Update GPS", "", ISS_OFF);
+    GPSUpdateSP[1].fill("Update Client", "", ISS_OFF);
+    GPSUpdateSP.fill(getDeviceName(), "GPS System", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&AltDecPecS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&AltDecPecS[1], "Disable", "", ISS_OFF);
-    IUFillSwitchVector(&AltDecPecSP, AltDecPecS, 2, getDeviceName(), "Alt/Dec PEC", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
+    AltDecPecSP[0].fill("Enable", "", ISS_OFF);
+    AltDecPecSP[1].fill("Disable", "", ISS_OFF);
+    AltDecPecSP.fill(getDeviceName(), "Alt/Dec PEC", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&AzRaPecS[0], "Enable", "", ISS_OFF);
-    IUFillSwitch(&AzRaPecS[1], "Disable", "", ISS_OFF);
-    IUFillSwitchVector(&AzRaPecSP, AzRaPecS, 2, getDeviceName(), "Az/RA PEC", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
+    AzRaPecSP[0].fill("Enable", "", ISS_OFF);
+    AzRaPecSP[1].fill("Disable", "", ISS_OFF);
+    AzRaPecSP.fill(getDeviceName(), "Az/RA PEC", "", GPS_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&SelenSyncS[0], "Sync", "", ISS_OFF);
-    IUFillSwitchVector(&SelenSyncSP, SelenSyncS, 1, getDeviceName(), "Selenographic Sync", "", GPS_TAB, IP_RW,
+    SelenSyncSP[0].fill("Sync", "", ISS_OFF);
+    SelenSyncSP.fill(getDeviceName(), "Selenographic Sync", "", GPS_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&AltDecBacklashS[0], "Activate", "", ISS_OFF);
-    IUFillSwitchVector(&AltDecBacklashSP, AltDecBacklashS, 1, getDeviceName(), "Alt/Dec Anti-backlash", "", GPS_TAB,
+    AltDecBacklashSP[0].fill("Activate", "", ISS_OFF);
+    AltDecBacklashSP.fill(getDeviceName(), "Alt/Dec Anti-backlash", "", GPS_TAB,
                        IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&AzRaBacklashS[0], "Activate", "", ISS_OFF);
-    IUFillSwitchVector(&AzRaBacklashSP, AzRaBacklashS, 1, getDeviceName(), "Az/Ra Anti-backlash", "", GPS_TAB, IP_RW,
+    AzRaBacklashSP[0].fill("Activate", "", ISS_OFF);
+    AzRaBacklashSP.fill(getDeviceName(), "Az/Ra Anti-backlash", "", GPS_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillSwitch(&OTAUpdateS[0], "Update", "", ISS_OFF);
-    IUFillSwitchVector(&OTAUpdateSP, OTAUpdateS, 1, getDeviceName(), "OTA Update", "", GPS_TAB, IP_RW, ISR_ATMOST1, 0,
+    OTAUpdateSP[0].fill("Update", "", ISS_OFF);
+    OTAUpdateSP.fill(getDeviceName(), "OTA Update", "", GPS_TAB, IP_RW, ISR_ATMOST1, 0,
                        IPS_IDLE);
 
-    IUFillNumber(&OTATempN[0], "Temp", "", "%03g", -200.0, 500.0, 0.0, 0);
-    IUFillNumberVector(&OTATempNP, OTATempN, 1, getDeviceName(), "OTA Temp (C)", "", GPS_TAB, IP_RO, 0, IPS_IDLE);
+    OTATempNP[0].fill("Temp", "", "%03g", -200.0, 500.0, 0.0, 0);
+    OTATempNP.fill(getDeviceName(), "OTA Temp (C)", "", GPS_TAB, IP_RO, 0, IPS_IDLE);
 
     return true;
 }
@@ -100,16 +100,16 @@ void LX200GPS::ISGetProperties(const char *dev)
     /*
     if (isConnected())
     {
-        defineProperty(&GPSPowerSP);
-        defineProperty(&GPSStatusSP);
-        defineProperty(&GPSUpdateSP);
-        defineProperty(&AltDecPecSP);
-        defineProperty(&AzRaPecSP);
-        defineProperty(&SelenSyncSP);
-        defineProperty(&AltDecBacklashSP);
-        defineProperty(&AzRaBacklashSP);
-        defineProperty(&OTATempNP);
-        defineProperty(&OTAUpdateSP);
+        defineProperty(GPSPowerSP);
+        defineProperty(GPSStatusSP);
+        defineProperty(GPSUpdateSP);
+        defineProperty(AltDecPecSP);
+        defineProperty(AzRaPecSP);
+        defineProperty(SelenSyncSP);
+        defineProperty(AltDecBacklashSP);
+        defineProperty(AzRaBacklashSP);
+        defineProperty(OTATempNP);
+        defineProperty(OTAUpdateSP);
     }
     */
 }
@@ -120,29 +120,29 @@ bool LX200GPS::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&GPSPowerSP);
-        defineProperty(&GPSStatusSP);
-        defineProperty(&GPSUpdateSP);
-        defineProperty(&AltDecPecSP);
-        defineProperty(&AzRaPecSP);
-        defineProperty(&SelenSyncSP);
-        defineProperty(&AltDecBacklashSP);
-        defineProperty(&AzRaBacklashSP);
-        defineProperty(&OTATempNP);
-        defineProperty(&OTAUpdateSP);
+        defineProperty(GPSPowerSP);
+        defineProperty(GPSStatusSP);
+        defineProperty(GPSUpdateSP);
+        defineProperty(AltDecPecSP);
+        defineProperty(AzRaPecSP);
+        defineProperty(SelenSyncSP);
+        defineProperty(AltDecBacklashSP);
+        defineProperty(AzRaBacklashSP);
+        defineProperty(OTATempNP);
+        defineProperty(OTAUpdateSP);
     }
     else
     {
-        deleteProperty(GPSPowerSP.name);
-        deleteProperty(GPSStatusSP.name);
-        deleteProperty(GPSUpdateSP.name);
-        deleteProperty(AltDecPecSP.name);
-        deleteProperty(AzRaPecSP.name);
-        deleteProperty(SelenSyncSP.name);
-        deleteProperty(AltDecBacklashSP.name);
-        deleteProperty(AzRaBacklashSP.name);
-        deleteProperty(OTATempNP.name);
-        deleteProperty(OTAUpdateSP.name);
+        deleteProperty(GPSPowerSP.getName());
+        deleteProperty(GPSStatusSP.getName());
+        deleteProperty(GPSUpdateSP.getName());
+        deleteProperty(AltDecPecSP.getName());
+        deleteProperty(AzRaPecSP.getName());
+        deleteProperty(SelenSyncSP.getName());
+        deleteProperty(AltDecBacklashSP.getName());
+        deleteProperty(AzRaBacklashSP.getName());
+        deleteProperty(OTATempNP.getName());
+        deleteProperty(OTAUpdateSP.getName());
     }
 
     return true;
@@ -156,33 +156,33 @@ bool LX200GPS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         /* GPS Power */
-        if (!strcmp(name, GPSPowerSP.name))
+        if (GPSPowerSP.isNameMatch(name))
         {
             int ret = 0;
 
-            if (IUUpdateSwitch(&GPSPowerSP, states, names, n) < 0)
+            if (!GPSPowerSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&GPSPowerSP);
+            index = GPSPowerSP.findOnSwitchIndex();
             if (index == 0)
                 ret = turnGPSOn(PortFD);
             else
                 ret = turnGPSOff(PortFD);
 
-            GPSPowerSP.s = IPS_OK;
-            IDSetSwitch(&GPSPowerSP, index == 0 ? "GPS System is ON" : "GPS System is OFF");
+            GPSPowerSP.setState(IPS_OK);
+            GPSPowerSP.apply(index == 0 ? "GPS System is ON" : "GPS System is OFF");
             return true;
         }
 
         /* GPS Status Update */
-        if (!strcmp(name, GPSStatusSP.name))
+        if (GPSStatusSP.isNameMatch(name))
         {
             int ret = 0;
 
-            if (IUUpdateSwitch(&GPSStatusSP, states, names, n) < 0)
+            if (!GPSStatusSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&GPSStatusSP);
+            index = GPSStatusSP.findOnSwitchIndex();
 
             if (index == 0)
             {
@@ -202,54 +202,54 @@ bool LX200GPS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
                 sendScopeLocation();
             }
 
-            GPSStatusSP.s = IPS_OK;
-            IDSetSwitch(&GPSStatusSP, "%s", msg);
+            GPSStatusSP.setState(IPS_OK);
+            GPSStatusSP.apply("%s", msg);
             return true;
         }
 
         /* GPS Update */
-        if (!strcmp(name, GPSUpdateSP.name))
+        if (GPSUpdateSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&GPSUpdateSP, states, names, n) < 0)
+            if (!GPSUpdateSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&GPSUpdateSP);
+            index = GPSUpdateSP.findOnSwitchIndex();
 
-            GPSUpdateSP.s = IPS_OK;
+            GPSUpdateSP.setState(IPS_OK);
 
             if (index == 0)
             {
-                IDSetSwitch(&GPSUpdateSP, "Updating GPS system. This operation might take few minutes to complete...");
+                GPSUpdateSP.apply("Updating GPS system. This operation might take few minutes to complete...");
                 if (updateGPS_System(PortFD))
                 {
-                    IDSetSwitch(&GPSUpdateSP, "GPS system update successful.");
+                    GPSUpdateSP.apply("GPS system update successful.");
                     sendScopeTime();
                     sendScopeLocation();
                 }
                 else
                 {
-                    GPSUpdateSP.s = IPS_IDLE;
-                    IDSetSwitch(&GPSUpdateSP, "GPS system update failed.");
+                    GPSUpdateSP.setState(IPS_IDLE);
+                    GPSUpdateSP.apply("GPS system update failed.");
                 }
             }
             else
             {
                 sendScopeTime();
                 sendScopeLocation();
-                IDSetSwitch(&GPSUpdateSP, "Client time and location is synced to LX200 GPS Data.");
+                GPSUpdateSP.apply("Client time and location is synced to LX200 GPS Data.");
             }
             return true;
         }
 
         /* Alt Dec Periodic Error correction */
-        if (!strcmp(name, AltDecPecSP.name))
+        if (AltDecPecSP.isNameMatch(name))
         {
             int ret = 0;
 
-            if (IUUpdateSwitch(&AltDecPecSP, states, names, n) < 0)
+            if (!AltDecPecSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&AltDecPecSP);
+            index = AltDecPecSP.findOnSwitchIndex();
 
             if (index == 0)
             {
@@ -262,21 +262,21 @@ bool LX200GPS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
                 strncpy(msg, "Alt/Dec Compensation Disabled.", 64);
             }
 
-            AltDecPecSP.s = IPS_OK;
-            IDSetSwitch(&AltDecPecSP, "%s", msg);
+            AltDecPecSP.setState(IPS_OK);
+            AltDecPecSP.apply("%s", msg);
 
             return true;
         }
 
         /* Az RA periodic error correction */
-        if (!strcmp(name, AzRaPecSP.name))
+        if (AzRaPecSP.isNameMatch(name))
         {
             int ret = 0;
 
-            if (IUUpdateSwitch(&AzRaPecSP, states, names, n) < 0)
+            if (!AzRaPecSP.update(states, names, n))
                 return false;
 
-            index = IUFindOnSwitchIndex(&AzRaPecSP);
+            index = AzRaPecSP.findOnSwitchIndex();
 
             if (index == 0)
             {
@@ -289,49 +289,49 @@ bool LX200GPS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
                 strncpy(msg, "Ra/Az Compensation Disabled.", 64);
             }
 
-            AzRaPecSP.s = IPS_OK;
-            IDSetSwitch(&AzRaPecSP, "%s", msg);
+            AzRaPecSP.setState(IPS_OK);
+            AzRaPecSP.apply("%s", msg);
 
             return true;
         }
 
-        if (!strcmp(name, AltDecBacklashSP.name))
+        if (AltDecBacklashSP.isNameMatch(name))
         {
             int ret = 0;
 
             ret = activateAltDecAntiBackSlash(PortFD);
-            AltDecBacklashSP.s = IPS_OK;
-            IDSetSwitch(&AltDecBacklashSP, "Alt/Dec Anti-backlash enabled");
+            AltDecBacklashSP.setState(IPS_OK);
+            AltDecBacklashSP.apply("Alt/Dec Anti-backlash enabled");
             return true;
         }
 
-        if (!strcmp(name, AzRaBacklashSP.name))
+        if (AzRaBacklashSP.isNameMatch(name))
         {
             int ret = 0;
 
             ret = activateAzRaAntiBackSlash(PortFD);
-            AzRaBacklashSP.s = IPS_OK;
-            IDSetSwitch(&AzRaBacklashSP, "Az/Ra Anti-backlash enabled");
+            AzRaBacklashSP.setState(IPS_OK);
+            AzRaBacklashSP.apply("Az/Ra Anti-backlash enabled");
             return true;
         }
 
-        if (!strcmp(name, OTAUpdateSP.name))
+        if (OTAUpdateSP.isNameMatch(name))
         {
-            IUResetSwitch(&OTAUpdateSP);
+            OTAUpdateSP.reset();
 
-            if (getOTATemp(PortFD, &OTATempNP.np[0].value) < 0)
+            if (getOTATemp(PortFD, &OTATempNP[0].value) < 0)
             {
-                OTAUpdateSP.s = IPS_ALERT;
-                OTATempNP.s   = IPS_ALERT;
-                IDSetNumber(&OTATempNP, "Error: OTA temperature read timed out.");
+                OTAUpdateSP.setState(IPS_ALERT);
+                OTATempNP.setState(IPS_ALERT);
+                OTATempNP.apply("Error: OTA temperature read timed out.");
                 return false;
             }
             else
             {
-                OTAUpdateSP.s = IPS_OK;
-                OTATempNP.s   = IPS_OK;
-                IDSetNumber(&OTATempNP, nullptr);
-                IDSetSwitch(&OTAUpdateSP, nullptr);
+                OTAUpdateSP.setState(IPS_OK);
+                OTATempNP.setState(IPS_OK);
+                OTATempNP.apply();
+                OTAUpdateSP.apply();
                 return true;
             }
         }

--- a/drivers/telescope/lx200gps.h
+++ b/drivers/telescope/lx200gps.h
@@ -22,6 +22,10 @@
 
 #include "lx200autostar.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200GPS : public LX200Autostar
 {
   public:
@@ -37,34 +41,14 @@ class LX200GPS : public LX200Autostar
 
   protected:
     virtual bool UnPark();
-
-    ISwitchVectorProperty GPSPowerSP;
-    ISwitch GPSPowerS[2];
-
-    ISwitchVectorProperty GPSStatusSP;
-    ISwitch GPSStatusS[3];
-
-    ISwitchVectorProperty GPSUpdateSP;
-    ISwitch GPSUpdateS[2];
-
-    ISwitchVectorProperty AltDecPecSP;
-    ISwitch AltDecPecS[2];
-
-    ISwitchVectorProperty AzRaPecSP;
-    ISwitch AzRaPecS[2];
-
-    ISwitchVectorProperty SelenSyncSP;
-    ISwitch SelenSyncS[1];
-
-    ISwitchVectorProperty AltDecBacklashSP;
-    ISwitch AltDecBacklashS[1];
-
-    ISwitchVectorProperty AzRaBacklashSP;
-    ISwitch AzRaBacklashS[1];
-
-    ISwitchVectorProperty OTAUpdateSP;
-    ISwitch OTAUpdateS[1];
-
-    INumberVectorProperty OTATempNP;
-    INumber OTATempN[1];
+    INDI::PropertySwitch GPSPowerSP {2};
+    INDI::PropertySwitch GPSStatusSP {3};
+    INDI::PropertySwitch GPSUpdateSP {2};
+    INDI::PropertySwitch AltDecPecSP {2};
+    INDI::PropertySwitch AzRaPecSP {2};
+    INDI::PropertySwitch SelenSyncSP {1};
+    INDI::PropertySwitch AltDecBacklashSP {1};
+    INDI::PropertySwitch AzRaBacklashSP {1};
+    INDI::PropertySwitch OTAUpdateSP {1};
+    INDI::PropertyNumber OTATempNP {1};
 };

--- a/drivers/telescope/lx200pulsar2.h
+++ b/drivers/telescope/lx200pulsar2.h
@@ -22,6 +22,10 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 
 class LX200Pulsar2 : public LX200Generic
 {
@@ -75,92 +79,68 @@ class LX200Pulsar2 : public LX200Generic
 
 
     // Pier Side
-    ISwitch PierSideS[2];
-    ISwitchVectorProperty PierSideSP;
-	ISwitch PierSideToggleS[1];
-	ISwitchVectorProperty PierSideToggleSP;
+    INDI::PropertySwitch PierSideSP {2};
+	INDI::PropertySwitch PierSideToggleSP {1};
 
     // Tracking Rates
-    ISwitchVectorProperty TrackingRateIndSP;
-    ISwitch TrackingRateIndS[numPulsarTrackingRates];
+    INDI::PropertySwitch TrackingRateIndSP {numPulsarTrackingRates};
 
     // Guide Speed Indicator
-    INumberVectorProperty GuideSpeedIndNP;
-    INumber GuideSpeedIndN[1];
+    INDI::PropertyNumber GuideSpeedIndNP {1};
     // Center Speed Indicator
-    INumberVectorProperty CenterSpeedIndNP;
-    INumber CenterSpeedIndN[1];
+    INDI::PropertyNumber CenterSpeedIndNP {1};
     // Find Speed Indicator
-    INumberVectorProperty FindSpeedIndNP;
-    INumber FindSpeedIndN[1];
+    INDI::PropertyNumber FindSpeedIndNP {1};
     // Slew Speed Indicator
-    INumberVectorProperty SlewSpeedIndNP;
-    INumber SlewSpeedIndN[1];
+    INDI::PropertyNumber SlewSpeedIndNP {1};
     // GoTo Speed Indicator
-    INumberVectorProperty GoToSpeedIndNP;
-    INumber GoToSpeedIndN[1];
+    INDI::PropertyNumber GoToSpeedIndNP {1};
 
 	// Ramp
-	INumberVectorProperty RampNP;
-	INumber RampN[2];
+	INDI::PropertyNumber RampNP {2};
 
 	// Reduction
-	INumberVectorProperty ReductionNP;
-	INumber ReductionN[2];
+	INDI::PropertyNumber ReductionNP {2};
 
 	// Maingear
-	INumberVectorProperty MaingearNP;
-	INumber MaingearN[2];
+	INDI::PropertyNumber MaingearNP {2};
 
 	// Backlash
-	INumberVectorProperty BacklashNP;
-	INumber BacklashN[2];
+	INDI::PropertyNumber BacklashNP {2};
 
 	// Home Position
-	INumberVectorProperty HomePositionNP;
-	INumber HomePositionN[2];
+	INDI::PropertyNumber HomePositionNP {2};
 	
 	// SwapTubeDelay
-	INumberVectorProperty SwapTubeDelayNP;
-	INumber SwapTubeDelayN[1];
+	INDI::PropertyNumber SwapTubeDelayNP {1};
 
 	// Mount Type
-	ISwitchVectorProperty MountTypeSP;
-	ISwitch MountTypeS[3];
+	INDI::PropertySwitch MountTypeSP {3};
 
     // Periodic error correction on or off
-    ISwitchVectorProperty PeriodicErrorCorrectionSP;
-    ISwitch PeriodicErrorCorrectionS[2];
+    INDI::PropertySwitch PeriodicErrorCorrectionSP {2};
 
     // Pole crossing on or off
-    ISwitchVectorProperty PoleCrossingSP;
-    ISwitch PoleCrossingS[2];
+    INDI::PropertySwitch PoleCrossingSP {2};
 
     // Refraction correction on or off
-    ISwitchVectorProperty RefractionCorrectionSP;
-    ISwitch RefractionCorrectionS[2];
+    INDI::PropertySwitch RefractionCorrectionSP {2};
 
 	// Rotation RA
-	ISwitchVectorProperty RotationRASP;
-	ISwitch RotationRAS[2];
+	INDI::PropertySwitch RotationRASP {2};
 	// Rotation DEC
-	ISwitchVectorProperty RotationDecSP;
-	ISwitch RotationDecS[2];
+	INDI::PropertySwitch RotationDecSP {2};
 	
 	// User1 Rate
-	INumberVectorProperty UserRate1NP;
-	INumber UserRate1N[2];
+	INDI::PropertyNumber UserRate1NP {2};
 	
 
 	// Tracking Current
-	INumberVectorProperty TrackingCurrentNP;
-	INumber TrackingCurrentN[1]; // only one entry for both RA and Dec
+	INDI::PropertyNumber TrackingCurrentNP {1}; // only one entry for both RA and Dec
 	// Stop Current
-	INumberVectorProperty StopCurrentNP;
-	INumber StopCurrentN[1]; // only one entry for both RA and Dec
+	INDI::PropertyNumber StopCurrentNP {1}; // only one entry for both RA and Dec
 	// GoTo Current
-	INumberVectorProperty GoToCurrentNP;
-	INumber GoToCurrentN[1]; // only one entry for both RA and Dec
+	INDI::PropertyNumber GoToCurrentNP {1}; // only one entry for both RA and Dec
 
   private:
 

--- a/drivers/telescope/lx200ss2000pc.h
+++ b/drivers/telescope/lx200ss2000pc.h
@@ -22,6 +22,9 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class LX200SS2000PC : public LX200Generic
 {
   public:
@@ -57,8 +60,7 @@ class LX200SS2000PC : public LX200Generic
     int setSiteLongitude(int fd, double Long);
     int setSiteLatitude(int fd, double Long);
 
-    INumber SlewAccuracyN[2];
-    INumberVectorProperty SlewAccuracyNP;
+    INDI::PropertyNumber SlewAccuracyNP {2};
 
     static const int ShortTimeOut;
     static const int LongTimeOut;

--- a/drivers/telescope/lx200telescope.cpp
+++ b/drivers/telescope/lx200telescope.cpp
@@ -65,10 +65,10 @@ bool LX200Telescope::initProperties()
     /* Make sure to init parent properties first */
     INDI::Telescope::initProperties();
 
-    IUFillSwitch(&AlignmentS[0], "Polar", "", ISS_ON);
-    IUFillSwitch(&AlignmentS[1], "AltAz", "", ISS_OFF);
-    IUFillSwitch(&AlignmentS[2], "Land", "", ISS_OFF);
-    IUFillSwitchVector(&AlignmentSP, AlignmentS, 3, getDeviceName(), "Alignment", "", MAIN_CONTROL_TAB, IP_RW,
+    AlignmentSP[0].fill("Polar", "", ISS_ON);
+    AlignmentSP[1].fill("AltAz", "", ISS_OFF);
+    AlignmentSP[2].fill("Land", "", ISS_OFF);
+    AlignmentSP.fill(getDeviceName(), "Alignment", "", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
 #if 0
@@ -96,25 +96,25 @@ bool LX200Telescope::initProperties()
 
     if (genericCapability & LX200_HAS_PRECISE_TRACKING_FREQ)
     {
-        IUFillNumber(&TrackFreqN[0], "trackFreq", "Freq", "%g", 55, 65, 0.00001, 60.16427);
+        TrackFreqNP[0].fill("trackFreq", "Freq", "%g", 55, 65, 0.00001, 60.16427);
     }
     else
     {
-        IUFillNumber(&TrackFreqN[0], "trackFreq", "Freq", "%g", 56.4, 60.1, 0.1, 60.1);
+        TrackFreqNP[0].fill("trackFreq", "Freq", "%g", 56.4, 60.1, 0.1, 60.1);
     }
-    IUFillNumberVector(&TrackFreqNP, TrackFreqN, 1, getDeviceName(), "Tracking Frequency", "", MOTION_TAB, IP_RW, 0,
+    TrackFreqNP.fill(getDeviceName(), "Tracking Frequency", "", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
-    IUFillSwitch(&UsePulseCmdS[0], "Off", "", ISS_OFF);
-    IUFillSwitch(&UsePulseCmdS[1], "On", "", ISS_ON);
-    IUFillSwitchVector(&UsePulseCmdSP, UsePulseCmdS, 2, getDeviceName(), "Use Pulse Cmd", "", MAIN_CONTROL_TAB, IP_RW,
+    UsePulseCmdSP[0].fill("Off", "", ISS_OFF);
+    UsePulseCmdSP[1].fill("On", "", ISS_ON);
+    UsePulseCmdSP.fill(getDeviceName(), "Use Pulse Cmd", "", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&SiteS[0], "Site 1", "", ISS_ON);
-    IUFillSwitch(&SiteS[1], "Site 2", "", ISS_OFF);
-    IUFillSwitch(&SiteS[2], "Site 3", "", ISS_OFF);
-    IUFillSwitch(&SiteS[3], "Site 4", "", ISS_OFF);
-    IUFillSwitchVector(&SiteSP, SiteS, 4, getDeviceName(), "Sites", "", SITE_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    SiteSP[0].fill("Site 1", "", ISS_ON);
+    SiteSP[1].fill("Site 2", "", ISS_OFF);
+    SiteSP[2].fill("Site 3", "", ISS_OFF);
+    SiteSP[3].fill("Site 4", "", ISS_OFF);
+    SiteSP.fill(getDeviceName(), "Sites", "", SITE_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     IUFillText(&SiteNameT[0], "Name", "", "");
     IUFillTextVector(&SiteNameTP, SiteNameT, 1, getDeviceName(), "Site Name", "", SITE_TAB, IP_RW, 0, IPS_IDLE);
@@ -124,16 +124,16 @@ bool LX200Telescope::initProperties()
         FI::SetCapability(FOCUSER_CAN_ABORT | FOCUSER_CAN_REVERSE | FOCUSER_HAS_VARIABLE_SPEED);
         FI::initProperties(FOCUS_TAB);
 
-        //        IUFillSwitch(&FocusModeS[0], "FOCUS_HALT", "Halt", ISS_ON);
-        //        IUFillSwitch(&FocusModeS[1], "FOCUS_SLOW", "Slow", ISS_OFF);
-        //        IUFillSwitch(&FocusModeS[2], "FOCUS_FAST", "Fast", ISS_OFF);
-        //        IUFillSwitchVector(&FocusModeSP, FocusModeS, 3, getDeviceName(), "FOCUS_MODE", "Mode", FOCUS_TAB, IP_RW,
+        //        FocusModeSP[0].fill("FOCUS_HALT", "Halt", ISS_ON);
+        //        FocusModeSP[1].fill("FOCUS_SLOW", "Slow", ISS_OFF);
+        //        FocusModeSP[2].fill("FOCUS_FAST", "Fast", ISS_OFF);
+        //        FocusModeSP.fill(getDeviceName(), "FOCUS_MODE", "Mode", FOCUS_TAB, IP_RW,
         //                           ISR_1OFMANY, 0, IPS_IDLE);
 
         // Classical speeds slow or fast
-        FocusSpeedN[0].min = 1;
-        FocusSpeedN[0].max = 2;
-        FocusSpeedN[0].value = 1;
+        FocusSpeedNP[0].setMin(1);
+        FocusSpeedNP[0].setMax(2);
+        FocusSpeedNP[0].setValue(1);
     }
 
     TrackState = SCOPE_IDLE;
@@ -166,17 +166,17 @@ void LX200Telescope::ISGetProperties(const char *dev)
     if (isConnected())
     {
         if (genericCapability & LX200_HAS_ALIGNMENT_TYPE)
-            defineProperty(&AlignmentSP);
+            defineProperty(AlignmentSP);
 
         if (genericCapability & LX200_HAS_TRACKING_FREQ)
-            defineProperty(&TrackFreqNP);
+            defineProperty(TrackFreqNP);
 
         if (genericCapability & LX200_HAS_PULSE_GUIDING)
-            defineProperty(&UsePulseCmdSP);
+            defineProperty(UsePulseCmdSP);
 
         if (genericCapability & LX200_HAS_SITES)
         {
-            defineProperty(&SiteSP);
+            defineProperty(SiteSP);
             defineProperty(&SiteNameTP);
         }
 
@@ -185,9 +185,9 @@ void LX200Telescope::ISGetProperties(const char *dev)
 
         if (genericCapability & LX200_HAS_FOCUS)
         {
-            defineProperty(&FocusMotionSP);
-            defineProperty(&FocusTimerNP);
-            defineProperty(&FocusModeSP);
+            defineProperty(FocusMotionSP);
+            defineProperty(FocusTimerNP);
+            defineProperty(FocusModeSP);
         }
     }
     */
@@ -200,17 +200,17 @@ bool LX200Telescope::updateProperties()
     if (isConnected())
     {
         if (genericCapability & LX200_HAS_ALIGNMENT_TYPE)
-            defineProperty(&AlignmentSP);
+            defineProperty(AlignmentSP);
 
         if (genericCapability & LX200_HAS_TRACKING_FREQ)
-            defineProperty(&TrackFreqNP);
+            defineProperty(TrackFreqNP);
 
         if (genericCapability & LX200_HAS_PULSE_GUIDING)
-            defineProperty(&UsePulseCmdSP);
+            defineProperty(UsePulseCmdSP);
 
         if (genericCapability & LX200_HAS_SITES)
         {
-            defineProperty(&SiteSP);
+            defineProperty(SiteSP);
             defineProperty(&SiteNameTP);
         }
 
@@ -220,7 +220,7 @@ bool LX200Telescope::updateProperties()
         if (genericCapability & LX200_HAS_FOCUS)
         {
             FI::updateProperties();
-            //defineProperty(&FocusModeSP);
+            //defineProperty(FocusModeSP);
         }
 
         getBasicData();
@@ -228,17 +228,17 @@ bool LX200Telescope::updateProperties()
     else
     {
         if (genericCapability & LX200_HAS_ALIGNMENT_TYPE)
-            deleteProperty(AlignmentSP.name);
+            deleteProperty(AlignmentSP.getName());
 
         if (genericCapability & LX200_HAS_TRACKING_FREQ)
-            deleteProperty(TrackFreqNP.name);
+            deleteProperty(TrackFreqNP.getName());
 
         if (genericCapability & LX200_HAS_PULSE_GUIDING)
-            deleteProperty(UsePulseCmdSP.name);
+            deleteProperty(UsePulseCmdSP.getName());
 
         if (genericCapability & LX200_HAS_SITES)
         {
-            deleteProperty(SiteSP.name);
+            deleteProperty(SiteSP.getName());
             deleteProperty(SiteNameTP.name);
         }
 
@@ -248,7 +248,7 @@ bool LX200Telescope::updateProperties()
         if (genericCapability & LX200_HAS_FOCUS)
         {
             FI::updateProperties();
-            //deleteProperty(FocusModeSP.name);
+            //deleteProperty(FocusModeSP.getName());
         }
     }
 
@@ -311,8 +311,8 @@ bool LX200Telescope::ReadScopeStatus()
 
     if (getLX200RA(PortFD, &currentRA) < 0 || getLX200DEC(PortFD, &currentDEC) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error reading RA/DEC.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error reading RA/DEC.");
         return false;
     }
 
@@ -346,29 +346,29 @@ bool LX200Telescope::Goto(double ra, double dec)
     fs_sexa(DecStr, targetDEC, 2, fracbase);
 
     // If moving, let's stop it first.
-    if (EqNP.s == IPS_BUSY)
+    if (EqNP.getState() == IPS_BUSY)
     {
         if (!isSimulation() && abortSlew(PortFD) < 0)
         {
-            AbortSP.s = IPS_ALERT;
-            IDSetSwitch(&AbortSP, "Abort slew failed.");
+            AbortSP.setState(IPS_ALERT);
+            AbortSP.apply("Abort slew failed.");
             return false;
         }
 
-        AbortSP.s = IPS_OK;
-        EqNP.s    = IPS_IDLE;
-        IDSetSwitch(&AbortSP, "Slew aborted.");
-        IDSetNumber(&EqNP, nullptr);
+        AbortSP.setState(IPS_OK);
+        EqNP.setState(IPS_IDLE);
+        AbortSP.apply("Slew aborted.");
+        EqNP.apply();
 
-        if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
         {
-            MovementNSSP.s = IPS_IDLE;
-            MovementWESP.s = IPS_IDLE;
-            EqNP.s = IPS_IDLE;
-            IUResetSwitch(&MovementNSSP);
-            IUResetSwitch(&MovementWESP);
-            IDSetSwitch(&MovementNSSP, nullptr);
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementNSSP.setState(IPS_IDLE);
+            MovementWESP.setState(IPS_IDLE);
+            EqNP.setState(IPS_IDLE);
+            MovementNSSP.reset();
+            MovementWESP.reset();
+            MovementNSSP.apply();
+            MovementWESP.apply();
         }
 
         // sleep for 100 mseconds
@@ -379,8 +379,8 @@ bool LX200Telescope::Goto(double ra, double dec)
     {
         if (setObjectRA(PortFD, targetRA) < 0 || (setObjectDEC(PortFD, targetDEC)) < 0)
         {
-            EqNP.s = IPS_ALERT;
-            IDSetNumber(&EqNP, "Error setting RA/DEC.");
+            EqNP.setState(IPS_ALERT);
+            EqNP.apply("Error setting RA/DEC.");
             return false;
         }
 
@@ -396,7 +396,7 @@ bool LX200Telescope::Goto(double ra, double dec)
     }
 
     TrackState = SCOPE_SLEWING;
-    //EqNP.s     = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
 
@@ -409,15 +409,15 @@ bool LX200Telescope::Sync(double ra, double dec)
 
     if (!isSimulation() && (setObjectRA(PortFD, ra) < 0 || (setObjectDEC(PortFD, dec)) < 0))
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Error setting RA/DEC. Unable to Sync.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Error setting RA/DEC. Unable to Sync.");
         return false;
     }
 
     if (!isSimulation() && ::Sync(PortFD, syncString) < 0)
     {
-        EqNP.s = IPS_ALERT;
-        IDSetNumber(&EqNP, "Synchronization failed.");
+        EqNP.setState(IPS_ALERT);
+        EqNP.apply("Synchronization failed.");
         return false;
     }
 
@@ -426,7 +426,7 @@ bool LX200Telescope::Sync(double ra, double dec)
 
     LOG_INFO("Synchronization successful.");
 
-    EqNP.s     = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -439,30 +439,30 @@ bool LX200Telescope::Park()
     if (!isSimulation())
     {
         // If scope is moving, let's stop it first.
-        if (EqNP.s == IPS_BUSY)
+        if (EqNP.getState() == IPS_BUSY)
         {
             if (!isSimulation() && abortSlew(PortFD) < 0)
             {
-                AbortSP.s = IPS_ALERT;
-                IDSetSwitch(&AbortSP, "Abort slew failed.");
+                AbortSP.setState(IPS_ALERT);
+                AbortSP.apply("Abort slew failed.");
                 return false;
             }
 
-            AbortSP.s = IPS_OK;
-            EqNP.s    = IPS_IDLE;
-            IDSetSwitch(&AbortSP, "Slew aborted.");
-            IDSetNumber(&EqNP, nullptr);
+            AbortSP.setState(IPS_OK);
+            EqNP.setState(IPS_IDLE);
+            AbortSP.apply("Slew aborted.");
+            EqNP.apply();
 
-            if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
+            if (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY)
             {
-                MovementNSSP.s = IPS_IDLE;
-                MovementWESP.s = IPS_IDLE;
-                EqNP.s = IPS_IDLE;
-                IUResetSwitch(&MovementNSSP);
-                IUResetSwitch(&MovementWESP);
+                MovementNSSP.setState(IPS_IDLE);
+                MovementWESP.setState(IPS_IDLE);
+                EqNP.setState(IPS_IDLE);
+                MovementNSSP.reset();
+                MovementWESP.reset();
 
-                IDSetSwitch(&MovementNSSP, nullptr);
-                IDSetSwitch(&MovementWESP, nullptr);
+                MovementNSSP.apply();
+                MovementWESP.apply();
             }
 
             // sleep for 100 msec
@@ -471,13 +471,13 @@ bool LX200Telescope::Park()
 
         if (!isSimulation() && slewToPark(PortFD) < 0)
         {
-            ParkSP.s = IPS_ALERT;
-            IDSetSwitch(&ParkSP, "Parking Failed.");
+            ParkSP.setState(IPS_ALERT);
+            ParkSP.apply("Parking Failed.");
             return false;
         }
     }
 
-    ParkSP.s   = IPS_BUSY;
+    ParkSP.setState(IPS_BUSY);
     TrackState = SCOPE_PARKING;
     LOG_INFO("Parking telescope in progress...");
     return true;
@@ -698,20 +698,20 @@ bool LX200Telescope::ISNewNumber(const char *dev, const char *name, double value
         }
 
         // Update Frequency
-        if (!strcmp(name, TrackFreqNP.name))
+        if (TrackFreqNP.isNameMatch(name))
         {
             LOGF_DEBUG("Trying to set track freq of: %04.1f", values[0]);
             if (genericCapability & LX200_HAS_PRECISE_TRACKING_FREQ)
             {
                 if (!isSimulation() && setPreciseTrackFreq(PortFD, values[0]) < 0)
                 {
-                    TrackFreqNP.s = IPS_ALERT;
-                    IDSetNumber(&TrackFreqNP, "Error setting tracking frequency");
+                    TrackFreqNP.setState(IPS_ALERT);
+                    TrackFreqNP.apply("Error setting tracking frequency");
                     return false;
                 }
-                TrackFreqNP.s           = IPS_OK;
-                TrackFreqNP.np[0].value = values[0];
-                IDSetNumber(&TrackFreqNP, "Tracking frequency set to %8.5f", values[0]);
+                TrackFreqNP.setState(IPS_OK);
+                TrackFreqNP[0].setValue(values[0]);
+                TrackFreqNP.apply("Tracking frequency set to %8.5f", values[0]);
             }
             else
             {
@@ -724,18 +724,18 @@ bool LX200Telescope::ISNewNumber(const char *dev, const char *name, double value
                     LOGF_DEBUG("Trying to set track freq of: %f\n", values[0]);
                     if (!isSimulation() && setTrackFreq(PortFD, values[0]) < 0)
                     {
-                        TrackFreqNP.s = IPS_ALERT;
-                        IDSetNumber(&TrackFreqNP, "Error setting tracking frequency");
+                        TrackFreqNP.setState(IPS_ALERT);
+                        TrackFreqNP.apply("Error setting tracking frequency");
                         return false;
                     }
-                    TrackFreqNP.s           = IPS_OK;
-                    IDSetNumber(&TrackFreqNP, "Error setting tracking frequency");
+                    TrackFreqNP.setState(IPS_OK);
+                    TrackFreqNP.apply("Error setting tracking frequency");
                     return false;
                 }
 
-                TrackFreqNP.s           = IPS_OK;
-                TrackFreqNP.np[0].value = values[0];
-                IDSetNumber(&TrackFreqNP, "Tracking frequency set to %04.1f", values[0]);
+                TrackFreqNP.setState(IPS_OK);
+                TrackFreqNP[0].setValue(values[0]);
+                TrackFreqNP.apply("Tracking frequency set to %04.1f", values[0]);
             }
 
             if (trackingMode != LX200_TRACK_MANUAL)
@@ -753,19 +753,19 @@ bool LX200Telescope::ISNewNumber(const char *dev, const char *name, double value
             return true;
         }
 
-        //        if (!strcmp(name, FocusTimerNP.name))
+        //        if (FocusTimerNP.isNameMatch(name))
         //        {
         //            // Don't update if busy
-        //            if (FocusTimerNP.s == IPS_BUSY)
+        //            if (FocusTimerNP.getState() == IPS_BUSY)
         //                return true;
 
-        //            IUUpdateNumber(&FocusTimerNP, values, names, n);
+        //            FocusTimerNP.update(values, names, n);
 
-        //            FocusTimerNP.s = IPS_OK;
+        //            FocusTimerNP.setState(IPS_OK);
 
-        //            IDSetNumber(&FocusTimerNP, nullptr);
+        //            FocusTimerNP.apply();
 
-        //            LOGF_DEBUG("Setting focus timer to %.2f", FocusTimerN[0].value);
+        //            LOGF_DEBUG("Setting focus timer to %.2f", FocusTimerNP[0].getValue());
 
         //            return true;
         //        }
@@ -789,37 +789,37 @@ bool LX200Telescope::ISNewSwitch(const char *dev, const char *name, ISState *sta
         }
 
         // Alignment
-        if (!strcmp(name, AlignmentSP.name))
+        if (AlignmentSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&AlignmentSP, states, names, n) < 0)
+            if (!AlignmentSP.update(states, names, n))
                 return false;
 
-            int index = IUFindOnSwitchIndex(&AlignmentSP);
+            int index = AlignmentSP.findOnSwitchIndex();
 
             if (!isSimulation() && setAlignmentMode(PortFD, index) < 0)
             {
-                AlignmentSP.s = IPS_ALERT;
-                IDSetSwitch(&AlignmentSP, "Error setting alignment mode.");
+                AlignmentSP.setState(IPS_ALERT);
+                AlignmentSP.apply("Error setting alignment mode.");
                 return false;
             }
 
-            AlignmentSP.s = IPS_OK;
-            IDSetSwitch(&AlignmentSP, nullptr);
+            AlignmentSP.setState(IPS_OK);
+            AlignmentSP.apply();
             return true;
         }
 
         // Sites
-        if (!strcmp(name, SiteSP.name))
+        if (SiteSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&SiteSP, states, names, n) < 0)
+            if (!SiteSP.update(states, names, n))
                 return false;
 
-            currentSiteNum = IUFindOnSwitchIndex(&SiteSP) + 1;
+            currentSiteNum = SiteSP.findOnSwitchIndex() + 1;
 
             if (!isSimulation() && selectSite(PortFD, currentSiteNum) < 0)
             {
-                SiteSP.s = IPS_ALERT;
-                IDSetSwitch(&SiteSP, "Error selecting sites.");
+                SiteSP.setState(IPS_ALERT);
+                SiteSP.apply("Error selecting sites.");
                 return false;
             }
 
@@ -832,96 +832,96 @@ bool LX200Telescope::ISNewSwitch(const char *dev, const char *name, ISState *sta
                 sendScopeLocation();
 
             SiteNameTP.s = IPS_OK;
-            SiteSP.s = IPS_OK;
+            SiteSP.setState(IPS_OK);
 
             IDSetText(&SiteNameTP, nullptr);
-            IDSetSwitch(&SiteSP, nullptr);
+            SiteSP.apply();
 
             return false;
         }
 
         //        // Focus Motion
-        //        if (!strcmp(name, FocusMotionSP.name))
+        //        if (FocusMotionSP.isNameMatch(name))
         //        {
         //            // If mode is "halt"
-        //            if (FocusModeS[0].s == ISS_ON)
+        //            if (FocusModeSP[0].getState() == ISS_ON)
         //            {
-        //                FocusMotionSP.s = IPS_IDLE;
-        //                IDSetSwitch(&FocusMotionSP, "Focus mode is halt. Select slow or fast mode");
+        //                FocusMotionSP.setState(IPS_IDLE);
+        //                FocusMotionSP.apply("Focus mode is halt. Select slow or fast mode");
         //                return true;
         //            }
 
-        //            int last_motion = IUFindOnSwitchIndex(&FocusMotionSP);
+        //            int last_motion = FocusMotionSP.findOnSwitchIndex();
 
-        //            if (IUUpdateSwitch(&FocusMotionSP, states, names, n) < 0)
+        //            if (!FocusMotionSP.update(states, names, n))
         //                return false;
 
-        //            index = IUFindOnSwitchIndex(&FocusMotionSP);
+        //            index = FocusMotionSP.findOnSwitchIndex();
 
         //            // If same direction and we're busy, stop
-        //            if (last_motion == index && FocusMotionSP.s == IPS_BUSY)
+        //            if (last_motion == index && FocusMotionSP.getState() == IPS_BUSY)
         //            {
-        //                IUResetSwitch(&FocusMotionSP);
-        //                FocusMotionSP.s = IPS_IDLE;
+        //                FocusMotionSP.reset();
+        //                FocusMotionSP.setState(IPS_IDLE);
         //                setFocuserSpeedMode(PortFD, 0);
-        //                IDSetSwitch(&FocusMotionSP, nullptr);
+        //                FocusMotionSP.apply();
         //                return true;
         //            }
 
         //            if (!isSimulation() && setFocuserMotion(PortFD, index) < 0)
         //            {
-        //                FocusMotionSP.s = IPS_ALERT;
-        //                IDSetSwitch(&FocusMotionSP, "Error setting focuser speed.");
+        //                FocusMotionSP.setState(IPS_ALERT);
+        //                FocusMotionSP.apply("Error setting focuser speed.");
         //                return false;
         //            }
 
         //            // with a timer
-        //            if (FocusTimerN[0].value > 0)
+        //            if (FocusTimerNP[0].value > 0)
         //            {
-        //                FocusTimerNP.s  = IPS_BUSY;
-        //                FocusMotionSP.s = IPS_BUSY;
+        //                FocusTimerNP.setState(IPS_BUSY);
+        //                FocusMotionSP.setState(IPS_BUSY);
         //                IEAddTimer(50, LX200Telescope::updateFocusHelper, this);
         //            }
 
-        //            FocusMotionSP.s = IPS_OK;
-        //            IDSetSwitch(&FocusMotionSP, nullptr);
+        //            FocusMotionSP.setState(IPS_OK);
+        //            FocusMotionSP.apply();
         //            return true;
         //        }
 
         //        // Focus speed
-        //        if (!strcmp(name, FocusModeSP.name))
+        //        if (FocusModeSP.isNameMatch(name))
         //        {
-        //            IUResetSwitch(&FocusModeSP);
-        //            IUUpdateSwitch(&FocusModeSP, states, names, n);
+        //            FocusModeSP.reset();
+        //            FocusModeSP.update(states, names, n);
 
-        //            index = IUFindOnSwitchIndex(&FocusModeSP);
+        //            index = FocusModeSP.findOnSwitchIndex();
 
         //            /* disable timer and motion */
         //            if (index == 0)
         //            {
-        //                IUResetSwitch(&FocusMotionSP);
-        //                FocusMotionSP.s = IPS_IDLE;
-        //                FocusTimerNP.s  = IPS_IDLE;
-        //                IDSetSwitch(&FocusMotionSP, nullptr);
-        //                IDSetNumber(&FocusTimerNP, nullptr);
+        //                FocusMotionSP.reset();
+        //                FocusMotionSP.setState(IPS_IDLE);
+        //                FocusTimerNP.setState(IPS_IDLE);
+        //                FocusMotionSP.apply();
+        //                FocusTimerNP.apply();
         //            }
 
         //            if (!isSimulation())
         //                setFocuserSpeedMode(PortFD, index);
-        //            FocusModeSP.s = IPS_OK;
-        //            IDSetSwitch(&FocusModeSP, nullptr);
+        //            FocusModeSP.setState(IPS_OK);
+        //            FocusModeSP.apply();
         //            return true;
         //        }
 
         // Pulse-Guide command support
-        if (!strcmp(name, UsePulseCmdSP.name))
+        if (UsePulseCmdSP.isNameMatch(name))
         {
-            IUResetSwitch(&UsePulseCmdSP);
-            IUUpdateSwitch(&UsePulseCmdSP, states, names, n);
+            UsePulseCmdSP.reset();
+            UsePulseCmdSP.update(states, names, n);
 
-            UsePulseCmdSP.s = IPS_OK;
-            IDSetSwitch(&UsePulseCmdSP, nullptr);
-            usePulseCommand = (UsePulseCmdS[1].s == ISS_ON);
+            UsePulseCmdSP.setState(IPS_OK);
+            UsePulseCmdSP.apply();
+            usePulseCommand = (UsePulseCmdSP[1].getState() == ISS_ON);
             LOGF_INFO("Pulse guiding is %s.", usePulseCommand ? "enabled" : "disabled");
             return true;
         }
@@ -942,8 +942,8 @@ bool LX200Telescope::SetTrackMode(uint8_t mode)
     // Note, that LX200_HAS_PRECISE_TRACKING_FREQ can use the same get function
     if (rc &&  (genericCapability & LX200_HAS_TRACKING_FREQ))
     {
-        getTrackFreq(PortFD, &TrackFreqN[0].value);
-        IDSetNumber(&TrackFreqNP, nullptr);
+        getTrackFreq(PortFD, &TrackFreqNP[0].value);
+        TrackFreqNP.apply();
     }
     return rc;
 }
@@ -988,26 +988,26 @@ void LX200Telescope::updateFocusHelper(void *p)
 
 void LX200Telescope::updateFocusTimer()
 {
-    //    switch (FocusTimerNP.s)
+    //    switch (FocusTimerNP.getState())
     //    {
     //        case IPS_IDLE:
     //            break;
 
     //        case IPS_BUSY:
     //            //if (isDebug())
-    //            //IDLog("Focus Timer Value is %g\n", FocusTimerN[0].value);
+    //            //IDLog("Focus Timer Value is %g\n", FocusTimerNP[0].getValue());
 
-    //            FocusTimerN[0].value -= 50;
+    //            FocusTimerNP[0].value -= 50;
 
-    //            if (FocusTimerN[0].value <= 0)
+    //            if (FocusTimerNP[0].value <= 0)
     //            {
     //                //if (isDebug())
     //                //IDLog("Focus Timer Expired\n");
 
     //                if (!isSimulation() && setFocuserSpeedMode(PortFD, 0) < 0)
     //                {
-    //                    FocusModeSP.s = IPS_ALERT;
-    //                    IDSetSwitch(&FocusModeSP, "Error setting focuser mode.");
+    //                    FocusModeSP.setState(IPS_ALERT);
+    //                    FocusModeSP.apply("Error setting focuser mode.");
 
     //                    //if (isDebug())
     //                    //IDLog("Error setting focuser mode\n");
@@ -1015,21 +1015,21 @@ void LX200Telescope::updateFocusTimer()
     //                    return;
     //                }
 
-    //                FocusMotionSP.s = IPS_IDLE;
-    //                FocusTimerNP.s  = IPS_OK;
-    //                FocusModeSP.s   = IPS_OK;
+    //                FocusMotionSP.setState(IPS_IDLE);
+    //                FocusTimerNP.setState(IPS_OK);
+    //                FocusModeSP.setState(IPS_OK);
 
-    //                IUResetSwitch(&FocusMotionSP);
-    //                IUResetSwitch(&FocusModeSP);
-    //                FocusModeS[0].s = ISS_ON;
+    //                FocusMotionSP.reset();
+    //                FocusModeSP.reset();
+    //                FocusModeSP[0].setState(ISS_ON);
 
-    //                IDSetSwitch(&FocusModeSP, nullptr);
-    //                IDSetSwitch(&FocusMotionSP, nullptr);
+    //                FocusModeSP.apply();
+    //                FocusMotionSP.apply();
     //            }
 
-    //            IDSetNumber(&FocusTimerNP, nullptr);
+    //            FocusTimerNP.apply();
 
-    //            if (FocusTimerN[0].value > 0)
+    //            if (FocusTimerNP[0].value > 0)
     //                IEAddTimer(50, LX200Telescope::updateFocusHelper, this);
     //            break;
 
@@ -1041,9 +1041,9 @@ void LX200Telescope::updateFocusTimer()
     //    }
 
     AbortFocuser();
-    FocusTimerNP.s = IPS_OK;
-    FocusTimerN[0].value = 0;
-    IDSetNumber(&FocusTimerNP, nullptr);
+    FocusTimerNP.setState(IPS_OK);
+    FocusTimerNP[0].setValue(0);
+    FocusTimerNP.apply();
 }
 
 void LX200Telescope::mountSim()
@@ -1090,8 +1090,8 @@ void LX200Telescope::mountSim()
                     break;
 
                 case TRACK_CUSTOM:
-                    da = ((TrackRateN[AXIS_RA].value - TRACKRATE_SIDEREAL) / 3600.0 * dt / 15.);
-                    dx = (TrackRateN[AXIS_DE].value / 3600.0 * dt);
+                    da = ((TrackRateNP[AXIS_RA].value - TRACKRATE_SIDEREAL) / 3600.0 * dt / 15.);
+                    dx = (TrackRateNP[AXIS_DE].value / 3600.0 * dt);
                     break;
 
             }
@@ -1185,10 +1185,10 @@ void LX200Telescope::getBasicData()
 
         if (genericCapability & LX200_HAS_TRACKING_FREQ)
         {
-            if (getTrackFreq(PortFD, &TrackFreqN[0].value) < 0)
+            if (getTrackFreq(PortFD, &TrackFreqNP[0].value) < 0)
                 LOG_ERROR("Failed to get tracking frequency from device.");
             else
-                IDSetNumber(&TrackFreqNP, nullptr);
+                TrackFreqNP.apply();
         }
 
     }
@@ -1208,8 +1208,8 @@ void LX200Telescope::slewError(int slewCode)
     else
         LOGF_ERROR("Slew failed (%d).", slewCode);
 
-    EqNP.s = IPS_ALERT;
-    IDSetNumber(&EqNP, nullptr);
+    EqNP.setState(IPS_ALERT);
+    EqNP.apply();
 }
 
 void LX200Telescope::getAlignment()
@@ -1217,29 +1217,29 @@ void LX200Telescope::getAlignment()
     signed char align = ACK(PortFD);
     if (align < 0)
     {
-        IDSetSwitch(&AlignmentSP, "Failed to get telescope alignment.");
+        AlignmentSP.apply("Failed to get telescope alignment.");
         return;
     }
 
-    AlignmentS[0].s = ISS_OFF;
-    AlignmentS[1].s = ISS_OFF;
-    AlignmentS[2].s = ISS_OFF;
+    AlignmentSP[0].setState(ISS_OFF);
+    AlignmentSP[1].setState(ISS_OFF);
+    AlignmentSP[2].setState(ISS_OFF);
 
     switch (align)
     {
         case 'P':
-            AlignmentS[0].s = ISS_ON;
+            AlignmentSP[0].setState(ISS_ON);
             break;
         case 'A':
-            AlignmentS[1].s = ISS_ON;
+            AlignmentSP[1].setState(ISS_ON);
             break;
         case 'L':
-            AlignmentS[2].s = ISS_ON;
+            AlignmentSP[2].setState(ISS_ON);
             break;
     }
 
-    AlignmentSP.s = IPS_OK;
-    IDSetSwitch(&AlignmentSP, nullptr);
+    AlignmentSP.setState(IPS_OK);
+    AlignmentSP.apply();
 }
 
 bool LX200Telescope::getLocalTime(char *timeString)
@@ -1304,7 +1304,7 @@ bool LX200Telescope::sendScopeTime()
     {
         char utcStr[8] = {0};
         snprintf(utcStr, 8, "%.2f", offset);
-        IUSaveText(&TimeT[1], utcStr);
+        TimeTP[1].setText(utcStr);
     }
     else
     {
@@ -1346,14 +1346,14 @@ bool LX200Telescope::sendScopeTime()
 
     // Format it into the final UTC ISO 8601
     strftime(cdate, MAXINDINAME, "%Y-%m-%dT%H:%M:%S", &utm);
-    IUSaveText(&TimeT[0], cdate);
+    TimeTP[0].setText(cdate);
 
-    LOGF_DEBUG("Mount controller UTC Time: %s", TimeT[0].text);
-    LOGF_DEBUG("Mount controller UTC Offset: %s", TimeT[1].text);
+    LOGF_DEBUG("Mount controller UTC Time: %s", TimeTP[0].getText());
+    LOGF_DEBUG("Mount controller UTC Offset: %s", TimeTP[1].getText());
 
     // Let's send everything to the client
-    TimeTP.s = IPS_OK;
-    IDSetText(&TimeTP, nullptr);
+    TimeTP.setState(IPS_OK);
+    TimeTP.apply();
 
     return true;
 }
@@ -1367,11 +1367,11 @@ bool LX200Telescope::sendScopeLocation()
 
     if (isSimulation())
     {
-        LocationNP.np[LOCATION_LATITUDE].value = 29.5;
-        LocationNP.np[LOCATION_LONGITUDE].value = 48.0;
-        LocationNP.np[LOCATION_ELEVATION].value = 10;
-        LocationNP.s           = IPS_OK;
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP[LOCATION_LATITUDE].setValue(29.5);
+        LocationNP[LOCATION_LONGITUDE].setValue(48.0);
+        LocationNP[LOCATION_ELEVATION].setValue(10);
+        LocationNP.setState(IPS_OK);
+        LocationNP.apply();
         return true;
     }
 
@@ -1383,7 +1383,7 @@ bool LX200Telescope::sendScopeLocation()
     else
     {
         snprintf(lat_sexagesimal, MAXINDIFORMAT,"%02d:%02d:%02.1lf", lat_dd, lat_mm, lat_ssf);
-        f_scansexa(lat_sexagesimal, &(LocationNP.np[LOCATION_LATITUDE].value));
+        f_scansexa(lat_sexagesimal, &(LocationNP[LOCATION_LATITUDE].value));
     }
 
     if (getSiteLongitude(PortFD, &long_dd, &long_mm, &long_ssf) < 0)
@@ -1394,16 +1394,16 @@ bool LX200Telescope::sendScopeLocation()
     else
     {
         snprintf(lng_sexagesimal, MAXINDIFORMAT,"%02d:%02d:%02.1lf", long_dd, long_mm, long_ssf);
-        f_scansexa(lng_sexagesimal, &(LocationNP.np[LOCATION_LONGITUDE].value));
+        f_scansexa(lng_sexagesimal, &(LocationNP[LOCATION_LONGITUDE].value));
     }
 
     LOGF_INFO("Mount has Latitude %s (%g) Longitude %s (%g) (Longitude sign in carthography format)",
               lat_sexagesimal,
-              LocationN[LOCATION_LATITUDE].value,
+              LocationNP[LOCATION_LATITUDE].getValue(),
               lng_sexagesimal,
-              LocationN[LOCATION_LONGITUDE].value);
+              LocationNP[LOCATION_LONGITUDE].getValue());
 
-    IDSetNumber(&LocationNP, nullptr);
+    LocationNP.apply();
 
     saveConfig(true, "GEOGRAPHIC_COORD");
 
@@ -1419,7 +1419,7 @@ IPState LX200Telescope::GuideNorth(uint32_t ms)
     }
 
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1440,8 +1440,8 @@ IPState LX200Telescope::GuideNorth(uint32_t ms)
         updateSlewRate(SLEW_GUIDE);
 
         ISState states[] = { ISS_ON, ISS_OFF };
-        const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
-        ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementNSSP[DIRECTION_NORTH].getName(), MovementNSSP[DIRECTION_SOUTH].getName()};
+        ISNewSwitch(MovementNSSP.getDeviceName(), MovementNSSP.getName(), states, const_cast<char **>(names), 2);
     }
 
     guide_direction_ns = LX200_NORTH;
@@ -1458,7 +1458,7 @@ IPState LX200Telescope::GuideSouth(uint32_t ms)
     }
 
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1479,8 +1479,8 @@ IPState LX200Telescope::GuideSouth(uint32_t ms)
         updateSlewRate(SLEW_GUIDE);
 
         ISState states[] = { ISS_OFF, ISS_ON };
-        const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
-        ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementNSSP[DIRECTION_NORTH].getName(), MovementNSSP[DIRECTION_SOUTH].getName()};
+        ISNewSwitch(MovementNSSP.getDeviceName(), MovementNSSP.getName(), states, const_cast<char **>(names), 2);
     }
 
     guide_direction_ns = LX200_SOUTH;
@@ -1497,7 +1497,7 @@ IPState LX200Telescope::GuideEast(uint32_t ms)
     }
 
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1518,8 +1518,8 @@ IPState LX200Telescope::GuideEast(uint32_t ms)
         updateSlewRate(SLEW_GUIDE);
 
         ISState states[] = { ISS_OFF, ISS_ON };
-        const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
-        ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementWESP[DIRECTION_WEST].getName(), MovementWESP[DIRECTION_EAST].getName()};
+        ISNewSwitch(MovementWESP.getDeviceName(), MovementWESP.getName(), states, const_cast<char **>(names), 2);
     }
 
     guide_direction_we = LX200_EAST;
@@ -1536,7 +1536,7 @@ IPState LX200Telescope::GuideWest(uint32_t ms)
     }
 
     // If we're using pulse command, then MovementXXX should NOT be active at all.
-    if (usePulseCommand && (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY))
+    if (usePulseCommand && (MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY))
     {
         LOG_ERROR("Cannot pulse guide while manually in motion. Stop first.");
         return IPS_ALERT;
@@ -1557,8 +1557,8 @@ IPState LX200Telescope::GuideWest(uint32_t ms)
         updateSlewRate(SLEW_GUIDE);
 
         ISState states[] = { ISS_ON, ISS_OFF };
-        const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
-        ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementWESP[DIRECTION_WEST].getName(), MovementWESP[DIRECTION_EAST].getName()};
+        ISNewSwitch(MovementWESP.getDeviceName(), MovementWESP.getName(), states, const_cast<char **>(names), 2);
     }
 
     guide_direction_we = LX200_WEST;
@@ -1586,8 +1586,8 @@ void LX200Telescope::guideTimeoutWE()
     if (usePulseCommand == false)
     {
         ISState states[] = { ISS_OFF, ISS_OFF };
-        const char *names[] = { MovementWES[DIRECTION_WEST].name, MovementWES[DIRECTION_EAST].name};
-        ISNewSwitch(MovementWESP.device, MovementWESP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementWESP[DIRECTION_WEST].getName(), MovementWESP[DIRECTION_EAST].getName()};
+        ISNewSwitch(MovementWESP.getDeviceName(), MovementWESP.getName(), states, const_cast<char **>(names), 2);
     }
 
     GuideWENP.np[DIRECTION_WEST].value = 0;
@@ -1602,8 +1602,8 @@ void LX200Telescope::guideTimeoutNS()
     if (usePulseCommand == false)
     {
         ISState states[] = { ISS_OFF, ISS_OFF };
-        const char *names[] = { MovementNSS[DIRECTION_NORTH].name, MovementNSS[DIRECTION_SOUTH].name};
-        ISNewSwitch(MovementNSSP.device, MovementNSSP.name, states, const_cast<char **>(names), 2);
+        const char *names[] = { MovementNSSP[DIRECTION_NORTH].getName(), MovementNSSP[DIRECTION_SOUTH].getName()};
+        ISNewSwitch(MovementNSSP.getDeviceName(), MovementNSSP.getName(), states, const_cast<char **>(names), 2);
     }
 
     GuideNSNP.np[0].value = 0;
@@ -1619,7 +1619,7 @@ bool LX200Telescope::saveConfigItems(FILE *fp)
     INDI::Telescope::saveConfigItems(fp);
 
     if (genericCapability & LX200_HAS_PULSE_GUIDING)
-        IUSaveConfigSwitch(fp, &UsePulseCmdSP);
+        UsePulseCmdSP.save(fp);
 
     if (genericCapability & LX200_HAS_FOCUS)
         FI::saveConfigItems(fp);
@@ -1642,7 +1642,7 @@ IPState LX200Telescope::MoveFocuser(FocusDirection dir, int speed, uint16_t dura
 {
     FocusDirection finalDirection = dir;
     // Reverse final direction if necessary
-    if (FocusReverseS[INDI_ENABLED].s == ISS_ON)
+    if (FocusReverseSP[INDI_ENABLED].getState() == ISS_ON)
         finalDirection = (dir == FOCUS_INWARD) ? FOCUS_OUTWARD : FOCUS_INWARD;
 
     SetFocuserSpeed(speed);

--- a/drivers/telescope/lx200telescope.h
+++ b/drivers/telescope/lx200telescope.h
@@ -31,6 +31,10 @@
 #include "indifocuserinterface.h"
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200Telescope : public INDI::Telescope, public INDI::GuiderInterface, public INDI::FocuserInterface
 {
     public:
@@ -179,29 +183,24 @@ class LX200Telescope : public INDI::Telescope, public INDI::GuiderInterface, pub
         int MaxReticleFlashRate {0};
 
         /* Telescope Alignment Mode */
-        ISwitchVectorProperty AlignmentSP;
-        ISwitch AlignmentS[3];
+        INDI::PropertySwitch AlignmentSP {3};
 
         /* Tracking Frequency */
-        INumberVectorProperty TrackFreqNP;
-        INumber TrackFreqN[1];
+        INDI::PropertyNumber TrackFreqNP {1};
 
         /* Use pulse-guide commands */
-        ISwitchVectorProperty UsePulseCmdSP;
-        ISwitch UsePulseCmdS[2];
+        INDI::PropertySwitch UsePulseCmdSP {2};
         bool usePulseCommand { false };
 
         /* Site Management */
-        ISwitchVectorProperty SiteSP;
-        ISwitch SiteS[4];
+        INDI::PropertySwitch SiteSP {4};
 
         /* Site Name */
         ITextVectorProperty SiteNameTP;
         IText SiteNameT[1] {};
 
         /* Focus Mode */
-        ISwitchVectorProperty FocusModeSP;
-        ISwitch FocusModeS[3];
+        INDI::PropertySwitch FocusModeSP {3};
 
         uint32_t genericCapability {0};
 };

--- a/drivers/telescope/lx200zeq25.h
+++ b/drivers/telescope/lx200zeq25.h
@@ -22,6 +22,10 @@
 
 #include "lx200generic.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class LX200ZEQ25 : public LX200Generic
 {
   public:
@@ -84,10 +88,8 @@ class LX200ZEQ25 : public LX200Generic
     bool getMountInfo();
     void mountSim();
 
-    ISwitch HomeS[1];
-    ISwitchVectorProperty HomeSP;
+    INDI::PropertySwitch HomeSP {1};
 
     /* Guide Rate */
-    INumber GuideRateN[1];
-    INumberVectorProperty GuideRateNP;
+    INDI::PropertyNumber GuideRateNP {1};
 };

--- a/drivers/telescope/paramount.cpp
+++ b/drivers/telescope/paramount.cpp
@@ -133,20 +133,20 @@ bool Paramount::initProperties()
     SlewRateSP.sp[5].s = ISS_ON;
 
     /* How fast do we guide compared to sidereal rate */
-    IUFillNumber(&JogRateN[RA_AXIS], "JOG_RATE_WE", "W/E Rate (arcmin)", "%g", 0, 600, 60, 30);
-    IUFillNumber(&JogRateN[DEC_AXIS], "JOG_RATE_NS", "N/S Rate (arcmin)", "%g", 0, 600, 60, 30);
-    IUFillNumberVector(&JogRateNP, JogRateN, 2, getDeviceName(), "JOG_RATE", "Jog Rate", MOTION_TAB, IP_RW, 0,
+    JogRateNP[RA_AXIS].fill("JOG_RATE_WE", "W/E Rate (arcmin)", "%g", 0, 600, 60, 30);
+    JogRateNP[DEC_AXIS].fill("JOG_RATE_NS", "N/S Rate (arcmin)", "%g", 0, 600, 60, 30);
+    JogRateNP.fill(getDeviceName(), "JOG_RATE", "Jog Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     /* How fast do we guide compared to sidereal rate */
-    IUFillNumber(&GuideRateN[RA_AXIS], "GUIDE_RATE_WE", "W/E Rate", "%1.1f", 0.0, 1.0, 0.1, 0.5);
-    IUFillNumber(&GuideRateN[DEC_AXIS], "GUIDE_RATE_NS", "N/S Rate", "%1.1f", 0.0, 1.0, 0.1, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
+    GuideRateNP[RA_AXIS].fill("GUIDE_RATE_WE", "W/E Rate", "%1.1f", 0.0, 1.0, 0.1, 0.5);
+    GuideRateNP[DEC_AXIS].fill("GUIDE_RATE_NS", "N/S Rate", "%1.1f", 0.0, 1.0, 0.1, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     // Homing
-    IUFillSwitch(&HomeS[0], "GO", "Go", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 1, getDeviceName(), "TELESCOPE_HOME", "Homing", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
+    HomeSP[0].fill("GO", "Go", ISS_OFF);
+    HomeSP.fill(getDeviceName(), "TELESCOPE_HOME", "Homing", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_IDLE);
     // Tracking Mode
 #if 0
@@ -165,17 +165,17 @@ bool Paramount::initProperties()
 
     // Custom Tracking Rate
 #if 0
-    IUFillNumber(&TrackRateN[0], "TRACK_RATE_RA", "RA (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001, 15.041067);
-    IUFillNumber(&TrackRateN[1], "TRACK_RATE_DE", "DE (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001, 0);
-    IUFillNumberVector(&TrackRateNP, TrackRateN, 2, getDeviceName(), "TELESCOPE_TRACK_RATE", "Track Rates",
+    TrackRateNP[0].fill("TRACK_RATE_RA", "RA (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001, 15.041067);
+    TrackRateNP[1].fill("TRACK_RATE_DE", "DE (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001, 0);
+    TrackRateNP.fill(getDeviceName(), "TELESCOPE_TRACK_RATE", "Track Rates",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 #endif
 
     // Let's simulate it to be an F/7.5 120mm telescope with 50m 175mm guide scope
-    ScopeParametersN[0].value = 120;
-    ScopeParametersN[1].value = 900;
-    ScopeParametersN[2].value = 50;
-    ScopeParametersN[3].value = 175;
+    ScopeParametersNP[0].setValue(120);
+    ScopeParametersNP[1].setValue(900);
+    ScopeParametersNP[2].setValue(50);
+    ScopeParametersNP[3].setValue(175);
 
     TrackState = SCOPE_IDLE;
 
@@ -216,13 +216,13 @@ bool Paramount::updateProperties()
         }
 
         //defineProperty(&TrackModeSP);
-        //defineProperty(&TrackRateNP);
+        //defineProperty(TrackRateNP);
 
-        defineProperty(&JogRateNP);
+        defineProperty(JogRateNP);
 
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
-        defineProperty(&GuideRateNP);
+        defineProperty(GuideRateNP);
 
         // Initial HA to 0 and currentDEC (+90 or -90)
         if (InitPark())
@@ -242,19 +242,19 @@ bool Paramount::updateProperties()
 
         SetParked(isTheSkyParked());
 
-        defineProperty(&HomeSP);
+        defineProperty(HomeSP);
     }
     else
     {
         //deleteProperty(TrackModeSP.name);
-        //deleteProperty(TrackRateNP.name);
+        //deleteProperty(TrackRateNP.getName());
 
-        deleteProperty(JogRateNP.name);
+        deleteProperty(JogRateNP.getName());
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
-        deleteProperty(GuideRateNP.name);
-        deleteProperty(HomeSP.name);
+        deleteProperty(GuideRateNP.getName());
+        deleteProperty(HomeSP.getName());
     }
 
     return true;
@@ -417,10 +417,10 @@ bool Paramount::ReadScopeStatus()
         {
             TrackState = SCOPE_TRACKING;
 
-            if (HomeSP.s == IPS_BUSY)
+            if (HomeSP.getState() == IPS_BUSY)
             {
-                IUResetSwitch(&HomeSP);
-                HomeSP.s = IPS_OK;
+                HomeSP.reset();
+                HomeSP.setState(IPS_OK);
                 LOG_INFO("Finding home completed.");
             }
             else
@@ -485,7 +485,7 @@ bool Paramount::Goto(double r, double d)
 
     TrackState = SCOPE_SLEWING;
 
-    //EqNP.s = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     LOGF_INFO("Slewing to RA: %s - DEC: %s", RAStr, DecStr);
     return true;
@@ -632,7 +632,7 @@ bool Paramount::Sync(double ra, double dec)
 
     LOG_INFO("Sync is successful.");
 
-    EqNP.s = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -642,7 +642,7 @@ bool Paramount::Sync(double ra, double dec)
 bool Paramount::Park()
 {
     double targetHA = GetAxis1Park();
-    targetRA  = range24(get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value) - targetHA);
+    targetRA  = range24(get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].value) - targetHA);
     targetDEC = GetAxis2Park();
 
     char pCMD[MAXRBUF] = {0};
@@ -675,18 +675,18 @@ bool Paramount::ISNewNumber(const char *dev, const char *name, double values[], 
     {
         if (strcmp(name, "JOG_RATE") == 0)
         {
-            IUUpdateNumber(&JogRateNP, values, names, n);
-            JogRateNP.s = IPS_OK;
-            IDSetNumber(&JogRateNP, nullptr);
+            JogRateNP.update(values, names, n);
+            JogRateNP.setState(IPS_OK);
+            JogRateNP.apply();
             return true;
         }
 
         // Guiding Rate
-        if (strcmp(name, GuideRateNP.name) == 0)
+        if (GuideRateNP.isNameMatch(name))
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
-            GuideRateNP.s = IPS_OK;
-            IDSetNumber(&GuideRateNP, nullptr);
+            GuideRateNP.update(values, names, n);
+            GuideRateNP.setState(IPS_OK);
+            GuideRateNP.apply();
             return true;
         }
 
@@ -706,24 +706,24 @@ bool Paramount::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(HomeSP.name, name))
+        if (HomeSP.isNameMatch(name))
         {
             LOG_INFO("Moving to home position. Please stand by...");
             if (findHome())
             {
-                HomeS[0].s = ISS_OFF;
+                HomeSP[0].setState(ISS_OFF);
                 TrackState = SCOPE_IDLE;
-                HomeSP.s = IPS_OK;
+                HomeSP.setState(IPS_OK);
                 LOG_INFO("Mount arrived at home position.");
             }
             else
             {
-                HomeS[0].s = ISS_OFF;
-                HomeSP.s = IPS_ALERT;
+                HomeSP[0].setState(ISS_OFF);
+                HomeSP.setState(IPS_ALERT);
                 LOG_ERROR("Failed to go to home position");
             }
 
-            IDSetSwitch(&HomeSP, nullptr);
+            HomeSP.apply();
             return true;
         }
     }
@@ -873,7 +873,7 @@ bool Paramount::SetCurrentPark()
     if (!sendTheSkyOKCommand(pCMD, "Setting Park Position"))
         return false;
 
-    double lst = get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value);
+    double lst = get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].value);
     double ha  = get_local_hour_angle(lst, currentRA);
 
     SetAxis1Park(ha);
@@ -888,7 +888,7 @@ bool Paramount::SetDefaultPark()
     SetAxis1Park(0);
 
     // Set DEC to 90 or -90 depending on the hemisphere
-    SetAxis2Park((LocationN[LOCATION_LATITUDE].value > 0) ? 90 : -90);
+    SetAxis2Park((LocationNP[LOCATION_LATITUDE].value > 0) ? 90 : -90);
 
     return true;
 }
@@ -940,22 +940,22 @@ void Paramount::mountSim()
 
     double motionRate = 0;
 
-    if (MovementNSSP.s == IPS_BUSY)
-        motionRate = JogRateN[0].value;
-    else if (MovementWESP.s == IPS_BUSY)
-        motionRate = JogRateN[1].value;
+    if (MovementNSSP.getState() == IPS_BUSY)
+        motionRate = JogRateNP[0].getValue();
+    else if (MovementWESP.getState() == IPS_BUSY)
+        motionRate = JogRateNP[1].getValue();
 
     if (motionRate != 0)
     {
         da_ra  = motionRate * dt * 0.05;
         da_dec = motionRate * dt * 0.05;
 
-        switch (MovementNSSP.s)
+        switch (MovementNSSP.getState())
         {
             case IPS_BUSY:
-                if (MovementNSS[DIRECTION_NORTH].s == ISS_ON)
+                if (MovementNSSP[DIRECTION_NORTH].getState() == ISS_ON)
                     currentDEC += da_dec;
-                else if (MovementNSS[DIRECTION_SOUTH].s == ISS_ON)
+                else if (MovementNSSP[DIRECTION_SOUTH].getState() == ISS_ON)
                     currentDEC -= da_dec;
                 break;
 
@@ -963,12 +963,12 @@ void Paramount::mountSim()
                 break;
         }
 
-        switch (MovementWESP.s)
+        switch (MovementWESP.getState())
         {
             case IPS_BUSY:
-                if (MovementWES[DIRECTION_WEST].s == ISS_ON)
+                if (MovementWESP[DIRECTION_WEST].getState() == ISS_ON)
                     currentRA += da_ra / 15.;
-                else if (MovementWES[DIRECTION_EAST].s == ISS_ON)
+                else if (MovementWESP[DIRECTION_EAST].getState() == ISS_ON)
                     currentRA -= da_ra / 15.;
                 break;
 
@@ -1095,7 +1095,7 @@ bool Paramount::sendTheSkyOKCommand(const char *command, const char *errorMessag
 IPState Paramount::GuideNorth(uint32_t ms)
 {
     // Movement in arcseconds
-    double dDec = GuideRateN[DEC_AXIS].value * TRACKRATE_SIDEREAL * ms / 1000.0;
+    double dDec = GuideRateNP[DEC_AXIS].value * TRACKRATE_SIDEREAL * ms / 1000.0;
 
     char pCMD[MAXRBUF] = {0};
     snprintf(pCMD, MAXRBUF, "sky6DirectGuide.MoveTelescope(%g, %g);", 0., dDec);
@@ -1109,7 +1109,7 @@ IPState Paramount::GuideNorth(uint32_t ms)
 IPState Paramount::GuideSouth(uint32_t ms)
 {
     // Movement in arcseconds
-    double dDec = GuideRateN[DEC_AXIS].value * TRACKRATE_SIDEREAL * ms / -1000.0;
+    double dDec = GuideRateNP[DEC_AXIS].value * TRACKRATE_SIDEREAL * ms / -1000.0;
     char pCMD[MAXRBUF] = {0};
 
     snprintf(pCMD, MAXRBUF, "sky6DirectGuide.MoveTelescope(%g, %g);", 0., dDec);
@@ -1122,7 +1122,7 @@ IPState Paramount::GuideSouth(uint32_t ms)
 IPState Paramount::GuideEast(uint32_t ms)
 {
     // Movement in arcseconds
-    double dRA = GuideRateN[RA_AXIS].value * TRACKRATE_SIDEREAL * ms / 1000.0;
+    double dRA = GuideRateNP[RA_AXIS].value * TRACKRATE_SIDEREAL * ms / 1000.0;
     char pCMD[MAXRBUF] = {0};
 
     snprintf(pCMD, MAXRBUF, "sky6DirectGuide.MoveTelescope(%g, %g);", dRA, 0.);
@@ -1135,7 +1135,7 @@ IPState Paramount::GuideEast(uint32_t ms)
 IPState Paramount::GuideWest(uint32_t ms)
 {
     // Movement in arcseconds
-    double dRA = GuideRateN[RA_AXIS].value * TRACKRATE_SIDEREAL * ms / -1000.0;
+    double dRA = GuideRateNP[RA_AXIS].value * TRACKRATE_SIDEREAL * ms / -1000.0;
     char pCMD[MAXRBUF] = {0};
 
     snprintf(pCMD, MAXRBUF, "sky6DirectGuide.MoveTelescope(%g, %g);", dRA, 0.);
@@ -1171,8 +1171,8 @@ bool Paramount::SetTrackMode(uint8_t mode)
         dRA = TRACKRATE_LUNAR;
     else if (mode == TRACK_CUSTOM)
     {
-        dRA = TrackRateN[RA_AXIS].value;
-        dDE = TrackRateN[DEC_AXIS].value;
+        dRA = TrackRateNP[RA_AXIS].getValue();
+        dDE = TrackRateNP[DEC_AXIS].getValue();
     }
     return setTheSkyTracking(true, isSidereal, dRA, dDE);
 }

--- a/drivers/telescope/paramount.h
+++ b/drivers/telescope/paramount.h
@@ -25,6 +25,10 @@
 #include "indiguiderinterface.h"
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class Paramount : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -95,22 +99,19 @@ class Paramount : public INDI::Telescope, public INDI::GuiderInterface
         unsigned int DBG_SCOPE { 0 };
 
         // Jog Rate
-        INumber JogRateN[2];
-        INumberVectorProperty JogRateNP;
+        INDI::PropertyNumber JogRateNP {2};
 
         // Guide Rate
-        INumber GuideRateN[2];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};
 
         // Tracking Mode
         ISwitch TrackModeS[4];
         ISwitchVectorProperty TrackModeSP;
 
         // Homing
-        ISwitchVectorProperty HomeSP;
-        ISwitch HomeS[1];
+        INDI::PropertySwitch HomeSP {1};
 
         // Tracking Rate
-        //    INumber TrackRateN[2];
-        //    INumberVectorProperty TrackRateNP;
+        //    INDI::PropertyNumber TrackRateNP {2};
+        //
 };

--- a/drivers/telescope/pmc8.h
+++ b/drivers/telescope/pmc8.h
@@ -29,6 +29,11 @@
 #include "indiguiderinterface.h"
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class PMC8 : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -114,12 +119,10 @@ class PMC8 : public INDI::Telescope, public INDI::GuiderInterface
         void getStartupData();
 
         /* Firmware */
-        IText FirmwareT[1] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {1};
 
         /* Mount Types */
-        ISwitch MountTypeS[3];
-        ISwitchVectorProperty MountTypeSP;
+        INDI::PropertySwitch MountTypeSP {3};
 
         //Moved to driver
         //enum { MOUNT_G11, MOUNT_EXOS2, MOUNT_iEXOS100 };
@@ -133,8 +136,7 @@ class PMC8 : public INDI::Telescope, public INDI::GuiderInterface
         //INumberVectorProperty CustomTrackRateNP;
 
         /* Guide Rate */
-        INumber GuideRateN[1];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {1};
 
         unsigned int DBG_SCOPE;
         double currentRA, currentDEC;

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -23,6 +23,10 @@
 #include "inditelescope.h"
 #include "indiguiderinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -148,14 +152,10 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         ///////////////////////////////////////////////////////////////////////////////////
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////////
-        ISwitchVectorProperty HomeSP;
-        ISwitch HomeS[1];
+        INDI::PropertySwitch HomeSP {1};
+        INDI::PropertyNumber HorizontalCoordsNP {2};
 
-        INumberVectorProperty HorizontalCoordsNP;
-        INumber HorizontalCoordsN[2];
-
-        INumber GuideRateN[1];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {1};
 
         const std::string getSlewErrorString(uint8_t code);
         uint8_t m_SlewErrorCode {0};

--- a/drivers/telescope/skywatcherAPIMount.cpp
+++ b/drivers/telescope/skywatcherAPIMount.cpp
@@ -138,19 +138,19 @@ bool SkywatcherAPIMount::Handshake()
 
     // The default slew mode is silent on Virtuoso mounts.
     //    if (Result && !RecoverAfterReconnection && IsVirtuosoMount() &&
-    //            IUFindSwitch(&SlewModesSP, "SLEW_SILENT") != nullptr &&
-    //            IUFindSwitch(&SlewModesSP, "SLEW_NORMAL") != nullptr)
+    //            SlewModesSP.findWidgetByName("SLEW_SILENT") != nullptr &&
+    //            SlewModesSP.findWidgetByName("SLEW_NORMAL") != nullptr)
     //    {
-    //        IUFindSwitch(&SlewModesSP, "SLEW_SILENT")->s = ISS_ON;
-    //        IUFindSwitch(&SlewModesSP, "SLEW_NORMAL")->s = ISS_OFF;
+    //        SlewModesSP.findWidgetByName("SLEW_SILENT")->s = ISS_ON;
+    //        SlewModesSP.findWidgetByName("SLEW_NORMAL")->s = ISS_OFF;
     //    }
     // The SoftPEC is enabled on Virtuoso mounts by default.
     //    if (Result && !RecoverAfterReconnection && IsVirtuosoMount() &&
-    //            IUFindSwitch(&SoftPECModesSP, "SOFTPEC_ENABLED") != nullptr &&
-    //            IUFindSwitch(&SoftPECModesSP, "SOFTPEC_DISABLED") != nullptr)
+    //            SoftPECModesSP.findWidgetByName("SOFTPEC_ENABLED") != nullptr &&
+    //            SoftPECModesSP.findWidgetByName("SOFTPEC_DISABLED") != nullptr)
     //    {
-    //        IUFindSwitch(&SoftPECModesSP, "SOFTPEC_ENABLED")->s  = ISS_ON;
-    //        IUFindSwitch(&SoftPECModesSP, "SOFTPEC_DISABLED")->s = ISS_OFF;
+    //        SoftPECModesSP.findWidgetByName("SOFTPEC_ENABLED")->s  = ISS_ON;
+    //        SoftPECModesSP.findWidgetByName("SOFTPEC_DISABLED")->s = ISS_OFF;
     //    }
     //    // The default position is parking on Virtuoso mounts (the telescope is oriented to polar).
     //    if (Result && !RecoverAfterReconnection && IsVirtuosoMount())
@@ -158,12 +158,12 @@ bool SkywatcherAPIMount::Handshake()
     //        SetParked(true);
     //    }
     // The default mode is Slew out of Track/Slew/Sync
-    //    if (!RecoverAfterReconnection && IUFindSwitch(&CoordSP, "TRACK") != nullptr &&
-    //            IUFindSwitch(&CoordSP, "SLEW") != nullptr && IUFindSwitch(&CoordSP, "SYNC") != nullptr)
+    //    if (!RecoverAfterReconnection && CoordSP.findWidgetByName("TRACK") != nullptr &&
+    //            CoordSP.findWidgetByName("SLEW") != nullptr && CoordSP.findWidgetByName("SYNC") != nullptr)
     //    {
-    //        IUFindSwitch(&CoordSP, "TRACK")->s = ISS_OFF;
-    //        IUFindSwitch(&CoordSP, "SLEW")->s  = ISS_ON;
-    //        IUFindSwitch(&CoordSP, "SYNC")->s  = ISS_OFF;
+    //        CoordSP.findWidgetByName("TRACK")->s = ISS_OFF;
+    //        CoordSP.findWidgetByName("SLEW")->s  = ISS_ON;
+    //        CoordSP.findWidgetByName("SYNC")->s  = ISS_OFF;
     //    }
     DEBUGF(DBG_SCOPE, "SkywatcherAPIMount::Handshake - Result: %d", Result);
     return Result;
@@ -183,7 +183,7 @@ bool SkywatcherAPIMount::Goto(double ra, double dec)
 
     DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "RA %lf DEC %lf", ra, dec);
 
-    if (IUFindSwitch(&CoordSP, "TRACK")->s == ISS_ON || IUFindSwitch(&CoordSP, "SLEW")->s == ISS_ON)
+    if (CoordSP.findWidgetByName("TRACK")->s == ISS_ON || CoordSP.findWidgetByName("SLEW")->s == ISS_ON)
     {
         char RAStr[32], DecStr[32];
         fs_sexa(RAStr, ra, 2, 3600);
@@ -208,12 +208,12 @@ bool SkywatcherAPIMount::Goto(double ra, double dec)
         bool HavePosition = false;
         ln_lnlat_posn Position { 0, 0 };
 
-        if ((nullptr != IUFindNumber(&LocationNP, "LAT")) && (0 != IUFindNumber(&LocationNP, "LAT")->value) &&
-                (nullptr != IUFindNumber(&LocationNP, "LONG")) && (0 != IUFindNumber(&LocationNP, "LONG")->value))
+        if ((nullptr != LocationNP.findWidgetByName("LAT")) && (0 != LocationNP.findWidgetByName("LAT")->value) &&
+                (nullptr != LocationNP.findWidgetByName("LONG")) && (0 != LocationNP.findWidgetByName("LONG")->value))
         {
             // I assume that being on the equator and exactly on the prime meridian is unlikely
-            Position.lat = IUFindNumber(&LocationNP, "LAT")->value;
-            Position.lng = IUFindNumber(&LocationNP, "LONG")->value;
+            Position.lat = LocationNP.findWidgetByName("LAT")->value;
+            Position.lng = LocationNP.findWidgetByName("LONG")->value;
             HavePosition = true;
         }
         ln_equ_posn EquatorialCoordinates { 0, 0 };
@@ -260,8 +260,8 @@ bool SkywatcherAPIMount::Goto(double ra, double dec)
     //    {
     //        // The initial position of the Virtuoso mount is polar aligned when switched on.
     //        // The altitude is corrected by the latitude.
-    //        if (IUFindNumber(&LocationNP, "LAT") != nullptr)
-    //            AltAz.alt = AltAz.alt - IUFindNumber(&LocationNP, "LAT")->value;
+    //        if (LocationNP.findWidgetByName("LAT") != nullptr)
+    //            AltAz.alt = AltAz.alt - LocationNP.findWidgetByName("LAT")->value;
 
     //        AltAz.az = 180 + AltAz.az;
     //    }
@@ -298,7 +298,7 @@ bool SkywatcherAPIMount::Goto(double ra, double dec)
     DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "Altitude offset %ld microsteps Azimuth offset %ld microsteps",
            AltitudeOffsetMicrosteps, AzimuthOffsetMicrosteps);
 
-    if (IUFindSwitch(&SlewModesSP, "SLEW_SILENT") != nullptr && IUFindSwitch(&SlewModesSP, "SLEW_SILENT")->s == ISS_ON)
+    if (SlewModesSP.findWidgetByName("SLEW_SILENT") != nullptr && SlewModesSP.findWidgetByName("SLEW_SILENT")->s == ISS_ON)
     {
         SilentSlewMode = true;
     }
@@ -311,7 +311,7 @@ bool SkywatcherAPIMount::Goto(double ra, double dec)
 
     TrackState = SCOPE_SLEWING;
 
-    //EqNP.s = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     return true;
 }
@@ -339,87 +339,87 @@ bool SkywatcherAPIMount::initProperties()
     getSwitch("ALIGNMENT_SUBSYSTEM_ACTIVE")->sp[0].s = ISS_ON;
 
     // Set up property variables
-    IUFillText(&BasicMountInfoT[MOTOR_CONTROL_FIRMWARE_VERSION], "MOTOR_CONTROL_FIRMWARE_VERSION",
+    BasicMountInfoTP[MOTOR_CONTROL_FIRMWARE_VERSION].fill("MOTOR_CONTROL_FIRMWARE_VERSION",
                "Motor control firmware version", "-");
-    IUFillText(&BasicMountInfoT[MOUNT_CODE], "MOUNT_CODE", "Mount code", "-");
-    IUFillText(&BasicMountInfoT[MOUNT_NAME], "MOUNT_NAME", "Mount name", "-");
-    IUFillText(&BasicMountInfoT[IS_DC_MOTOR], "IS_DC_MOTOR", "Is DC motor", "-");
-    IUFillTextVector(&BasicMountInfoTP, BasicMountInfoT, 4, getDeviceName(), "BASIC_MOUNT_INFO",
+    BasicMountInfoTP[MOUNT_CODE].fill("MOUNT_CODE", "Mount code", "-");
+    BasicMountInfoTP[MOUNT_NAME].fill("MOUNT_NAME", "Mount name", "-");
+    BasicMountInfoTP[IS_DC_MOTOR].fill("IS_DC_MOTOR", "Is DC motor", "-");
+    BasicMountInfoTP.fill(getDeviceName(), "BASIC_MOUNT_INFO",
                      "Basic mount information", DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisOneInfoN[MICROSTEPS_PER_REVOLUTION], "MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
+    AxisOneInfoNP[MICROSTEPS_PER_REVOLUTION].fill("MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
                  "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneInfoN[STEPPER_CLOCK_FREQUENCY], "STEPPER_CLOCK_FREQUENCY", "Stepper clock frequency", "%.0f", 0,
+    AxisOneInfoNP[STEPPER_CLOCK_FREQUENCY].fill("STEPPER_CLOCK_FREQUENCY", "Stepper clock frequency", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneInfoN[HIGH_SPEED_RATIO], "HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneInfoN[MICROSTEPS_PER_WORM_REVOLUTION], "MICROSTEPS_PER_WORM_REVOLUTION",
+    AxisOneInfoNP[HIGH_SPEED_RATIO].fill("HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisOneInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].fill("MICROSTEPS_PER_WORM_REVOLUTION",
                  "Microsteps per worm revolution", "%.0f", 0, 0xFFFFFF, 1, 0);
 
-    IUFillNumberVector(&AxisOneInfoNP, AxisOneInfoN, 4, getDeviceName(), "AXIS_ONE_INFO", "Axis one information",
+    AxisOneInfoNP.fill(getDeviceName(), "AXIS_ONE_INFO", "Axis one information",
                        DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&AxisOneStateS[FULL_STOP], "FULL_STOP", "FULL_STOP", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[SLEWING], "SLEWING", "SLEWING", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[SLEWING_TO], "SLEWING_TO", "SLEWING_TO", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[SLEWING_FORWARD], "SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[HIGH_SPEED], "HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[NOT_INITIALISED], "NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
-    IUFillSwitchVector(&AxisOneStateSP, AxisOneStateS, 6, getDeviceName(), "AXIS_ONE_STATE", "Axis one state",
+    AxisOneStateSP[FULL_STOP].fill("FULL_STOP", "FULL_STOP", ISS_OFF);
+    AxisOneStateSP[SLEWING].fill("SLEWING", "SLEWING", ISS_OFF);
+    AxisOneStateSP[SLEWING_TO].fill("SLEWING_TO", "SLEWING_TO", ISS_OFF);
+    AxisOneStateSP[SLEWING_FORWARD].fill("SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
+    AxisOneStateSP[HIGH_SPEED].fill("HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
+    AxisOneStateSP[NOT_INITIALISED].fill("NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
+    AxisOneStateSP.fill(getDeviceName(), "AXIS_ONE_STATE", "Axis one state",
                        DetailedMountInfoPage, IP_RO, ISR_NOFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisTwoInfoN[MICROSTEPS_PER_REVOLUTION], "MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
+    AxisTwoInfoNP[MICROSTEPS_PER_REVOLUTION].fill("MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
                  "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoInfoN[STEPPER_CLOCK_FREQUENCY], "STEPPER_CLOCK_FREQUENCY", "Step timer frequency", "%.0f", 0,
+    AxisTwoInfoNP[STEPPER_CLOCK_FREQUENCY].fill("STEPPER_CLOCK_FREQUENCY", "Step timer frequency", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoInfoN[HIGH_SPEED_RATIO], "HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoInfoN[MICROSTEPS_PER_WORM_REVOLUTION], "MICROSTEPS_PER_WORM_REVOLUTION",
+    AxisTwoInfoNP[HIGH_SPEED_RATIO].fill("HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisTwoInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].fill("MICROSTEPS_PER_WORM_REVOLUTION",
                  "Mictosteps per worm revolution", "%.0f", 0, 0xFFFFFF, 1, 0);
 
-    IUFillNumberVector(&AxisTwoInfoNP, AxisTwoInfoN, 4, getDeviceName(), "AXIS_TWO_INFO", "Axis two information",
+    AxisTwoInfoNP.fill(getDeviceName(), "AXIS_TWO_INFO", "Axis two information",
                        DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&AxisTwoStateS[FULL_STOP], "FULL_STOP", "FULL_STOP", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[SLEWING], "SLEWING", "SLEWING", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[SLEWING_TO], "SLEWING_TO", "SLEWING_TO", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[SLEWING_FORWARD], "SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[HIGH_SPEED], "HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[NOT_INITIALISED], "NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
-    IUFillSwitchVector(&AxisTwoStateSP, AxisTwoStateS, 6, getDeviceName(), "AXIS_TWO_STATE", "Axis two state",
+    AxisTwoStateSP[FULL_STOP].fill("FULL_STOP", "FULL_STOP", ISS_OFF);
+    AxisTwoStateSP[SLEWING].fill("SLEWING", "SLEWING", ISS_OFF);
+    AxisTwoStateSP[SLEWING_TO].fill("SLEWING_TO", "SLEWING_TO", ISS_OFF);
+    AxisTwoStateSP[SLEWING_FORWARD].fill("SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
+    AxisTwoStateSP[HIGH_SPEED].fill("HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
+    AxisTwoStateSP[NOT_INITIALISED].fill("NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
+    AxisTwoStateSP.fill(getDeviceName(), "AXIS_TWO_STATE", "Axis two state",
                        DetailedMountInfoPage, IP_RO, ISR_NOFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisOneEncoderValuesN[RAW_MICROSTEPS], "RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneEncoderValuesN[MICROSTEPS_PER_ARCSEC], "MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
+    AxisOneEncoderValuesNP[RAW_MICROSTEPS].fill("RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisOneEncoderValuesNP[MICROSTEPS_PER_ARCSEC].fill("MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
                  "%.4f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneEncoderValuesN[OFFSET_FROM_INITIAL], "OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
+    AxisOneEncoderValuesNP[OFFSET_FROM_INITIAL].fill("OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneEncoderValuesN[DEGREES_FROM_INITIAL], "DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
+    AxisOneEncoderValuesNP[DEGREES_FROM_INITIAL].fill("DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
                  -1000.0, 1000.0, 1, 0);
 
-    IUFillNumberVector(&AxisOneEncoderValuesNP, AxisOneEncoderValuesN, 4, getDeviceName(), "AXIS1_ENCODER_VALUES",
+    AxisOneEncoderValuesNP.fill(getDeviceName(), "AXIS1_ENCODER_VALUES",
                        "Axis 1 Encoder values", DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisTwoEncoderValuesN[RAW_MICROSTEPS], "RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoEncoderValuesN[MICROSTEPS_PER_ARCSEC], "MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
+    AxisTwoEncoderValuesNP[RAW_MICROSTEPS].fill("RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisTwoEncoderValuesNP[MICROSTEPS_PER_ARCSEC].fill("MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
                  "%.4f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoEncoderValuesN[OFFSET_FROM_INITIAL], "OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
+    AxisTwoEncoderValuesNP[OFFSET_FROM_INITIAL].fill("OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoEncoderValuesN[DEGREES_FROM_INITIAL], "DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
+    AxisTwoEncoderValuesNP[DEGREES_FROM_INITIAL].fill("DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
                  -1000.0, 1000.0, 1, 0);
 
-    IUFillNumberVector(&AxisTwoEncoderValuesNP, AxisTwoEncoderValuesN, 4, getDeviceName(), "AXIS2_ENCODER_VALUES",
+    AxisTwoEncoderValuesNP.fill(getDeviceName(), "AXIS2_ENCODER_VALUES",
                        "Axis 2 Encoder values", DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
     // Register any visible before connection properties
 
     // Slew modes
-    IUFillSwitch(&SlewModesS[SLEW_SILENT], "SLEW_SILENT", "Silent", ISS_OFF);
-    IUFillSwitch(&SlewModesS[SLEW_NORMAL], "SLEW_NORMAL", "Normal", ISS_ON);
-    IUFillSwitchVector(&SlewModesSP, SlewModesS, 2, getDeviceName(), "TELESCOPE_MOTION_SLEWMODE", "Slew Mode",
+    SlewModesSP[SLEW_SILENT].fill("SLEW_SILENT", "Silent", ISS_OFF);
+    SlewModesSP[SLEW_NORMAL].fill("SLEW_NORMAL", "Normal", ISS_ON);
+    SlewModesSP.fill(getDeviceName(), "TELESCOPE_MOTION_SLEWMODE", "Slew Mode",
                        MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // SoftPEC modes
-    IUFillSwitch(&SoftPECModesS[SOFTPEC_ENABLED], "SOFTPEC_ENABLED", "Enable for tracking", ISS_OFF);
-    IUFillSwitch(&SoftPECModesS[SOFTPEC_DISABLED], "SOFTPEC_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&SoftPECModesSP, SoftPECModesS, 2, getDeviceName(), "TELESCOPE_MOTION_SOFTPECMODE",
+    SoftPECModesSP[SOFTPEC_ENABLED].fill("SOFTPEC_ENABLED", "Enable for tracking", ISS_OFF);
+    SoftPECModesSP[SOFTPEC_DISABLED].fill("SOFTPEC_DISABLED", "Disabled", ISS_ON);
+    SoftPECModesSP.fill(getDeviceName(), "TELESCOPE_MOTION_SOFTPECMODE",
                        "SoftPEC Mode", MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // SoftPEC value for tracking mode
@@ -428,31 +428,31 @@ bool SkywatcherAPIMount::initProperties()
                        IPS_IDLE);
 
     // Guiding rates for RA/DEC axes
-    IUFillNumber(&GuidingRatesN[0], "GUIDERA_RATE", "arcsec/seconds (RA)", "%1.3f", 1.0, 6000.0, 1.0, 120.0);
-    IUFillNumber(&GuidingRatesN[1], "GUIDEDEC_RATE", "arcsec/seconds (Dec)", "%1.3f", 1.0, 6000.0, 1.0, 120.0);
-    IUFillNumberVector(&GuidingRatesNP, GuidingRatesN, 2, getDeviceName(), "GUIDE_RATES", "Guide Rates", MOTION_TAB,
+    GuidingRatesNP[0].fill("GUIDERA_RATE", "arcsec/seconds (RA)", "%1.3f", 1.0, 6000.0, 1.0, 120.0);
+    GuidingRatesNP[1].fill("GUIDEDEC_RATE", "arcsec/seconds (Dec)", "%1.3f", 1.0, 6000.0, 1.0, 120.0);
+    GuidingRatesNP.fill(getDeviceName(), "GUIDE_RATES", "Guide Rates", MOTION_TAB,
                        IP_RW, 60, IPS_IDLE);
 
     // Park movement directions
-    //    IUFillSwitch(&ParkMovementDirectionS[PARK_COUNTERCLOCKWISE], "PMD_COUNTERCLOCKWISE", "Counterclockwise", ISS_ON);
-    //    IUFillSwitch(&ParkMovementDirectionS[PARK_CLOCKWISE], "PMD_CLOCKWISE", "Clockwise", ISS_OFF);
-    //    IUFillSwitchVector(&ParkMovementDirectionSP, ParkMovementDirection, 2, getDeviceName(), "PARK_DIRECTION",
+    //    ParkMovementDirectionSP[PARK_COUNTERCLOCKWISE].fill("PMD_COUNTERCLOCKWISE", "Counterclockwise", ISS_ON);
+    //    ParkMovementDirectionSP[PARK_CLOCKWISE].fill("PMD_CLOCKWISE", "Clockwise", ISS_OFF);
+    //    ParkMovementDirectionSP.fill(getDeviceName(), "PARK_DIRECTION",
     //                       "Park Direction", MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     //    // Park positions
-    //    IUFillSwitch(&ParkPositionS[PARK_NORTH], "PARK_NORTH", "North", ISS_ON);
-    //    IUFillSwitch(&ParkPositionS[PARK_EAST], "PARK_EAST", "East", ISS_OFF);
-    //    IUFillSwitch(&ParkPositionS[PARK_SOUTH], "PARK_SOUTH", "South", ISS_OFF);
-    //    IUFillSwitch(&ParkPositionS[PARK_WEST], "PARK_WEST", "West", ISS_OFF);
-    //    IUFillSwitchVector(&ParkPositionSP, ParkPosition, 4, getDeviceName(), "PARK_POSITION", "Park Position", MOTION_TAB,
+    //    ParkPositionSP[PARK_NORTH].fill("PARK_NORTH", "North", ISS_ON);
+    //    ParkPositionSP[PARK_EAST].fill("PARK_EAST", "East", ISS_OFF);
+    //    ParkPositionSP[PARK_SOUTH].fill("PARK_SOUTH", "South", ISS_OFF);
+    //    ParkPositionSP[PARK_WEST].fill("PARK_WEST", "West", ISS_OFF);
+    //    ParkPositionSP.fill(getDeviceName(), "PARK_POSITION", "Park Position", MOTION_TAB,
     //                       IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     //    // Unpark positions
-    //    IUFillSwitch(&UnparkPositionS[PARK_NORTH], "UNPARK_NORTH", "North", ISS_ON);
-    //    IUFillSwitch(&UnparkPositionS[PARK_EAST], "UNPARK_EAST", "East", ISS_OFF);
-    //    IUFillSwitch(&UnparkPositionS[PARK_SOUTH], "UNPARK_SOUTH", "South", ISS_OFF);
-    //    IUFillSwitch(&UnparkPositionS[PARK_WEST], "UNPARK_WEST", "West", ISS_OFF);
-    //    IUFillSwitchVector(&UnparkPositionSP, UnparkPosition, 4, getDeviceName(), "UNPARK_POSITION", "Unpark Position",
+    //    UnparkPositionSP[PARK_NORTH].fill("UNPARK_NORTH", "North", ISS_ON);
+    //    UnparkPositionSP[PARK_EAST].fill("UNPARK_EAST", "East", ISS_OFF);
+    //    UnparkPositionSP[PARK_SOUTH].fill("UNPARK_SOUTH", "South", ISS_OFF);
+    //    UnparkPositionSP[PARK_WEST].fill("UNPARK_WEST", "West", ISS_OFF);
+    //    UnparkPositionSP.fill(getDeviceName(), "UNPARK_POSITION", "Unpark Position",
     //                       MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     tcpConnection->setDefaultHost("192.168.4.1");
@@ -480,20 +480,20 @@ void SkywatcherAPIMount::ISGetProperties(const char *dev)
         // Define our connected only properties to the base driver
         // e.g. defineProperty(MyNumberVectorPointer);
         // This will register our properties and send a IDDefXXXX mewssage to any connected clients
-        defineProperty(&BasicMountInfoTP);
-        defineProperty(&AxisOneInfoNP);
-        defineProperty(&AxisOneStateSP);
-        defineProperty(&AxisTwoInfoNP);
-        defineProperty(&AxisTwoStateSP);
-        defineProperty(&AxisOneEncoderValuesNP);
-        defineProperty(&AxisTwoEncoderValuesNP);
-        defineProperty(&SlewModesSP);
-        defineProperty(&SoftPECModesSP);
+        defineProperty(BasicMountInfoTP);
+        defineProperty(AxisOneInfoNP);
+        defineProperty(AxisOneStateSP);
+        defineProperty(AxisTwoInfoNP);
+        defineProperty(AxisTwoStateSP);
+        defineProperty(AxisOneEncoderValuesNP);
+        defineProperty(AxisTwoEncoderValuesNP);
+        defineProperty(SlewModesSP);
+        defineProperty(SoftPECModesSP);
         defineProperty(&SoftPecNP);
-        defineProperty(&GuidingRatesNP);
-        //        defineProperty(&ParkMovementDirectionSP);
-        //        defineProperty(&ParkPositionSP);
-        //        defineProperty(&UnparkPositionSP);
+        defineProperty(GuidingRatesNP);
+        //        defineProperty(ParkMovementDirectionSP);
+        //        defineProperty(ParkPositionSP);
+        //        defineProperty(UnparkPositionSP);
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
     }
@@ -528,9 +528,9 @@ bool SkywatcherAPIMount::ISNewNumber(const char *dev, const char *name, double v
         if (strcmp(name, "GUIDE_RATES") == 0)
         {
             ResetGuidePulses();
-            GuidingRatesNP.s = IPS_OK;
-            IUUpdateNumber(&GuidingRatesNP, values, names, n);
-            IDSetNumber(&GuidingRatesNP, nullptr);
+            GuidingRatesNP.setState(IPS_OK);
+            GuidingRatesNP.update(values, names, n);
+            GuidingRatesNP.apply();
             return true;
         }
 
@@ -542,19 +542,19 @@ bool SkywatcherAPIMount::ISNewNumber(const char *dev, const char *name, double v
 
             for (int x = 0; x < n; x++)
             {
-                INumber *eqp = IUFindNumber(&EqNP, names[x]);
-                if (eqp == &EqN[AXIS_RA])
+                INumber *eqp = EqNP.findWidgetByName(names[x]);
+                if (eqp == &EqNP[AXIS_RA])
                 {
                     ra = values[x];
                 }
-                else if (eqp == &EqN[AXIS_DE])
+                else if (eqp == &EqNP[AXIS_DE])
                 {
                     dec = values[x];
                 }
             }
             if ((ra >= 0) && (ra <= 24) && (dec >= -90) && (dec <= 90))
             {
-                ISwitch *sw = IUFindSwitch(&CoordSP, "SYNC");
+                ISwitch *sw = CoordSP.findWidgetByName("SYNC");
 
                 if (sw != nullptr && sw->s == ISS_ON && isParked())
                 {
@@ -573,11 +573,11 @@ bool SkywatcherAPIMount::ISNewSwitch(const char *dev, const char *name, ISState 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        //        if (!strcmp(name, ParkMovementDirectionSP.name) ||
-        //                !strcmp(name, ParkPositionSP.name) ||
-        //                !strcmp(name, UnparkPositionSP.name) ||
-        //                !strcmp(name, SoftPECModesSP.name) ||
-        //                !strcmp(name, SlewModesSP.name))
+        //        if (!strcmp(name, ParkMovementDirectionSP.getName()) ||
+        //                !strcmp(name, ParkPositionSP.getName()) ||
+        //                !strcmp(name, UnparkPositionSP.getName()) ||
+        //                !strcmp(name, SoftPECModesSP.getName()) ||
+        //                !strcmp(name, SlewModesSP.getName()))
         //        {
         //            ISwitchVectorProperty *svp = getSwitch(name);
         //            IUUpdateSwitch(svp, states, names, n);
@@ -868,8 +868,8 @@ bool SkywatcherAPIMount::Park()
     //    double DeltaAlt                 = 0;
     //    double DeltaAz                  = 0;
 
-    //    TargetPosition = static_cast<ParkPosition_t>(IUFindOnSwitchIndex(&ParkPositionSP));
-    //    TargetDirection = static_cast<ParkDirection_t>(IUFindOnSwitchIndex(&ParkMovementDirectionSP));
+    //    TargetPosition = static_cast<ParkPosition_t>(ParkPositionSP.findOnSwitchIndex());
+    //    TargetDirection = static_cast<ParkDirection_t>(ParkMovementDirectionSP.findOnSwitchIndex());
 
     //    DeltaAz = GetParkDeltaAz(TargetDirection, TargetPosition);
 
@@ -880,7 +880,7 @@ bool SkywatcherAPIMount::Park()
            "Parking: Altitude offset %ld microsteps Azimuth offset %ld microsteps", AltitudeOffsetMicrosteps,
            AzimuthOffsetMicrosteps);
 
-    if (IUFindSwitch(&SlewModesSP, "SLEW_SILENT") != nullptr && IUFindSwitch(&SlewModesSP, "SLEW_SILENT")->s == ISS_ON)
+    if (SlewModesSP.findWidgetByName("SLEW_SILENT") != nullptr && SlewModesSP.findWidgetByName("SLEW_SILENT")->s == ISS_ON)
     {
         SilentSlewMode = true;
     }
@@ -905,8 +905,8 @@ bool SkywatcherAPIMount::UnPark()
         double DeltaAlt                 = 0;
         double DeltaAz                  = 0;
 
-        TargetPosition = static_cast<ParkPosition_t>(IUFindOnSwitchIndex(&ParkPositionSP));
-        TargetDirection = static_cast<ParkDirection_t>(IUFindOnSwitchIndex(&ParkMovementDirectionSP));
+        TargetPosition = static_cast<ParkPosition_t>(ParkPositionSP.findOnSwitchIndex());
+        TargetDirection = static_cast<ParkDirection_t>(ParkMovementDirectionSP.findOnSwitchIndex());
 
         DeltaAz = GetParkDeltaAz(TargetDirection, TargetPosition);
         // Altitude 3360 points the telescope upwards
@@ -923,8 +923,8 @@ bool SkywatcherAPIMount::UnPark()
                "Unparking: Altitude offset %ld microsteps Azimuth offset %ld microsteps", AltitudeOffsetMicrosteps,
                AzimuthOffsetMicrosteps);
 
-        if (IUFindSwitch(&SlewModesSP, "SLEW_SILENT") != nullptr &&
-                IUFindSwitch(&SlewModesSP, "SLEW_SILENT")->s == ISS_ON)
+        if (SlewModesSP.findWidgetByName("SLEW_SILENT") != nullptr &&
+                SlewModesSP.findWidgetByName("SLEW_SILENT")->s == ISS_ON)
         {
             SilentSlewMode = true;
         }
@@ -986,14 +986,14 @@ bool SkywatcherAPIMount::ReadScopeStatus()
 
     //        // The initial position of the Virtuoso mount is polar aligned when switched on.
     //        // The altitude is corrected by the latitude.
-    //        if (IUFindNumber(&LocationNP, "LAT") != nullptr)
-    //            MountDegree += IUFindNumber(&LocationNP, "LAT")->value;
+    //        if (LocationNP.findWidgetByName("LAT") != nullptr)
+    //            MountDegree += LocationNP.findWidgetByName("LAT")->value;
 
     //        // The altitude degrees in the Virtuoso Alt-Az mount are inverted.
     //        AltAz.alt = 3420 - MountDegree;
     //        // Drift compensation for tracking mode (SoftPEC)
-    //        if (IUFindSwitch(&SoftPECModesSP, "SOFTPEC_ENABLED") != nullptr &&
-    //                IUFindSwitch(&SoftPECModesSP, "SOFTPEC_ENABLED")->s == ISS_ON &&
+    //        if (SoftPECModesSP.findWidgetByName("SOFTPEC_ENABLED") != nullptr &&
+    //                SoftPECModesSP.findWidgetByName("SOFTPEC_ENABLED")->s == ISS_ON &&
     //                IUFindNumber(&SoftPecNP, "SOFTPEC_VALUE") != nullptr)
     //        {
     //            AltAz.alt += (IUFindNumber(&SoftPecNP, "SOFTPEC_VALUE")->value / 60) * TrackingMsecs / 1000;
@@ -1021,12 +1021,12 @@ bool SkywatcherAPIMount::ReadScopeStatus()
         bool HavePosition = false;
         ln_lnlat_posn Position { 0, 0 };
 
-        if ((nullptr != IUFindNumber(&LocationNP, "LAT")) && (0 != IUFindNumber(&LocationNP, "LAT")->value) &&
-                (nullptr != IUFindNumber(&LocationNP, "LONG")) && (0 != IUFindNumber(&LocationNP, "LONG")->value))
+        if ((nullptr != LocationNP.findWidgetByName("LAT")) && (0 != LocationNP.findWidgetByName("LAT")->value) &&
+                (nullptr != LocationNP.findWidgetByName("LONG")) && (0 != LocationNP.findWidgetByName("LONG")->value))
         {
             // I assume that being on the equator and exactly on the prime meridian is unlikely
-            Position.lat = IUFindNumber(&LocationNP, "LAT")->value;
-            Position.lng = IUFindNumber(&LocationNP, "LONG")->value;
+            Position.lat = LocationNP.findWidgetByName("LAT")->value;
+            Position.lng = LocationNP.findWidgetByName("LONG")->value;
             HavePosition = true;
         }
         ln_equ_posn EquatorialCoordinates { 0, 0 };
@@ -1110,8 +1110,8 @@ bool SkywatcherAPIMount::Sync(double ra, double dec)
             //            {
             //                // The initial position of the Virtuoso mount is polar aligned when switched on.
             //                // The altitude is corrected by the latitude.
-            //                if (IUFindNumber(&LocationNP, "LAT") != nullptr)
-            //                    AltAz.alt = AltAz.alt - IUFindNumber(&LocationNP, "LAT")->value;
+            //                if (LocationNP.findWidgetByName("LAT") != nullptr)
+            //                    AltAz.alt = AltAz.alt - LocationNP.findWidgetByName("LAT")->value;
 
             //                AltAz.az = 180 + AltAz.az;
             //            }
@@ -1137,8 +1137,8 @@ bool SkywatcherAPIMount::Sync(double ra, double dec)
 
     //        // The initial position of the Virtuoso mount is polar aligned when switched on.
     //        // The altitude is corrected by the latitude.
-    //        if (IUFindNumber(&LocationNP, "LAT") != nullptr)
-    //            MountDegree += IUFindNumber(&LocationNP, "LAT")->value;
+    //        if (LocationNP.findWidgetByName("LAT") != nullptr)
+    //            MountDegree += LocationNP.findWidgetByName("LAT")->value;
 
     //        // The altitude degrees in the Virtuoso Alt-Az mount are inverted.
     //        AltAz.alt = 3420 - MountDegree;
@@ -1206,7 +1206,7 @@ void SkywatcherAPIMount::TimerHit()
             GuidingPulses.clear();
             if ((AxesStatus[AXIS1].FullStop) && (AxesStatus[AXIS2].FullStop))
             {
-                if (ISS_ON == IUFindSwitch(&CoordSP, "TRACK")->s)
+                if (ISS_ON == CoordSP.findWidgetByName("TRACK")->s)
                 {
                     // Goto has finished start tracking
                     TrackState = SCOPE_TRACKING;
@@ -1235,8 +1235,8 @@ void SkywatcherAPIMount::TimerHit()
             if (moving)
             {
                 TrackedAltAz  = CurrentAltAz;
-                CurrentTrackingTarget.ra = EqN[AXIS_RA].value;
-                CurrentTrackingTarget.dec = EqN[AXIS_DE].value;
+                CurrentTrackingTarget.ra = EqNP[AXIS_RA].getValue();
+                CurrentTrackingTarget.dec = EqNP[AXIS_DE].getValue();
             }
             else
             {
@@ -1290,12 +1290,12 @@ void SkywatcherAPIMount::TimerHit()
                     bool HavePosition = false;
                     ln_lnlat_posn Position { 0, 0 };
 
-                    if ((nullptr != IUFindNumber(&LocationNP, "LAT")) && (0 != IUFindNumber(&LocationNP, "LAT")->value) &&
-                            (nullptr != IUFindNumber(&LocationNP, "LONG")) && (0 != IUFindNumber(&LocationNP, "LONG")->value))
+                    if ((nullptr != LocationNP.findWidgetByName("LAT")) && (0 != LocationNP.findWidgetByName("LAT")->value) &&
+                            (nullptr != LocationNP.findWidgetByName("LONG")) && (0 != LocationNP.findWidgetByName("LONG")->value))
                     {
                         // I assume that being on the equator and exactly on the prime meridian is unlikely
-                        Position.lat = IUFindNumber(&LocationNP, "LAT")->value;
-                        Position.lng = IUFindNumber(&LocationNP, "LONG")->value;
+                        Position.lat = LocationNP.findWidgetByName("LAT")->value;
+                        Position.lng = LocationNP.findWidgetByName("LONG")->value;
                         HavePosition = true;
                     }
                     ln_equ_posn EquatorialCoordinates { 0, 0 };
@@ -1321,13 +1321,13 @@ void SkywatcherAPIMount::TimerHit()
                 //                {
                 //                    // The initial position of the Virtuoso mount is polar aligned when switched on.
                 //                    // The altitude is corrected by the latitude.
-                //                    if (IUFindNumber(&LocationNP, "LAT") != nullptr)
+                //                    if (LocationNP.findWidgetByName("LAT") != nullptr)
                 //                    {
-                //                        AltAz.alt = AltAz.alt - IUFindNumber(&LocationNP, "LAT")->value;
+                //                        AltAz.alt = AltAz.alt - LocationNP.findWidgetByName("LAT")->value;
                 //                    }
                 //                    // Drift compensation for tracking mode (SoftPEC)
-                //                    if (IUFindSwitch(&SoftPECModesSP, "SOFTPEC_ENABLED") != nullptr &&
-                //                            IUFindSwitch(&SoftPECModesSP, "SOFTPEC_ENABLED")->s == ISS_ON &&
+                //                    if (SoftPECModesSP.findWidgetByName("SOFTPEC_ENABLED") != nullptr &&
+                //                            SoftPECModesSP.findWidgetByName("SOFTPEC_ENABLED")->s == ISS_ON &&
                 //                            IUFindNumber(&SoftPecNP, "SOFTPEC_VALUE") != nullptr)
                 //                    {
                 //                        AltAz.alt += (IUFindNumber(&SoftPecNP, "SOFTPEC_VALUE")->value / 60) * TrackingMsecs / 1000;
@@ -1520,20 +1520,20 @@ bool SkywatcherAPIMount::updateProperties()
         // This will register our properties and send a IDDefXXXX message to any connected clients
         // I have now idea why I have to do this here as well as in ISGetProperties. It makes me
         // concerned there is a design or implementation flaw somewhere.
-        defineProperty(&BasicMountInfoTP);
-        defineProperty(&AxisOneInfoNP);
-        defineProperty(&AxisOneStateSP);
-        defineProperty(&AxisTwoInfoNP);
-        defineProperty(&AxisTwoStateSP);
-        defineProperty(&AxisOneEncoderValuesNP);
-        defineProperty(&AxisTwoEncoderValuesNP);
-        defineProperty(&SlewModesSP);
-        defineProperty(&SoftPECModesSP);
+        defineProperty(BasicMountInfoTP);
+        defineProperty(AxisOneInfoNP);
+        defineProperty(AxisOneStateSP);
+        defineProperty(AxisTwoInfoNP);
+        defineProperty(AxisTwoStateSP);
+        defineProperty(AxisOneEncoderValuesNP);
+        defineProperty(AxisTwoEncoderValuesNP);
+        defineProperty(SlewModesSP);
+        defineProperty(SoftPECModesSP);
         defineProperty(&SoftPecNP);
-        defineProperty(&GuidingRatesNP);
-        //        defineProperty(&ParkMovementDirectionSP);
-        //        defineProperty(&ParkPositionSP);
-        //        defineProperty(&UnparkPositionSP);
+        defineProperty(GuidingRatesNP);
+        //        defineProperty(ParkMovementDirectionSP);
+        //        defineProperty(ParkPositionSP);
+        //        defineProperty(UnparkPositionSP);
 
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
@@ -1541,7 +1541,7 @@ bool SkywatcherAPIMount::updateProperties()
         // Try to read latitude from config file if exists.
         double latitude = 0;
         if (IUGetConfigNumber(getDeviceName(), "GEOGRAPHIC_COORD", "LAT", &latitude) == 0)
-            LocationN[LOCATION_LATITUDE].value = latitude;
+            LocationNP[LOCATION_LATITUDE].setValue(latitude);
         if (InitPark())
         {
             // If loading parking data is successful, we just set the default parking values.
@@ -1569,20 +1569,20 @@ bool SkywatcherAPIMount::updateProperties()
     {
         // Delete any connected only properties from the base driver's list
         // e.g. deleteProperty(MyNumberVector.name);
-        deleteProperty(BasicMountInfoTP.name);
-        deleteProperty(AxisOneInfoNP.name);
-        deleteProperty(AxisOneStateSP.name);
-        deleteProperty(AxisTwoInfoNP.name);
-        deleteProperty(AxisTwoStateSP.name);
-        deleteProperty(AxisOneEncoderValuesNP.name);
-        deleteProperty(AxisTwoEncoderValuesNP.name);
-        deleteProperty(SlewModesSP.name);
-        deleteProperty(SoftPECModesSP.name);
+        deleteProperty(BasicMountInfoTP.getName());
+        deleteProperty(AxisOneInfoNP.getName());
+        deleteProperty(AxisOneStateSP.getName());
+        deleteProperty(AxisTwoInfoNP.getName());
+        deleteProperty(AxisTwoStateSP.getName());
+        deleteProperty(AxisOneEncoderValuesNP.getName());
+        deleteProperty(AxisTwoEncoderValuesNP.getName());
+        deleteProperty(SlewModesSP.getName());
+        deleteProperty(SoftPECModesSP.getName());
         deleteProperty(SoftPecNP.name);
-        deleteProperty(GuidingRatesNP.name);
-        //        deleteProperty(ParkMovementDirectionSP.name);
-        //        deleteProperty(ParkPositionSP.name);
-        //        deleteProperty(UnparkPositionSP.name);
+        deleteProperty(GuidingRatesNP.getName());
+        //        deleteProperty(ParkMovementDirectionSP.getName());
+        //        deleteProperty(ParkPositionSP.getName());
+        //        deleteProperty(UnparkPositionSP.getName());
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
@@ -1660,14 +1660,14 @@ void SkywatcherAPIMount::CalculateGuidePulses()
 
     // Calculate the west reference delta
     // Note: The RA is multiplied by 3.75 (90/24) to be more comparable with DEC values.
-    const double WestRate = IUFindNumber(&GuidingRatesNP, "GUIDERA_RATE")->value / 10 * -(double)1 / 60 / 60 * 3.75 / 100;
+    const double WestRate = GuidingRatesNP.findWidgetByName("GUIDERA_RATE")->value / 10 * -(double)1 / 60 / 60 * 3.75 / 100;
 
     ConvertGuideCorrection(WestRate, 0, WestPulse.DeltaAlt, WestPulse.DeltaAz);
     WestPulse.Duration = 1;
 
     // Calculate the north reference delta
     // Note: By some reason, it must be multiplied by 100 to match with the RA values.
-    const double NorthRate = IUFindNumber(&GuidingRatesNP, "GUIDEDEC_RATE")->value / 10 * (double)1 / 60 / 60 * 100 / 100;
+    const double NorthRate = GuidingRatesNP.findWidgetByName("GUIDEDEC_RATE")->value / 10 * (double)1 / 60 / 60 * 100 / 100;
 
     ConvertGuideCorrection(0, NorthRate, NorthPulse.DeltaAlt, NorthPulse.DeltaAz);
     NorthPulse.Duration = 1;
@@ -1778,178 +1778,176 @@ void SkywatcherAPIMount::UpdateDetailedMountInformation(bool InformClient)
 {
     bool BasicMountInfoHasChanged = false;
 
-    if (std::string(BasicMountInfoT[MOTOR_CONTROL_FIRMWARE_VERSION].text) != std::to_string(MCVersion))
+    if (std::string(BasicMountInfoTP[MOTOR_CONTROL_FIRMWARE_VERSION].getText()) != std::to_string(MCVersion))
     {
-        IUSaveText(&BasicMountInfoT[MOTOR_CONTROL_FIRMWARE_VERSION], std::to_string(MCVersion).c_str());
+        BasicMountInfoTP[MOTOR_CONTROL_FIRMWARE_VERSION].setText(std::to_string(MCVersion));
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[MOUNT_CODE].text) != std::to_string(MountCode))
+    if (std::string(BasicMountInfoTP[MOUNT_CODE].getText()) != std::to_string(MountCode))
     {
-        IUSaveText(&BasicMountInfoT[MOUNT_CODE], std::to_string(MountCode).c_str());
+        BasicMountInfoTP[MOUNT_CODE].setText(std::to_string(MountCode));
         SetApproximateMountAlignmentFromMountType(ALTAZ);
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[IS_DC_MOTOR].text) != std::to_string(IsDCMotor))
+    if (std::string(BasicMountInfoTP[IS_DC_MOTOR].getText()) != std::to_string(IsDCMotor))
     {
-        IUSaveText(&BasicMountInfoT[IS_DC_MOTOR], std::to_string(IsDCMotor).c_str());
+        BasicMountInfoTP[IS_DC_MOTOR].setText(std::to_string(IsDCMotor));
         BasicMountInfoHasChanged = true;
     }
     if (BasicMountInfoHasChanged && InformClient)
-        IDSetText(&BasicMountInfoTP, nullptr);
+        BasicMountInfoTP.apply();
 
     if (MountCode == AZEQ6)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "AZEQ6");
+        BasicMountInfoTP[MOUNT_NAME].setText("AZEQ6");
     else if (MountCode >= 128 && MountCode <= 143)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "Az Goto");
+        BasicMountInfoTP[MOUNT_NAME].setText("Az Goto");
     else if (MountCode >= 144 && MountCode <= 159)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "Dob Goto");
+        BasicMountInfoTP[MOUNT_NAME].setText("Dob Goto");
     else if (MountCode >= 160)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "AllView Goto");
+        BasicMountInfoTP[MOUNT_NAME].setText("AllView Goto");
 
     bool AxisOneInfoHasChanged = false;
 
-    if (AxisOneInfoN[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[0])
+    if (AxisOneInfoNP[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[0])
     {
-        AxisOneInfoN[MICROSTEPS_PER_REVOLUTION].value = MicrostepsPerRevolution[0];
+        AxisOneInfoNP[MICROSTEPS_PER_REVOLUTION].setValue(MicrostepsPerRevolution[0]);
         AxisOneInfoHasChanged                        = true;
     }
-    if (AxisOneInfoN[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[0])
+    if (AxisOneInfoNP[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[0])
     {
-        AxisOneInfoN[STEPPER_CLOCK_FREQUENCY].value = StepperClockFrequency[0];
+        AxisOneInfoNP[STEPPER_CLOCK_FREQUENCY].setValue(StepperClockFrequency[0]);
         AxisOneInfoHasChanged                      = true;
     }
-    if (AxisOneInfoN[HIGH_SPEED_RATIO].value != HighSpeedRatio[0])
+    if (AxisOneInfoNP[HIGH_SPEED_RATIO].value != HighSpeedRatio[0])
     {
-        AxisOneInfoN[HIGH_SPEED_RATIO].value = HighSpeedRatio[0];
+        AxisOneInfoNP[HIGH_SPEED_RATIO].setValue(HighSpeedRatio[0]);
         AxisOneInfoHasChanged               = true;
     }
-    if (AxisOneInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[0])
+    if (AxisOneInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[0])
     {
-        AxisOneInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value = MicrostepsPerWormRevolution[0];
+        AxisOneInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].setValue(MicrostepsPerWormRevolution[0]);
         AxisOneInfoHasChanged                             = true;
     }
     if (AxisOneInfoHasChanged && InformClient)
-        IDSetNumber(&AxisOneInfoNP, nullptr);
+        AxisOneInfoNP.apply();
 
     bool AxisOneStateHasChanged = false;
-    if (AxisOneStateS[FULL_STOP].s != (AxesStatus[0].FullStop ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[FULL_STOP].getState() != (AxesStatus[0].FullStop ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[FULL_STOP].s = AxesStatus[0].FullStop ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[FULL_STOP].setState(AxesStatus[0].FullStop ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged    = true;
     }
-    if (AxisOneStateS[SLEWING].s != (AxesStatus[0].Slewing ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[SLEWING].getState() != (AxesStatus[0].Slewing ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[SLEWING].s = AxesStatus[0].Slewing ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[SLEWING].setState(AxesStatus[0].Slewing ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged  = true;
     }
-    if (AxisOneStateS[SLEWING_TO].s != (AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[SLEWING_TO].getState() != (AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[SLEWING_TO].s = AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[SLEWING_TO].setState(AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged     = true;
     }
-    if (AxisOneStateS[SLEWING_FORWARD].s != (AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[SLEWING_FORWARD].getState() != (AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[SLEWING_FORWARD].s = AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[SLEWING_FORWARD].setState(AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged          = true;
     }
-    if (AxisOneStateS[HIGH_SPEED].s != (AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[HIGH_SPEED].getState() != (AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[HIGH_SPEED].s = AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[HIGH_SPEED].setState(AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged     = true;
     }
-    if (AxisOneStateS[NOT_INITIALISED].s != (AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[NOT_INITIALISED].getState() != (AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[NOT_INITIALISED].s = AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[NOT_INITIALISED].setState(AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged          = true;
     }
     if (AxisOneStateHasChanged && InformClient)
-        IDSetSwitch(&AxisOneStateSP, nullptr);
+        AxisOneStateSP.apply();
 
     bool AxisTwoInfoHasChanged = false;
-    if (AxisTwoInfoN[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[1])
+    if (AxisTwoInfoNP[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[1])
     {
-        AxisTwoInfoN[MICROSTEPS_PER_REVOLUTION].value = MicrostepsPerRevolution[1];
+        AxisTwoInfoNP[MICROSTEPS_PER_REVOLUTION].setValue(MicrostepsPerRevolution[1]);
         AxisTwoInfoHasChanged                        = true;
     }
-    if (AxisTwoInfoN[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[1])
+    if (AxisTwoInfoNP[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[1])
     {
-        AxisTwoInfoN[STEPPER_CLOCK_FREQUENCY].value = StepperClockFrequency[1];
+        AxisTwoInfoNP[STEPPER_CLOCK_FREQUENCY].setValue(StepperClockFrequency[1]);
         AxisTwoInfoHasChanged                      = true;
     }
-    if (AxisTwoInfoN[HIGH_SPEED_RATIO].value != HighSpeedRatio[1])
+    if (AxisTwoInfoNP[HIGH_SPEED_RATIO].value != HighSpeedRatio[1])
     {
-        AxisTwoInfoN[HIGH_SPEED_RATIO].value = HighSpeedRatio[1];
+        AxisTwoInfoNP[HIGH_SPEED_RATIO].setValue(HighSpeedRatio[1]);
         AxisTwoInfoHasChanged               = true;
     }
-    if (AxisTwoInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[1])
+    if (AxisTwoInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[1])
     {
-        AxisTwoInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value = MicrostepsPerWormRevolution[1];
+        AxisTwoInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].setValue(MicrostepsPerWormRevolution[1]);
         AxisTwoInfoHasChanged                             = true;
     }
     if (AxisTwoInfoHasChanged && InformClient)
-        IDSetNumber(&AxisTwoInfoNP, nullptr);
+        AxisTwoInfoNP.apply();
 
     bool AxisTwoStateHasChanged = false;
-    if (AxisTwoStateS[FULL_STOP].s != (AxesStatus[1].FullStop ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[FULL_STOP].getState() != (AxesStatus[1].FullStop ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[FULL_STOP].s = AxesStatus[1].FullStop ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[FULL_STOP].setState(AxesStatus[1].FullStop ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged    = true;
     }
-    if (AxisTwoStateS[SLEWING].s != (AxesStatus[1].Slewing ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[SLEWING].getState() != (AxesStatus[1].Slewing ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[SLEWING].s = AxesStatus[1].Slewing ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[SLEWING].setState(AxesStatus[1].Slewing ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged  = true;
     }
-    if (AxisTwoStateS[SLEWING_TO].s != (AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[SLEWING_TO].getState() != (AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[SLEWING_TO].s = AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[SLEWING_TO].setState(AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged     = true;
     }
-    if (AxisTwoStateS[SLEWING_FORWARD].s != (AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[SLEWING_FORWARD].getState() != (AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[SLEWING_FORWARD].s = AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[SLEWING_FORWARD].setState(AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged          = true;
     }
-    if (AxisTwoStateS[HIGH_SPEED].s != (AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[HIGH_SPEED].getState() != (AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[HIGH_SPEED].s = AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[HIGH_SPEED].setState(AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged     = true;
     }
-    if (AxisTwoStateS[NOT_INITIALISED].s != (AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[NOT_INITIALISED].getState() != (AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[NOT_INITIALISED].s = AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[NOT_INITIALISED].setState(AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged          = true;
     }
     if (AxisTwoStateHasChanged && InformClient)
-        IDSetSwitch(&AxisTwoStateSP, nullptr);
+        AxisTwoStateSP.apply();
 
     bool AxisOneEncoderValuesHasChanged = false;
-    if ((AxisOneEncoderValuesN[RAW_MICROSTEPS].value != CurrentEncoders[AXIS1]) ||
-            (AxisOneEncoderValuesN[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]))
+    if ((AxisOneEncoderValuesNP[RAW_MICROSTEPS].value != CurrentEncoders[AXIS1]) ||
+            (AxisOneEncoderValuesNP[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]))
     {
-        AxisOneEncoderValuesN[RAW_MICROSTEPS].value = CurrentEncoders[AXIS1];
-        AxisOneEncoderValuesN[MICROSTEPS_PER_ARCSEC].value = MicrostepsPerDegree[AXIS1] / 3600.0;
-        AxisOneEncoderValuesN[OFFSET_FROM_INITIAL].value = CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1];
-        AxisOneEncoderValuesN[DEGREES_FROM_INITIAL].value =
-            MicrostepsToDegrees(AXIS1, CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]);
+        AxisOneEncoderValuesNP[RAW_MICROSTEPS].setValue(CurrentEncoders[AXIS1]);
+        AxisOneEncoderValuesNP[MICROSTEPS_PER_ARCSEC].setValue(MicrostepsPerDegree[AXIS1] / 3600.0);
+        AxisOneEncoderValuesNP[OFFSET_FROM_INITIAL].setValue(CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]);
+        AxisOneEncoderValuesNP[DEGREES_FROM_INITIAL].setValue(MicrostepsToDegrees(AXIS1, CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]));
         AxisOneEncoderValuesHasChanged = true;
     }
     if (AxisOneEncoderValuesHasChanged && InformClient)
-        IDSetNumber(&AxisOneEncoderValuesNP, nullptr);
+        AxisOneEncoderValuesNP.apply();
 
     bool AxisTwoEncoderValuesHasChanged = false;
-    if ((AxisTwoEncoderValuesN[RAW_MICROSTEPS].value != CurrentEncoders[AXIS2]) ||
-            (AxisTwoEncoderValuesN[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]))
+    if ((AxisTwoEncoderValuesNP[RAW_MICROSTEPS].value != CurrentEncoders[AXIS2]) ||
+            (AxisTwoEncoderValuesNP[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]))
     {
-        AxisTwoEncoderValuesN[RAW_MICROSTEPS].value      = CurrentEncoders[AXIS2];
-        AxisTwoEncoderValuesN[MICROSTEPS_PER_ARCSEC].value = MicrostepsPerDegree[AXIS2] / 3600.0;
-        AxisTwoEncoderValuesN[OFFSET_FROM_INITIAL].value = CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2];
-        AxisTwoEncoderValuesN[DEGREES_FROM_INITIAL].value =
-            MicrostepsToDegrees(AXIS2, CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]);
+        AxisTwoEncoderValuesNP[RAW_MICROSTEPS].setValue(CurrentEncoders[AXIS2]);
+        AxisTwoEncoderValuesNP[MICROSTEPS_PER_ARCSEC].setValue(MicrostepsPerDegree[AXIS2] / 3600.0);
+        AxisTwoEncoderValuesNP[OFFSET_FROM_INITIAL].setValue(CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]);
+        AxisTwoEncoderValuesNP[DEGREES_FROM_INITIAL].setValue(MicrostepsToDegrees(AXIS2, CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]));
         AxisTwoEncoderValuesHasChanged = true;
     }
     if (AxisTwoEncoderValuesHasChanged && InformClient)
-        IDSetNumber(&AxisTwoEncoderValuesNP, nullptr);
+        AxisTwoEncoderValuesNP.apply();
 }
 
 bool SkywatcherAPIMount::SetCurrentPark()

--- a/drivers/telescope/skywatcherAPIMount.h
+++ b/drivers/telescope/skywatcherAPIMount.h
@@ -20,6 +20,11 @@
 
 #include "alignment/AlignmentSubsystemForDrivers.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 typedef enum { PARK_COUNTERCLOCKWISE = 0, PARK_CLOCKWISE } ParkDirection_t;
 typedef enum { PARK_NORTH = 0, PARK_EAST, PARK_SOUTH, PARK_WEST } ParkPosition_t;
 
@@ -105,8 +110,7 @@ class SkywatcherAPIMount : public SkywatcherAPI,
             MOUNT_NAME,
             IS_DC_MOTOR
         };
-        IText BasicMountInfoT[4] {};
-        ITextVectorProperty BasicMountInfoTP;
+        INDI::PropertyText BasicMountInfoTP {4};
 
         enum
         {
@@ -115,10 +119,8 @@ class SkywatcherAPIMount : public SkywatcherAPI,
             HIGH_SPEED_RATIO,
             MICROSTEPS_PER_WORM_REVOLUTION
         };
-        INumber AxisOneInfoN[4];
-        INumberVectorProperty AxisOneInfoNP;
-        INumber AxisTwoInfoN[4];
-        INumberVectorProperty AxisTwoInfoNP;
+        INDI::PropertyNumber AxisOneInfoNP {4};
+        INDI::PropertyNumber AxisTwoInfoNP {4};
         enum
         {
             FULL_STOP,
@@ -128,10 +130,8 @@ class SkywatcherAPIMount : public SkywatcherAPI,
             HIGH_SPEED,
             NOT_INITIALISED
         };
-        ISwitch AxisOneStateS[6];
-        ISwitchVectorProperty AxisOneStateSP;
-        ISwitch AxisTwoStateS[6];
-        ISwitchVectorProperty AxisTwoStateSP;
+        INDI::PropertySwitch AxisOneStateSP {6};
+        INDI::PropertySwitch AxisTwoStateSP {6};
         enum
         {
             RAW_MICROSTEPS,
@@ -139,10 +139,8 @@ class SkywatcherAPIMount : public SkywatcherAPI,
             OFFSET_FROM_INITIAL,
             DEGREES_FROM_INITIAL
         };
-        INumber AxisOneEncoderValuesN[4];
-        INumberVectorProperty AxisOneEncoderValuesNP;
-        INumber AxisTwoEncoderValuesN[4];
-        INumberVectorProperty AxisTwoEncoderValuesNP;
+        INDI::PropertyNumber AxisOneEncoderValuesNP {4};
+        INDI::PropertyNumber AxisTwoEncoderValuesNP {4};
 
         // A switch for silent/highspeed slewing modes
         enum
@@ -150,8 +148,7 @@ class SkywatcherAPIMount : public SkywatcherAPI,
             SLEW_SILENT,
             SLEW_NORMAL
         };
-        ISwitch SlewModesS[2];
-        ISwitchVectorProperty SlewModesSP;
+        INDI::PropertySwitch SlewModesSP {2};
 
         // A switch for SoftPEC modes
         enum
@@ -159,28 +156,26 @@ class SkywatcherAPIMount : public SkywatcherAPI,
             SOFTPEC_ENABLED,
             SOFTPEC_DISABLED
         };
-        ISwitch SoftPECModesS[2];
-        ISwitchVectorProperty SoftPECModesSP;
+        INDI::PropertySwitch SoftPECModesSP {2};
 
         // SoftPEC value for tracking mode
         INumber SoftPecN;
         INumberVectorProperty SoftPecNP;
 
         // Guiding rates (RA/Dec)
-        INumber GuidingRatesN[2];
-        INumberVectorProperty GuidingRatesNP;
+        INDI::PropertyNumber GuidingRatesNP {2};
 
         // A switch for park movement directions (clockwise/counterclockwise)
-//        ISwitch ParkMovementDirectionS[2];
-//        ISwitchVectorProperty ParkMovementDirectionSP;
+//        INDI::PropertySwitch ParkMovementDirectionSP {2};
+//
 
 //        // A switch for park positions
-//        ISwitch ParkPositionS[4];
-//        ISwitchVectorProperty ParkPositionSP;
+//        INDI::PropertySwitch ParkPositionSP {4};
+//
 
 //        // A switch for unpark positions
-//        ISwitch UnparkPositionS[4];
-//        ISwitchVectorProperty UnparkPositionSP;
+//        INDI::PropertySwitch UnparkPositionSP {4};
+//
 
         // Tracking
         ln_equ_posn CurrentTrackingTarget { 0, 0 };

--- a/drivers/telescope/skywatcherAltAzSimple.cpp
+++ b/drivers/telescope/skywatcherAltAzSimple.cpp
@@ -176,7 +176,7 @@ bool SkywatcherAltAzSimple::Goto(double ra, double dec)
 
     DEBUGF(DBG_SCOPE, "RA %lf DEC %lf", ra, dec);
 
-    if (IUFindSwitch(&CoordSP, "TRACK")->s == ISS_ON || IUFindSwitch(&CoordSP, "SLEW")->s == ISS_ON)
+    if (CoordSP.findWidgetByName("TRACK")->s == ISS_ON || CoordSP.findWidgetByName("SLEW")->s == ISS_ON)
     {
         char RAStr[32], DecStr[32];
         fs_sexa(RAStr, ra, 2, 3600);
@@ -232,7 +232,7 @@ bool SkywatcherAltAzSimple::Goto(double ra, double dec)
     DEBUGF(DBG_SCOPE, "Altitude offset %ld microsteps Azimuth offset %ld microsteps",
            AltitudeOffsetMicrosteps, AzimuthOffsetMicrosteps);
 
-    if (IUFindSwitch(&SlewModesSP, "SLEW_NORMAL")->s == ISS_ON)
+    if (SlewModesSP.findWidgetByName("SLEW_NORMAL")->s == ISS_ON)
     {
         SilentSlewMode = false;
     }
@@ -245,7 +245,7 @@ bool SkywatcherAltAzSimple::Goto(double ra, double dec)
 
     TrackState = SCOPE_SLEWING;
 
-    //EqNP.s = IPS_BUSY;
+    //EqNP.setState(IPS_BUSY);
 
     return true;
 }
@@ -269,100 +269,100 @@ bool SkywatcherAltAzSimple::initProperties()
     addConfigurationControl();
 
     // Set up property variables
-    IUFillText(&BasicMountInfoT[MOTOR_CONTROL_FIRMWARE_VERSION], "MOTOR_CONTROL_FIRMWARE_VERSION",
+    BasicMountInfoTP[MOTOR_CONTROL_FIRMWARE_VERSION].fill("MOTOR_CONTROL_FIRMWARE_VERSION",
                "Motor control firmware version", "-");
-    IUFillText(&BasicMountInfoT[MOUNT_CODE], "MOUNT_CODE", "Mount code", "-");
-    IUFillText(&BasicMountInfoT[MOUNT_NAME], "MOUNT_NAME", "Mount name", "-");
-    IUFillText(&BasicMountInfoT[IS_DC_MOTOR], "IS_DC_MOTOR", "Is DC motor", "-");
-    IUFillTextVector(&BasicMountInfoTP, BasicMountInfoT, 4, getDeviceName(), "BASIC_MOUNT_INFO",
+    BasicMountInfoTP[MOUNT_CODE].fill("MOUNT_CODE", "Mount code", "-");
+    BasicMountInfoTP[MOUNT_NAME].fill("MOUNT_NAME", "Mount name", "-");
+    BasicMountInfoTP[IS_DC_MOTOR].fill("IS_DC_MOTOR", "Is DC motor", "-");
+    BasicMountInfoTP.fill(getDeviceName(), "BASIC_MOUNT_INFO",
                      "Basic mount information", DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisOneInfoN[MICROSTEPS_PER_REVOLUTION], "MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
+    AxisOneInfoNP[MICROSTEPS_PER_REVOLUTION].fill("MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
                  "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneInfoN[STEPPER_CLOCK_FREQUENCY], "STEPPER_CLOCK_FREQUENCY", "Stepper clock frequency", "%.0f", 0,
+    AxisOneInfoNP[STEPPER_CLOCK_FREQUENCY].fill("STEPPER_CLOCK_FREQUENCY", "Stepper clock frequency", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneInfoN[HIGH_SPEED_RATIO], "HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneInfoN[MICROSTEPS_PER_WORM_REVOLUTION], "MICROSTEPS_PER_WORM_REVOLUTION",
+    AxisOneInfoNP[HIGH_SPEED_RATIO].fill("HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisOneInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].fill("MICROSTEPS_PER_WORM_REVOLUTION",
                  "Microsteps per worm revolution", "%.0f", 0, 0xFFFFFF, 1, 0);
 
-    IUFillNumberVector(&AxisOneInfoNP, AxisOneInfoN, 4, getDeviceName(), "AXIS_ONE_INFO", "Axis one information",
+    AxisOneInfoNP.fill(getDeviceName(), "AXIS_ONE_INFO", "Axis one information",
                        DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&AxisOneStateS[FULL_STOP], "FULL_STOP", "FULL_STOP", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[SLEWING], "SLEWING", "SLEWING", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[SLEWING_TO], "SLEWING_TO", "SLEWING_TO", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[SLEWING_FORWARD], "SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[HIGH_SPEED], "HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
-    IUFillSwitch(&AxisOneStateS[NOT_INITIALISED], "NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
-    IUFillSwitchVector(&AxisOneStateSP, AxisOneStateS, 6, getDeviceName(), "AXIS_ONE_STATE", "Axis one state",
+    AxisOneStateSP[FULL_STOP].fill("FULL_STOP", "FULL_STOP", ISS_OFF);
+    AxisOneStateSP[SLEWING].fill("SLEWING", "SLEWING", ISS_OFF);
+    AxisOneStateSP[SLEWING_TO].fill("SLEWING_TO", "SLEWING_TO", ISS_OFF);
+    AxisOneStateSP[SLEWING_FORWARD].fill("SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
+    AxisOneStateSP[HIGH_SPEED].fill("HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
+    AxisOneStateSP[NOT_INITIALISED].fill("NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
+    AxisOneStateSP.fill(getDeviceName(), "AXIS_ONE_STATE", "Axis one state",
                        DetailedMountInfoPage, IP_RO, ISR_NOFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisTwoInfoN[MICROSTEPS_PER_REVOLUTION], "MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
+    AxisTwoInfoNP[MICROSTEPS_PER_REVOLUTION].fill("MICROSTEPS_PER_REVOLUTION", "Microsteps per revolution",
                  "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoInfoN[STEPPER_CLOCK_FREQUENCY], "STEPPER_CLOCK_FREQUENCY", "Step timer frequency", "%.0f", 0,
+    AxisTwoInfoNP[STEPPER_CLOCK_FREQUENCY].fill("STEPPER_CLOCK_FREQUENCY", "Step timer frequency", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoInfoN[HIGH_SPEED_RATIO], "HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoInfoN[MICROSTEPS_PER_WORM_REVOLUTION], "MICROSTEPS_PER_WORM_REVOLUTION",
+    AxisTwoInfoNP[HIGH_SPEED_RATIO].fill("HIGH_SPEED_RATIO", "High speed ratio", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisTwoInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].fill("MICROSTEPS_PER_WORM_REVOLUTION",
                  "Mictosteps per worm revolution", "%.0f", 0, 0xFFFFFF, 1, 0);
 
-    IUFillNumberVector(&AxisTwoInfoNP, AxisTwoInfoN, 4, getDeviceName(), "AXIS_TWO_INFO", "Axis two information",
+    AxisTwoInfoNP.fill(getDeviceName(), "AXIS_TWO_INFO", "Axis two information",
                        DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&AxisTwoStateS[FULL_STOP], "FULL_STOP", "FULL_STOP", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[SLEWING], "SLEWING", "SLEWING", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[SLEWING_TO], "SLEWING_TO", "SLEWING_TO", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[SLEWING_FORWARD], "SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[HIGH_SPEED], "HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
-    IUFillSwitch(&AxisTwoStateS[NOT_INITIALISED], "NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
-    IUFillSwitchVector(&AxisTwoStateSP, AxisTwoStateS, 6, getDeviceName(), "AXIS_TWO_STATE", "Axis two state",
+    AxisTwoStateSP[FULL_STOP].fill("FULL_STOP", "FULL_STOP", ISS_OFF);
+    AxisTwoStateSP[SLEWING].fill("SLEWING", "SLEWING", ISS_OFF);
+    AxisTwoStateSP[SLEWING_TO].fill("SLEWING_TO", "SLEWING_TO", ISS_OFF);
+    AxisTwoStateSP[SLEWING_FORWARD].fill("SLEWING_FORWARD", "SLEWING_FORWARD", ISS_OFF);
+    AxisTwoStateSP[HIGH_SPEED].fill("HIGH_SPEED", "HIGH_SPEED", ISS_OFF);
+    AxisTwoStateSP[NOT_INITIALISED].fill("NOT_INITIALISED", "NOT_INITIALISED", ISS_ON);
+    AxisTwoStateSP.fill(getDeviceName(), "AXIS_TWO_STATE", "Axis two state",
                        DetailedMountInfoPage, IP_RO, ISR_NOFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisOneEncoderValuesN[RAW_MICROSTEPS], "RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneEncoderValuesN[MICROSTEPS_PER_ARCSEC], "MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
+    AxisOneEncoderValuesNP[RAW_MICROSTEPS].fill("RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisOneEncoderValuesNP[MICROSTEPS_PER_ARCSEC].fill("MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
                  "%.4f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneEncoderValuesN[OFFSET_FROM_INITIAL], "OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
+    AxisOneEncoderValuesNP[OFFSET_FROM_INITIAL].fill("OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisOneEncoderValuesN[DEGREES_FROM_INITIAL], "DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
+    AxisOneEncoderValuesNP[DEGREES_FROM_INITIAL].fill("DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
                  -1000.0, 1000.0, 1, 0);
 
-    IUFillNumberVector(&AxisOneEncoderValuesNP, AxisOneEncoderValuesN, 4, getDeviceName(), "AXIS1_ENCODER_VALUES",
+    AxisOneEncoderValuesNP.fill(getDeviceName(), "AXIS1_ENCODER_VALUES",
                        "Axis 1 Encoder values", DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
 
-    IUFillNumber(&AxisTwoEncoderValuesN[RAW_MICROSTEPS], "RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoEncoderValuesN[MICROSTEPS_PER_ARCSEC], "MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
+    AxisTwoEncoderValuesNP[RAW_MICROSTEPS].fill("RAW_MICROSTEPS", "Raw Microsteps", "%.0f", 0, 0xFFFFFF, 1, 0);
+    AxisTwoEncoderValuesNP[MICROSTEPS_PER_ARCSEC].fill("MICROSTEPS_PER_ARCSEC", "Microsteps/arcsecond",
                  "%.4f", 0, 0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoEncoderValuesN[OFFSET_FROM_INITIAL], "OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
+    AxisTwoEncoderValuesNP[OFFSET_FROM_INITIAL].fill("OFFSET_FROM_INITIAL", "Offset from initial", "%.0f", 0,
                  0xFFFFFF, 1, 0);
-    IUFillNumber(&AxisTwoEncoderValuesN[DEGREES_FROM_INITIAL], "DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
+    AxisTwoEncoderValuesNP[DEGREES_FROM_INITIAL].fill("DEGREES_FROM_INITIAL", "Degrees from initial", "%.2f",
                  -1000.0, 1000.0, 1, 0);
 
-    IUFillNumberVector(&AxisTwoEncoderValuesNP, AxisTwoEncoderValuesN, 4, getDeviceName(), "AXIS2_ENCODER_VALUES",
+    AxisTwoEncoderValuesNP.fill(getDeviceName(), "AXIS2_ENCODER_VALUES",
                        "Axis 2 Encoder values", DetailedMountInfoPage, IP_RO, 60, IPS_IDLE);
     // Register any visible before connection properties
 
     // Slew modes
-    IUFillSwitch(&SlewModesS[SLEW_SILENT], "SLEW_SILENT", "Silent", ISS_OFF);
-    IUFillSwitch(&SlewModesS[SLEW_NORMAL], "SLEW_NORMAL", "Normal", ISS_OFF);
-    IUFillSwitchVector(&SlewModesSP, SlewModesS, 2, getDeviceName(), "TELESCOPE_MOTION_SLEWMODE", "Slew Mode",
+    SlewModesSP[SLEW_SILENT].fill("SLEW_SILENT", "Silent", ISS_OFF);
+    SlewModesSP[SLEW_NORMAL].fill("SLEW_NORMAL", "Normal", ISS_OFF);
+    SlewModesSP.fill(getDeviceName(), "TELESCOPE_MOTION_SLEWMODE", "Slew Mode",
                        MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Wedge mode
-    IUFillSwitch(&WedgeModeS[WEDGE_SIMPLE], "WEDGE_SIMPLE", "Simple wedge", ISS_OFF);
-    IUFillSwitch(&WedgeModeS[WEDGE_EQ], "WEDGE_EQ", "EQ wedge", ISS_OFF);
-    IUFillSwitch(&WedgeModeS[WEDGE_DISABLED], "WEDGE_DISABLED", "Disabled", ISS_OFF);
-    IUFillSwitchVector(&WedgeModeSP, WedgeModeS, 3, getDeviceName(), "TELESCOPE_MOTION_WEDGEMODE",
+    WedgeModeSP[WEDGE_SIMPLE].fill("WEDGE_SIMPLE", "Simple wedge", ISS_OFF);
+    WedgeModeSP[WEDGE_EQ].fill("WEDGE_EQ", "EQ wedge", ISS_OFF);
+    WedgeModeSP[WEDGE_DISABLED].fill("WEDGE_DISABLED", "Disabled", ISS_OFF);
+    WedgeModeSP.fill(getDeviceName(), "TELESCOPE_MOTION_WEDGEMODE",
                        "Wedge Mode", MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Track logging mode
-    IUFillSwitch(&TrackLogModeS[TRACKLOG_ENABLED], "TRACKLOG_ENABLED", "Enable logging", ISS_OFF);
-    IUFillSwitch(&TrackLogModeS[TRACKLOG_DISABLED], "TRACKLOG_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&TrackLogModeSP, TrackLogModeS, 2, getDeviceName(), "TELESCOPE_MOTION_TRACKLOGMODE",
+    TrackLogModeSP[TRACKLOG_ENABLED].fill("TRACKLOG_ENABLED", "Enable logging", ISS_OFF);
+    TrackLogModeSP[TRACKLOG_DISABLED].fill("TRACKLOG_DISABLED", "Disabled", ISS_ON);
+    TrackLogModeSP.fill(getDeviceName(), "TELESCOPE_MOTION_TRACKLOGMODE",
                        "Track Logging Mode", MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Guiding rates for RA/DEC axes
-    IUFillNumber(&GuidingRatesN[0], "GUIDERA_RATE", "microsteps/seconds (RA)", "%1.3f", 0.00001, 100000.0, 0.00001, 1.0);
-    IUFillNumber(&GuidingRatesN[1], "GUIDEDEC_RATE", "microsteps/seconds (Dec)", "%1.3f", 0.00001, 100000.0, 0.00001, 1.0);
-    IUFillNumberVector(&GuidingRatesNP, GuidingRatesN, 2, getDeviceName(), "GUIDE_RATES", "Guide Rates", MOTION_TAB,
+    GuidingRatesNP[0].fill("GUIDERA_RATE", "microsteps/seconds (RA)", "%1.3f", 0.00001, 100000.0, 0.00001, 1.0);
+    GuidingRatesNP[1].fill("GUIDEDEC_RATE", "microsteps/seconds (Dec)", "%1.3f", 0.00001, 100000.0, 0.00001, 1.0);
+    GuidingRatesNP.fill(getDeviceName(), "GUIDE_RATES", "Guide Rates", MOTION_TAB,
                        IP_RW, 60, IPS_IDLE);
 
     // Tracking rate
@@ -370,32 +370,32 @@ bool SkywatcherAltAzSimple::initProperties()
     // Alt rate: 0.72, Az rate: 0.72, timeout: 1000 msec
     // For Skywatcher Merlin:
     // Alt rate: 0.64, Az rate: 0.64, timeout: 1000 msec
-    IUFillNumber(&TrackingValuesN[0], "TRACKING_RATE_ALT", "rate (Alt)", "%1.3f", 0.001, 10.0, 0.000001, 0.64);
-    IUFillNumber(&TrackingValuesN[1], "TRACKING_RATE_AZ", "rate (Az)", "%1.3f", 0.001, 10.0, 0.000001, 0.64);
-    IUFillNumber(&TrackingValuesN[2], "TRACKING_TIMEOUT", "msec (period)", "%1.3f", 0.001, 10000.0, 0.000001, 1000.0);
-    IUFillNumberVector(&TrackingValuesNP, TrackingValuesN, 3, getDeviceName(), "TRACKING_VALUES", "Tracking Values", MOTION_TAB,
+    TrackingValuesNP[0].fill("TRACKING_RATE_ALT", "rate (Alt)", "%1.3f", 0.001, 10.0, 0.000001, 0.64);
+    TrackingValuesNP[1].fill("TRACKING_RATE_AZ", "rate (Az)", "%1.3f", 0.001, 10.0, 0.000001, 0.64);
+    TrackingValuesNP[2].fill("TRACKING_TIMEOUT", "msec (period)", "%1.3f", 0.001, 10000.0, 0.000001, 1000.0);
+    TrackingValuesNP.fill(getDeviceName(), "TRACKING_VALUES", "Tracking Values", MOTION_TAB,
                        IP_RW, 60, IPS_IDLE);
 
     // Park movement directions
-    IUFillSwitch(&ParkMovementDirectionS[PARK_COUNTERCLOCKWISE], "PMD_COUNTERCLOCKWISE", "Counterclockwise", ISS_ON);
-    IUFillSwitch(&ParkMovementDirectionS[PARK_CLOCKWISE], "PMD_CLOCKWISE", "Clockwise", ISS_OFF);
-    IUFillSwitchVector(&ParkMovementDirectionSP, ParkMovementDirectionS, 2, getDeviceName(), "PARK_DIRECTION",
+    ParkMovementDirectionSP[PARK_COUNTERCLOCKWISE].fill("PMD_COUNTERCLOCKWISE", "Counterclockwise", ISS_ON);
+    ParkMovementDirectionSP[PARK_CLOCKWISE].fill("PMD_CLOCKWISE", "Clockwise", ISS_OFF);
+    ParkMovementDirectionSP.fill(getDeviceName(), "PARK_DIRECTION",
                        "Park Direction", MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Park positions
-    IUFillSwitch(&ParkPositionS[PARK_NORTH], "PARK_NORTH", "North", ISS_ON);
-    IUFillSwitch(&ParkPositionS[PARK_EAST], "PARK_EAST", "East", ISS_OFF);
-    IUFillSwitch(&ParkPositionS[PARK_SOUTH], "PARK_SOUTH", "South", ISS_OFF);
-    IUFillSwitch(&ParkPositionS[PARK_WEST], "PARK_WEST", "West", ISS_OFF);
-    IUFillSwitchVector(&ParkPositionSP, ParkPositionS, 4, getDeviceName(), "PARK_POSITION", "Park Position", MOTION_TAB,
+    ParkPositionSP[PARK_NORTH].fill("PARK_NORTH", "North", ISS_ON);
+    ParkPositionSP[PARK_EAST].fill("PARK_EAST", "East", ISS_OFF);
+    ParkPositionSP[PARK_SOUTH].fill("PARK_SOUTH", "South", ISS_OFF);
+    ParkPositionSP[PARK_WEST].fill("PARK_WEST", "West", ISS_OFF);
+    ParkPositionSP.fill(getDeviceName(), "PARK_POSITION", "Park Position", MOTION_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Unpark positions
-    IUFillSwitch(&UnparkPositionS[PARK_NORTH], "UNPARK_NORTH", "North", ISS_OFF);
-    IUFillSwitch(&UnparkPositionS[PARK_EAST], "UNPARK_EAST", "East", ISS_OFF);
-    IUFillSwitch(&UnparkPositionS[PARK_SOUTH], "UNPARK_SOUTH", "South", ISS_OFF);
-    IUFillSwitch(&UnparkPositionS[PARK_WEST], "UNPARK_WEST", "West", ISS_OFF);
-    IUFillSwitchVector(&UnparkPositionSP, UnparkPositionS, 4, getDeviceName(), "UNPARK_POSITION", "Unpark Position",
+    UnparkPositionSP[PARK_NORTH].fill("UNPARK_NORTH", "North", ISS_OFF);
+    UnparkPositionSP[PARK_EAST].fill("UNPARK_EAST", "East", ISS_OFF);
+    UnparkPositionSP[PARK_SOUTH].fill("UNPARK_SOUTH", "South", ISS_OFF);
+    UnparkPositionSP[PARK_WEST].fill("UNPARK_WEST", "West", ISS_OFF);
+    UnparkPositionSP.fill(getDeviceName(), "UNPARK_POSITION", "Unpark Position",
                        MOTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Guiding support
@@ -418,21 +418,21 @@ void SkywatcherAltAzSimple::ISGetProperties(const char *dev)
         // Define our connected only properties to the base driver
         // e.g. defineProperty(MyNumberVectorPointer);
         // This will register our properties and send a IDDefXXXX mewssage to any connected clients
-        defineProperty(&BasicMountInfoTP);
-        defineProperty(&AxisOneInfoNP);
-        defineProperty(&AxisOneStateSP);
-        defineProperty(&AxisTwoInfoNP);
-        defineProperty(&AxisTwoStateSP);
-        defineProperty(&AxisOneEncoderValuesNP);
-        defineProperty(&AxisTwoEncoderValuesNP);
-        defineProperty(&SlewModesSP);
-        defineProperty(&WedgeModeSP);
-        defineProperty(&TrackLogModeSP);
-        defineProperty(&GuidingRatesNP);
-        defineProperty(&TrackingValuesNP);
-        defineProperty(&ParkMovementDirectionSP);
-        defineProperty(&ParkPositionSP);
-        defineProperty(&UnparkPositionSP);
+        defineProperty(BasicMountInfoTP);
+        defineProperty(AxisOneInfoNP);
+        defineProperty(AxisOneStateSP);
+        defineProperty(AxisTwoInfoNP);
+        defineProperty(AxisTwoStateSP);
+        defineProperty(AxisOneEncoderValuesNP);
+        defineProperty(AxisTwoEncoderValuesNP);
+        defineProperty(SlewModesSP);
+        defineProperty(WedgeModeSP);
+        defineProperty(TrackLogModeSP);
+        defineProperty(GuidingRatesNP);
+        defineProperty(TrackingValuesNP);
+        defineProperty(ParkMovementDirectionSP);
+        defineProperty(ParkPositionSP);
+        defineProperty(UnparkPositionSP);
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
     }
@@ -456,17 +456,17 @@ bool SkywatcherAltAzSimple::ISNewNumber(const char *dev, const char *name, doubl
         if (strcmp(name, "GUIDE_RATES") == 0)
         {
             ResetGuidePulses();
-            GuidingRatesNP.s = IPS_OK;
-            IUUpdateNumber(&GuidingRatesNP, values, names, n);
-            IDSetNumber(&GuidingRatesNP, nullptr);
+            GuidingRatesNP.setState(IPS_OK);
+            GuidingRatesNP.update(values, names, n);
+            GuidingRatesNP.apply();
             return true;
         }
 
         if (strcmp(name, "TRACKING_VALUES") == 0)
         {
-            TrackingValuesNP.s = IPS_OK;
-            IUUpdateNumber(&TrackingValuesNP, values, names, n);
-            IDSetNumber(&TrackingValuesNP, nullptr);
+            TrackingValuesNP.setState(IPS_OK);
+            TrackingValuesNP.update(values, names, n);
+            TrackingValuesNP.apply();
             return true;
         }
 
@@ -478,19 +478,19 @@ bool SkywatcherAltAzSimple::ISNewNumber(const char *dev, const char *name, doubl
 
             for (int x = 0; x < n; x++)
             {
-                INumber *eqp = IUFindNumber(&EqNP, names[x]);
-                if (eqp == &EqN[AXIS_RA])
+                INumber *eqp = EqNP.findWidgetByName(names[x]);
+                if (eqp == &EqNP[AXIS_RA])
                 {
                     ra = values[x];
                 }
-                else if (eqp == &EqN[AXIS_DE])
+                else if (eqp == &EqNP[AXIS_DE])
                 {
                     dec = values[x];
                 }
             }
             if ((ra >= 0) && (ra <= 24) && (dec >= -90) && (dec <= 90))
             {
-                ISwitch *sw = IUFindSwitch(&CoordSP, "SYNC");
+                ISwitch *sw = CoordSP.findWidgetByName("SYNC");
 
                 if (sw != nullptr && sw->s == ISS_ON && isParked())
                 {
@@ -809,34 +809,34 @@ bool SkywatcherAltAzSimple::Park()
     double DeltaAz                  = 0;
 
     // Determinate the target position and direction
-    if (IUFindSwitch(&ParkPositionSP, "PARK_NORTH") != nullptr &&
-            IUFindSwitch(&ParkPositionSP, "PARK_NORTH")->s == ISS_ON)
+    if (ParkPositionSP.findWidgetByName("PARK_NORTH") != nullptr &&
+            ParkPositionSP.findWidgetByName("PARK_NORTH")->s == ISS_ON)
     {
         TargetPosition = PARK_NORTH;
     }
-    if (IUFindSwitch(&ParkPositionSP, "PARK_EAST") != nullptr &&
-            IUFindSwitch(&ParkPositionSP, "PARK_EAST")->s == ISS_ON)
+    if (ParkPositionSP.findWidgetByName("PARK_EAST") != nullptr &&
+            ParkPositionSP.findWidgetByName("PARK_EAST")->s == ISS_ON)
     {
         TargetPosition = PARK_EAST;
     }
-    if (IUFindSwitch(&ParkPositionSP, "PARK_SOUTH") != nullptr &&
-            IUFindSwitch(&ParkPositionSP, "PARK_SOUTH")->s == ISS_ON)
+    if (ParkPositionSP.findWidgetByName("PARK_SOUTH") != nullptr &&
+            ParkPositionSP.findWidgetByName("PARK_SOUTH")->s == ISS_ON)
     {
         TargetPosition = PARK_SOUTH;
     }
-    if (IUFindSwitch(&ParkPositionSP, "PARK_WEST") != nullptr &&
-            IUFindSwitch(&ParkPositionSP, "PARK_WEST")->s == ISS_ON)
+    if (ParkPositionSP.findWidgetByName("PARK_WEST") != nullptr &&
+            ParkPositionSP.findWidgetByName("PARK_WEST")->s == ISS_ON)
     {
         TargetPosition = PARK_WEST;
     }
 
-    if (IUFindSwitch(&ParkMovementDirectionSP, "PMD_COUNTERCLOCKWISE") != nullptr &&
-            IUFindSwitch(&ParkMovementDirectionSP, "PMD_COUNTERCLOCKWISE")->s == ISS_ON)
+    if (ParkMovementDirectionSP.findWidgetByName("PMD_COUNTERCLOCKWISE") != nullptr &&
+            ParkMovementDirectionSP.findWidgetByName("PMD_COUNTERCLOCKWISE")->s == ISS_ON)
     {
         TargetDirection = PARK_COUNTERCLOCKWISE;
     }
-    if (IUFindSwitch(&ParkMovementDirectionSP, "PMD_CLOCKWISE") != nullptr &&
-            IUFindSwitch(&ParkMovementDirectionSP, "PMD_CLOCKWISE")->s == ISS_ON)
+    if (ParkMovementDirectionSP.findWidgetByName("PMD_CLOCKWISE") != nullptr &&
+            ParkMovementDirectionSP.findWidgetByName("PMD_CLOCKWISE")->s == ISS_ON)
     {
         TargetDirection = PARK_CLOCKWISE;
     }
@@ -850,7 +850,7 @@ bool SkywatcherAltAzSimple::Park()
     DEBUGF(DBG_SCOPE, "Parking: Altitude offset %ld microsteps Azimuth offset %ld microsteps",
            AltitudeOffsetMicrosteps, AzimuthOffsetMicrosteps);
 
-    if (IUFindSwitch(&SlewModesSP, "SLEW_NORMAL")->s == ISS_ON)
+    if (SlewModesSP.findWidgetByName("SLEW_NORMAL")->s == ISS_ON)
     {
         SilentSlewMode = false;
     }
@@ -875,35 +875,35 @@ bool SkywatcherAltAzSimple::UnPark()
     double DeltaAz                  = 0;
 
     // Determinate the target position and direction
-    if (IUFindSwitch(&UnparkPositionSP, "UNPARK_NORTH") != nullptr &&
-            IUFindSwitch(&UnparkPositionSP, "UNPARK_NORTH")->s == ISS_ON)
+    if (UnparkPositionSP.findWidgetByName("UNPARK_NORTH") != nullptr &&
+            UnparkPositionSP.findWidgetByName("UNPARK_NORTH")->s == ISS_ON)
     {
         TargetPosition = PARK_NORTH;
     }
-    if (IUFindSwitch(&UnparkPositionSP, "UNPARK_EAST") != nullptr &&
-            IUFindSwitch(&UnparkPositionSP, "UNPARK_EAST")->s == ISS_ON)
+    if (UnparkPositionSP.findWidgetByName("UNPARK_EAST") != nullptr &&
+            UnparkPositionSP.findWidgetByName("UNPARK_EAST")->s == ISS_ON)
     {
         TargetPosition = PARK_EAST;
     }
-    if (IUFindSwitch(&UnparkPositionSP, "UNPARK_SOUTH") != nullptr &&
-            IUFindSwitch(&UnparkPositionSP, "UNPARK_SOUTH")->s == ISS_ON)
+    if (UnparkPositionSP.findWidgetByName("UNPARK_SOUTH") != nullptr &&
+            UnparkPositionSP.findWidgetByName("UNPARK_SOUTH")->s == ISS_ON)
     {
         TargetPosition = PARK_SOUTH;
     }
-    if (IUFindSwitch(&UnparkPositionSP, "UNPARK_WEST") != nullptr &&
-            IUFindSwitch(&UnparkPositionSP, "UNPARK_WEST")->s == ISS_ON)
+    if (UnparkPositionSP.findWidgetByName("UNPARK_WEST") != nullptr &&
+            UnparkPositionSP.findWidgetByName("UNPARK_WEST")->s == ISS_ON)
     {
         TargetPosition = PARK_WEST;
     }
 
     // Note: The reverse direction is used for unparking.
-    if (IUFindSwitch(&ParkMovementDirectionSP, "PMD_COUNTERCLOCKWISE") != nullptr &&
-            IUFindSwitch(&ParkMovementDirectionSP, "PMD_COUNTERCLOCKWISE")->s == ISS_ON)
+    if (ParkMovementDirectionSP.findWidgetByName("PMD_COUNTERCLOCKWISE") != nullptr &&
+            ParkMovementDirectionSP.findWidgetByName("PMD_COUNTERCLOCKWISE")->s == ISS_ON)
     {
         TargetDirection = PARK_CLOCKWISE;
     }
-    if (IUFindSwitch(&ParkMovementDirectionSP, "PMD_CLOCKWISE") != nullptr &&
-            IUFindSwitch(&ParkMovementDirectionSP, "PMD_CLOCKWISE")->s == ISS_ON)
+    if (ParkMovementDirectionSP.findWidgetByName("PMD_CLOCKWISE") != nullptr &&
+            ParkMovementDirectionSP.findWidgetByName("PMD_CLOCKWISE")->s == ISS_ON)
     {
         TargetDirection = PARK_COUNTERCLOCKWISE;
     }
@@ -919,7 +919,7 @@ bool SkywatcherAltAzSimple::UnPark()
     DEBUGF(DBG_SCOPE, "Unparking: Altitude offset %ld microsteps Azimuth offset %ld microsteps",
            AltitudeOffsetMicrosteps, AzimuthOffsetMicrosteps);
 
-    if (IUFindSwitch(&SlewModesSP, "SLEW_NORMAL")->s == ISS_ON)
+    if (SlewModesSP.findWidgetByName("SLEW_NORMAL")->s == ISS_ON)
     {
         SilentSlewMode = false;
     }
@@ -1004,14 +1004,14 @@ bool SkywatcherAltAzSimple::ReadScopeStatus()
 
 bool SkywatcherAltAzSimple::saveConfigItems(FILE *fp)
 {
-    IUSaveConfigSwitch(fp, &SlewModesSP);
-    IUSaveConfigSwitch(fp, &WedgeModeSP);
-    IUSaveConfigSwitch(fp, &TrackLogModeSP);
-    IUSaveConfigNumber(fp, &GuidingRatesNP);
-    IUSaveConfigNumber(fp, &TrackingValuesNP);
-    IUSaveConfigSwitch(fp, &ParkMovementDirectionSP);
-    IUSaveConfigSwitch(fp, &ParkPositionSP);
-    IUSaveConfigSwitch(fp, &UnparkPositionSP);
+    SlewModesSP.save(fp);
+    WedgeModeSP.save(fp);
+    TrackLogModeSP.save(fp);
+    GuidingRatesNP.save(fp);
+    TrackingValuesNP.save(fp);
+    ParkMovementDirectionSP.save(fp);
+    ParkPositionSP.save(fp);
+    UnparkPositionSP.save(fp);
 
     return INDI::Telescope::saveConfigItems(fp);
 }
@@ -1099,8 +1099,8 @@ void SkywatcherAltAzSimple::TimerHit()
                 if (TrackingStartTimer < 3000)
                     return;
 
-                if (IUFindSwitch(&WedgeModeSP, "WEDGE_EQ")->s == ISS_ON ||
-                        IUFindSwitch(&CoordSP, "TRACK")->s == ISS_ON)
+                if (WedgeModeSP.findWidgetByName("WEDGE_EQ")->s == ISS_ON ||
+                        CoordSP.findWidgetByName("TRACK")->s == ISS_ON)
 
                 {
                     // Goto has finished start tracking
@@ -1120,7 +1120,7 @@ void SkywatcherAltAzSimple::TimerHit()
             {
                 LOG_INFO("Tracking started");
                 TrackingMsecs   = 0;
-                TimeoutDuration = (int)IUFindNumber(&TrackingValuesNP, "TRACKING_TIMEOUT")->value;
+                TimeoutDuration = (int)TrackingValuesNP.findWidgetByName("TRACKING_TIMEOUT")->value;
                 GuideDeltaAlt   = 0;
                 GuideDeltaAz    = 0;
                 ResetGuidePulses();
@@ -1129,8 +1129,8 @@ void SkywatcherAltAzSimple::TimerHit()
             if (moving)
             {
                 //                TrackedAltAz  = CurrentAltAz;
-                CurrentTrackingTarget.ra = EqN[AXIS_RA].value;
-                CurrentTrackingTarget.dec = EqN[AXIS_DE].value;
+                CurrentTrackingTarget.ra = EqNP[AXIS_RA].getValue();
+                CurrentTrackingTarget.dec = EqNP[AXIS_DE].getValue();
             }
             else
             {
@@ -1179,10 +1179,10 @@ void SkywatcherAltAzSimple::TimerHit()
 
                 // When the Alt/Az mount is on the top of an EQ mount, the EQ mount already tracks in
                 // sidereal speed. Only autoguiding is enabled in tracking mode.
-                if (IUFindSwitch(&WedgeModeSP, "WEDGE_EQ")->s == ISS_ON)
+                if (WedgeModeSP.findWidgetByName("WEDGE_EQ")->s == ISS_ON)
                 {
-                    AltitudeOffsetMicrosteps = (long)((float)IUFindNumber(&GuidingRatesNP, "GUIDEDEC_RATE")->value * GuideDeltaAlt);
-                    AzimuthOffsetMicrosteps = (long)((float)IUFindNumber(&GuidingRatesNP, "GUIDERA_RATE")->value * GuideDeltaAz);
+                    AltitudeOffsetMicrosteps = (long)((float)GuidingRatesNP.findWidgetByName("GUIDEDEC_RATE")->value * GuideDeltaAlt);
+                    AzimuthOffsetMicrosteps = (long)((float)GuidingRatesNP.findWidgetByName("GUIDERA_RATE")->value * GuideDeltaAz);
                     GuideDeltaAlt = 0;
                     GuideDeltaAz = 0;
                     // Correct the movements of the EQ mount
@@ -1216,10 +1216,8 @@ void SkywatcherAltAzSimple::TimerHit()
                     AzimuthOffsetMicrosteps += MicrostepsPerRevolution[AXIS1];
                 }
 
-                AltitudeOffsetMicrosteps = (long)((double)AltitudeOffsetMicrosteps * IUFindNumber(&TrackingValuesNP,
-                                                  "TRACKING_RATE_ALT")->value);
-                AzimuthOffsetMicrosteps = (long)((double)AzimuthOffsetMicrosteps * IUFindNumber(&TrackingValuesNP,
-                                                 "TRACKING_RATE_AZ")->value);
+                AltitudeOffsetMicrosteps = (long)((double)AltitudeOffsetMicrosteps * TrackingValuesNP.findWidgetByName("TRACKING_RATE_ALT")->value);
+                AzimuthOffsetMicrosteps = (long)((double)AzimuthOffsetMicrosteps * TrackingValuesNP.findWidgetByName("TRACKING_RATE_AZ")->value);
 
                 LogMessage("TRACKING: now Alt %lf Az %lf - future Alt %lf Az %lf - microsteps_diff Alt %ld Az %ld",
                            CurrentAltAz.alt, CurrentAltAz.az, FutureAltAz.alt, FutureAltAz.az,
@@ -1294,21 +1292,21 @@ bool SkywatcherAltAzSimple::updateProperties()
         // This will register our properties and send a IDDefXXXX message to any connected clients
         // I have now idea why I have to do this here as well as in ISGetProperties. It makes me
         // concerned there is a design or implementation flaw somewhere.
-        defineProperty(&BasicMountInfoTP);
-        defineProperty(&AxisOneInfoNP);
-        defineProperty(&AxisOneStateSP);
-        defineProperty(&AxisTwoInfoNP);
-        defineProperty(&AxisTwoStateSP);
-        defineProperty(&AxisOneEncoderValuesNP);
-        defineProperty(&AxisTwoEncoderValuesNP);
-        defineProperty(&SlewModesSP);
-        defineProperty(&WedgeModeSP);
-        defineProperty(&TrackLogModeSP);
-        defineProperty(&GuidingRatesNP);
-        defineProperty(&TrackingValuesNP);
-        defineProperty(&ParkMovementDirectionSP);
-        defineProperty(&ParkPositionSP);
-        defineProperty(&UnparkPositionSP);
+        defineProperty(BasicMountInfoTP);
+        defineProperty(AxisOneInfoNP);
+        defineProperty(AxisOneStateSP);
+        defineProperty(AxisTwoInfoNP);
+        defineProperty(AxisTwoStateSP);
+        defineProperty(AxisOneEncoderValuesNP);
+        defineProperty(AxisTwoEncoderValuesNP);
+        defineProperty(SlewModesSP);
+        defineProperty(WedgeModeSP);
+        defineProperty(TrackLogModeSP);
+        defineProperty(GuidingRatesNP);
+        defineProperty(TrackingValuesNP);
+        defineProperty(ParkMovementDirectionSP);
+        defineProperty(ParkPositionSP);
+        defineProperty(UnparkPositionSP);
 
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
@@ -1318,21 +1316,21 @@ bool SkywatcherAltAzSimple::updateProperties()
     {
         // Delete any connected only properties from the base driver's list
         // e.g. deleteProperty(MyNumberVector.name);
-        deleteProperty(BasicMountInfoTP.name);
-        deleteProperty(AxisOneInfoNP.name);
-        deleteProperty(AxisOneStateSP.name);
-        deleteProperty(AxisTwoInfoNP.name);
-        deleteProperty(AxisTwoStateSP.name);
-        deleteProperty(AxisOneEncoderValuesNP.name);
-        deleteProperty(AxisTwoEncoderValuesNP.name);
-        deleteProperty(SlewModesSP.name);
-        deleteProperty(WedgeModeSP.name);
-        deleteProperty(TrackLogModeSP.name);
-        deleteProperty(GuidingRatesNP.name);
-        deleteProperty(TrackingValuesNP.name);
-        deleteProperty(ParkMovementDirectionSP.name);
-        deleteProperty(ParkPositionSP.name);
-        deleteProperty(UnparkPositionSP.name);
+        deleteProperty(BasicMountInfoTP.getName());
+        deleteProperty(AxisOneInfoNP.getName());
+        deleteProperty(AxisOneStateSP.getName());
+        deleteProperty(AxisTwoInfoNP.getName());
+        deleteProperty(AxisTwoStateSP.getName());
+        deleteProperty(AxisOneEncoderValuesNP.getName());
+        deleteProperty(AxisTwoEncoderValuesNP.getName());
+        deleteProperty(SlewModesSP.getName());
+        deleteProperty(WedgeModeSP.getName());
+        deleteProperty(TrackLogModeSP.getName());
+        deleteProperty(GuidingRatesNP.getName());
+        deleteProperty(TrackingValuesNP.getName());
+        deleteProperty(ParkMovementDirectionSP.getName());
+        deleteProperty(ParkPositionSP.getName());
+        deleteProperty(UnparkPositionSP.getName());
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
@@ -1451,179 +1449,177 @@ void SkywatcherAltAzSimple::UpdateDetailedMountInformation(bool InformClient)
 {
     bool BasicMountInfoHasChanged = false;
 
-    if (std::string(BasicMountInfoT[MOTOR_CONTROL_FIRMWARE_VERSION].text) != std::to_string(MCVersion))
+    if (std::string(BasicMountInfoTP[MOTOR_CONTROL_FIRMWARE_VERSION].getText()) != std::to_string(MCVersion))
     {
-        IUSaveText(&BasicMountInfoT[MOTOR_CONTROL_FIRMWARE_VERSION], std::to_string(MCVersion).c_str());
+        BasicMountInfoTP[MOTOR_CONTROL_FIRMWARE_VERSION].setText(std::to_string(MCVersion));
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[MOUNT_CODE].text) != std::to_string(MountCode))
+    if (std::string(BasicMountInfoTP[MOUNT_CODE].getText()) != std::to_string(MountCode))
     {
-        IUSaveText(&BasicMountInfoT[MOUNT_CODE], std::to_string(MountCode).c_str());
+        BasicMountInfoTP[MOUNT_CODE].setText(std::to_string(MountCode));
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[IS_DC_MOTOR].text) != std::to_string(IsDCMotor))
+    if (std::string(BasicMountInfoTP[IS_DC_MOTOR].getText()) != std::to_string(IsDCMotor))
     {
-        IUSaveText(&BasicMountInfoT[IS_DC_MOTOR], std::to_string(IsDCMotor).c_str());
+        BasicMountInfoTP[IS_DC_MOTOR].setText(std::to_string(IsDCMotor));
         BasicMountInfoHasChanged = true;
     }
     if (BasicMountInfoHasChanged && InformClient)
-        IDSetText(&BasicMountInfoTP, nullptr);
+        BasicMountInfoTP.apply();
 
     if (MountCode == 128)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "Merlin");
+        BasicMountInfoTP[MOUNT_NAME].setText("Merlin");
     else if (MountCode >= 129 && MountCode <= 143)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "Az Goto");
+        BasicMountInfoTP[MOUNT_NAME].setText("Az Goto");
     else if (MountCode >= 144 && MountCode <= 159)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "Dob Goto");
+        BasicMountInfoTP[MOUNT_NAME].setText("Dob Goto");
     else if (MountCode == 161)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "Virtuoso");
+        BasicMountInfoTP[MOUNT_NAME].setText("Virtuoso");
     else if (MountCode >= 160)
-        IUSaveText(&BasicMountInfoT[MOUNT_NAME], "AllView Goto");
+        BasicMountInfoTP[MOUNT_NAME].setText("AllView Goto");
 
     bool AxisOneInfoHasChanged = false;
 
-    if (AxisOneInfoN[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[0])
+    if (AxisOneInfoNP[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[0])
     {
-        AxisOneInfoN[MICROSTEPS_PER_REVOLUTION].value = MicrostepsPerRevolution[0];
+        AxisOneInfoNP[MICROSTEPS_PER_REVOLUTION].setValue(MicrostepsPerRevolution[0]);
         AxisOneInfoHasChanged                        = true;
     }
-    if (AxisOneInfoN[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[0])
+    if (AxisOneInfoNP[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[0])
     {
-        AxisOneInfoN[STEPPER_CLOCK_FREQUENCY].value = StepperClockFrequency[0];
+        AxisOneInfoNP[STEPPER_CLOCK_FREQUENCY].setValue(StepperClockFrequency[0]);
         AxisOneInfoHasChanged                      = true;
     }
-    if (AxisOneInfoN[HIGH_SPEED_RATIO].value != HighSpeedRatio[0])
+    if (AxisOneInfoNP[HIGH_SPEED_RATIO].value != HighSpeedRatio[0])
     {
-        AxisOneInfoN[HIGH_SPEED_RATIO].value = HighSpeedRatio[0];
+        AxisOneInfoNP[HIGH_SPEED_RATIO].setValue(HighSpeedRatio[0]);
         AxisOneInfoHasChanged               = true;
     }
-    if (AxisOneInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[0])
+    if (AxisOneInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[0])
     {
-        AxisOneInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value = MicrostepsPerWormRevolution[0];
+        AxisOneInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].setValue(MicrostepsPerWormRevolution[0]);
         AxisOneInfoHasChanged                             = true;
     }
     if (AxisOneInfoHasChanged && InformClient)
-        IDSetNumber(&AxisOneInfoNP, nullptr);
+        AxisOneInfoNP.apply();
 
     bool AxisOneStateHasChanged = false;
-    if (AxisOneStateS[FULL_STOP].s != (AxesStatus[0].FullStop ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[FULL_STOP].getState() != (AxesStatus[0].FullStop ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[FULL_STOP].s = AxesStatus[0].FullStop ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[FULL_STOP].setState(AxesStatus[0].FullStop ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged    = true;
     }
-    if (AxisOneStateS[SLEWING].s != (AxesStatus[0].Slewing ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[SLEWING].getState() != (AxesStatus[0].Slewing ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[SLEWING].s = AxesStatus[0].Slewing ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[SLEWING].setState(AxesStatus[0].Slewing ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged  = true;
     }
-    if (AxisOneStateS[SLEWING_TO].s != (AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[SLEWING_TO].getState() != (AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[SLEWING_TO].s = AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[SLEWING_TO].setState(AxesStatus[0].SlewingTo ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged     = true;
     }
-    if (AxisOneStateS[SLEWING_FORWARD].s != (AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[SLEWING_FORWARD].getState() != (AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[SLEWING_FORWARD].s = AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[SLEWING_FORWARD].setState(AxesStatus[0].SlewingForward ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged          = true;
     }
-    if (AxisOneStateS[HIGH_SPEED].s != (AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[HIGH_SPEED].getState() != (AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[HIGH_SPEED].s = AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[HIGH_SPEED].setState(AxesStatus[0].HighSpeed ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged     = true;
     }
-    if (AxisOneStateS[NOT_INITIALISED].s != (AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF))
+    if (AxisOneStateSP[NOT_INITIALISED].getState() != (AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF))
     {
-        AxisOneStateS[NOT_INITIALISED].s = AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF;
+        AxisOneStateSP[NOT_INITIALISED].setState(AxesStatus[0].NotInitialized ? ISS_ON : ISS_OFF);
         AxisOneStateHasChanged          = true;
     }
     if (AxisOneStateHasChanged && InformClient)
-        IDSetSwitch(&AxisOneStateSP, nullptr);
+        AxisOneStateSP.apply();
 
     bool AxisTwoInfoHasChanged = false;
-    if (AxisTwoInfoN[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[1])
+    if (AxisTwoInfoNP[MICROSTEPS_PER_REVOLUTION].value != MicrostepsPerRevolution[1])
     {
-        AxisTwoInfoN[MICROSTEPS_PER_REVOLUTION].value = MicrostepsPerRevolution[1];
+        AxisTwoInfoNP[MICROSTEPS_PER_REVOLUTION].setValue(MicrostepsPerRevolution[1]);
         AxisTwoInfoHasChanged                        = true;
     }
-    if (AxisTwoInfoN[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[1])
+    if (AxisTwoInfoNP[STEPPER_CLOCK_FREQUENCY].value != StepperClockFrequency[1])
     {
-        AxisTwoInfoN[STEPPER_CLOCK_FREQUENCY].value = StepperClockFrequency[1];
+        AxisTwoInfoNP[STEPPER_CLOCK_FREQUENCY].setValue(StepperClockFrequency[1]);
         AxisTwoInfoHasChanged                      = true;
     }
-    if (AxisTwoInfoN[HIGH_SPEED_RATIO].value != HighSpeedRatio[1])
+    if (AxisTwoInfoNP[HIGH_SPEED_RATIO].value != HighSpeedRatio[1])
     {
-        AxisTwoInfoN[HIGH_SPEED_RATIO].value = HighSpeedRatio[1];
+        AxisTwoInfoNP[HIGH_SPEED_RATIO].setValue(HighSpeedRatio[1]);
         AxisTwoInfoHasChanged               = true;
     }
-    if (AxisTwoInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[1])
+    if (AxisTwoInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].value != MicrostepsPerWormRevolution[1])
     {
-        AxisTwoInfoN[MICROSTEPS_PER_WORM_REVOLUTION].value = MicrostepsPerWormRevolution[1];
+        AxisTwoInfoNP[MICROSTEPS_PER_WORM_REVOLUTION].setValue(MicrostepsPerWormRevolution[1]);
         AxisTwoInfoHasChanged                             = true;
     }
     if (AxisTwoInfoHasChanged && InformClient)
-        IDSetNumber(&AxisTwoInfoNP, nullptr);
+        AxisTwoInfoNP.apply();
 
     bool AxisTwoStateHasChanged = false;
-    if (AxisTwoStateS[FULL_STOP].s != (AxesStatus[1].FullStop ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[FULL_STOP].getState() != (AxesStatus[1].FullStop ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[FULL_STOP].s = AxesStatus[1].FullStop ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[FULL_STOP].setState(AxesStatus[1].FullStop ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged    = true;
     }
-    if (AxisTwoStateS[SLEWING].s != (AxesStatus[1].Slewing ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[SLEWING].getState() != (AxesStatus[1].Slewing ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[SLEWING].s = AxesStatus[1].Slewing ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[SLEWING].setState(AxesStatus[1].Slewing ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged  = true;
     }
-    if (AxisTwoStateS[SLEWING_TO].s != (AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[SLEWING_TO].getState() != (AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[SLEWING_TO].s = AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[SLEWING_TO].setState(AxesStatus[1].SlewingTo ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged     = true;
     }
-    if (AxisTwoStateS[SLEWING_FORWARD].s != (AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[SLEWING_FORWARD].getState() != (AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[SLEWING_FORWARD].s = AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[SLEWING_FORWARD].setState(AxesStatus[1].SlewingForward ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged          = true;
     }
-    if (AxisTwoStateS[HIGH_SPEED].s != (AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[HIGH_SPEED].getState() != (AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[HIGH_SPEED].s = AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[HIGH_SPEED].setState(AxesStatus[1].HighSpeed ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged     = true;
     }
-    if (AxisTwoStateS[NOT_INITIALISED].s != (AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF))
+    if (AxisTwoStateSP[NOT_INITIALISED].getState() != (AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF))
     {
-        AxisTwoStateS[NOT_INITIALISED].s = AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF;
+        AxisTwoStateSP[NOT_INITIALISED].setState(AxesStatus[1].NotInitialized ? ISS_ON : ISS_OFF);
         AxisTwoStateHasChanged          = true;
     }
     if (AxisTwoStateHasChanged && InformClient)
-        IDSetSwitch(&AxisTwoStateSP, nullptr);
+        AxisTwoStateSP.apply();
 
     bool AxisOneEncoderValuesHasChanged = false;
-    if ((AxisOneEncoderValuesN[RAW_MICROSTEPS].value != CurrentEncoders[AXIS1]) ||
-            (AxisOneEncoderValuesN[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]))
+    if ((AxisOneEncoderValuesNP[RAW_MICROSTEPS].value != CurrentEncoders[AXIS1]) ||
+            (AxisOneEncoderValuesNP[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]))
     {
-        AxisOneEncoderValuesN[RAW_MICROSTEPS].value = CurrentEncoders[AXIS1];
-        AxisOneEncoderValuesN[MICROSTEPS_PER_ARCSEC].value = MicrostepsPerDegree[AXIS1] / 3600.0;
-        AxisOneEncoderValuesN[OFFSET_FROM_INITIAL].value = CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1];
-        AxisOneEncoderValuesN[DEGREES_FROM_INITIAL].value =
-            MicrostepsToDegrees(AXIS1, CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]);
+        AxisOneEncoderValuesNP[RAW_MICROSTEPS].setValue(CurrentEncoders[AXIS1]);
+        AxisOneEncoderValuesNP[MICROSTEPS_PER_ARCSEC].setValue(MicrostepsPerDegree[AXIS1] / 3600.0);
+        AxisOneEncoderValuesNP[OFFSET_FROM_INITIAL].setValue(CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]);
+        AxisOneEncoderValuesNP[DEGREES_FROM_INITIAL].setValue(MicrostepsToDegrees(AXIS1, CurrentEncoders[AXIS1] - ZeroPositionEncoders[AXIS1]));
         AxisOneEncoderValuesHasChanged = true;
     }
     if (AxisOneEncoderValuesHasChanged && InformClient)
-        IDSetNumber(&AxisOneEncoderValuesNP, nullptr);
+        AxisOneEncoderValuesNP.apply();
 
     bool AxisTwoEncoderValuesHasChanged = false;
-    if ((AxisTwoEncoderValuesN[RAW_MICROSTEPS].value != CurrentEncoders[AXIS2]) ||
-            (AxisTwoEncoderValuesN[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]))
+    if ((AxisTwoEncoderValuesNP[RAW_MICROSTEPS].value != CurrentEncoders[AXIS2]) ||
+            (AxisTwoEncoderValuesNP[OFFSET_FROM_INITIAL].value != CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]))
     {
-        AxisTwoEncoderValuesN[RAW_MICROSTEPS].value      = CurrentEncoders[AXIS2];
-        AxisTwoEncoderValuesN[MICROSTEPS_PER_ARCSEC].value = MicrostepsPerDegree[AXIS2] / 3600.0;
-        AxisTwoEncoderValuesN[OFFSET_FROM_INITIAL].value = CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2];
-        AxisTwoEncoderValuesN[DEGREES_FROM_INITIAL].value =
-            MicrostepsToDegrees(AXIS2, CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]);
+        AxisTwoEncoderValuesNP[RAW_MICROSTEPS].setValue(CurrentEncoders[AXIS2]);
+        AxisTwoEncoderValuesNP[MICROSTEPS_PER_ARCSEC].setValue(MicrostepsPerDegree[AXIS2] / 3600.0);
+        AxisTwoEncoderValuesNP[OFFSET_FROM_INITIAL].setValue(CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]);
+        AxisTwoEncoderValuesNP[DEGREES_FROM_INITIAL].setValue(MicrostepsToDegrees(AXIS2, CurrentEncoders[AXIS2] - ZeroPositionEncoders[AXIS2]));
         AxisTwoEncoderValuesHasChanged = true;
     }
     if (AxisTwoEncoderValuesHasChanged && InformClient)
-        IDSetNumber(&AxisTwoEncoderValuesNP, nullptr);
+        AxisTwoEncoderValuesNP.apply();
 }
 
 
@@ -1635,15 +1631,15 @@ ln_hrz_posn SkywatcherAltAzSimple::GetAltAzPosition(double ra, double dec, doubl
     double JulianOffset = offset_in_sec / (24.0 * 60 * 60);
 
     // Set the current location
-    if (IUFindSwitch(&WedgeModeSP, "WEDGE_SIMPLE")->s == ISS_OFF &&
-            IUFindSwitch(&WedgeModeSP, "WEDGE_EQ")->s == ISS_OFF)
+    if (WedgeModeSP.findWidgetByName("WEDGE_SIMPLE")->s == ISS_OFF &&
+            WedgeModeSP.findWidgetByName("WEDGE_EQ")->s == ISS_OFF)
     {
-        Location.lat = LocationN[LOCATION_LATITUDE].value;
-        Location.lng = LocationN[LOCATION_LONGITUDE].value;
+        Location.lat = LocationNP[LOCATION_LATITUDE].getValue();
+        Location.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     }
     else
     {
-        if (LocationN[LOCATION_LATITUDE].value > 0)
+        if (LocationNP[LOCATION_LATITUDE].value > 0)
         {
             Location.lat = 90;
             Location.lng = 0;
@@ -1672,15 +1668,15 @@ ln_equ_posn SkywatcherAltAzSimple::GetRaDecPosition(double alt, double az)
     ln_hrz_posn AltAz { az, alt };
 
     // Set the current location
-    if (IUFindSwitch(&WedgeModeSP, "WEDGE_SIMPLE")->s == ISS_OFF &&
-            IUFindSwitch(&WedgeModeSP, "WEDGE_EQ")->s == ISS_OFF)
+    if (WedgeModeSP.findWidgetByName("WEDGE_SIMPLE")->s == ISS_OFF &&
+            WedgeModeSP.findWidgetByName("WEDGE_EQ")->s == ISS_OFF)
     {
-        Location.lat = LocationN[LOCATION_LATITUDE].value;
-        Location.lng = LocationN[LOCATION_LONGITUDE].value;
+        Location.lat = LocationNP[LOCATION_LATITUDE].getValue();
+        Location.lng = LocationNP[LOCATION_LONGITUDE].getValue();
     }
     else
     {
-        if (LocationN[LOCATION_LATITUDE].value > 0)
+        if (LocationNP[LOCATION_LATITUDE].value > 0)
         {
             Location.lat = 90;
             Location.lng = 0;
@@ -1703,7 +1699,7 @@ ln_equ_posn SkywatcherAltAzSimple::GetRaDecPosition(double alt, double az)
 
 void SkywatcherAltAzSimple::LogMessage(const char* format, ...)
 {
-    if (!format || IUFindSwitch(&TrackLogModeSP, "TRACKLOG_ENABLED")->s == ISS_OFF)
+    if (!format || TrackLogModeSP.findWidgetByName("TRACKLOG_ENABLED")->s == ISS_OFF)
         return;
 
     va_list Ap;

--- a/drivers/telescope/skywatcherAltAzSimple.h
+++ b/drivers/telescope/skywatcherAltAzSimple.h
@@ -18,6 +18,11 @@
 #include "indiguiderinterface.h"
 #include "skywatcherAPI.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 typedef enum { PARK_COUNTERCLOCKWISE = 0, PARK_CLOCKWISE } ParkDirection_t;
 typedef enum { PARK_NORTH = 0, PARK_EAST, PARK_SOUTH, PARK_WEST } ParkPosition_t;
 
@@ -87,8 +92,7 @@ private:
         MOUNT_NAME,
         IS_DC_MOTOR
     };
-    IText BasicMountInfoT[4] {};
-    ITextVectorProperty BasicMountInfoTP;
+    INDI::PropertyText BasicMountInfoTP {4};
 
     enum
     {
@@ -97,10 +101,8 @@ private:
         HIGH_SPEED_RATIO,
         MICROSTEPS_PER_WORM_REVOLUTION
     };
-    INumber AxisOneInfoN[4];
-    INumberVectorProperty AxisOneInfoNP;
-    INumber AxisTwoInfoN[4];
-    INumberVectorProperty AxisTwoInfoNP;
+    INDI::PropertyNumber AxisOneInfoNP {4};
+    INDI::PropertyNumber AxisTwoInfoNP {4};
     enum
     {
         FULL_STOP,
@@ -110,10 +112,8 @@ private:
         HIGH_SPEED,
         NOT_INITIALISED
     };
-    ISwitch AxisOneStateS[6];
-    ISwitchVectorProperty AxisOneStateSP;
-    ISwitch AxisTwoStateS[6];
-    ISwitchVectorProperty AxisTwoStateSP;
+    INDI::PropertySwitch AxisOneStateSP {6};
+    INDI::PropertySwitch AxisTwoStateSP {6};
     enum
     {
         RAW_MICROSTEPS,
@@ -121,10 +121,8 @@ private:
         OFFSET_FROM_INITIAL,
         DEGREES_FROM_INITIAL
     };
-    INumber AxisOneEncoderValuesN[4];
-    INumberVectorProperty AxisOneEncoderValuesNP;
-    INumber AxisTwoEncoderValuesN[4];
-    INumberVectorProperty AxisTwoEncoderValuesNP;
+    INDI::PropertyNumber AxisOneEncoderValuesNP {4};
+    INDI::PropertyNumber AxisTwoEncoderValuesNP {4};
 
     // A switch for silent/highspeed slewing modes
     enum
@@ -132,8 +130,7 @@ private:
         SLEW_SILENT,
         SLEW_NORMAL
     };
-    ISwitch SlewModesS[2];
-    ISwitchVectorProperty SlewModesSP;
+    INDI::PropertySwitch SlewModesSP {2};
 
     // A switch for wedge mode
     enum
@@ -142,8 +139,7 @@ private:
         WEDGE_EQ,
         WEDGE_DISABLED
     };
-    ISwitch WedgeModeS[3];
-    ISwitchVectorProperty WedgeModeSP;
+    INDI::PropertySwitch WedgeModeSP {3};
 
     // A switch for tracking logging
     enum
@@ -151,28 +147,22 @@ private:
         TRACKLOG_ENABLED,
         TRACKLOG_DISABLED
     };
-    ISwitch TrackLogModeS[2];
-    ISwitchVectorProperty TrackLogModeSP;
+    INDI::PropertySwitch TrackLogModeSP {2};
 
     // Guiding rates (RA/Dec)
-    INumber GuidingRatesN[2];
-    INumberVectorProperty GuidingRatesNP;
+    INDI::PropertyNumber GuidingRatesNP {2};
 
     // Tracking values
-    INumber TrackingValuesN[3];
-    INumberVectorProperty TrackingValuesNP;
+    INDI::PropertyNumber TrackingValuesNP {3};
 
     // A switch for park movement directions (clockwise/counterclockwise)
-    ISwitch ParkMovementDirectionS[2];
-    ISwitchVectorProperty ParkMovementDirectionSP;
+    INDI::PropertySwitch ParkMovementDirectionSP {2};
 
     // A switch for park positions
-    ISwitch ParkPositionS[4];
-    ISwitchVectorProperty ParkPositionSP;
+    INDI::PropertySwitch ParkPositionSP {4};
 
     // A switch for unpark positions
-    ISwitch UnparkPositionS[4];
-    ISwitchVectorProperty UnparkPositionSP;
+    INDI::PropertySwitch UnparkPositionSP {4};
 
     // Tracking
     ln_equ_posn CurrentTrackingTarget { 0, 0 };

--- a/drivers/telescope/synscandriver.cpp
+++ b/drivers/telescope/synscandriver.cpp
@@ -80,45 +80,45 @@ bool SynscanDriver::initProperties()
     //////////////////////////////////////////////////////////////////////////////////////////////////
     /// Mount Info Text Property
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    IUFillText(&StatusT[MI_FW_VERSION], "MI_FW_VERSION", "Firmware", "-");
-    IUFillText(&StatusT[MI_MOUNT_MODEL], "MI_MOUNT_MODEL", "Model", "-");
-    IUFillText(&StatusT[MI_GOTO_STATUS], "MI_GOTO_STATUS", "Goto", "-");
-    IUFillText(&StatusT[MI_POINT_STATUS], "MI_POINT_STATUS", "Pointing", "-");
-    IUFillText(&StatusT[MI_TRACK_MODE], "MI_TRACK_MODE", "Tracking Mode", "-");
-    IUFillTextVector(&StatusTP, StatusT, 5, getDeviceName(), "MOUNT_STATUS",
+    StatusTP[MI_FW_VERSION].fill("MI_FW_VERSION", "Firmware", "-");
+    StatusTP[MI_MOUNT_MODEL].fill("MI_MOUNT_MODEL", "Model", "-");
+    StatusTP[MI_GOTO_STATUS].fill("MI_GOTO_STATUS", "Goto", "-");
+    StatusTP[MI_POINT_STATUS].fill("MI_POINT_STATUS", "Pointing", "-");
+    StatusTP[MI_TRACK_MODE].fill("MI_TRACK_MODE", "Tracking Mode", "-");
+    StatusTP.fill(getDeviceName(), "MOUNT_STATUS",
                      "Status", MOUNT_TAB, IP_RO, 60, IPS_IDLE);
 
     //////////////////////////////////////////////////////////////////////////////////////////////////
     /// Custom Slew Rate
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    IUFillNumber(&CustomSlewRateN[AXIS_RA], "AXIS1", "RA/AZ (arcsecs/s)", "%.2f", 0.05, 800, 10, 0);
-    IUFillNumber(&CustomSlewRateN[AXIS_DE], "AXIS2", "DE/AL (arcsecs/s)", "%.2f", 0.05, 800, 10, 0);
-    IUFillNumberVector(&CustomSlewRateNP, CustomSlewRateN, 2, getDeviceName(), "CUSTOM_SLEW_RATE", "Custom Slew", MOTION_TAB,
+    CustomSlewRateNP[AXIS_RA].fill("AXIS1", "RA/AZ (arcsecs/s)", "%.2f", 0.05, 800, 10, 0);
+    CustomSlewRateNP[AXIS_DE].fill("AXIS2", "DE/AL (arcsecs/s)", "%.2f", 0.05, 800, 10, 0);
+    CustomSlewRateNP.fill(getDeviceName(), "CUSTOM_SLEW_RATE", "Custom Slew", MOTION_TAB,
                        IP_RW, 60, IPS_IDLE);
 
     //////////////////////////////////////////////////////////////////////////////////////////////////
     /// Guide Rate
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    IUFillNumber(&GuideRateN[AXIS_RA], "GUIDE_RATE_WE", "W/E Rate", "%.2f", 0, 1, 0.1, 0.5);
-    IUFillNumber(&GuideRateN[AXIS_DE], "GUIDE_RATE_NS", "N/S Rate", "%.2f", 0, 1, 0.1, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", GUIDE_TAB, IP_RW, 0,
+    GuideRateNP[AXIS_RA].fill("GUIDE_RATE_WE", "W/E Rate", "%.2f", 0, 1, 0.1, 0.5);
+    GuideRateNP[AXIS_DE].fill("GUIDE_RATE_NS", "N/S Rate", "%.2f", 0, 1, 0.1, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", GUIDE_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     //////////////////////////////////////////////////////////////////////////////////////////////////
     /// Horizontal Coords
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    IUFillNumber(&HorizontalCoordsN[AXIS_AZ], "AZ", "Az D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
-    IUFillNumber(&HorizontalCoordsN[AXIS_ALT], "ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
-    IUFillNumberVector(&HorizontalCoordsNP, HorizontalCoordsN, 2, getDeviceName(), "HORIZONTAL_COORD",
+    HorizontalCoordsNP[AXIS_AZ].fill("AZ", "Az D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
+    HorizontalCoordsNP[AXIS_ALT].fill("ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
+    HorizontalCoordsNP.fill(getDeviceName(), "HORIZONTAL_COORD",
                        "Horizontal Coord", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     AddTrackMode("TRACK_ALTAZ", "Alt/Az");
     AddTrackMode("TRACK_EQ", "Equatorial", true);
     AddTrackMode("TRACK_PEC", "PEC Mode");
 
-    IUFillSwitch(&GotoModeS[0], "ALTAZ", "Alt/Az", ISS_OFF);
-    IUFillSwitch(&GotoModeS[1], "RADEC", "Ra/Dec", ISS_ON);
-    IUFillSwitchVector(&GotoModeSP, GotoModeS, NARRAY(GotoModeS), getDeviceName(), "GOTOMODE", "Goto mode",
+    GotoModeSP[0].fill("ALTAZ", "Alt/Az", ISS_OFF);
+    GotoModeSP[1].fill("RADEC", "Ra/Dec", ISS_ON);
+    GotoModeSP.fill(getDeviceName(), "GOTOMODE", "Goto mode",
                        MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     SetParkDataType(PARK_AZ_ALT);
@@ -142,42 +142,42 @@ bool SynscanDriver::updateProperties()
     {
         setupParams();
 
-        defineProperty(&HorizontalCoordsNP);
-        defineProperty(&StatusTP);
-        defineProperty(&CustomSlewRateNP);
+        defineProperty(HorizontalCoordsNP);
+        defineProperty(StatusTP);
+        defineProperty(CustomSlewRateNP);
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
-        defineProperty(&GuideRateNP);
+        defineProperty(GuideRateNP);
 
         if (m_isAltAz)
         {
-            defineProperty(&GotoModeSP);
+            defineProperty(GotoModeSP);
         }
 
         if (InitPark())
         {
             SetAxis1ParkDefault(359);
-            SetAxis2ParkDefault(m_isAltAz ? 0 : LocationN[LOCATION_LATITUDE].value);
+            SetAxis2ParkDefault(m_isAltAz ? 0 : LocationNP[LOCATION_LATITUDE].getValue());
         }
         else
         {
             SetAxis1Park(359);
-            SetAxis2Park(m_isAltAz ? 0 : LocationN[LOCATION_LATITUDE].value);
+            SetAxis2Park(m_isAltAz ? 0 : LocationNP[LOCATION_LATITUDE].getValue());
             SetAxis1ParkDefault(359);
-            SetAxis2ParkDefault(m_isAltAz ? 0 : LocationN[LOCATION_LATITUDE].value);
+            SetAxis2ParkDefault(m_isAltAz ? 0 : LocationNP[LOCATION_LATITUDE].getValue());
         }
     }
     else
     {
-        deleteProperty(HorizontalCoordsNP.name);
-        deleteProperty(StatusTP.name);
-        deleteProperty(CustomSlewRateNP.name);
+        deleteProperty(HorizontalCoordsNP.getName());
+        deleteProperty(StatusTP.getName());
+        deleteProperty(CustomSlewRateNP.getName());
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
-        deleteProperty(GuideRateNP.name);
+        deleteProperty(GuideRateNP.getName());
         if (m_isAltAz)
         {
-            deleteProperty(GotoModeSP.name);
+            deleteProperty(GotoModeSP.getName());
         }
     }
 
@@ -243,37 +243,37 @@ bool SynscanDriver::ISNewNumber(const char * dev, const char * name, double valu
         // Guide Rate
         if (strcmp(name, "GUIDE_RATE") == 0)
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
-            GuideRateNP.s = IPS_OK;
-            IDSetNumber(&GuideRateNP, nullptr);
+            GuideRateNP.update(values, names, n);
+            GuideRateNP.setState(IPS_OK);
+            GuideRateNP.apply();
             return true;
         }
 
         // Custom Slew Rate
-        if (strcmp(name, CustomSlewRateNP.name) == 0)
+        if (CustomSlewRateNP.isNameMatch(name))
         {
             if (TrackState == SCOPE_SLEWING)
             {
                 LOG_ERROR("Cannot change rate while slewing.");
-                CustomSlewRateNP.s = IPS_ALERT;
-                IDSetNumber(&CustomSlewRateNP, nullptr);
+                CustomSlewRateNP.setState(IPS_ALERT);
+                CustomSlewRateNP.apply();
                 return true;
             }
 
-            IUUpdateNumber(&CustomSlewRateNP, values, names, n);
-            CustomSlewRateNP.s = IPS_OK;
-            IDSetNumber(&CustomSlewRateNP, nullptr);
+            CustomSlewRateNP.update(values, names, n);
+            CustomSlewRateNP.setState(IPS_OK);
+            CustomSlewRateNP.apply();
             return true;
         }
 
         // Horizonal Coords
-        if (!strcmp(name, HorizontalCoordsNP.name))
+        if (HorizontalCoordsNP.isNameMatch(name))
         {
             if (isParked())
             {
                 LOG_WARN("Unpark mount before issuing GOTO commands.");
-                HorizontalCoordsNP.s = IPS_IDLE;
-                IDSetNumber(&HorizontalCoordsNP, nullptr);
+                HorizontalCoordsNP.setState(IPS_IDLE);
+                HorizontalCoordsNP.apply();
                 return true;
             }
 
@@ -281,13 +281,13 @@ bool SynscanDriver::ISNewNumber(const char * dev, const char * name, double valu
             double newAlt = 0, newAz = 0;
             for (int i = 0; i < n; i++)
             {
-                INumber * horp = IUFindNumber(&HorizontalCoordsNP, names[i]);
-                if (horp == &HorizontalCoordsN[AXIS_AZ])
+                INumber * horp = HorizontalCoordsNP.findWidgetByName(names[i]);
+                if (horp == &HorizontalCoordsNP[AXIS_AZ])
                 {
                     newAz = values[i];
                     nset += newAz >= 0. && newAz <= 360.0;
                 }
-                else if (horp == &HorizontalCoordsN[AXIS_ALT])
+                else if (horp == &HorizontalCoordsNP[AXIS_ALT])
                 {
                     newAlt = values[i];
                     nset += newAlt >= -90. && newAlt <= 90.0;
@@ -297,8 +297,8 @@ bool SynscanDriver::ISNewNumber(const char * dev, const char * name, double valu
             if (nset == 2 && GotoAzAlt(newAz, newAlt))
                 return true;
 
-            HorizontalCoordsNP.s = IPS_ALERT;
-            IDSetNumber(&HorizontalCoordsNP, "Altitude or Azimuth missing or invalid.");
+            HorizontalCoordsNP.setState(IPS_ALERT);
+            HorizontalCoordsNP.apply("Altitude or Azimuth missing or invalid.");
             return false;
         }
 
@@ -319,14 +319,14 @@ bool SynscanDriver::ISNewSwitch(const char *dev, const char *name, ISState *stat
     {
         ISwitchVectorProperty *svp = getSwitch(name);
 
-        if (!strcmp(svp->name, GotoModeSP.name))
+        if (!strcmp(svp->name, GotoModeSP.getName()))
         {
             IUUpdateSwitch(svp, states, names, n);
             ISwitch *sp = IUFindOnSwitch(svp);
 
             assert(sp != nullptr);
 
-            if (!strcmp(sp->name, GotoModeS[0].name))
+            if (!strcmp(sp->name, GotoModeSP[0].getName()))
                 SetAltAzMode(true);
             else
                 SetAltAzMode(false);
@@ -356,7 +356,7 @@ bool SynscanDriver::readFirmware()
 
         LOGF_INFO("Firmware version: %lf", m_FirmwareVersion);
         m_MountInfo[MI_FW_VERSION] = std::to_string(m_FirmwareVersion);
-        IUSaveText(&StatusT[MI_FW_VERSION], m_MountInfo[MI_FW_VERSION].c_str());
+        StatusTP[MI_FW_VERSION].setText(m_MountInfo[MI_FW_VERSION]);
 
         if (m_FirmwareVersion < 3.38 || (m_FirmwareVersion >= 4.0 && m_FirmwareVersion < 4.38))
         {
@@ -439,20 +439,20 @@ bool SynscanDriver::readModel()
 
     // 128 - 143 --> AZ Goto series
     if (m_MountModel >= 128 && m_MountModel <= 143)
-        IUSaveText(&StatusT[MI_MOUNT_MODEL], "AZ GOTO Series");
+        StatusTP[MI_MOUNT_MODEL].setText("AZ GOTO Series");
     // 144 - 159 --> DOB Goto series
     else if (m_MountModel >= 144 && m_MountModel <= 159)
-        IUSaveText(&StatusT[MI_MOUNT_MODEL], "Dob GOTO Series");
+        StatusTP[MI_MOUNT_MODEL].setText("Dob GOTO Series");
     else if (models.count(m_MountModel) > 0)
-        IUSaveText(&StatusT[MI_MOUNT_MODEL], models[m_MountModel].c_str());
+        StatusTP[MI_MOUNT_MODEL].setText(models[m_MountModel]);
     else
-        IUSaveText(&StatusT[MI_MOUNT_MODEL], "Unknown model");
+        StatusTP[MI_MOUNT_MODEL].setText("Unknown model");
 
     m_isAltAz = m_MountModel > 4;
 
     LOGF_INFO("Driver is running in %s mode.", m_isAltAz ? "Alt-Az" : "Equatorial");
     LOGF_INFO("Detected mount: %s. Mount must be aligned from the handcontroller before using the driver.",
-              StatusT[MI_MOUNT_MODEL].text);
+              StatusTP[MI_MOUNT_MODEL].getText());
 
     return true;
 }
@@ -486,16 +486,16 @@ bool SynscanDriver::ReadScopeStatus()
             if (isSlewComplete())
             {
                 TrackState = (m_TrackingFlag == 2) ? SCOPE_TRACKING : SCOPE_IDLE;
-                HorizontalCoordsNP.s = (m_TrackingFlag == 2) ? IPS_OK : IPS_IDLE;
-                IDSetNumber(&HorizontalCoordsNP, nullptr);
+                HorizontalCoordsNP.setState((m_TrackingFlag == 2) ? IPS_OK : IPS_IDLE);
+                HorizontalCoordsNP.apply();
             }
         }
         else if (TrackState == SCOPE_PARKING)
         {
             if (isSlewComplete())
             {
-                HorizontalCoordsNP.s = IPS_IDLE;
-                IDSetNumber(&HorizontalCoordsNP, nullptr);
+                HorizontalCoordsNP.setState(IPS_IDLE);
+                HorizontalCoordsNP.apply();
                 TrackState = SCOPE_PARKED;
                 SetTrackEnabled(false);
                 SetParked(true);
@@ -552,8 +552,8 @@ bool SynscanDriver::ReadScopeStatus()
     double al  = static_cast<double>(n2) / 0x100000000 * 360.0;
     al = rangeDec(al);
 
-    HorizontalCoordsN[AXIS_AZ].value = az;
-    HorizontalCoordsN[AXIS_ALT].value = al;
+    HorizontalCoordsNP[AXIS_AZ].setValue(az);
+    HorizontalCoordsNP[AXIS_ALT].setValue(al);
 
     memset(Axis1Coords, 0, MAXINDINAME);
     memset(Axis2Coords, 0, MAXINDINAME);
@@ -561,7 +561,7 @@ bool SynscanDriver::ReadScopeStatus()
     fs_sexa(Axis2Coords, al, 2, 3600);
     LOGF_DEBUG("AZ <%s> ALT <%s>", Axis1Coords, Axis2Coords);
 
-    IDSetNumber(&HorizontalCoordsNP, nullptr);
+    HorizontalCoordsNP.apply();
 
     return true;
 }
@@ -592,11 +592,11 @@ bool SynscanDriver::SetTrackMode(uint8_t mode)
 
 bool SynscanDriver::SetAltAzMode(bool enable)
 {
-    IUResetSwitch(&GotoModeSP);
+    GotoModeSP.reset();
 
     if (enable)
     {
-        ISwitch *sp = IUFindSwitch(&GotoModeSP, "ALTAZ");
+        ISwitch *sp = GotoModeSP.findWidgetByName("ALTAZ");
         if (sp)
         {
             LOG_INFO("Using AltAz goto.");
@@ -606,7 +606,7 @@ bool SynscanDriver::SetAltAzMode(bool enable)
     }
     else
     {
-        ISwitch *sp = IUFindSwitch(&GotoModeSP, "RADEC");
+        ISwitch *sp = GotoModeSP.findWidgetByName("RADEC");
         if (sp)
         {
             sp->s = ISS_ON;
@@ -615,8 +615,8 @@ bool SynscanDriver::SetAltAzMode(bool enable)
         goto_AltAz = false;
     }
 
-    GotoModeSP.s = IPS_OK;
-    IDSetSwitch(&GotoModeSP, nullptr);
+    GotoModeSP.setState(IPS_OK);
+    GotoModeSP.apply();
     return true;
 }
 
@@ -642,10 +642,10 @@ bool SynscanDriver::Goto(double ra, double dec)
         struct ln_lnlat_posn lnobserver;
         struct ln_hrz_posn lnaltaz;
 
-        lnobserver.lng = LocationN[LOCATION_LONGITUDE].value;
+        lnobserver.lng = LocationNP[LOCATION_LONGITUDE].getValue();
         if (lnobserver.lng > 180)
             lnobserver.lng -= 360;
-        lnobserver.lat = LocationN[LOCATION_LATITUDE].value;
+        lnobserver.lat = LocationNP[LOCATION_LATITUDE].getValue();
         get_hrz_from_equ(&epochPos, &lnobserver, ln_get_julian_from_sys(), &lnaltaz);
         /* libnova measures azimuth from south towards west */
         double az = lnaltaz.az;
@@ -670,8 +670,8 @@ bool SynscanDriver::Goto(double ra, double dec)
     if (sendCommand(cmd, res, 18))
     {
         TrackState = SCOPE_SLEWING;
-        HorizontalCoordsNP.s = IPS_BUSY;
-        IDSetNumber(&HorizontalCoordsNP, nullptr);
+        HorizontalCoordsNP.setState(IPS_BUSY);
+        HorizontalCoordsNP.apply();
         return true;
     }
 
@@ -692,10 +692,10 @@ bool SynscanDriver::GotoAzAlt(double az, double alt)
         ln_hrz_posn horizontalPos;
         ln_equ_posn equatorialPos;
 
-        observer.lng = LocationN[LOCATION_LONGITUDE].value;
+        observer.lng = LocationNP[LOCATION_LONGITUDE].getValue();
         if (observer.lng > 180)
             observer.lng -= 360;
-        observer.lat = LocationN[LOCATION_LATITUDE].value;
+        observer.lat = LocationNP[LOCATION_LATITUDE].getValue();
 
         horizontalPos.az = az;
         horizontalPos.alt = alt;
@@ -714,8 +714,8 @@ bool SynscanDriver::GotoAzAlt(double az, double alt)
     if (sendCommand(cmd, res, 18))
     {
         TrackState = SCOPE_SLEWING;
-        HorizontalCoordsNP.s = IPS_BUSY;
-        IDSetNumber(&HorizontalCoordsNP, nullptr);
+        HorizontalCoordsNP.setState(IPS_BUSY);
+        HorizontalCoordsNP.apply();
         return true;
     }
 
@@ -782,7 +782,7 @@ bool SynscanDriver::SetDefaultPark()
     // By default az to north, and alt to pole
     LOG_DEBUG("Setting Park Data to Default.");
     SetAxis1Park(359);
-    SetAxis2Park(LocationN[LOCATION_LATITUDE].value);
+    SetAxis2Park(LocationNP[LOCATION_LATITUDE].value);
 
     return true;
 }
@@ -818,7 +818,7 @@ bool SynscanDriver::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
         move = (dir == DIRECTION_NORTH) ? SYN_S : SYN_N;
 
     uint8_t rate = static_cast<uint8_t>(IUFindOnSwitchIndex(&SlewRateSP)) + 1;
-    double customRate = CustomSlewRateN[AXIS_DE].value;
+    double customRate = CustomSlewRateNP[AXIS_DE].getValue();
 
     // If we have pulse guiding
     if (m_CustomGuideDE > 0)
@@ -863,7 +863,7 @@ bool SynscanDriver::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
     bool rc = false;
     SynscanDirection move = (dir == DIRECTION_WEST) ? SYN_W : SYN_E;
     uint8_t rate = static_cast<uint8_t>(IUFindOnSwitchIndex(&SlewRateSP)) + 1;
-    double customRate = CustomSlewRateN[AXIS_RA].value;
+    double customRate = CustomSlewRateNP[AXIS_RA].getValue();
 
     // If we have pulse guiding
     if (m_CustomGuideRA > 0)
@@ -966,10 +966,10 @@ bool SynscanDriver::sendTime()
         char timeString[MAXINDINAME] = {0};
         time_t now = time (nullptr);
         strftime(timeString, MAXINDINAME, "%T", gmtime(&now));
-        IUSaveText(&TimeT[0], "3");
-        IUSaveText(&TimeT[1], timeString);
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP[0].setText("3");
+        TimeTP[1].setText(timeString);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
         return true;
     }
 
@@ -1009,10 +1009,10 @@ bool SynscanDriver::sendTime()
             offset = offset + 1;
         sprintf(ofs, "%d", offset);
 
-        IUSaveText(&TimeT[0], utc);
-        IUSaveText(&TimeT[1], ofs);
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP[0].setText(utc);
+        TimeTP[1].setText(ofs);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
 
         LOGF_INFO("Mount UTC Time %s Offset %d", utc, offset);
 
@@ -1029,9 +1029,9 @@ bool SynscanDriver::sendLocation()
 
     if (isSimulation())
     {
-        LocationN[LOCATION_LATITUDE].value  = 29.5;
-        LocationN[LOCATION_LONGITUDE].value = 48;
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP[LOCATION_LATITUDE].setValue(29.5);
+        LocationNP[LOCATION_LONGITUDE].setValue(48);
+        LocationNP.apply();
         return true;
     }
 
@@ -1070,9 +1070,9 @@ bool SynscanDriver::sendLocation()
         lat = lat * -1;
     if (h == 1)
         lon = 360 - lon;
-    LocationN[LOCATION_LATITUDE].value  = lat;
-    LocationN[LOCATION_LONGITUDE].value = lon;
-    IDSetNumber(&LocationNP, nullptr);
+    LocationNP[LOCATION_LATITUDE].setValue(lat);
+    LocationNP[LOCATION_LONGITUDE].setValue(lon);
+    LocationNP.apply();
 
     saveConfig(true, "GEOGRAPHIC_COORD");
 
@@ -1129,9 +1129,9 @@ bool SynscanDriver::updateLocation(double latitude, double longitude, double ele
     ln_lnlat_posn p1 { 0, 0 };
     lnh_lnlat_posn p2;
 
-    LocationN[LOCATION_LATITUDE].value  = latitude;
-    LocationN[LOCATION_LONGITUDE].value = longitude;
-    IDSetNumber(&LocationNP, nullptr);
+    LocationNP[LOCATION_LATITUDE].setValue(latitude);
+    LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+    LocationNP.apply();
 
     if (isSimulation())
     {
@@ -1206,8 +1206,8 @@ ln_hrz_posn SynscanDriver::getAltAzPosition(double ra, double dec)
     ln_hrz_posn AltAz { 0, 0 };
 
     // Set the current location
-    Location.lat = LocationN[LOCATION_LATITUDE].value;
-    Location.lng = LocationN[LOCATION_LONGITUDE].value;
+    Location.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    Location.lng = LocationNP[LOCATION_LONGITUDE].getValue();
 
     Eq.ra  = ra * 360.0 / 24.0;
     Eq.dec = dec;
@@ -1219,26 +1219,26 @@ void SynscanDriver::sendStatus()
 {
     bool BasicMountInfoHasChanged = false;
 
-    if (std::string(StatusT[MI_GOTO_STATUS].text) != m_MountInfo[MI_GOTO_STATUS])
+    if (std::string(StatusTP[MI_GOTO_STATUS].getText()) != m_MountInfo[MI_GOTO_STATUS])
     {
-        IUSaveText(&StatusT[MI_GOTO_STATUS], m_MountInfo[MI_GOTO_STATUS].c_str());
+        StatusTP[MI_GOTO_STATUS].setText(m_MountInfo[MI_GOTO_STATUS]);
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(StatusT[MI_POINT_STATUS].text) != m_MountInfo[MI_POINT_STATUS])
+    if (std::string(StatusTP[MI_POINT_STATUS].getText()) != m_MountInfo[MI_POINT_STATUS])
     {
-        IUSaveText(&StatusT[MI_POINT_STATUS], m_MountInfo[MI_POINT_STATUS].c_str());
+        StatusTP[MI_POINT_STATUS].setText(m_MountInfo[MI_POINT_STATUS]);
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(StatusT[MI_TRACK_MODE].text) != m_MountInfo[MI_TRACK_MODE])
+    if (std::string(StatusTP[MI_TRACK_MODE].getText()) != m_MountInfo[MI_TRACK_MODE])
     {
-        IUSaveText(&StatusT[MI_TRACK_MODE], m_MountInfo[MI_TRACK_MODE].c_str());
+        StatusTP[MI_TRACK_MODE].setText(m_MountInfo[MI_TRACK_MODE]);
         BasicMountInfoHasChanged = true;
     }
 
     if (BasicMountInfoHasChanged)
     {
-        StatusTP.s = IPS_OK;
-        IDSetText(&StatusTP, nullptr);
+        StatusTP.setState(IPS_OK);
+        StatusTP.apply();
     }
 }
 
@@ -1332,7 +1332,7 @@ void SynscanDriver::mountSim()
     switch (TrackState)
     {
         case SCOPE_IDLE:
-            CurrentRA += (TrackRateN[AXIS_RA].value / 3600.0 * dt) / 15.0;
+            CurrentRA += (TrackRateNP[AXIS_RA].value / 3600.0 * dt) / 15.0;
             CurrentRA = range24(CurrentRA);
             break;
 
@@ -1442,7 +1442,7 @@ IPState SynscanDriver::GuideNorth(uint32_t ms)
         m_GuideNSTID = 0;
     }
 
-    m_CustomGuideDE = TRACKRATE_SIDEREAL + GuideRateN[AXIS_DE].value * TRACKRATE_SIDEREAL;
+    m_CustomGuideDE = TRACKRATE_SIDEREAL + GuideRateNP[AXIS_DE].value * TRACKRATE_SIDEREAL;
     MoveNS(DIRECTION_NORTH, MOTION_START);
     m_GuideNSTID = IEAddTimer(ms, guideTimeoutHelperNS, this);
     return IPS_BUSY;
@@ -1456,7 +1456,7 @@ IPState SynscanDriver::GuideSouth(uint32_t ms)
         m_GuideNSTID = 0;
     }
 
-    m_CustomGuideDE = TRACKRATE_SIDEREAL + GuideRateN[AXIS_DE].value * TRACKRATE_SIDEREAL;
+    m_CustomGuideDE = TRACKRATE_SIDEREAL + GuideRateNP[AXIS_DE].value * TRACKRATE_SIDEREAL;
     MoveNS(DIRECTION_SOUTH, MOTION_START);
     m_GuideNSTID = IEAddTimer(ms, guideTimeoutHelperNS, this);
     return IPS_BUSY;
@@ -1474,8 +1474,8 @@ IPState SynscanDriver::GuideEast(uint32_t ms)
     // but for east we'd be going a lot faster since the stars are moving toward the west
     // in sideral rate. Just standing still we would SID_RATE moving across. So for east
     // we just go GuideRate * SID_RATE without adding any more values.
-    //m_CustomGuideRA = TRACKRATE_SIDEREAL + GuideRateN[AXIS_RA].value * TRACKRATE_SIDEREAL;
-    m_CustomGuideRA = GuideRateN[AXIS_RA].value * TRACKRATE_SIDEREAL;
+    //m_CustomGuideRA = TRACKRATE_SIDEREAL + GuideRateNP[AXIS_RA].value * TRACKRATE_SIDEREAL;
+    m_CustomGuideRA = GuideRateNP[AXIS_RA].value * TRACKRATE_SIDEREAL;
 
     MoveWE(DIRECTION_EAST, MOTION_START);
     m_GuideWETID = IEAddTimer(ms, guideTimeoutHelperWE, this);
@@ -1492,7 +1492,7 @@ IPState SynscanDriver::GuideWest(uint32_t ms)
 
     // Sky already going westward (or earth rotating eastward, pick your favorite)
     // So we go SID_RATE + whatever guide rate was set to.
-    m_CustomGuideRA = TRACKRATE_SIDEREAL + GuideRateN[AXIS_RA].value * TRACKRATE_SIDEREAL;
+    m_CustomGuideRA = TRACKRATE_SIDEREAL + GuideRateNP[AXIS_RA].value * TRACKRATE_SIDEREAL;
     MoveWE(DIRECTION_WEST, MOTION_START);
     m_GuideWETID = IEAddTimer(ms, guideTimeoutHelperWE, this);
     return IPS_BUSY;
@@ -1510,7 +1510,7 @@ void SynscanDriver::guideTimeoutHelperWE(void * context)
 
 void SynscanDriver::guideTimeoutCallbackNS()
 {
-    INDI_DIR_NS direction = static_cast<INDI_DIR_NS>(IUFindOnSwitchIndex(&MovementNSSP));
+    INDI_DIR_NS direction = static_cast<INDI_DIR_NS>(MovementNSSP.findOnSwitchIndex());
     MoveNS(direction, MOTION_STOP);
     GuideComplete(AXIS_DE);
     m_CustomGuideDE = m_GuideNSTID = 0;
@@ -1518,7 +1518,7 @@ void SynscanDriver::guideTimeoutCallbackNS()
 
 void SynscanDriver::guideTimeoutCallbackWE()
 {
-    INDI_DIR_WE direction = static_cast<INDI_DIR_WE>(IUFindOnSwitchIndex(&MovementWESP));
+    INDI_DIR_WE direction = static_cast<INDI_DIR_WE>(MovementWESP.findOnSwitchIndex());
     MoveWE(direction, MOTION_STOP);
     GuideComplete(AXIS_RA);
     m_CustomGuideRA = m_GuideWETID = 0;

--- a/drivers/telescope/synscandriver.h
+++ b/drivers/telescope/synscandriver.h
@@ -21,6 +21,11 @@
 #include "inditelescope.h"
 #include "indiguiderinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -144,24 +149,19 @@ class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
         //////////////////////////////////////////////////////////////////
 
         // Mount Status
-        IText StatusT[5] = {};
-        ITextVectorProperty StatusTP;
+        INDI::PropertyText StatusTP {5};
 
         // Custom Slew Rate
-        INumber CustomSlewRateN[2];
-        INumberVectorProperty CustomSlewRateNP;
+        INDI::PropertyNumber CustomSlewRateNP {2};
 
         // Guide Rate
-        INumber GuideRateN[2];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};
 
         // Horizontal Coords
-        INumber HorizontalCoordsN[2];
-        INumberVectorProperty HorizontalCoordsNP;
+        INDI::PropertyNumber HorizontalCoordsNP {2};
 
         // Goto mode
-        ISwitch GotoModeS[2];
-        ISwitchVectorProperty GotoModeSP;
+        INDI::PropertySwitch GotoModeSP {2};
 
         // Mount Info
         enum MountInfo

--- a/drivers/telescope/synscandriverlegacy.cpp
+++ b/drivers/telescope/synscandriverlegacy.cpp
@@ -89,22 +89,22 @@ bool SynscanLegacyDriver::initProperties()
     //////////////////////////////////////////////////////////////////////////////////////////////////
     /// Mount Info Text Property
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    IUFillText(&BasicMountInfoT[MI_FW_VERSION], "FW_VERSION", "Firmware version", "-");
-    IUFillText(&BasicMountInfoT[MI_MOUNT_CODE], "MOUNT_CODE", "Mount code", "-");
-    IUFillText(&BasicMountInfoT[MI_ALIGN_STATUS], "ALIGNMENT_STATUS", "Alignment status", "-");
-    IUFillText(&BasicMountInfoT[MI_GOTO_STATUS], "GOTO_STATUS", "Goto status", "-");
-    IUFillText(&BasicMountInfoT[MI_POINT_STATUS], "MOUNT_POINTING_STATUS",
+    BasicMountInfoTP[MI_FW_VERSION].fill("FW_VERSION", "Firmware version", "-");
+    BasicMountInfoTP[MI_MOUNT_CODE].fill("MOUNT_CODE", "Mount code", "-");
+    BasicMountInfoTP[MI_ALIGN_STATUS].fill("ALIGNMENT_STATUS", "Alignment status", "-");
+    BasicMountInfoTP[MI_GOTO_STATUS].fill("GOTO_STATUS", "Goto status", "-");
+    BasicMountInfoTP[MI_POINT_STATUS].fill("MOUNT_POINTING_STATUS",
                "Mount pointing status", "-");
-    IUFillText(&BasicMountInfoT[MI_TRACK_MODE], "TRACKING_MODE", "Tracking mode", "-");
-    IUFillTextVector(&BasicMountInfoTP, BasicMountInfoT, 6, getDeviceName(), "BASIC_MOUNT_INFO",
+    BasicMountInfoTP[MI_TRACK_MODE].fill("TRACKING_MODE", "Tracking mode", "-");
+    BasicMountInfoTP.fill(getDeviceName(), "BASIC_MOUNT_INFO",
                      "Mount information", MountInfoPage, IP_RO, 60, IPS_IDLE);
 
     //////////////////////////////////////////////////////////////////////////////////////////////////
     /// Use WiFi Switch Property
     //////////////////////////////////////////////////////////////////////////////////////////////////
-    //    IUFillSwitch(&UseWiFiS[WIFI_ENABLED], "Enabled", "Enabled", ISS_OFF);
-    //    IUFillSwitch(&UseWiFiS[WIFI_DISABLED], "Disabled", "Disabled", ISS_ON);
-    //    IUFillSwitchVector(&UseWiFiSP, UseWiFiS, 2, getDeviceName(), "WIFI_SELECT", "Use WiFi?", CONNECTION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    //    UseWiFiSP[WIFI_ENABLED].fill("Enabled", "Enabled", ISS_OFF);
+    //    UseWiFiSP[WIFI_DISABLED].fill("Disabled", "Disabled", ISS_ON);
+    //    UseWiFiSP.fill(getDeviceName(), "WIFI_SELECT", "Use WiFi?", CONNECTION_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     addAuxControls();
 
@@ -121,19 +121,19 @@ bool SynscanLegacyDriver::ISNewSwitch(const char *dev, const char *name, ISState
 #if 0
     if (!strcmp(dev, getDeviceName()))
     {
-        if (!strcmp(name, UseWiFiSP.name))
+        if (UseWiFiSP.isNameMatch(name))
         {
             if (isConnected())
             {
-                UseWiFiSP.s = IPS_ALERT;
-                IDSetSwitch(&UseWiFiSP, nullptr);
+                UseWiFiSP.setState(IPS_ALERT);
+                UseWiFiSP.apply();
                 LOG_ERROR("Cannot select WiFi mode while already connected. It must be selected when when disconnected.");
                 return true;
             }
 
-            IUUpdateSwitch(&UseWiFiSP, states, names, n);
+            UseWiFiSP.update(states, names, n);
 
-            if (UseWiFiS[WIFI_ENABLED].s == ISS_ON)
+            if (UseWiFiSP[WIFI_ENABLED].getState() == ISS_ON)
             {
                 setTelescopeConnection(CONNECTION_TCP);
                 tcpConnection->setDefaultHost("192.168.4.2");
@@ -142,8 +142,8 @@ bool SynscanLegacyDriver::ISNewSwitch(const char *dev, const char *name, ISState
                 LOG_INFO("Driver is configured for WiFi connection to 192.168.4.2 at TCP port 11882");
 
                 saveConfig(true, "WIFI_SELECT");
-                UseWiFiSP.s = IPS_OK;
-                IDSetSwitch(&UseWiFiSP, nullptr);
+                UseWiFiSP.setState(IPS_OK);
+                UseWiFiSP.apply();
 
                 ISState newStates[] = { ISS_OFF, ISS_ON };
                 const char *newNames[] = { "CONNECTION_SERIAL", "CONNECTION_TCP" };
@@ -154,8 +154,8 @@ bool SynscanLegacyDriver::ISNewSwitch(const char *dev, const char *name, ISState
                 setTelescopeConnection(CONNECTION_SERIAL);
                 LOG_INFO("Driver is configured for serial connection to the hand controller.");
 
-                UseWiFiSP.s = IPS_OK;
-                IDSetSwitch(&UseWiFiSP, nullptr);
+                UseWiFiSP.setState(IPS_OK);
+                UseWiFiSP.apply();
 
                 ISState newStates[] = { ISS_ON, ISS_OFF };
                 const char *newNames[] = { "CONNECTION_SERIAL", "CONNECTION_TCP" };
@@ -187,11 +187,11 @@ bool SynscanLegacyDriver::updateProperties()
     if (isConnected())
     {
         UpdateMountInformation(false);
-        defineProperty(&BasicMountInfoTP);
+        defineProperty(BasicMountInfoTP);
     }
     else
     {
-        deleteProperty(BasicMountInfoTP.name);
+        deleteProperty(BasicMountInfoTP.getName());
     }
 
     return true;
@@ -554,8 +554,8 @@ bool SynscanLegacyDriver::ReadScopeStatus()
                     else
                     {
                         TrackState = SCOPE_PARKED;
-                        //ParkSP.s=IPS_OK;
-                        //IDSetSwitch(&ParkSP,nullptr);
+                        //ParkSP.setState(PS_OK);
+                        //ParkSP.apply();
                         //IDMessage(getDeviceName(),"Telescope is Parked.");
                         SetParked(true);
                     }
@@ -1062,10 +1062,10 @@ bool SynscanLegacyDriver::ReadTime()
         char timeString[MAXINDINAME] = {0};
         time_t now = time (nullptr);
         strftime(timeString, MAXINDINAME, "%T", gmtime(&now));
-        IUSaveText(&TimeT[0], "3");
-        IUSaveText(&TimeT[1], timeString);
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP[0].setText("3");
+        TimeTP[1].setText(timeString);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
         return true;
     }
 
@@ -1115,10 +1115,10 @@ bool SynscanLegacyDriver::ReadTime()
             offset = offset + 1;
         sprintf(ofs, "%d", offset);
 
-        IUSaveText(&TimeT[0], utc);
-        IUSaveText(&TimeT[1], ofs);
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP[0].setText(utc);
+        TimeTP[1].setText(ofs);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
 
         LOGF_INFO("Mount UTC Time %s Offset %d", utc, offset);
 
@@ -1133,9 +1133,9 @@ bool SynscanLegacyDriver::ReadLocation()
 
     if (isSimulation())
     {
-        LocationN[LOCATION_LATITUDE].value  = 29.5;
-        LocationN[LOCATION_LONGITUDE].value = 48;
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP[LOCATION_LATITUDE].setValue(29.5);
+        LocationNP[LOCATION_LONGITUDE].setValue(48);
+        LocationNP.apply();
         ReadLatLong = false;
         return true;
     }
@@ -1200,9 +1200,9 @@ bool SynscanLegacyDriver::ReadLocation()
                 lat = lat * -1;
             if (h == 1)
                 lon = 360 - lon;
-            LocationN[LOCATION_LATITUDE].value  = lat;
-            LocationN[LOCATION_LONGITUDE].value = lon;
-            IDSetNumber(&LocationNP, nullptr);
+            LocationNP[LOCATION_LATITUDE].setValue(lat);
+            LocationNP[LOCATION_LONGITUDE].setValue(lon);
+            LocationNP.apply();
 
             saveConfig(true, "GEOGRAPHIC_COORD");
 
@@ -1285,9 +1285,9 @@ bool SynscanLegacyDriver::updateLocation(double latitude, double longitude, doub
     ln_lnlat_posn p1 { 0, 0 };
     lnh_lnlat_posn p2;
 
-    LocationN[LOCATION_LATITUDE].value  = latitude;
-    LocationN[LOCATION_LONGITUDE].value = longitude;
-    IDSetNumber(&LocationNP, nullptr);
+    LocationNP[LOCATION_LATITUDE].setValue(latitude);
+    LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+    LocationNP.apply();
 
     if (isSimulation())
     {
@@ -1486,8 +1486,8 @@ ln_hrz_posn SynscanLegacyDriver::GetAltAzPosition(double ra, double dec)
     ln_hrz_posn AltAz { 0, 0 };
 
     // Set the current location
-    Location.lat = LocationN[LOCATION_LATITUDE].value;
-    Location.lng = LocationN[LOCATION_LONGITUDE].value;
+    Location.lat = LocationNP[LOCATION_LATITUDE].getValue();
+    Location.lng = LocationNP[LOCATION_LONGITUDE].getValue();
 
     Eq.ra  = ra * 360.0 / 24.0;
     Eq.dec = dec;
@@ -1500,40 +1500,40 @@ void SynscanLegacyDriver::UpdateMountInformation(bool inform_client)
     bool BasicMountInfoHasChanged = false;
     std::string MountCodeStr = std::to_string(MountCode);
 
-    if (std::string(BasicMountInfoT[MI_FW_VERSION].text) != HandsetFwVersion)
+    if (std::string(BasicMountInfoTP[MI_FW_VERSION].getText()) != HandsetFwVersion)
     {
-        IUSaveText(&BasicMountInfoT[MI_FW_VERSION], HandsetFwVersion.c_str());
+        BasicMountInfoTP[MI_FW_VERSION].setText(HandsetFwVersion);
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[MI_MOUNT_CODE].text) != MountCodeStr)
+    if (std::string(BasicMountInfoTP[MI_MOUNT_CODE].getText()) != MountCodeStr)
     {
-        IUSaveText(&BasicMountInfoT[MI_MOUNT_CODE], MountCodeStr.c_str());
+        BasicMountInfoTP[MI_MOUNT_CODE].setText(MountCodeStr);
         BasicMountInfoHasChanged = true;
     }
 
-    if (std::string(BasicMountInfoT[MI_ALIGN_STATUS].text) != AlignmentStatus)
+    if (std::string(BasicMountInfoTP[MI_ALIGN_STATUS].getText()) != AlignmentStatus)
     {
-        IUSaveText(&BasicMountInfoT[MI_ALIGN_STATUS], AlignmentStatus.c_str());
+        BasicMountInfoTP[MI_ALIGN_STATUS].setText(AlignmentStatus);
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[MI_GOTO_STATUS].text) != GotoStatus)
+    if (std::string(BasicMountInfoTP[MI_GOTO_STATUS].getText()) != GotoStatus)
     {
-        IUSaveText(&BasicMountInfoT[MI_GOTO_STATUS], GotoStatus.c_str());
+        BasicMountInfoTP[MI_GOTO_STATUS].setText(GotoStatus);
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[MI_POINT_STATUS].text) != PointingStatus)
+    if (std::string(BasicMountInfoTP[MI_POINT_STATUS].getText()) != PointingStatus)
     {
-        IUSaveText(&BasicMountInfoT[MI_POINT_STATUS], PointingStatus.c_str());
+        BasicMountInfoTP[MI_POINT_STATUS].setText(PointingStatus);
         BasicMountInfoHasChanged = true;
     }
-    if (std::string(BasicMountInfoT[MI_TRACK_MODE].text) != TrackingMode)
+    if (std::string(BasicMountInfoTP[MI_TRACK_MODE].getText()) != TrackingMode)
     {
-        IUSaveText(&BasicMountInfoT[MI_TRACK_MODE], TrackingMode.c_str());
+        BasicMountInfoTP[MI_TRACK_MODE].setText(TrackingMode);
         BasicMountInfoHasChanged = true;
     }
 
     if (BasicMountInfoHasChanged && inform_client)
-        IDSetText(&BasicMountInfoTP, nullptr);
+        BasicMountInfoTP.apply();
 }
 
 void SynscanLegacyDriver::MountSim()
@@ -1558,7 +1558,7 @@ void SynscanLegacyDriver::MountSim()
     switch (TrackState)
     {
         case SCOPE_IDLE:
-            CurrentRA += (TrackRateN[AXIS_RA].value / 3600.0 * dt) / 15.0;
+            CurrentRA += (TrackRateNP[AXIS_RA].value / 3600.0 * dt) / 15.0;
             CurrentRA = range24(CurrentRA);
             break;
 

--- a/drivers/telescope/synscandriverlegacy.h
+++ b/drivers/telescope/synscandriverlegacy.h
@@ -21,6 +21,10 @@
 
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+
 class SynscanLegacyDriver : public INDI::Telescope
 {
   public:
@@ -97,8 +101,7 @@ private:
     int CustomWESlewRate { -1 };
     int RecoverTrials { 0 };
 
-    IText BasicMountInfoT[6] = {};
-    ITextVectorProperty BasicMountInfoTP;
+    INDI::PropertyText BasicMountInfoTP {6};
     enum MountInfo
     {
         MI_FW_VERSION,
@@ -109,8 +112,8 @@ private:
         MI_TRACK_MODE
     };
 
-//    ISwitch UseWiFiS[2];
-//    ISwitchVectorProperty UseWiFiSP;
+//    INDI::PropertySwitch UseWiFiSP {2};
+//
 //    enum UseWiFiMembers
 //    {
 //        WIFI_ENABLED,

--- a/drivers/telescope/telescope_script.cpp
+++ b/drivers/telescope/telescope_script.cpp
@@ -99,23 +99,23 @@ bool ScopeScript::initProperties()
     INDI::Telescope::initProperties();
 
 #if defined(__APPLE__)
-    IUFillText(&ScriptsT[0], "FOLDER", "Folder", "/usr/local/share/indi/scripts");
+    ScriptsTP[0].fill("FOLDER", "Folder", "/usr/local/share/indi/scripts");
 #else
-    IUFillText(&ScriptsT[0], "FOLDER", "Folder", "/usr/share/indi/scripts");
+    ScriptsTP[0].fill("FOLDER", "Folder", "/usr/share/indi/scripts");
 #endif
-    IUFillText(&ScriptsT[SCRIPT_CONNECT], "SCRIPT_CONNECT", "Connect script", "connect.py");
-    IUFillText(&ScriptsT[SCRIPT_DISCONNECT], "SCRIPT_DISCONNECT", "Disconnect script", "disconnect.py");
-    IUFillText(&ScriptsT[SCRIPT_STATUS], "SCRIPT_STATUS", "Get status script", "status.py");
-    IUFillText(&ScriptsT[SCRIPT_GOTO], "SCRIPT_GOTO", "Goto script", "goto.py");
-    IUFillText(&ScriptsT[SCRIPT_SYNC], "SCRIPT_SYNC", "Sync script", "sync.py");
-    IUFillText(&ScriptsT[SCRIPT_PARK], "SCRIPT_PARK", "Park script", "park.py");
-    IUFillText(&ScriptsT[SCRIPT_UNPARK], "SCRIPT_UNPARK", "Unpark script", "unpark.py");
-    IUFillText(&ScriptsT[SCRIPT_MOVE_NORTH], "SCRIPT_MOVE_NORTH", "Move north script", "move_north.py");
-    IUFillText(&ScriptsT[SCRIPT_MOVE_EAST], "SCRIPT_MOVE_EAST", "Move east script", "move_east.py");
-    IUFillText(&ScriptsT[SCRIPT_MOVE_SOUTH], "SCRIPT_MOVE_SOUTH", "Move south script", "move_south.py");
-    IUFillText(&ScriptsT[SCRIPT_MOVE_WEST], "SCRIPT_MOVE_WEST", "Move west script", "move_west.py");
-    IUFillText(&ScriptsT[SCRIPT_ABORT], "SCRIPT_ABORT", "Abort motion script", "abort.py");
-    IUFillTextVector(&ScriptsTP, ScriptsT, SCRIPT_COUNT, getDefaultName(), "SCRIPTS", "Scripts", OPTIONS_TAB, IP_RW, 60,
+    ScriptsTP[SCRIPT_CONNECT].fill("SCRIPT_CONNECT", "Connect script", "connect.py");
+    ScriptsTP[SCRIPT_DISCONNECT].fill("SCRIPT_DISCONNECT", "Disconnect script", "disconnect.py");
+    ScriptsTP[SCRIPT_STATUS].fill("SCRIPT_STATUS", "Get status script", "status.py");
+    ScriptsTP[SCRIPT_GOTO].fill("SCRIPT_GOTO", "Goto script", "goto.py");
+    ScriptsTP[SCRIPT_SYNC].fill("SCRIPT_SYNC", "Sync script", "sync.py");
+    ScriptsTP[SCRIPT_PARK].fill("SCRIPT_PARK", "Park script", "park.py");
+    ScriptsTP[SCRIPT_UNPARK].fill("SCRIPT_UNPARK", "Unpark script", "unpark.py");
+    ScriptsTP[SCRIPT_MOVE_NORTH].fill("SCRIPT_MOVE_NORTH", "Move north script", "move_north.py");
+    ScriptsTP[SCRIPT_MOVE_EAST].fill("SCRIPT_MOVE_EAST", "Move east script", "move_east.py");
+    ScriptsTP[SCRIPT_MOVE_SOUTH].fill("SCRIPT_MOVE_SOUTH", "Move south script", "move_south.py");
+    ScriptsTP[SCRIPT_MOVE_WEST].fill("SCRIPT_MOVE_WEST", "Move west script", "move_west.py");
+    ScriptsTP[SCRIPT_ABORT].fill("SCRIPT_ABORT", "Abort motion script", "abort.py");
+    ScriptsTP.fill(getDefaultName(), "SCRIPTS", "Scripts", OPTIONS_TAB, IP_RW, 60,
                      IPS_IDLE);
 
     addDebugControl();
@@ -126,22 +126,22 @@ bool ScopeScript::initProperties()
 bool ScopeScript::saveConfigItems(FILE *fp)
 {
     INDI::Telescope::saveConfigItems(fp);
-    IUSaveConfigText(fp, &ScriptsTP);
+    ScriptsTP.save(fp);
     return true;
 }
 
 void ScopeScript::ISGetProperties(const char *dev)
 {
     INDI::Telescope::ISGetProperties(dev);
-    defineProperty(&ScriptsTP);
+    defineProperty(ScriptsTP);
 }
 
 bool ScopeScript::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
 {
-    if (strcmp(dev, getDeviceName()) == 0 && strcmp(name, ScriptsTP.name) == 0)
+    if (strcmp(dev, getDeviceName()) == 0 && strcmp(name, ScriptsTP.getName()) == 0)
     {
-        IUUpdateText(&ScriptsTP, texts, names, n);
-        IDSetText(&ScriptsTP, nullptr);
+        ScriptsTP.update(texts, names, n);
+        ScriptsTP.apply();
         return true;
     }
     return Telescope::ISNewText(dev, name, texts, names, n);
@@ -150,7 +150,7 @@ bool ScopeScript::ISNewText(const char *dev, const char *name, char *texts[], ch
 bool ScopeScript::RunScript(int script, ...)
 {
     char tmp[256];
-    strncpy(tmp, ScriptsT[script].text, sizeof(tmp));
+    strncpy(tmp, ScriptsTP[script].getText(), sizeof(tmp));
 
     char **args = (char **)malloc(MAXARGS * sizeof(char *));
     int arg     = 1;
@@ -176,7 +176,7 @@ bool ScopeScript::RunScript(int script, ...)
     }
     va_end(ap);
     char path[1024];
-    snprintf(path, sizeof(path), "%s/%s", ScriptsT[0].text, tmp);
+    snprintf(path, sizeof(path), "%s/%s", ScriptsTP[0].getText(), tmp);
 
     if (access(path, F_OK | X_OK) != 0)
     {
@@ -213,7 +213,7 @@ bool ScopeScript::RunScript(int script, ...)
     {
         int status;
         waitpid(pid, &status, 0);
-        LOGF_DEBUG("Script %s returned %d", ScriptsT[script].text, status);
+        LOGF_DEBUG("Script %s returned %d", ScriptsTP[script].getText(), status);
         return status == 0;
     }
 }

--- a/drivers/telescope/telescope_script.h
+++ b/drivers/telescope/telescope_script.h
@@ -20,6 +20,9 @@
 
 #include "inditelescope.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+
 class ScopeScript : public INDI::Telescope
 {
   public:
@@ -49,7 +52,5 @@ class ScopeScript : public INDI::Telescope
 
   private:
     bool RunScript(int script, ...);
-
-    ITextVectorProperty ScriptsTP;
-    IText ScriptsT[15] {};
+    INDI::PropertyText ScriptsTP {15};
 };

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -105,40 +105,40 @@ bool ScopeSim::initProperties()
 
 #ifdef USE_SIM_TAB
     // mount type and alignment properties, these are in the Simulation tab
-    IUFillSwitch(&mountTypeS[Alignment::ALTAZ], "ALTAZ", "AltAz", ISS_OFF);
-    IUFillSwitch(&mountTypeS[Alignment::EQ_FORK], "EQ_FORK", "Fork (Eq)", ISS_OFF);
-    IUFillSwitch(&mountTypeS[Alignment::EQ_GEM], "EQ_GEM", "GEM", ISS_ON);
-    IUFillSwitchVector(&mountTypeSP, mountTypeS, 3, getDeviceName(), "MOUNT_TYPE", "Mount Type",
+    mountTypeSP[Alignment::ALTAZ].fill("ALTAZ", "AltAz", ISS_OFF);
+    mountTypeSP[Alignment::EQ_FORK].fill("EQ_FORK", "Fork (Eq)", ISS_OFF);
+    mountTypeSP[Alignment::EQ_GEM].fill("EQ_GEM", "GEM", ISS_ON);
+    mountTypeSP.fill(getDeviceName(), "MOUNT_TYPE", "Mount Type",
                        "Simulation", IP_WO, ISR_1OFMANY, 60, IPS_IDLE );
 
-    IUFillSwitch(&simPierSideS[0], "PS_OFF", "Off", ISS_OFF);
-    IUFillSwitch(&simPierSideS[1], "PS_ON", "On", ISS_ON);
-    IUFillSwitchVector(&simPierSideSP, simPierSideS, 2, getDeviceName(), "SIM_PIER_SIDE", "Sim Pier Side",
+    simPierSideSP[0].fill("PS_OFF", "Off", ISS_OFF);
+    simPierSideSP[1].fill("PS_ON", "On", ISS_ON);
+    simPierSideSP.fill(getDeviceName(), "SIM_PIER_SIDE", "Sim Pier Side",
                        "Simulation", IP_WO, ISR_1OFMANY, 60, IPS_IDLE );
 
-    IUFillNumber(&mountModelN[0], "MM_IH", "Ha Zero (IH)", "%g", -5, 5, 0.01, 0);
-    IUFillNumber(&mountModelN[1], "MM_ID", "Dec Zero (ID)", "%g", -5, 5, 0.01, 0);
-    IUFillNumber(&mountModelN[2], "MM_CH", "Cone (CH)", "%g", -5, 5, 0.01, 0);
-    IUFillNumber(&mountModelN[3], "MM_NP", "Ha/Dec (NP)", "%g", -5, 5, 0.01, 0);
-    IUFillNumber(&mountModelN[4], "MM_MA", "Pole Azm (MA)", "%g", -5, 5, 0.01, 0);
-    IUFillNumber(&mountModelN[5], "MM_ME", "Pole elev (ME)", "%g", -5, 5, 0.01, 0);
-    IUFillNumberVector(&mountModelNP, mountModelN, 6, getDeviceName(), "MOUNT_MODEL", "Mount Model",
+    mountModelNP[0].fill("MM_IH", "Ha Zero (IH)", "%g", -5, 5, 0.01, 0);
+    mountModelNP[1].fill("MM_ID", "Dec Zero (ID)", "%g", -5, 5, 0.01, 0);
+    mountModelNP[2].fill("MM_CH", "Cone (CH)", "%g", -5, 5, 0.01, 0);
+    mountModelNP[3].fill("MM_NP", "Ha/Dec (NP)", "%g", -5, 5, 0.01, 0);
+    mountModelNP[4].fill("MM_MA", "Pole Azm (MA)", "%g", -5, 5, 0.01, 0);
+    mountModelNP[5].fill("MM_ME", "Pole elev (ME)", "%g", -5, 5, 0.01, 0);
+    mountModelNP.fill(getDeviceName(), "MOUNT_MODEL", "Mount Model",
                        "Simulation", IP_WO, 0, IPS_IDLE);
 
-    IUFillNumber(&flipHourAngleN[0], "FLIP_HA", "Hour Angle (deg)", "%g", -20, 20, 0.1, 0);
-    IUFillNumberVector(&flipHourAngleNP, flipHourAngleN, 1, getDeviceName(), "FLIP_HA", "Flip Posn.",
+    flipHourAngleNP[0].fill("FLIP_HA", "Hour Angle (deg)", "%g", -20, 20, 0.1, 0);
+    flipHourAngleNP.fill(getDeviceName(), "FLIP_HA", "Flip Posn.",
                        "Simulation", IP_WO, 0, IPS_IDLE);
 
-    IUFillNumber(&mountAxisN[0], "PRIMARY", "Primary (Ha)", "%g", -180, 180, 0.01, 0);
-    IUFillNumber(&mountAxisN[1], "SECONDARY", "Secondary (Dec)", "%g", -180, 180, 0.01, 0);
-    IUFillNumberVector(&mountAxisNP, mountAxisN, 2, getDeviceName(), "MOUNT_AXES", "Mount Axes",
+    mountAxisNP[0].fill("PRIMARY", "Primary (Ha)", "%g", -180, 180, 0.01, 0);
+    mountAxisNP[1].fill("SECONDARY", "Secondary (Dec)", "%g", -180, 180, 0.01, 0);
+    mountAxisNP.fill(getDeviceName(), "MOUNT_AXES", "Mount Axes",
                        "Simulation", IP_RO, 0, IPS_IDLE);
 #endif
 
     /* How fast do we guide compared to sidereal rate */
-    IUFillNumber(&GuideRateN[RA_AXIS], "GUIDE_RATE_WE", "W/E Rate", "%g", 0, 1, 0.1, 0.5);
-    IUFillNumber(&GuideRateN[DEC_AXIS], "GUIDE_RATE_NS", "N/S Rate", "%g", 0, 1, 0.1, 0.5);
-    IUFillNumberVector(&GuideRateNP, GuideRateN, 2, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
+    GuideRateNP[RA_AXIS].fill("GUIDE_RATE_WE", "W/E Rate", "%g", 0, 1, 0.1, 0.5);
+    GuideRateNP[DEC_AXIS].fill("GUIDE_RATE_NS", "N/S Rate", "%g", 0, 1, 0.1, 0.5);
+    GuideRateNP.fill(getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
     IUFillSwitch(&SlewRateS[SLEW_GUIDE], "SLEW_GUIDE", "Guide", ISS_OFF);
@@ -155,10 +155,10 @@ bool ScopeSim::initProperties()
     AddTrackMode("TRACK_CUSTOM", "Custom");
 
     // Let's simulate it to be an F/7.5 120mm telescope
-    ScopeParametersN[0].value = 120;
-    ScopeParametersN[1].value = 900;
-    ScopeParametersN[2].value = 120;
-    ScopeParametersN[3].value = 900;
+    ScopeParametersNP[0].setValue(120);
+    ScopeParametersNP[1].setValue(900);
+    ScopeParametersNP[2].setValue(120);
+    ScopeParametersNP[3].setValue(900);
 
     // RA is a rotating frame, while HA or Alt/Az is not
     SetParkDataType(PARK_HA_DEC);
@@ -181,22 +181,22 @@ void ScopeSim::ISGetProperties(const char *dev)
     INDI::Telescope::ISGetProperties(dev);
 
 #ifdef USE_SIM_TAB
-    defineProperty(&mountTypeSP);
-    loadConfig(true, mountTypeSP.name);
-    defineProperty(&simPierSideSP);
-    loadConfig(true, simPierSideSP.name);
-    defineProperty(&mountModelNP);
-    loadConfig(true, mountModelNP.name);
-    defineProperty(&mountAxisNP);
-    defineProperty(&flipHourAngleNP);
-    loadConfig(true, flipHourAngleNP.name);
+    defineProperty(mountTypeSP);
+    loadConfig(true, mountTypeSP.getName());
+    defineProperty(simPierSideSP);
+    loadConfig(true, simPierSideSP.getName());
+    defineProperty(mountModelNP);
+    loadConfig(true, mountModelNP.getName());
+    defineProperty(mountAxisNP);
+    defineProperty(flipHourAngleNP);
+    loadConfig(true, flipHourAngleNP.getName());
 #endif
     /*
     if (isConnected())
     {
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
-        defineProperty(&GuideRateNP);
+        defineProperty(GuideRateNP);
         defineProperty(&EqPENV);
         defineProperty(&PEErrNSSP);
         defineProperty(&PEErrWESP);
@@ -214,8 +214,8 @@ bool ScopeSim::updateProperties()
     {
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
-        defineProperty(&GuideRateNP);
-        loadConfig(true, GuideRateNP.name);
+        defineProperty(GuideRateNP);
+        loadConfig(true, GuideRateNP.getName());
 
         if (InitPark())
         {
@@ -229,8 +229,8 @@ bool ScopeSim::updateProperties()
 	        alignment.latitude = Angle(latitude);
 		alignment.longitude = Angle(longitude);
 
-	        currentRA = (alignment.lst() - Angle(ParkPositionN[AXIS_RA].value, Angle::ANGLE_UNITS::HOURS)).Hours();
-                currentDEC = ParkPositionN[AXIS_DE].value;
+	        currentRA = (alignment.lst() - Angle(ParkPositionNP[AXIS_RA].value, Angle::ANGLE_UNITS::HOURS)).Hours();
+                currentDEC = ParkPositionNP[AXIS_DE].getValue();
                 Sync(currentRA, currentDEC);
 
             }
@@ -253,7 +253,7 @@ bool ScopeSim::updateProperties()
     {
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
-        deleteProperty(GuideRateNP.name);
+        deleteProperty(GuideRateNP.getName());
     }
 
     return true;
@@ -299,7 +299,7 @@ bool ScopeSim::ReadScopeStatus()
             if (!slewing)
             {
                 SetParked(true);
-                EqNP.s = IPS_IDLE;
+                EqNP.setState(IPS_IDLE);
                 LOG_INFO("Telescope slew is complete. Parked");
             }
             break;
@@ -310,7 +310,7 @@ bool ScopeSim::ReadScopeStatus()
                 // if the mount was not tracking before the slew should it remain not tracking?
                 TrackState = SCOPE_TRACKING;
                 SetTrackEnabled(true);
-                EqNP.s = IPS_IDLE;
+                EqNP.setState(IPS_IDLE);
                 LOG_INFO("Telescope slew is complete. Tracking...");
 
                 // check the slew accuracy
@@ -343,16 +343,16 @@ bool ScopeSim::ReadScopeStatus()
     double axisRA = axisPrimary.position.Degrees();
     double axisDE = axisSecondary.position.Degrees();
     // No need to spam log until we have some actual changes.
-    if (std::fabs(mountAxisN[AXIS_RA].value - axisRA) > 0.0001 ||
-            std::fabs(mountAxisN[AXIS_DE].value - axisDE) > 0.0001)
+    if (std::fabs(mountAxisNP[AXIS_RA].value - axisRA) > 0.0001 ||
+            std::fabs(mountAxisNP[AXIS_DE].value - axisDE) > 0.0001)
     {
-        mountAxisN[AXIS_RA].value = axisRA;
-        mountAxisN[AXIS_DE].value = axisDE;
+        mountAxisNP[AXIS_RA].setValue(axisRA);
+        mountAxisNP[AXIS_DE].setValue(axisDE);
 
         LOGF_EXTRA1("%s: %f, ra %f", axisPrimary.axisName, axisPrimary.position.Degrees(), ra.Hours());
         LOGF_EXTRA1("%s: %f, dec %f", axisSecondary.axisName, axisSecondary.position.Degrees(), dec.Degrees());
 
-        IDSetNumber(&mountAxisNP, nullptr);
+        mountAxisNP.apply();
     }
 #endif
 
@@ -388,7 +388,7 @@ bool ScopeSim::Sync(double ra, double dec)
 
     LOG_INFO("Sync is successful.");
 
-    EqNP.s = IPS_OK;
+    EqNP.setState(IPS_OK);
 
     NewRaDec(currentRA, currentDEC);
 
@@ -449,9 +449,9 @@ bool ScopeSim::ISNewNumber(const char *dev, const char *name, double values[], c
     {
         if (strcmp(name, "GUIDE_RATE") == 0)
         {
-            IUUpdateNumber(&GuideRateNP, values, names, n);
-            GuideRateNP.s = IPS_OK;
-            IDSetNumber(&GuideRateNP, nullptr);
+            GuideRateNP.update(values, names, n);
+            GuideRateNP.setState(IPS_OK);
+            GuideRateNP.apply();
             return true;
         }
 
@@ -462,24 +462,24 @@ bool ScopeSim::ISNewNumber(const char *dev, const char *name, double values[], c
         }
 
 #ifdef USE_SIM_TAB
-        if (strcmp(name, mountModelNP.name) == 0)
+        if (mountModelNP.isNameMatch(name))
         {
-            IUUpdateNumber(&mountModelNP, values, names, n);
-            mountModelNP.s = IPS_OK;
-            IDSetNumber(&mountModelNP, nullptr);
-            alignment.setCorrections(mountModelN[0].value, mountModelN[1].value,
-                                     mountModelN[2].value, mountModelN[3].value,
-                                     mountModelN[4].value, mountModelN[5].value);
+            mountModelNP.update(values, names, n);
+            mountModelNP.setState(IPS_OK);
+            mountModelNP.apply();
+            alignment.setCorrections(mountModelNP[0].value, mountModelNP[1].getValue(),
+                                     mountModelNP[2].getValue(), mountModelNP[3].getValue(),
+                                     mountModelNP[4].getValue(), mountModelNP[5].getValue());
 
             return true;
         }
 
-        if (strcmp(name, flipHourAngleNP.name) == 0)
+        if (flipHourAngleNP.isNameMatch(name))
         {
-            IUUpdateNumber(&flipHourAngleNP, values, names, n);
-            flipHourAngleNP.s = IPS_OK;
-            IDSetNumber(&flipHourAngleNP, nullptr);
-            alignment.setFlipHourAngle(flipHourAngleN[0].value);
+            flipHourAngleNP.update(values, names, n);
+            flipHourAngleNP.setState(IPS_OK);
+            flipHourAngleNP.apply();
+            alignment.setFlipHourAngle(flipHourAngleNP[0].value);
             return true;
         }
 #endif
@@ -495,23 +495,23 @@ bool ScopeSim::ISNewSwitch(const char *dev, const char *name, ISState *states, c
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
 #ifdef USE_SIM_TAB
-        if (strcmp(name, mountTypeSP.name) == 0)
+        if (mountTypeSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&mountTypeSP, states, names, n) < 0)
+            if (!mountTypeSP.update(states, names, n))
                 return false;
 
-            mountTypeSP.s = IPS_OK;
-            IDSetSwitch(&mountTypeSP, nullptr);
+            mountTypeSP.setState(IPS_OK);
+            mountTypeSP.apply();
             updateMountAndPierSide();
             return true;
         }
-        if (strcmp(name, simPierSideSP.name) == 0)
+        if (simPierSideSP.isNameMatch(name))
         {
-            if (IUUpdateSwitch(&simPierSideSP, states, names, n) < 0)
+            if (!simPierSideSP.update(states, names, n))
                 return false;
 
-            simPierSideSP.s = IPS_OK;
-            IDSetSwitch(&simPierSideSP, nullptr);
+            simPierSideSP.setState(IPS_OK);
+            simPierSideSP.apply();
             updateMountAndPierSide();
             return true;
         }
@@ -574,7 +574,7 @@ bool ScopeSim::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
 
 IPState ScopeSim::GuideNorth(uint32_t ms)
 {
-    double rate = GuideRateN[DEC_AXIS].value;
+    double rate = GuideRateNP[DEC_AXIS].getValue();
     axisSecondary.StartGuide(rate, ms);
     guidingNS = true;
     return IPS_BUSY;
@@ -582,7 +582,7 @@ IPState ScopeSim::GuideNorth(uint32_t ms)
 
 IPState ScopeSim::GuideSouth(uint32_t ms)
 {
-    double rate = GuideRateN[DEC_AXIS].value;
+    double rate = GuideRateNP[DEC_AXIS].getValue();
     axisSecondary.StartGuide(-rate, ms);
     guidingNS = true;
     return IPS_BUSY;
@@ -590,7 +590,7 @@ IPState ScopeSim::GuideSouth(uint32_t ms)
 
 IPState ScopeSim::GuideEast(uint32_t ms)
 {
-    double rate = GuideRateN[RA_AXIS].value;
+    double rate = GuideRateNP[RA_AXIS].getValue();
     axisPrimary.StartGuide(-rate, ms);
     guidingEW = true;
     return IPS_BUSY;
@@ -598,7 +598,7 @@ IPState ScopeSim::GuideEast(uint32_t ms)
 
 IPState ScopeSim::GuideWest(uint32_t ms)
 {
-    double rate = GuideRateN[RA_AXIS].value;
+    double rate = GuideRateNP[RA_AXIS].getValue();
     axisPrimary.StartGuide(rate, ms);
     guidingEW = true;
     return IPS_BUSY;
@@ -641,7 +641,7 @@ bool ScopeSim::SetTrackMode(uint8_t mode)
             axisSecondary.TrackRate(Axis::OFF);
             return true;
         case TRACK_CUSTOM:
-            SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+            SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
             return true;
     }
     return false;
@@ -666,11 +666,11 @@ bool ScopeSim::saveConfigItems(FILE *fp)
     INDI::Telescope::saveConfigItems(fp);
 
 #ifdef USE_SIM_TAB
-    IUSaveConfigNumber(fp, &GuideRateNP);
-    IUSaveConfigSwitch(fp, &mountTypeSP);
-    IUSaveConfigSwitch(fp, &simPierSideSP);
-    IUSaveConfigNumber(fp, &mountModelNP);
-    IUSaveConfigNumber(fp, &flipHourAngleNP);
+    GuideRateNP.save(fp);
+    mountTypeSP.save(fp);
+    simPierSideSP.save(fp);
+    mountModelNP.save(fp);
+    flipHourAngleNP.save(fp);
 #endif
     return true;
 }
@@ -689,8 +689,8 @@ bool ScopeSim::updateLocation(double latitude, double longitude, double elevatio
 bool ScopeSim::updateMountAndPierSide()
 {
 #ifdef USE_SIM_TAB
-    int mountType = IUFindOnSwitchIndex(&mountTypeSP);
-    int pierSide = IUFindOnSwitchIndex(&simPierSideSP);
+    int mountType = mountTypeSP.findOnSwitchIndex();
+    int pierSide = simPierSideSP.findOnSwitchIndex();
     if (mountType < 0 || pierSide < 0)
         return false;
 

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -22,6 +22,10 @@
 #include "inditelescope.h"
 #include "scopesim_helper.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 #define USE_SIM_TAB
 
 /**
@@ -103,8 +107,7 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface
         bool guidingNS = false;
         bool guidingEW = false;
 
-        INumber GuideRateN[2];
-        INumberVectorProperty GuideRateNP;
+        INDI::PropertyNumber GuideRateNP {2};
 
         Axis axisPrimary { "HaAxis" };         // hour angle mount axis
         Axis axisSecondary { "DecAxis" };       // declination mount axis
@@ -118,18 +121,13 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface
 #ifdef USE_SIM_TAB
         // Simulator Tab properties
         // Scope type and alignment
-        ISwitch mountTypeS[3];
-        ISwitchVectorProperty mountTypeSP;
-        ISwitch simPierSideS[2];
-        ISwitchVectorProperty simPierSideSP;
+        INDI::PropertySwitch mountTypeSP {3};
+        INDI::PropertySwitch simPierSideSP {2};
 
-        INumber mountModelN[6];
-        INumberVectorProperty mountModelNP;
-        INumber mountAxisN[2];
-        INumberVectorProperty mountAxisNP;
+        INDI::PropertyNumber mountModelNP {6};
+        INDI::PropertyNumber mountAxisNP {2};
 
-        INumber flipHourAngleN[1];
-        INumberVectorProperty flipHourAngleNP;
+        INDI::PropertyNumber flipHourAngleNP {1};
 #endif
 
 };

--- a/drivers/telescope/temmadriver.cpp
+++ b/drivers/telescope/temmadriver.cpp
@@ -148,7 +148,7 @@ void TemmaMount::ISGetProperties(const char *dev)
     //defineProperty(&GuideWENP);
 
     // JM 2016-11-10: This is not used anywhere in the code now. Enable it again when you use it
-    //defineProperty(&GuideRateNP);
+    //defineProperty(GuideRateNP);
 }
 #endif
 
@@ -456,7 +456,7 @@ bool TemmaMount::ReadScopeStatus()
         struct ln_equ_posn RaDec;
         bool aligned;
         juliandate = ln_get_julian_from_sys();
-        lst = ln_get_apparent_sidereal_time(juliandate) + (LocationN[1].value * 24.0 / 360.0);
+        lst = ln_get_apparent_sidereal_time(juliandate) + (LocationNP[1].value * 24.0 / 360.0);
         // Use HA/Dec as  telescope coordinate system
         RaDec.ra = ((lst - currentRA) * 360.0) / 24.0;
         //RaDec.ra = (ra * 360.0) / 24.0;
@@ -965,8 +965,8 @@ ln_equ_posn TemmaMount::TelescopeToSky(double ra, double dec)
             ln_lnlat_posn here;
             ln_hrz_posn altaz;
 
-            here.lat=LocationN[LOCATION_LATITUDE].value;
-            here.lng=LocationN[LOCATION_LONGITUDE].value;
+            here.lat=LocationNP[LOCATION_LATITUDE].getValue();
+            here.lng=LocationNP[LOCATION_LONGITUDE].getValue();
             eq.ra=ra*360.0/24.0;	//  this is wanted in degrees, not hours
             eq.dec=dec;
             ln_get_hrz_from_equ(&eq,&here,ln_get_julian_from_sys(),&altaz);
@@ -975,7 +975,7 @@ ln_equ_posn TemmaMount::TelescopeToSky(double ra, double dec)
 
         /*  and here we convert from ra/dec to hour angle / dec before calling alignment stuff */
         double lha, lst;
-        lst = get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value);
+        lst = get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].value);
         lha = get_local_hour_angle(lst, ra);
         //  convert lha to degrees
         lha    = lha * 360 / 24;
@@ -1036,8 +1036,8 @@ ln_equ_posn TemmaMount::SkyToTelescope(double ra, double dec)
             /*
                 eq.ra=ra*360/24;
                 eq.dec=dec;
-                here.lat=LocationN[LOCATION_LATITUDE].value;
-                here.lng=LocationN[LOCATION_LONGITUDE].value;
+                here.lat=LocationNP[LOCATION_LATITUDE].getValue();
+                here.lng=LocationNP[LOCATION_LONGITUDE].getValue();
                 ln_get_hrz_from_equ(&eq,&here,ln_get_julian_from_sys(),&altaz);
             AltitudeAzimuthFromTelescopeDirectionVector(TDV,altaz);
             //  now convert the resulting altaz into radec
@@ -1050,7 +1050,7 @@ ln_equ_posn TemmaMount::SkyToTelescope(double ra, double dec)
             double lst;
             LocalHourAngleDeclinationFromTelescopeDirectionVector(TDV, eq);
             //  and now we have to convert from lha back to RA
-            lst            = get_local_sidereal_time(LocationN[LOCATION_LONGITUDE].value);
+            lst            = get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].value);
             eq.ra          = eq.ra * 24 / 360;
             RightAscension = lst - eq.ra;
             RightAscension = range24(RightAscension);
@@ -1351,8 +1351,8 @@ void TemmaMount::mountSim()
                     break;
 
                 case TRACK_CUSTOM:
-                    da = ((TrackRateN[AXIS_RA].value - TRACKRATE_SIDEREAL) / 3600.0 * dt / 15.);
-                    dx = (TrackRateN[AXIS_DE].value / 3600.0 * dt);
+                    da = ((TrackRateNP[AXIS_RA].value - TRACKRATE_SIDEREAL) / 3600.0 * dt / 15.);
+                    dx = (TrackRateNP[AXIS_DE].value / 3600.0 * dt);
                     break;
 
             }

--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -98,7 +98,7 @@ V4L2_Driver::~V4L2_Driver()
 
 void V4L2_Driver::updateFrameSize()
 {
-    if (ISS_ON == ImageColorS[IMAGE_GRAYSCALE].s)
+    if (ISS_ON == ImageColorSP[IMAGE_GRAYSCALE].getState())
         frameBytes =
             PrimaryCCD.getSubW() * PrimaryCCD.getSubH() * (PrimaryCCD.getBPP() / 8 + (PrimaryCCD.getBPP() % 8 ? 1 : 0));
     else
@@ -124,29 +124,29 @@ bool V4L2_Driver::initProperties()
                      IPS_IDLE);
 
     /* Color space */
-    IUFillSwitch(&ImageColorS[IMAGE_GRAYSCALE], "CCD_COLOR_GRAY", "Gray", ISS_ON);
-    IUFillSwitch(&ImageColorS[1], "CCD_COLOR_RGB", "Color", ISS_OFF);
-    IUFillSwitchVector(&ImageColorSP, ImageColorS, NARRAY(ImageColorS), getDeviceName(), "CCD_COLOR_SPACE",
+    ImageColorSP[IMAGE_GRAYSCALE].fill("CCD_COLOR_GRAY", "Gray", ISS_ON);
+    ImageColorSP[1].fill("CCD_COLOR_RGB", "Color", ISS_OFF);
+    ImageColorSP.fill(getDeviceName(), "CCD_COLOR_SPACE",
                        "Image Type", IMAGE_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Image depth */
-    IUFillSwitch(&ImageDepthS[0], "8 bits", "", ISS_ON);
-    IUFillSwitch(&ImageDepthS[1], "16 bits", "", ISS_OFF);
-    IUFillSwitchVector(&ImageDepthSP, ImageDepthS, NARRAY(ImageDepthS), getDeviceName(), "Image Depth", "",
+    ImageDepthSP[0].fill("8 bits", "", ISS_ON);
+    ImageDepthSP[1].fill("16 bits", "", ISS_OFF);
+    ImageDepthSP.fill(getDeviceName(), "Image Depth", "",
                        IMAGE_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Camera Name */
-    IUFillText(&camNameT[0], "Model", "", nullptr);
-    IUFillTextVector(&camNameTP, camNameT, NARRAY(camNameT), getDeviceName(), "Camera", "", IMAGE_INFO_TAB, IP_RO, 0,
+    camNameTP[0].fill("Model", "", nullptr);
+    camNameTP.fill(getDeviceName(), "Camera", "", IMAGE_INFO_TAB, IP_RO, 0,
                      IPS_IDLE);
 
     /* Stacking Mode */
-    IUFillSwitch(&StackModeS[STACK_NONE], "None", "", ISS_ON);
-    IUFillSwitch(&StackModeS[STACK_MEAN], "Mean", "", ISS_OFF);
-    IUFillSwitch(&StackModeS[STACK_ADDITIVE], "Additive", "", ISS_OFF);
-    IUFillSwitch(&StackModeS[STACK_TAKE_DARK], "Take Dark", "", ISS_OFF);
-    IUFillSwitch(&StackModeS[STACK_RESET_DARK], "Reset Dark", "", ISS_OFF);
-    IUFillSwitchVector(&StackModeSP, StackModeS, NARRAY(StackModeS), getDeviceName(), "Stack", "", MAIN_CONTROL_TAB,
+    StackModeSP[STACK_NONE].fill("None", "", ISS_ON);
+    StackModeSP[STACK_MEAN].fill("Mean", "", ISS_OFF);
+    StackModeSP[STACK_ADDITIVE].fill("Additive", "", ISS_OFF);
+    StackModeSP[STACK_TAKE_DARK].fill("Take Dark", "", ISS_OFF);
+    StackModeSP[STACK_RESET_DARK].fill("Reset Dark", "", ISS_OFF);
+    StackModeSP.fill(getDeviceName(), "Stack", "", MAIN_CONTROL_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     stackMode = STACK_NONE;
@@ -165,20 +165,20 @@ bool V4L2_Driver::initProperties()
     /* Frame Rate */
     IUFillSwitchVector(&FrameRatesSP, nullptr, 0, getDeviceName(), "V4L2_FRAMEINT_DISCRETE", "Frame Interval",
                        CAPTURE_FORMAT, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillNumberVector(&FrameRateNP, nullptr, 0, getDeviceName(), "V4L2_FRAMEINT_STEP", "Frame Interval",
+    FrameRateNP.fill(getDeviceName(), "V4L2_FRAMEINT_STEP", "Frame Interval",
                        CAPTURE_FORMAT, IP_RW, 60, IPS_IDLE);
     /* Capture Colorspace */
-    IUFillText(&CaptureColorSpaceT[0], "Name", "", nullptr);
-    IUFillText(&CaptureColorSpaceT[1], "YCbCr Encoding", "", nullptr);
-    IUFillText(&CaptureColorSpaceT[2], "Quantization", "", nullptr);
-    IUFillTextVector(&CaptureColorSpaceTP, CaptureColorSpaceT, NARRAY(CaptureColorSpaceT), getDeviceName(),
+    CaptureColorSpaceTP[0].fill("Name", "", nullptr);
+    CaptureColorSpaceTP[1].fill("YCbCr Encoding", "", nullptr);
+    CaptureColorSpaceTP[2].fill("Quantization", "", nullptr);
+    CaptureColorSpaceTP.fill(getDeviceName(),
                      "V4L2_COLORSPACE", "ColorSpace", IMAGE_INFO_TAB, IP_RO, 0, IPS_IDLE);
 
     /* Color Processing */
-    IUFillSwitch(&ColorProcessingS[0], "Quantization", "", ISS_ON);
-    IUFillSwitch(&ColorProcessingS[1], "Color Conversion", "", ISS_OFF);
-    IUFillSwitch(&ColorProcessingS[2], "Linearization", "", ISS_OFF);
-    IUFillSwitchVector(&ColorProcessingSP, ColorProcessingS, NARRAY(ColorProcessingS), getDeviceName(),
+    ColorProcessingSP[0].fill("Quantization", "", ISS_ON);
+    ColorProcessingSP[1].fill("Color Conversion", "", ISS_OFF);
+    ColorProcessingSP[2].fill("Linearization", "", ISS_OFF);
+    ColorProcessingSP.fill(getDeviceName(),
                        "V4L2_COLOR_PROCESSING", "Color Process", CAPTURE_FORMAT, IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
 
     /* V4L2 Settings */
@@ -219,9 +219,9 @@ void V4L2_Driver::ISGetProperties(const char * dev)
 
     if (isConnected())
     {
-        defineProperty(&camNameTP);
+        defineProperty(camNameTP);
 
-        defineProperty(&ImageColorSP);
+        defineProperty(ImageColorSP);
         defineProperty(&InputsSP);
         defineProperty(&CaptureFormatsSP);
 
@@ -231,15 +231,15 @@ void V4L2_Driver::ISGetProperties(const char * dev)
             defineProperty(&CaptureSizesNP);
         if (FrameRatesSP.sp != nullptr)
             defineProperty(&FrameRatesSP);
-        else if (FrameRateNP.np != nullptr)
-            defineProperty(&FrameRateNP);
+        else if (!FrameRateNP.isEmpty())
+            defineProperty(FrameRateNP);
 
-        defineProperty(&StackModeSP);
+        defineProperty(StackModeSP);
 
 #ifdef WITH_V4L2_EXPERIMENTS
-        defineProperty(&ImageDepthSP);
-        defineProperty(&ColorProcessingSP);
-        defineProperty(&CaptureColorSpaceTP);
+        defineProperty(ImageDepthSP);
+        defineProperty(ColorProcessingSP);
+        defineProperty(CaptureColorSpaceTP);
 #endif
     }
 }
@@ -259,10 +259,10 @@ bool V4L2_Driver::updateProperties()
         FrameNP = getNumber("CCD_FRAME");
         FrameN  = FrameNP->np;
 
-        defineProperty(&camNameTP);
+        defineProperty(camNameTP);
         getBasicData();
 
-        defineProperty(&ImageColorSP);
+        defineProperty(ImageColorSP);
         defineProperty(&InputsSP);
         defineProperty(&CaptureFormatsSP);
 
@@ -272,15 +272,15 @@ bool V4L2_Driver::updateProperties()
             defineProperty(&CaptureSizesNP);
         if (FrameRatesSP.sp != nullptr)
             defineProperty(&FrameRatesSP);
-        else if (FrameRateNP.np != nullptr)
-            defineProperty(&FrameRateNP);
+        else if (!FrameRateNP.isEmpty())
+            defineProperty(FrameRateNP);
 
-        defineProperty(&StackModeSP);
+        defineProperty(StackModeSP);
 
 #ifdef WITH_V4L2_EXPERIMENTS
-        defineProperty(&ImageDepthSP);
-        defineProperty(&ColorProcessingSP);
-        defineProperty(&CaptureColorSpaceTP);
+        defineProperty(ImageDepthSP);
+        defineProperty(ColorProcessingSP);
+        defineProperty(CaptureColorSpaceTP);
 #endif
 
         // Check if we have pixel size info
@@ -331,9 +331,9 @@ bool V4L2_Driver::updateProperties()
         if (v4l_base->isLXmodCapable())
             lx->updateProperties();
 
-        deleteProperty(camNameTP.name);
+        deleteProperty(camNameTP.getName());
 
-        deleteProperty(ImageColorSP.name);
+        deleteProperty(ImageColorSP.getName());
         deleteProperty(InputsSP.name);
         deleteProperty(CaptureFormatsSP.name);
 
@@ -343,8 +343,8 @@ bool V4L2_Driver::updateProperties()
             deleteProperty(CaptureSizesNP.name);
         if (FrameRatesSP.sp != nullptr)
             deleteProperty(FrameRatesSP.name);
-        else if (FrameRateNP.np != nullptr)
-            deleteProperty(FrameRateNP.name);
+        else if (!FrameRateNP.isEmpty())
+            deleteProperty(FrameRateNP.getName());
 
         deleteProperty(ImageAdjustNP.name);
         for (i = 0; i < v4loptions; i++)
@@ -354,12 +354,12 @@ bool V4L2_Driver::updateProperties()
         Options    = nullptr;
         v4loptions = 0;
 
-        deleteProperty(StackModeSP.name);
+        deleteProperty(StackModeSP.getName());
 
 #ifdef WITH_V4L2_EXPERIMENTS
-        deleteProperty(ImageDepthSP.name);
-        deleteProperty(ColorProcessingSP.name);
-        deleteProperty(CaptureColorSpaceTP.name);
+        deleteProperty(ImageDepthSP.getName());
+        deleteProperty(ColorProcessingSP.getName());
+        deleteProperty(CaptureColorSpaceTP.getName());
 #endif
 
         return true;
@@ -378,7 +378,7 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
     /* Input */
     if (strcmp(name, InputsSP.name) == 0)
     {
-        //if ((StreamSP.s == IPS_BUSY) ||  (ExposeTimeNP->s == IPS_BUSY) || (RecordStreamSP.s == IPS_BUSY)) {
+        //if ((StreamSP.getState() == IPS_BUSY) ||  (ExposeTimeNP->s == IPS_BUSY) || (RecordStreamSP.getState() == IPS_BUSY)) {
         if (PrimaryCCD.isExposing() || Streamer->isBusy())
         {
             LOG_ERROR("Can not set input while capturing.");
@@ -428,7 +428,7 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
     /* Capture Format */
     if (strcmp(name, CaptureFormatsSP.name) == 0)
     {
-        //if ((StreamSP.s == IPS_BUSY) ||  (ExposeTimeNP->s == IPS_BUSY) || (RecordStreamSP.s == IPS_BUSY)) {
+        //if ((StreamSP.getState() == IPS_BUSY) ||  (ExposeTimeNP->s == IPS_BUSY) || (RecordStreamSP.getState() == IPS_BUSY)) {
         if (PrimaryCCD.isExposing() || Streamer->isBusy())
         {
             LOG_ERROR("Can not set format while capturing.");
@@ -470,10 +470,10 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
             CaptureFormatsSP.s = IPS_OK;
 
 #ifdef WITH_V4L2_EXPERIMENTS
-            IUSaveText(&CaptureColorSpaceT[0], getColorSpaceName(&v4l_base->fmt));
-            IUSaveText(&CaptureColorSpaceT[1], getYCbCrEncodingName(&v4l_base->fmt));
-            IUSaveText(&CaptureColorSpaceT[2], getQuantizationName(&v4l_base->fmt));
-            IDSetText(&CaptureColorSpaceTP, nullptr);
+            CaptureColorSpaceTP[0].setText(getColorSpaceName(&v4l_base->fmt));
+            CaptureColorSpaceTP[1].setText(getYCbCrEncodingName(&v4l_base->fmt));
+            CaptureColorSpaceTP[2].setText(getQuantizationName(&v4l_base->fmt));
+            CaptureColorSpaceTP.apply();
 #endif
             //direct_record=recorder->setpixelformat(v4l_base->fmt.fmt.pix.pixelformat);
             INDI_PIXEL_FORMAT pixelFormat;
@@ -490,7 +490,7 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
     /* Capture Size (Discrete) */
     if (strcmp(name, CaptureSizesSP.name) == 0)
     {
-        //if ((StreamSP.s == IPS_BUSY) ||  (ExposeTimeNP->s == IPS_BUSY) || (RecordStreamSP.s == IPS_BUSY)) {
+        //if ((StreamSP.getState() == IPS_BUSY) ||  (ExposeTimeNP->s == IPS_BUSY) || (RecordStreamSP.getState() == IPS_BUSY)) {
         if (PrimaryCCD.isExposing() || Streamer->isBusy())
         {
             LOG_ERROR("Can not set capture size while capturing.");
@@ -514,13 +514,13 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
 
             if (FrameRatesSP.sp != nullptr)
                 deleteProperty(FrameRatesSP.name);
-            else if (FrameRateNP.np != nullptr)
-                deleteProperty(FrameRateNP.name);
+            else if (!FrameRateNP.isEmpty())
+                deleteProperty(FrameRateNP.getName());
             v4l_base->getframerates(&FrameRatesSP, &FrameRateNP);
             if (FrameRatesSP.sp != nullptr)
                 defineProperty(&FrameRatesSP);
-            else if (FrameRateNP.np != nullptr)
-                defineProperty(&FrameRateNP);
+            else if (!FrameRateNP.isEmpty())
+                defineProperty(FrameRateNP);
 
             PrimaryCCD.setFrame(0, 0, w, h);
             V4LFrame->width  = w;
@@ -566,7 +566,7 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
     }
 
     /* Image Type */
-    if (strcmp(name, ImageColorSP.name) == 0)
+    if (ImageColorSP.isNameMatch(name))
     {
         if (Streamer->isRecording())
         {
@@ -574,10 +574,10 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
             return false;
         }
 
-        IUResetSwitch(&ImageColorSP);
-        IUUpdateSwitch(&ImageColorSP, states, names, n);
-        ImageColorSP.s = IPS_OK;
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        ImageColorSP.reset();
+        ImageColorSP.update(states, names, n);
+        ImageColorSP.setState(IPS_OK);
+        if (ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON)
         {
             //PrimaryCCD.setBPP(8);
             PrimaryCCD.setNAxis(2);
@@ -596,15 +596,15 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
         if (getPixelFormat(v4l_base->fmt.fmt.pix.pixelformat, pixelFormat, pixelDepth))
             Streamer->setPixelFormat(pixelFormat, pixelDepth);
 #endif
-        Streamer->setPixelFormat((ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON) ? INDI_MONO : INDI_RGB, 8);
-        IDSetSwitch(&ImageColorSP, nullptr);
+        Streamer->setPixelFormat((ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON) ? INDI_MONO : INDI_RGB, 8);
+        ImageColorSP.apply();
 
-        saveConfig(true, ImageColorSP.name);
+        saveConfig(true, ImageColorSP.getName());
         return true;
     }
 
     /* Image Depth */
-    if (strcmp(name, ImageDepthSP.name) == 0)
+    if (ImageDepthSP.isNameMatch(name))
     {
         if (Streamer->isRecording())
         {
@@ -612,10 +612,10 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
             return false;
         }
 
-        IUResetSwitch(&ImageDepthSP);
-        IUUpdateSwitch(&ImageDepthSP, states, names, n);
-        ImageDepthSP.s = IPS_OK;
-        if (ImageDepthS[0].s == ISS_ON)
+        ImageDepthSP.reset();
+        ImageDepthSP.update(states, names, n);
+        ImageDepthSP.setState(IPS_OK);
+        if (ImageDepthSP[0].getState() == ISS_ON)
         {
             PrimaryCCD.setBPP(8);
         }
@@ -623,17 +623,17 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
         {
             PrimaryCCD.setBPP(16);
         }
-        IDSetSwitch(&ImageDepthSP, nullptr);
+        ImageDepthSP.apply();
         return true;
     }
 
     /* Stacking Mode */
-    if (strcmp(name, StackModeSP.name) == 0)
+    if (StackModeSP.isNameMatch(name))
     {
-        IUResetSwitch(&StackModeSP);
-        IUUpdateSwitch(&StackModeSP, states, names, n);
-        StackModeSP.s = IPS_OK;
-        stackMode     = IUFindOnSwitchIndex(&StackModeSP);
+        StackModeSP.reset();
+        StackModeSP.update(states, names, n);
+        StackModeSP.setState(IPS_OK);
+        stackMode     = StackModeSP.findOnSwitchIndex();
         if (stackMode == STACK_RESET_DARK)
         {
             if (V4LFrame->darkFrame != nullptr)
@@ -643,7 +643,7 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
             }
         }
 
-        IDSetSwitch(&StackModeSP, "Setting Stacking Mode: %s", StackModeS[stackMode].name);
+        StackModeSP.apply("Setting Stacking Mode: %s", StackModeSP[stackMode].getName());
         return true;
     }
 
@@ -691,15 +691,15 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
     }
 
     /* ColorProcessing */
-    if (strcmp(name, ColorProcessingSP.name) == 0)
+    if (ColorProcessingSP.isNameMatch(name))
     {
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        if (ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON)
         {
-            IUUpdateSwitch(&ColorProcessingSP, states, names, n);
-            v4l_base->setColorProcessing(ColorProcessingS[0].s == ISS_ON, ColorProcessingS[1].s == ISS_ON,
-                                         ColorProcessingS[2].s == ISS_ON);
-            ColorProcessingSP.s = IPS_OK;
-            IDSetSwitch(&ColorProcessingSP, nullptr);
+            ColorProcessingSP.update(states, names, n);
+            v4l_base->setColorProcessing(ColorProcessingSP[0].getState() == ISS_ON, ColorProcessingSP[1].getState() == ISS_ON,
+                                         ColorProcessingSP[2].getState() == ISS_ON);
+            ColorProcessingSP.setState(IPS_OK);
+            ColorProcessingSP.apply();
             V4LFrame->bpp = v4l_base->getBpp();
             PrimaryCCD.setBPP(V4LFrame->bpp);
             PrimaryCCD.setBPP(V4LFrame->bpp);
@@ -955,10 +955,10 @@ bool V4L2_Driver::setManualExposure(double duration)
     if (nullptr == AbsExposureN)
     {
         /* We don't have an absolute exposure control but we can stack gray frames until the exposure elapses */
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
+        if (ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
         {
             LOGF_WARN("Absolute exposure duration control is undefined, stacking up to %.3f seconds using %.16s.",
-                      duration, StackModeS[stackMode].name);
+                      duration, StackModeSP[stackMode].getName());
             return true;
         }
         /* We don't have an absolute exposure control and stacking is not configured, bail out */
@@ -972,21 +972,21 @@ bool V4L2_Driver::setManualExposure(double duration)
     /* Then if we have an exposure control, check the requested exposure duration */
     else if (AbsExposureN->max < ticks)
     {
-        if( ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON && stackMode == STACK_NONE ) {
+        if( ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON && stackMode == STACK_NONE ) {
             LOG_WARN("Requested manual exposure is out of device bounds auto set stackMode to ADDITIVE" );
             stackMode = STACK_ADDITIVE;
-            StackModeSP.sp[ STACK_NONE ].s = ISS_OFF;
-            StackModeSP.sp[ STACK_ADDITIVE ].s = ISS_ON;
+            StackModeSP[ STACK_NONE ].setState(ISS_OFF);
+            StackModeSP[ STACK_ADDITIVE ].setState(ISS_ON);
             IDSetSwitch(ManualExposureSP, nullptr);
         }
 
         /* We can't expose as long as requested but we can stack gray frames until the exposure elapses */
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
+        if (ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
         {
             if( AbsExposureN->value != AbsExposureN->max ) {
                 LOGF_WARN("Requested manual exposure is out of device bounds [%.3f,%.3f], stacking up to %.3f seconds using %.16s.",
                       (double) AbsExposureN->min / 10000.0f, (double) AbsExposureN->max / 10000.0f,
-                      duration, StackModeS[stackMode].name);
+                      duration, StackModeSP[stackMode].getName());
             }
             ticks = AbsExposureN->max;
         }
@@ -1199,7 +1199,7 @@ void V4L2_Driver::lxtimerCallback(void * userpointer)
 
 bool V4L2_Driver::UpdateCCDBin(int hor, int ver)
 {
-    if (ImageColorS[IMAGE_COLOR].s == ISS_ON)
+    if (ImageColorSP[IMAGE_COLOR].getState() == ISS_ON)
     {
         if (hor == 1 && ver == 1)
         {
@@ -1332,7 +1332,7 @@ void V4L2_Driver::newFrame()
         unsigned char * buffer = nullptr;
 
         std::unique_lock<std::mutex> guard(ccdBufferLock);
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        if (ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON)
         {
             V4LFrame->Y = v4l_base->getY();
             totalBytes  = width * height * (dbpp / 8);
@@ -1428,20 +1428,20 @@ void V4L2_Driver::newFrame()
         PrimaryCCD.setExposureLeft(remaining);
 
         // Stack Mono frames
-        if ((stackMode) && !(lx->isEnabled()) && !(ImageColorS[1].s == ISS_ON))
+        if ((stackMode) && !(lx->isEnabled()) && !(ImageColorSP[1].getState() == ISS_ON))
         {
             stackFrame();
         }
 
         /* FIXME: stacking does not account for transfer time, so we'll miss the last frames probably */
-        if ((stackMode) && !(lx->isEnabled()) && !(ImageColorS[1].s == ISS_ON) &&
+        if ((stackMode) && !(lx->isEnabled()) && !(ImageColorSP[1].getState() == ISS_ON) &&
                 (timercmp(&elapsed_exposure, &exposure_duration, < )))
             return; // go on stacking
         
         struct timeval const current_exposure = getElapsedExposure();
 
         //IDLog("Copying frame.\n");
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        if (ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON)
         {
             if (!stackMode)
             {
@@ -1481,7 +1481,7 @@ void V4L2_Driver::newFrame()
                 //IDLog("Copying stack frame from %p to %p.\n", src, dest);
                 if (stackMode == STACK_MEAN)
                 {
-                    if (ImageDepthS[0].s == ISS_ON)
+                    if (ImageDepthSP[0].getState() == ISS_ON)
                     {
                         // depth 8 bits
                         unsigned char * dest = (unsigned char *)PrimaryCCD.getFrameBuffer();
@@ -1508,7 +1508,7 @@ void V4L2_Driver::newFrame()
                 else if (stackMode == STACK_ADDITIVE)
                 {
                     /* Clamp additive stacking to frame dynamic range - that is, do not consider normalized source greater than 1.0f */
-                    if (ImageDepthS[0].s == ISS_ON)
+                    if (ImageDepthSP[0].getState() == ISS_ON)
                     {
                         // depth 8 bits
                         unsigned char * dest = (unsigned char *)PrimaryCCD.getFrameBuffer();
@@ -1543,7 +1543,7 @@ void V4L2_Driver::newFrame()
                     V4LFrame->darkFrame    = V4LFrame->stackedFrame;
                     V4LFrame->stackedFrame = nullptr;
                     src                    = V4LFrame->darkFrame;
-                    if (ImageDepthS[0].s == ISS_ON)
+                    if (ImageDepthSP[0].getState() == ISS_ON)
                     {
                         // depth 8 bits
                         unsigned char * dest = (unsigned char *)PrimaryCCD.getFrameBuffer();
@@ -1716,13 +1716,13 @@ void V4L2_Driver::getBasicData()
         LOGF_INFO("Found initial size %dx%d, frame interval %d/%ds", w, h, frate.numerator,
                   frate.denominator);
 
-    IUSaveText(&camNameT[0], v4l_base->getDeviceName());
-    IDSetText(&camNameTP, nullptr);
+    camNameTP[0].setText(v4l_base->getDeviceName());
+    camNameTP.apply();
 #ifdef WITH_V4L2_EXPERIMENTS
-    IUSaveText(&CaptureColorSpaceT[0], getColorSpaceName(&v4l_base->fmt));
-    IUSaveText(&CaptureColorSpaceT[1], getYCbCrEncodingName(&v4l_base->fmt));
-    IUSaveText(&CaptureColorSpaceT[2], getQuantizationName(&v4l_base->fmt));
-    IDSetText(&CaptureColorSpaceTP, nullptr);
+    CaptureColorSpaceTP[0].setText(getColorSpaceName(&v4l_base->fmt));
+    CaptureColorSpaceTP[1].setText(getYCbCrEncodingName(&v4l_base->fmt));
+    CaptureColorSpaceTP[2].setText(getQuantizationName(&v4l_base->fmt));
+    CaptureColorSpaceTP.apply();
 #endif
     if (Options)
         free(Options);

--- a/drivers/video/v4l2driver.h
+++ b/drivers/video/v4l2driver.h
@@ -29,6 +29,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 #include "indiccd.h"
 #include "webcam/v4l2_base.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 #define IMAGE_CONTROL  "Image Control"
 #define IMAGE_GROUP    "V4L2 Control"
 #define IMAGE_BOOLEAN  "V4L2 Options"
@@ -109,37 +114,33 @@ class V4L2_Driver : public INDI::CCD
     /* Switches */
 
     ISwitch *CompressS;
-    ISwitch ImageColorS[2];
+    INDI::PropertySwitch ImageColorSP {2};
     enum
     {
         IMAGE_GRAYSCALE,
         IMAGE_COLOR
     };
-    ISwitch ImageDepthS[2];
-    ISwitch StackModeS[5];
-    ISwitch ColorProcessingS[3];
+    INDI::PropertySwitch ImageDepthSP {2};
+    INDI::PropertySwitch StackModeSP {5};
+    INDI::PropertySwitch ColorProcessingSP {3};
 
     /* Texts */
     IText PortT[1] {};
-    IText camNameT[1] {};
-    IText CaptureColorSpaceT[3] {};
+    INDI::PropertyText camNameTP {1};
+    INDI::PropertyText CaptureColorSpaceTP {3};
 
     /* Numbers */
     //INumber *ExposeTimeN;
     INumber *FrameN;
-    INumber FrameRateN[1];
+    INDI::PropertyNumber FrameRateNP {1};
 
     /* Switch vectors */
-    ISwitchVectorProperty *CompressSP;      /* Compress stream switch */
-    ISwitchVectorProperty ImageColorSP;     /* Color or grey switch */
-    ISwitchVectorProperty ImageDepthSP;     /* 8 bits or 16 bits switch */
-    ISwitchVectorProperty StackModeSP;      /* StackMode switch */
+    ISwitchVectorProperty *CompressSP;      /* Compress stream switch */     /* Color or grey switch */     /* 8 bits or 16 bits switch */      /* StackMode switch */
     ISwitchVectorProperty InputsSP;         /* Select input switch */
     ISwitchVectorProperty CaptureFormatsSP; /* Select Capture format switch */
     ISwitchVectorProperty CaptureSizesSP;   /* Select Capture size switch (Discrete)*/
     ISwitchVectorProperty FrameRatesSP;     /* Select Frame rate (Discrete) */
     ISwitchVectorProperty *Options;
-    ISwitchVectorProperty ColorProcessingSP;
 
     unsigned int v4loptions;
     unsigned int v4ladjustments;
@@ -147,15 +148,12 @@ class V4L2_Driver : public INDI::CCD
 
     /* Number vectors */
     //INumberVectorProperty *ExposeTimeNP;			/* Exposure */
-    INumberVectorProperty CaptureSizesNP; /* Select Capture size switch (Step/Continuous)*/
-    INumberVectorProperty FrameRateNP;    /* Frame rate (Step/Continuous) */
+    INumberVectorProperty CaptureSizesNP; /* Select Capture size switch (Step/Continuous)*/    /* Frame rate (Step/Continuous) */
     INumberVectorProperty *FrameNP;       /* Frame dimenstion */
     INumberVectorProperty ImageAdjustNP;  /* Image controls */
 
     /* Text vectors */
     ITextVectorProperty PortTP;
-    ITextVectorProperty camNameTP;
-    ITextVectorProperty CaptureColorSpaceTP;
 
     /* Pointers to optional properties */
     INumber *AbsExposureN;

--- a/drivers/weather/mbox.cpp
+++ b/drivers/weather/mbox.cpp
@@ -98,18 +98,18 @@ bool MBox::initProperties()
     setCriticalParameter("WEATHER_TEMPERATURE");
 
     // Reset Calibration
-    IUFillSwitch(&ResetS[0], "RESET", "Reset", ISS_OFF);
-    IUFillSwitchVector(&ResetSP, ResetS, 1, getDeviceName(), "CALIBRATION_RESET", "Reset", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    ResetSP[0].fill("RESET", "Reset", ISS_OFF);
+    ResetSP.fill(getDeviceName(), "CALIBRATION_RESET", "Reset", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Calibration Properties
-    IUFillNumber(&CalibrationN[CAL_TEMPERATURE], "CAL_TEMPERATURE", "Temperature", "%.f", -50, 50, 1, 0);
-    IUFillNumber(&CalibrationN[CAL_PRESSURE], "CAL_PRESSURE", "Pressure", "%.f", -100, 100, 10, 0);
-    IUFillNumber(&CalibrationN[CAL_HUMIDITY], "CAL_HUMIDITY", "Humidity", "%.f", -50, 50, 1, 0);
-    IUFillNumberVector(&CalibrationNP, CalibrationN, 3, getDeviceName(), "CALIBRATION", "Calibration", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
+    CalibrationNP[CAL_TEMPERATURE].fill("CAL_TEMPERATURE", "Temperature", "%.f", -50, 50, 1, 0);
+    CalibrationNP[CAL_PRESSURE].fill("CAL_PRESSURE", "Pressure", "%.f", -100, 100, 10, 0);
+    CalibrationNP[CAL_HUMIDITY].fill("CAL_HUMIDITY", "Humidity", "%.f", -50, 50, 1, 0);
+    CalibrationNP.fill(getDeviceName(), "CALIBRATION", "Calibration", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     // Firmware Information
-    IUFillText(&FirmwareT[0], "VERSION", "Version", "--");
-    IUFillTextVector(&FirmwareTP, FirmwareT, 1, getDeviceName(), "DEVICE_FIRMWARE", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
+    FirmwareTP[0].fill("VERSION", "Version", "--");
+    FirmwareTP.fill(getDeviceName(), "DEVICE_FIRMWARE", "Firmware", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     serialConnection->setDefaultBaudRate(Connection::Serial::B_38400);
 
@@ -124,15 +124,15 @@ bool MBox::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&CalibrationNP);
-        defineProperty(&ResetSP);
-        defineProperty(&FirmwareTP);
+        defineProperty(CalibrationNP);
+        defineProperty(ResetSP);
+        defineProperty(FirmwareTP);
     }
     else
     {
-        deleteProperty(CalibrationNP.name);
-        deleteProperty(ResetSP.name);
-        deleteProperty(FirmwareTP.name);
+        deleteProperty(CalibrationNP.getName());
+        deleteProperty(ResetSP.getName());
+        deleteProperty(FirmwareTP.getName());
     }
 
     return true;
@@ -159,7 +159,7 @@ bool MBox::Handshake()
     else if (rc == ACK_OK_INIT)
     {
         //getCalibration(true);
-        CalibrationNP.s = IPS_BUSY;
+        CalibrationNP.setState(IPS_BUSY);
         return true;
     }
 
@@ -170,12 +170,12 @@ IPState MBox::updateWeather()
 {
     char response[MBOX_BUF];
 
-    if (CalibrationNP.s == IPS_BUSY)
+    if (CalibrationNP.getState() == IPS_BUSY)
     {
         if (getCalibration(true))
         {
-            CalibrationNP.s = IPS_OK;
-            IDSetNumber(&CalibrationNP, nullptr);
+            CalibrationNP.setState(IPS_OK);
+            CalibrationNP.apply();
         }
     }
 
@@ -222,11 +222,11 @@ IPState MBox::updateWeather()
     setParameterValue("WEATHER_TEMPERATURE", std::stod(result[SENSOR_TEMPERATURE]));
     setParameterValue("WEATHER_HUMIDITY", std::stod(result[SENSOR_HUMIDITY]));
     setParameterValue("WEATHER_DEWPOINT", std::stod(result[SENSOR_DEW]));
-    if (strcmp(result[FIRMWARE].c_str(), FirmwareT[0].text))
+    if (strcmp(result[FIRMWARE].c_str(), FirmwareTP[0].getText()))
     {
-        IUSaveText(&FirmwareT[0], result[FIRMWARE].c_str());
-        FirmwareTP.s = IPS_OK;
-        IDSetText(&FirmwareTP, nullptr);
+        FirmwareTP[0].setText(result[FIRMWARE]);
+        FirmwareTP.setState(IPS_OK);
+        FirmwareTP.apply();
     }
 
     return IPS_OK;
@@ -284,15 +284,15 @@ bool MBox::ISNewNumber(const char *dev, const char *name, double values[], char 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, CalibrationNP.name))
+        if (CalibrationNP.isNameMatch(name))
         {
-            double prevPressure = CalibrationN[CAL_PRESSURE].value;
-            double prevTemperature = CalibrationN[CAL_TEMPERATURE].value;
-            double prevHumidaty = CalibrationN[CAL_HUMIDITY].value;
-            IUUpdateNumber(&CalibrationNP, values, names, n);
-            double targetPressure = CalibrationN[CAL_PRESSURE].value;
-            double targetTemperature = CalibrationN[CAL_TEMPERATURE].value;
-            double targetHumidity = CalibrationN[CAL_HUMIDITY].value;
+            double prevPressure = CalibrationNP[CAL_PRESSURE].getValue();
+            double prevTemperature = CalibrationNP[CAL_TEMPERATURE].getValue();
+            double prevHumidaty = CalibrationNP[CAL_HUMIDITY].getValue();
+            CalibrationNP.update(values, names, n);
+            double targetPressure = CalibrationNP[CAL_PRESSURE].getValue();
+            double targetTemperature = CalibrationNP[CAL_TEMPERATURE].getValue();
+            double targetHumidity = CalibrationNP[CAL_HUMIDITY].getValue();
 
             bool rc = true;
             if (targetPressure != prevPressure)
@@ -310,8 +310,8 @@ bool MBox::ISNewNumber(const char *dev, const char *name, double values[], char 
                 rc = setCalibration(CAL_HUMIDITY);
             }
 
-            CalibrationNP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetNumber(&CalibrationNP, nullptr);
+            CalibrationNP.setState(rc ? IPS_OK : IPS_ALERT);
+            CalibrationNP.apply();
             return true;
         }
     }
@@ -323,24 +323,24 @@ bool MBox::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, ResetSP.name))
+        if (ResetSP.isNameMatch(name))
         {
             if (resetCalibration())
             {
-                ResetSP.s = IPS_OK;
-                IDSetSwitch(&ResetSP, nullptr);
+                ResetSP.setState(IPS_OK);
+                ResetSP.apply();
                 LOG_INFO("Calibration values are reset.");
 
-                CalibrationN[CAL_PRESSURE].value = 0;
-                CalibrationN[CAL_TEMPERATURE].value = 0;
-                CalibrationN[CAL_HUMIDITY].value = 0;
-                CalibrationNP.s = IPS_IDLE;
-                IDSetNumber(&CalibrationNP, nullptr);
+                CalibrationNP[CAL_PRESSURE].setValue(0);
+                CalibrationNP[CAL_TEMPERATURE].setValue(0);
+                CalibrationNP[CAL_HUMIDITY].setValue(0);
+                CalibrationNP.setState(IPS_IDLE);
+                CalibrationNP.apply();
             }
             else
             {
-                ResetSP.s = IPS_ALERT;
-                IDSetSwitch(&ResetSP, nullptr);
+                ResetSP.setState(IPS_ALERT);
+                ResetSP.apply();
             }
 
 
@@ -419,9 +419,9 @@ bool MBox::getCalibration(bool sendCommand)
 
     // PCAL
     std::vector<std::string> result = split(response, ",");
-    CalibrationN[CAL_PRESSURE].value = std::stod(result[SENSOR_PRESSURE]) / 10.0;
-    CalibrationN[CAL_TEMPERATURE].value = std::stod(result[SENSOR_PRESSURE + 2]) / 10.0;
-    CalibrationN[CAL_HUMIDITY].value = std::stod(result[SENSOR_PRESSURE + 4]) / 10.0;
+    CalibrationNP[CAL_PRESSURE].setValue(std::stod(result[SENSOR_PRESSURE]) / 10.0);
+    CalibrationNP[CAL_TEMPERATURE].setValue(std::stod(result[SENSOR_PRESSURE + 2]) / 10.0);
+    CalibrationNP[CAL_HUMIDITY].setValue(std::stod(result[SENSOR_PRESSURE + 4]) / 10.0);
     return true;
 }
 
@@ -434,7 +434,7 @@ bool MBox::setCalibration(CalibrationType type)
     if (type == CAL_PRESSURE)
     {
         // Pressure.
-        snprintf(command, 16, ":calp,%d*", static_cast<int32_t>(CalibrationN[CAL_PRESSURE].value * 10.0));
+        snprintf(command, 16, ":calp,%d*", static_cast<int32_t>(CalibrationNP[CAL_PRESSURE].value * 10.0));
 
         LOGF_DEBUG("CMD <%s>", command);
 
@@ -454,7 +454,7 @@ bool MBox::setCalibration(CalibrationType type)
     else if (type == CAL_TEMPERATURE)
     {
         // Temperature
-        snprintf(command, 16, ":calt,%d*", static_cast<int32_t>(CalibrationN[CAL_TEMPERATURE].value * 10.0));
+        snprintf(command, 16, ":calt,%d*", static_cast<int32_t>(CalibrationNP[CAL_TEMPERATURE].value * 10.0));
 
         LOGF_DEBUG("CMD <%s>", command);
 
@@ -473,7 +473,7 @@ bool MBox::setCalibration(CalibrationType type)
     else
     {
         // Humidity
-        snprintf(command, 16, ":calh,%d*", static_cast<int32_t>(CalibrationN[CAL_HUMIDITY].value * 10.0));
+        snprintf(command, 16, ":calh,%d*", static_cast<int32_t>(CalibrationNP[CAL_HUMIDITY].value * 10.0));
 
         LOGF_DEBUG("CMD <%s>", command);
 

--- a/drivers/weather/mbox.h
+++ b/drivers/weather/mbox.h
@@ -26,6 +26,11 @@
 
 #include "indiweather.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 class MBox : public INDI::Weather
 {
     public:
@@ -64,14 +69,11 @@ class MBox : public INDI::Weather
 
         std::vector<std::string> split(const std::string &input, const std::string &regex);
 
-        INumber CalibrationN[3];
-        INumberVectorProperty CalibrationNP;
+        INDI::PropertyNumber CalibrationNP {3};
 
-        ISwitch ResetS[1];
-        ISwitchVectorProperty ResetSP;
+        INDI::PropertySwitch ResetSP {1};
 
-        IText FirmwareT[1] {};
-        ITextVectorProperty FirmwareTP;
+        INDI::PropertyText FirmwareTP {1};
 
 
 

--- a/drivers/weather/weather_safety_proxy.cpp
+++ b/drivers/weather/weather_safety_proxy.cpp
@@ -105,28 +105,28 @@ bool WeatherSafetyProxy::initProperties()
 {
     INDI::Weather::initProperties();
 
-    IUFillText(&keywordT[0], "WEATHER_CONDITION", "Weather Condition", "condition");
-    IUFillTextVector(&keywordTP, keywordT, 1, getDeviceName(), "KEYWORD", "Keywords", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
+    keywordTP[0].fill("WEATHER_CONDITION", "Weather Condition", "condition");
+    keywordTP.fill(getDeviceName(), "KEYWORD", "Keywords", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillText(&ScriptsT[WSP_SCRIPT], "WEATHER_SAFETY_SCRIPT", "Weather safety script", "/usr/local/share/indi/scripts/weather_status.py");
-    IUFillTextVector(&ScriptsTP, ScriptsT, WSP_SCRIPT_COUNT, getDefaultName(), "WEATHER_SAFETY_SCRIPTS", "Script", OPTIONS_TAB, IP_RW, 100, IPS_IDLE);
+    ScriptsTP[WSP_SCRIPT].fill("WEATHER_SAFETY_SCRIPT", "Weather safety script", "/usr/local/share/indi/scripts/weather_status.py");
+    ScriptsTP.fill(getDefaultName(), "WEATHER_SAFETY_SCRIPTS", "Script", OPTIONS_TAB, IP_RW, 100, IPS_IDLE);
 
-    IUFillText(&UrlT[WSP_URL], "WEATHER_SAFETY_URL", "Weather safety URL", "http://0.0.0.0:5000/weather/safety");
-    IUFillTextVector(&UrlTP, UrlT, WSP_URL_COUNT, getDefaultName(), "WEATHER_SAFETY_URLS", "Url", OPTIONS_TAB, IP_RW, 100, IPS_IDLE);
+    UrlTP[WSP_URL].fill("WEATHER_SAFETY_URL", "Weather safety URL", "http://0.0.0.0:5000/weather/safety");
+    UrlTP.fill(getDefaultName(), "WEATHER_SAFETY_URLS", "Url", OPTIONS_TAB, IP_RW, 100, IPS_IDLE);
 
-    IUFillSwitch(&ScriptOrCurlS[WSP_USE_SCRIPT], "Use script", "", ISS_ON);
-    IUFillSwitch(&ScriptOrCurlS[WSP_USE_CURL], "Use url", "", ISS_OFF);
-    IUFillSwitchVector(&ScriptOrCurlSP, ScriptOrCurlS, WSP_USE_COUNT, getDeviceName(), "SCRIPT_OR_CURL", "Script or url", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    ScriptOrCurlSP[WSP_USE_SCRIPT].fill("Use script", "", ISS_ON);
+    ScriptOrCurlSP[WSP_USE_CURL].fill("Use url", "", ISS_OFF);
+    ScriptOrCurlSP.fill(getDeviceName(), "SCRIPT_OR_CURL", "Script or url", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&softErrorHysteresisN[WSP_SOFT_ERROR_MAX], "SOFT_ERROR_MAX", "Max soft errors", "%g", 0.0, 1000.0, 1.0, 30.0);
-    IUFillNumber(&softErrorHysteresisN[WSP_SOFT_ERROR_RECOVERY], "SOFT_ERROR_RECOVERY", "Minimum soft error for recovery", "%g", 0.0, 1000.0, 1.0, 7.0);
-    IUFillNumberVector(&softErrorHysteresisNP, softErrorHysteresisN, 2, getDeviceName(), "SOFT_ERROR_HYSTERESIS", "Soft error hysterese", OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
+    softErrorHysteresisNP[WSP_SOFT_ERROR_MAX].fill("SOFT_ERROR_MAX", "Max soft errors", "%g", 0.0, 1000.0, 1.0, 30.0);
+    softErrorHysteresisNP[WSP_SOFT_ERROR_RECOVERY].fill("SOFT_ERROR_RECOVERY", "Minimum soft error for recovery", "%g", 0.0, 1000.0, 1.0, 7.0);
+    softErrorHysteresisNP.fill(getDeviceName(), "SOFT_ERROR_HYSTERESIS", "Soft error hysterese", OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 
     addParameter("WEATHER_SAFETY", "Weather Safety", 0.9, 1.1, 0); // 0 is unsafe, 1 is safe
     setCriticalParameter("WEATHER_SAFETY");
 
-    IUFillText(&reasonsT[0], "Reasons", "", nullptr);
-    IUFillTextVector(&reasonsTP, reasonsT, 1, getDeviceName(), "WEATHER_SAFETY_REASONS", "Weather Safety Reasons", MAIN_CONTROL_TAB, IP_RO, 120, IPS_IDLE);
+    reasonsTP[0].fill("Reasons", "", nullptr);
+    reasonsTP.fill(getDeviceName(), "WEATHER_SAFETY_REASONS", "Weather Safety Reasons", MAIN_CONTROL_TAB, IP_RO, 120, IPS_IDLE);
 
     addDebugControl();
 
@@ -139,11 +139,11 @@ bool WeatherSafetyProxy::updateProperties()
 
     if (isConnected())
     {
-        defineProperty(&reasonsTP);
+        defineProperty(reasonsTP);
     }
     else
     {
-        deleteProperty(reasonsTP.name);
+        deleteProperty(reasonsTP.getName());
     }
 
     return true;
@@ -152,10 +152,10 @@ bool WeatherSafetyProxy::updateProperties()
 bool WeatherSafetyProxy::saveConfigItems(FILE *fp)
 {
     INDI::Weather::saveConfigItems(fp);
-    IUSaveConfigText(fp, &ScriptsTP);
-    IUSaveConfigText(fp, &UrlTP);
-    IUSaveConfigSwitch(fp, &ScriptOrCurlSP);
-    IUSaveConfigNumber(fp, &softErrorHysteresisNP);
+    ScriptsTP.save(fp);
+    UrlTP.save(fp);
+    ScriptOrCurlSP.save(fp);
+    softErrorHysteresisNP.save(fp);
     return true;
 }
 
@@ -166,10 +166,10 @@ void WeatherSafetyProxy::ISGetProperties(const char *dev)
     if (once)
     {
         once = false;
-        defineProperty(&ScriptsTP);
-        defineProperty(&UrlTP);
-        defineProperty(&ScriptOrCurlSP);
-        defineProperty(&softErrorHysteresisNP);
+        defineProperty(ScriptsTP);
+        defineProperty(UrlTP);
+        defineProperty(ScriptOrCurlSP);
+        defineProperty(softErrorHysteresisNP);
         loadConfig(false, "WEATHER_SAFETY_SCRIPTS");
         loadConfig(false, "WEATHER_SAFETY_URLS");
         loadConfig(false, "SCRIPT_OR_CURL");
@@ -181,12 +181,12 @@ bool WeatherSafetyProxy::ISNewNumber(const char *dev, const char *name, double v
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, softErrorHysteresisNP.name) == 0)
+        if (softErrorHysteresisNP.isNameMatch(name))
         {
             LOG_DEBUG("WeatherSafetyProxy::ISNewNumber");
-            IUUpdateNumber(&softErrorHysteresisNP, values, names, n);
-            softErrorHysteresisNP.s = IPS_OK;
-            IDSetNumber(&softErrorHysteresisNP, nullptr);
+            softErrorHysteresisNP.update(values, names, n);
+            softErrorHysteresisNP.setState(IPS_OK);
+            softErrorHysteresisNP.apply();
             return true;
         }
     }
@@ -197,28 +197,28 @@ bool WeatherSafetyProxy::ISNewText(const char *dev, const char *name, char *text
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, keywordTP.name) == 0)
+        if (keywordTP.isNameMatch(name))
         {
-            keywordTP.s = IPS_OK;
-            IUUpdateText(&keywordTP, texts, names, n);
+            keywordTP.setState(IPS_OK);
+            keywordTP.update(texts, names, n);
             // update client display
-            IDSetText(&keywordTP, nullptr);
+            keywordTP.apply();
             return true;
         }
-        if (strcmp(name, ScriptsTP.name) == 0)
+        if (ScriptsTP.isNameMatch(name))
         {
-            ScriptsTP.s = IPS_OK;
-            IUUpdateText(&ScriptsTP, texts, names, n);
+            ScriptsTP.setState(IPS_OK);
+            ScriptsTP.update(texts, names, n);
             // update client display
-            IDSetText(&ScriptsTP, nullptr);
+            ScriptsTP.apply();
             return true;
         }
-        if (strcmp(name, UrlTP.name) == 0)
+        if (UrlTP.isNameMatch(name))
         {
-            UrlTP.s = IPS_OK;
-            IUUpdateText(&UrlTP, texts, names, n);
+            UrlTP.setState(IPS_OK);
+            UrlTP.update(texts, names, n);
             // update client display
-            IDSetText(&UrlTP, nullptr);
+            UrlTP.apply();
             return true;
         }
     }
@@ -230,12 +230,12 @@ bool WeatherSafetyProxy::ISNewSwitch(const char *dev, const char *name, ISState 
 {
     if (!strcmp(getDeviceName(), dev))
     {
-        if (!strcmp(name, ScriptOrCurlSP.name))
+        if (ScriptOrCurlSP.isNameMatch(name))
         {
             LOG_DEBUG("WeatherSafetyProxy::ISNewSwitch");
-            IUUpdateSwitch(&ScriptOrCurlSP, states, names, n);
-            ScriptOrCurlSP.s = IPS_OK;
-            IDSetSwitch(&ScriptOrCurlSP, nullptr);
+            ScriptOrCurlSP.update(states, names, n);
+            ScriptOrCurlSP.setState(IPS_OK);
+            ScriptOrCurlSP.apply();
             return true;
         }
     }
@@ -243,11 +243,11 @@ bool WeatherSafetyProxy::ISNewSwitch(const char *dev, const char *name, ISState 
     return INDI::Weather::ISNewSwitch(dev, name, states, names, n);
 }
 
-// Called by Weather::TimerHit every UpdatePeriodN[0].value seconds if we return IPS_OK or every 5 seconds otherwise
+// Called by Weather::TimerHit every UpdatePeriodNP[0].value seconds if we return IPS_OK or every 5 seconds otherwise
 IPState WeatherSafetyProxy::updateWeather()
 {
     IPState ret = IPS_ALERT;
-    if (ScriptOrCurlS[WSP_USE_SCRIPT].s == ISS_ON)
+    if (ScriptOrCurlSP[WSP_USE_SCRIPT].getState() == ISS_ON)
     {
         ret = executeScript();
     }
@@ -261,15 +261,15 @@ IPState WeatherSafetyProxy::updateWeather()
         {
             SofterrorCount++;
             LOGF_WARN("Soft error %d occurred during SAFE conditions, counting", SofterrorCount);
-            if (SofterrorCount > softErrorHysteresisN[WSP_SOFT_ERROR_MAX].value)
+            if (SofterrorCount > softErrorHysteresisNP[WSP_SOFT_ERROR_MAX].getValue())
             {
                 char Warning[] = "Max softerrors reached while Weather was SAFE";
                 LOG_WARN(Warning);
                 Safety = WSP_UNSAFE;
                 setParameterValue("WEATHER_SAFETY", WSP_UNSAFE);
-                IUSaveText(&reasonsT[0], Warning);
-                reasonsTP.s = IPS_OK;
-                IDSetText(&reasonsTP, nullptr);
+                reasonsTP[0].setText(Warning);
+                reasonsTP.setState(IPS_OK);
+                reasonsTP.apply();
                 SofterrorRecoveryMode = true;
                 ret = IPS_OK; // So that indiweather actually syncs the CriticalParameters we just set
             }
@@ -290,7 +290,7 @@ IPState WeatherSafetyProxy::updateWeather()
 
 IPState WeatherSafetyProxy::executeScript()
 {
-    const char *cmd = ScriptsT[WSP_SCRIPT].text;
+    const char *cmd = ScriptsTP[WSP_SCRIPT].getText();
 
     if (access(cmd, F_OK|X_OK) == -1)
     {
@@ -331,11 +331,11 @@ IPState WeatherSafetyProxy::executeCurl()
     curl_handle = curl_easy_init();
     if (curl_handle)
     {
-        curl_easy_setopt(curl_handle, CURLOPT_URL, UrlT[WSP_URL].text);
+        curl_easy_setopt(curl_handle, CURLOPT_URL, UrlTP[WSP_URL].getText());
         curl_easy_setopt(curl_handle, CURLOPT_WRITEFUNCTION, WSP_WriteCallback);
         curl_easy_setopt(curl_handle, CURLOPT_WRITEDATA, &readBuffer);
         curl_easy_setopt(curl_handle, CURLOPT_USERAGENT, "libcurl-agent/1.0");
-        LOGF_DEBUG("Call curl %s", UrlT[WSP_URL].text);
+        LOGF_DEBUG("Call curl %s", UrlTP[WSP_URL].getText());
         res = curl_easy_perform(curl_handle);
         if (res != CURLE_OK)
         {
@@ -399,7 +399,7 @@ IPState WeatherSafetyProxy::parseSafetyJSON(const char *clean_buf, int byte_coun
                             if (SofterrorRecoveryMode == true)
                             {
                                 SofterrorRecoveryCount++;
-                                if (SofterrorRecoveryCount > softErrorHysteresisN[WSP_SOFT_ERROR_RECOVERY].value)
+                                if (SofterrorRecoveryCount > softErrorHysteresisNP[WSP_SOFT_ERROR_RECOVERY].getValue())
                                 {
                                     LOG_INFO("Minimum soft recovery errors reached while Weather was SAFE");
                                     SofterrorRecoveryCount = 0;
@@ -428,14 +428,14 @@ IPState WeatherSafetyProxy::parseSafetyJSON(const char *clean_buf, int byte_coun
                     {
                         char newReasons[MAXRBUF];
                         snprintf(newReasons, MAXRBUF, "SofterrorRecoveryMode, %s", reasons);
-                        IUSaveText(&reasonsT[0], newReasons);
+                        reasonsTP[0].setText(newReasons);
                     }
                     else
                     {
-                        IUSaveText(&reasonsT[0], reasons);
+                        reasonsTP[0].setText(reasons);
                     }
-                    reasonsTP.s = IPS_OK;
-                    IDSetText(&reasonsTP, nullptr);
+                    reasonsTP.setState(IPS_OK);
+                    reasonsTP.apply();
                 }
             }
         }

--- a/drivers/weather/weather_safety_proxy.h
+++ b/drivers/weather/weather_safety_proxy.h
@@ -26,6 +26,11 @@
 
 #include "indiweather.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 typedef enum
 {
     WSP_SCRIPT = 0,
@@ -86,23 +91,17 @@ class WeatherSafetyProxy : public INDI::Weather
     IPState executeCurl();
     IPState parseSafetyJSON(const char *buf, int byte_count);
 
-    IText keywordT[1] {};
-    ITextVectorProperty keywordTP;
+    INDI::PropertyText keywordTP {1};
 
-    IText ScriptsT[WSP_SCRIPT_COUNT] {};
-    ITextVectorProperty ScriptsTP;
+    INDI::PropertyText ScriptsTP {WSP_SCRIPT_COUNT};
 
-    IText UrlT[WSP_URL_COUNT] {};
-    ITextVectorProperty UrlTP;
+    INDI::PropertyText UrlTP {WSP_URL_COUNT};
 
-    ISwitch ScriptOrCurlS[WSP_USE_COUNT];
-    ISwitchVectorProperty ScriptOrCurlSP;
+    INDI::PropertySwitch ScriptOrCurlSP {WSP_USE_COUNT};
 
-    IText reasonsT[1] {};
-    ITextVectorProperty reasonsTP;
+    INDI::PropertyText reasonsTP {1};
 
-    INumber softErrorHysteresisN[WSP_SOFT_ERROR_COUNT];
-    INumberVectorProperty softErrorHysteresisNP;
+    INDI::PropertyNumber softErrorHysteresisNP {WSP_SOFT_ERROR_COUNT};
 
     int Safety = -1;
     int SofterrorCount = 0;

--- a/drivers/weather/weathermeta.cpp
+++ b/drivers/weather/weathermeta.cpp
@@ -94,23 +94,23 @@ bool WeatherMeta::initProperties()
     INDI::DefaultDevice::initProperties();
 
     // Active Devices
-    IUFillText(&ActiveDeviceT[0], "ACTIVE_WEATHER_1", "Station #1", nullptr);
-    IUFillText(&ActiveDeviceT[1], "ACTIVE_WEATHER_2", "Station #2", nullptr);
-    IUFillText(&ActiveDeviceT[2], "ACTIVE_WEATHER_3", "Station #3", nullptr);
-    IUFillText(&ActiveDeviceT[3], "ACTIVE_WEATHER_4", "Station #4", nullptr);
-    IUFillTextVector(&ActiveDeviceTP, ActiveDeviceT, 4, getDeviceName(), "ACTIVE_DEVICES", "Stations", OPTIONS_TAB,
+    ActiveDeviceTP[0].fill("ACTIVE_WEATHER_1", "Station #1", nullptr);
+    ActiveDeviceTP[1].fill("ACTIVE_WEATHER_2", "Station #2", nullptr);
+    ActiveDeviceTP[2].fill("ACTIVE_WEATHER_3", "Station #3", nullptr);
+    ActiveDeviceTP[3].fill("ACTIVE_WEATHER_4", "Station #4", nullptr);
+    ActiveDeviceTP.fill(getDeviceName(), "ACTIVE_DEVICES", "Stations", OPTIONS_TAB,
                      IP_RW, 60, IPS_IDLE);
 
     // Station Status
-    IUFillLight(&StationL[0], "STATION_STATUS_1", "Station #1", IPS_IDLE);
-    IUFillLight(&StationL[1], "STATION_STATUS_2", "Station #2", IPS_IDLE);
-    IUFillLight(&StationL[2], "STATION_STATUS_3", "Station #3", IPS_IDLE);
-    IUFillLight(&StationL[3], "STATION_STATUS_4", "Station #4", IPS_IDLE);
-    IUFillLightVector(&StationLP, StationL, 4, getDeviceName(), "WEATHER_STATUS", "Status", MAIN_CONTROL_TAB, IPS_IDLE);
+    StationLP[0].fill("STATION_STATUS_1", "Station #1", IPS_IDLE);
+    StationLP[1].fill("STATION_STATUS_2", "Station #2", IPS_IDLE);
+    StationLP[2].fill("STATION_STATUS_3", "Station #3", IPS_IDLE);
+    StationLP[3].fill("STATION_STATUS_4", "Station #4", IPS_IDLE);
+    StationLP.fill(getDeviceName(), "WEATHER_STATUS", "Status", MAIN_CONTROL_TAB, IPS_IDLE);
 
     // Update Period
-    IUFillNumber(&UpdatePeriodN[0], "PERIOD", "Period (secs)", "%4.2f", 0, 3600, 60, 60);
-    IUFillNumberVector(&UpdatePeriodNP, UpdatePeriodN, 1, getDeviceName(), "WEATHER_UPDATE", "Update", MAIN_CONTROL_TAB,
+    UpdatePeriodNP[0].fill("PERIOD", "Period (secs)", "%4.2f", 0, 3600, 60, 60);
+    UpdatePeriodNP.fill(getDeviceName(), "WEATHER_UPDATE", "Update", MAIN_CONTROL_TAB,
                        IP_RO, 60, IPS_IDLE);
 
     addDebugControl();
@@ -124,7 +124,7 @@ void WeatherMeta::ISGetProperties(const char *dev)
 {
     INDI::DefaultDevice::ISGetProperties(dev);
 
-    defineProperty(&ActiveDeviceTP);
+    defineProperty(ActiveDeviceTP);
 
     loadConfig(true, "ACTIVE_DEVICES");
 }
@@ -138,17 +138,17 @@ bool WeatherMeta::updateProperties()
         // If Active devices are already defined, let's set the active devices as labels
         for (int i = 0; i < 4; i++)
         {
-            if (ActiveDeviceT[i].text != nullptr && ActiveDeviceT[i].text[0] != 0)
-                strncpy(StationL[i].label, ActiveDeviceT[i].text, MAXINDILABEL);
+            if (ActiveDeviceTP[i].text != nullptr && ActiveDeviceTP[i].text[0] != 0)
+                StationLP[i].setLabel(ActiveDeviceTP[i].getText());
         }
 
-        defineProperty(&StationLP);
-        defineProperty(&UpdatePeriodNP);
+        defineProperty(StationLP);
+        defineProperty(UpdatePeriodNP);
     }
     else
     {
-        deleteProperty(StationLP.name);
-        deleteProperty(UpdatePeriodNP.name);
+        deleteProperty(StationLP.getName());
+        deleteProperty(UpdatePeriodNP.getName());
     }
     return true;
 }
@@ -157,32 +157,32 @@ bool WeatherMeta::ISNewText(const char *dev, const char *name, char *texts[], ch
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, ActiveDeviceTP.name) == 0)
+        if (ActiveDeviceTP.isNameMatch(name))
         {
-            ActiveDeviceTP.s = IPS_OK;
-            IUUpdateText(&ActiveDeviceTP, texts, names, n);
+            ActiveDeviceTP.setState(IPS_OK);
+            ActiveDeviceTP.update(texts, names, n);
             //  Update client display
-            IDSetText(&ActiveDeviceTP, nullptr);
+            ActiveDeviceTP.apply();
 
-            if (ActiveDeviceT[0].text != nullptr)
+            if (ActiveDeviceTP[0].text != nullptr)
             {
-                IDSnoopDevice(ActiveDeviceT[0].text, "WEATHER_STATUS");
-                IDSnoopDevice(ActiveDeviceT[0].text, "WEATHER_UPDATE");
+                IDSnoopDevice(ActiveDeviceTP[0].getText(), "WEATHER_STATUS");
+                IDSnoopDevice(ActiveDeviceTP[0].getText(), "WEATHER_UPDATE");
             }
-            if (ActiveDeviceT[1].text != nullptr)
+            if (ActiveDeviceTP[1].text != nullptr)
             {
-                IDSnoopDevice(ActiveDeviceT[1].text, "WEATHER_STATUS");
-                IDSnoopDevice(ActiveDeviceT[1].text, "WEATHER_UPDATE");
+                IDSnoopDevice(ActiveDeviceTP[1].getText(), "WEATHER_STATUS");
+                IDSnoopDevice(ActiveDeviceTP[1].getText(), "WEATHER_UPDATE");
             }
-            if (ActiveDeviceT[2].text != nullptr)
+            if (ActiveDeviceTP[2].text != nullptr)
             {
-                IDSnoopDevice(ActiveDeviceT[2].text, "WEATHER_STATUS");
-                IDSnoopDevice(ActiveDeviceT[2].text, "WEATHER_UPDATE");
+                IDSnoopDevice(ActiveDeviceTP[2].getText(), "WEATHER_STATUS");
+                IDSnoopDevice(ActiveDeviceTP[2].getText(), "WEATHER_UPDATE");
             }
-            if (ActiveDeviceT[3].text != nullptr)
+            if (ActiveDeviceTP[3].text != nullptr)
             {
-                IDSnoopDevice(ActiveDeviceT[3].text, "WEATHER_STATUS");
-                IDSnoopDevice(ActiveDeviceT[3].text, "WEATHER_UPDATE");
+                IDSnoopDevice(ActiveDeviceTP[3].getText(), "WEATHER_STATUS");
+                IDSnoopDevice(ActiveDeviceTP[3].getText(), "WEATHER_UPDATE");
             }
 
             return true;
@@ -196,8 +196,8 @@ bool WeatherMeta::saveConfigItems(FILE *fp)
 {
     INDI::DefaultDevice::saveConfigItems(fp);
 
-    IUSaveConfigText(fp, &ActiveDeviceTP);
-    IUSaveConfigNumber(fp, &UpdatePeriodNP);
+    ActiveDeviceTP.save(fp);
+    UpdatePeriodNP.save(fp);
 
     return true;
 }
@@ -213,14 +213,14 @@ bool WeatherMeta::ISSnoopDevice(XMLEle *root)
         {
             for (int i = 0; i < 4; i++)
             {
-                if (ActiveDeviceT[i].text != nullptr && strcmp(ActiveDeviceT[i].text, deviceName) == 0)
+                if (ActiveDeviceTP[i].text != nullptr && strcmp(ActiveDeviceTP[i].getText(), deviceName) == 0)
                 {
                     IPState stationState;
 
                     if (crackIPState(findXMLAttValu(root, "state"), &stationState) < 0)
                         break;
 
-                    StationL[i].s = stationState;
+                    StationLP[i].setState(stationState);
 
                     updateOverallState();
 
@@ -237,7 +237,7 @@ bool WeatherMeta::ISSnoopDevice(XMLEle *root)
 
             for (int i = 0; i < 4; i++)
             {
-                if (ActiveDeviceT[i].text != nullptr && strcmp(ActiveDeviceT[i].text, deviceName) == 0)
+                if (ActiveDeviceTP[i].text != nullptr && strcmp(ActiveDeviceTP[i].getText(), deviceName) == 0)
                 {
                     updatePeriods[i] = atof(pcdataXMLEle(ep));
 
@@ -253,20 +253,20 @@ bool WeatherMeta::ISSnoopDevice(XMLEle *root)
 
 void WeatherMeta::updateOverallState()
 {
-    StationLP.s = IPS_IDLE;
+    StationLP.setState(IPS_IDLE);
 
     for (int i = 0; i < 4; i++)
     {
-        if (StationL[i].s > StationLP.s)
-            StationLP.s = StationL[i].s;
+        if (StationLP[i].getState() > StationLP.getState())
+            StationLP.setState(StationLP[i].getState());
     }
 
-    IDSetLight(&StationLP, nullptr);
+    StationLP.apply();
 }
 
 void WeatherMeta::updateUpdatePeriod()
 {
-    double minPeriod = UpdatePeriodN[0].max;
+    double minPeriod = UpdatePeriodNP[0].getMax();
 
     for (int i = 0; i < 4; i++)
     {
@@ -274,9 +274,9 @@ void WeatherMeta::updateUpdatePeriod()
             minPeriod = updatePeriods[i];
     }
 
-    if (minPeriod != UpdatePeriodN[0].max)
+    if (minPeriod != UpdatePeriodNP[0].max)
     {
-        UpdatePeriodN[0].value = minPeriod;
-        IDSetNumber(&UpdatePeriodNP, nullptr);
+        UpdatePeriodNP[0].setValue(minPeriod);
+        UpdatePeriodNP.apply();
     }
 }

--- a/drivers/weather/weathermeta.h
+++ b/drivers/weather/weathermeta.h
@@ -27,6 +27,11 @@
 
 #include "defaultdevice.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertylight.h"
+
 class WeatherMeta : public INDI::DefaultDevice
 {
   public:
@@ -53,16 +58,13 @@ class WeatherMeta : public INDI::DefaultDevice
     void updateUpdatePeriod();
 
     // Active stations
-    IText ActiveDeviceT[4] {};
-    ITextVectorProperty ActiveDeviceTP;
+    INDI::PropertyText ActiveDeviceTP {4};
 
     // Stations status
-    ILight StationL[4];
-    ILightVectorProperty StationLP;
+    INDI::PropertyLight StationLP {4};
 
     // Update Period
-    INumber UpdatePeriodN[1];
-    INumberVectorProperty UpdatePeriodNP;
+    INDI::PropertyNumber UpdatePeriodNP {1};
 
     double updatePeriods[4];
 };

--- a/drivers/weather/weathersimulator.cpp
+++ b/drivers/weather/weathersimulator.cpp
@@ -93,12 +93,12 @@ bool WeatherSimulator::initProperties()
 {
     INDI::Weather::initProperties();
 
-    IUFillNumber(&ControlWeatherN[CONTROL_WEATHER], "Weather", "Weather", "%.f", 0, 1, 1, 0);
-    IUFillNumber(&ControlWeatherN[CONTROL_TEMPERATURE], "Temperature", "Temperature", "%.2f", -50, 70, 10, 15);
-    IUFillNumber(&ControlWeatherN[CONTROL_WIND], "Wind", "Wind", "%.2f", 0, 100, 5, 0);
-    IUFillNumber(&ControlWeatherN[CONTROL_GUST], "Gust", "Gust", "%.2f", 0, 50, 5, 0);
-    IUFillNumber(&ControlWeatherN[CONTROL_RAIN], "Precip", "Precip", "%.f", 0, 100, 10, 0);
-    IUFillNumberVector(&ControlWeatherNP, ControlWeatherN, 5, getDeviceName(), "WEATHER_CONTROL", "Control", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
+    ControlWeatherNP[CONTROL_WEATHER].fill("Weather", "Weather", "%.f", 0, 1, 1, 0);
+    ControlWeatherNP[CONTROL_TEMPERATURE].fill("Temperature", "Temperature", "%.2f", -50, 70, 10, 15);
+    ControlWeatherNP[CONTROL_WIND].fill("Wind", "Wind", "%.2f", 0, 100, 5, 0);
+    ControlWeatherNP[CONTROL_GUST].fill("Gust", "Gust", "%.2f", 0, 50, 5, 0);
+    ControlWeatherNP[CONTROL_RAIN].fill("Precip", "Precip", "%.f", 0, 100, 10, 0);
+    ControlWeatherNP.fill(getDeviceName(), "WEATHER_CONTROL", "Control", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
     addParameter("WEATHER_FORECAST", "Weather", 0, 0, 15);
     addParameter("WEATHER_TEMPERATURE", "Temperature (C)", -10, 30, 15);
@@ -121,20 +121,20 @@ bool WeatherSimulator::updateProperties()
     INDI::Weather::updateProperties();
 
     if (isConnected())
-        defineProperty(&ControlWeatherNP);
+        defineProperty(ControlWeatherNP);
     else
-        deleteProperty(ControlWeatherNP.name);
+        deleteProperty(ControlWeatherNP.getName());
 
     return true;
 }
 
 IPState WeatherSimulator::updateWeather()
 {
-    setParameterValue("WEATHER_FORECAST", ControlWeatherN[CONTROL_WEATHER].value);
-    setParameterValue("WEATHER_TEMPERATURE", ControlWeatherN[CONTROL_TEMPERATURE].value);
-    setParameterValue("WEATHER_WIND_SPEED", ControlWeatherN[CONTROL_WIND].value);
-    setParameterValue("WEATHER_WIND_GUST", ControlWeatherN[CONTROL_GUST].value);
-    setParameterValue("WEATHER_RAIN_HOUR", ControlWeatherN[CONTROL_RAIN].value);
+    setParameterValue("WEATHER_FORECAST", ControlWeatherNP[CONTROL_WEATHER].getValue());
+    setParameterValue("WEATHER_TEMPERATURE", ControlWeatherNP[CONTROL_TEMPERATURE].getValue());
+    setParameterValue("WEATHER_WIND_SPEED", ControlWeatherNP[CONTROL_WIND].getValue());
+    setParameterValue("WEATHER_WIND_GUST", ControlWeatherNP[CONTROL_GUST].getValue());
+    setParameterValue("WEATHER_RAIN_HOUR", ControlWeatherNP[CONTROL_RAIN].getValue());
 
     return IPS_OK;
 }
@@ -143,11 +143,11 @@ bool WeatherSimulator::ISNewNumber(const char *dev, const char *name, double val
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, ControlWeatherNP.name))
+        if (ControlWeatherNP.isNameMatch(name))
         {
-            IUUpdateNumber(&ControlWeatherNP, values, names, n);
-            ControlWeatherNP.s = IPS_OK;
-            IDSetNumber(&ControlWeatherNP, nullptr);
+            ControlWeatherNP.update(values, names, n);
+            ControlWeatherNP.setState(IPS_OK);
+            ControlWeatherNP.apply();
             LOG_INFO("Values are updated and should be active on the next weather update.");
             return true;
         }
@@ -160,7 +160,7 @@ bool WeatherSimulator::saveConfigItems(FILE *fp)
 {
     INDI::Weather::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &ControlWeatherNP);
+    ControlWeatherNP.save(fp);
 
     return true;
 }

--- a/drivers/weather/weathersimulator.h
+++ b/drivers/weather/weathersimulator.h
@@ -26,6 +26,9 @@
 
 #include "indiweather.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 class WeatherSimulator : public INDI::Weather
 {
   public:
@@ -45,8 +48,7 @@ class WeatherSimulator : public INDI::Weather
     virtual bool saveConfigItems(FILE *fp) override;
 
   private:
-    INumber ControlWeatherN[5];
-    INumberVectorProperty ControlWeatherNP;
+    INDI::PropertyNumber ControlWeatherNP {5};
     enum
     {
         CONTROL_WEATHER,

--- a/drivers/weather/weatherwatcher.cpp
+++ b/drivers/weather/weatherwatcher.cpp
@@ -90,7 +90,7 @@ const char *WeatherWatcher::getDefaultName()
 
 bool WeatherWatcher::Connect()
 {
-    if (watchFileT[0].text == nullptr || watchFileT[0].text[0] == '\0')
+    if (watchFileTP[0].text == nullptr || watchFileTP[0].text[0] == '\0')
     {
         LOG_ERROR("Watch file must be specified first in options.");
         return false;
@@ -116,7 +116,7 @@ bool WeatherWatcher::createPropertiesFromMap()
     double minOK = 0, maxOK = 0, percWarn = 15;
     for (auto const &x : weatherMap)
     {
-        if (x.first == keywordT[0].text)
+        if (x.first == keywordTP[0].getText())
         {
             minOK = 0;
             maxOK = 0;
@@ -128,7 +128,7 @@ bool WeatherWatcher::createPropertiesFromMap()
             addParameter("WEATHER_RAIN_HOUR", "Rain (mm)", minOK, maxOK, percWarn);
             setCriticalParameter("WEATHER_RAIN_HOUR");
         }
-        else if (x.first == keywordT[1].text)
+        else if (x.first == keywordTP[1].getText())
         {
             minOK = -10;
             maxOK = 30;
@@ -140,7 +140,7 @@ bool WeatherWatcher::createPropertiesFromMap()
             addParameter("WEATHER_TEMPERATURE", "Temperature (C)", minOK, maxOK, percWarn);
             setCriticalParameter("WEATHER_TEMPERATURE");
         }
-        else if (x.first == keywordT[2].text)
+        else if (x.first == keywordTP[2].getText())
         {
             minOK = 0;
             maxOK = 20;
@@ -152,7 +152,7 @@ bool WeatherWatcher::createPropertiesFromMap()
             addParameter("WEATHER_WIND_SPEED", "Wind (kph)", minOK, maxOK, percWarn);
             setCriticalParameter("WEATHER_WIND_SPEED");
         }
-        else if (x.first == keywordT[3].text)
+        else if (x.first == keywordTP[3].getText())
         {
             minOK = 0;
             maxOK = 20;
@@ -163,7 +163,7 @@ bool WeatherWatcher::createPropertiesFromMap()
 
             addParameter("WEATHER_WIND_GUST", "Gust (kph)", minOK, maxOK, percWarn);
         }
-        else if (x.first == keywordT[4].text)
+        else if (x.first == keywordTP[4].getText())
         {
             minOK = 0;
             maxOK = 20;
@@ -175,7 +175,7 @@ bool WeatherWatcher::createPropertiesFromMap()
             addParameter("WEATHER_CLOUDS", "Clouds (%)", minOK, maxOK, percWarn);
             setCriticalParameter("WEATHER_CLOUDS");
         }
-        else if (x.first == keywordT[5].text)
+        else if (x.first == keywordTP[5].getText())
         {
             minOK = 0;
             maxOK = 100;
@@ -187,7 +187,7 @@ bool WeatherWatcher::createPropertiesFromMap()
             addParameter("WEATHER_HUMIDITY", "Humidity (%)", minOK, maxOK, percWarn);
             setCriticalParameter("WEATHER_HUMIDITY");
         }
-        else if (x.first == keywordT[6].text)
+        else if (x.first == keywordTP[6].getText())
         {
             minOK = 983;
             maxOK = 1043;
@@ -199,7 +199,7 @@ bool WeatherWatcher::createPropertiesFromMap()
             addParameter("WEATHER_PRESSURE", "Pressure (hPa)", minOK, maxOK, percWarn);
             setCriticalParameter("WEATHER_PRESSURE");
         }
-        else if (x.first == keywordT[7].text)
+        else if (x.first == keywordTP[7].getText())
         {
             minOK = 0;
             maxOK = 0;
@@ -222,23 +222,23 @@ bool WeatherWatcher::initProperties()
 {
     INDI::Weather::initProperties();
 
-    IUFillText(&keywordT[0], "RAIN", "Rain", "precip");
-    IUFillText(&keywordT[1], "TEMP", "Temperature", "temperature");
-    IUFillText(&keywordT[2], "WIND", "Wind", "wind");
-    IUFillText(&keywordT[3], "GUST", "Gust", "gust");
-    IUFillText(&keywordT[4], "CLOUDS", "Clouds", "clouds");
-    IUFillText(&keywordT[5], "HUMIDITY", "Humidity", "humidity");
-    IUFillText(&keywordT[6], "PRESSURE", "Pressure", "pressure");
-    IUFillText(&keywordT[7], "FORECAST", "Forecast", "forecast");
-    IUFillTextVector(&keywordTP, keywordT, 8, getDeviceName(), "KEYWORD", "Keywords", OPTIONS_TAB, IP_RW,
+    keywordTP[0].fill("RAIN", "Rain", "precip");
+    keywordTP[1].fill("TEMP", "Temperature", "temperature");
+    keywordTP[2].fill("WIND", "Wind", "wind");
+    keywordTP[3].fill("GUST", "Gust", "gust");
+    keywordTP[4].fill("CLOUDS", "Clouds", "clouds");
+    keywordTP[5].fill("HUMIDITY", "Humidity", "humidity");
+    keywordTP[6].fill("PRESSURE", "Pressure", "pressure");
+    keywordTP[7].fill("FORECAST", "Forecast", "forecast");
+    keywordTP.fill(getDeviceName(), "KEYWORD", "Keywords", OPTIONS_TAB, IP_RW,
                      60, IPS_IDLE);
 
-    IUFillText(&watchFileT[0], "URL", "File", nullptr);
-    IUFillTextVector(&watchFileTP, watchFileT, 1, getDeviceName(), "WATCH_SOURCE", "Source", OPTIONS_TAB, IP_RW,
+    watchFileTP[0].fill("URL", "File", nullptr);
+    watchFileTP.fill(getDeviceName(), "WATCH_SOURCE", "Source", OPTIONS_TAB, IP_RW,
                      60, IPS_IDLE);
 
-    IUFillText(&separatorT[0], "SEPARATOR", "Separator", "=");
-    IUFillTextVector(&separatorTP, separatorT, 1, getDeviceName(), "SEPARATOR_KEYWORD", "Separator", OPTIONS_TAB, IP_RW,
+    separatorTP[0].fill("SEPARATOR", "Separator", "=");
+    separatorTP.fill(getDeviceName(), "SEPARATOR_KEYWORD", "Separator", OPTIONS_TAB, IP_RW,
                      60, IPS_IDLE);
 
     addDebugControl();
@@ -250,13 +250,13 @@ void WeatherWatcher::ISGetProperties(const char *dev)
 {
     INDI::Weather::ISGetProperties(dev);
 
-    defineProperty(&watchFileTP);
+    defineProperty(watchFileTP);
     loadConfig(true, "WATCH_SOURCE");
 
-    defineProperty(&keywordTP);
+    defineProperty(keywordTP);
     loadConfig(true, "KEYWORD");
 
-    defineProperty(&separatorTP);
+    defineProperty(separatorTP);
     loadConfig(true, "SEPARATOR_KEYWORD");
 
 }
@@ -265,26 +265,26 @@ bool WeatherWatcher::ISNewText(const char *dev, const char *name, char *texts[],
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(watchFileTP.name, name))
+        if (watchFileTP.isNameMatch(name))
         {
-            IUUpdateText(&watchFileTP, texts, names, n);
-            watchFileTP.s = IPS_OK;
-            IDSetText(&watchFileTP, nullptr);
+            watchFileTP.update(texts, names, n);
+            watchFileTP.setState(IPS_OK);
+            watchFileTP.apply();
             return true;
         }
-        if (!strcmp(keywordTP.name, name))
+        if (keywordTP.isNameMatch(name))
         {
-            IUUpdateText(&keywordTP, texts, names, n);
-            keywordTP.s = IPS_OK;
-            IDSetText(&keywordTP, nullptr);
+            keywordTP.update(texts, names, n);
+            keywordTP.setState(IPS_OK);
+            keywordTP.apply();
             return true;
         }
 
-        if (!strcmp(separatorTP.name, name))
+        if (separatorTP.isNameMatch(name))
         {
-            IUUpdateText(&separatorTP, texts, names, n);
-            separatorTP.s = IPS_OK;
-            IDSetText(&separatorTP, nullptr);
+            separatorTP.update(texts, names, n);
+            separatorTP.setState(IPS_OK);
+            separatorTP.apply();
             return true;
         }
     }
@@ -300,35 +300,35 @@ IPState WeatherWatcher::updateWeather()
 
     for (auto const &x : weatherMap)
     {
-        if (x.first == keywordT[0].text)
+        if (x.first == keywordTP[0].getText())
         {
             setParameterValue("WEATHER_RAIN_HOUR", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordT[1].text)
+        else if (x.first == keywordTP[1].getText())
         {
             setParameterValue("WEATHER_TEMPERATURE", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordT[2].text)
+        else if (x.first == keywordTP[2].getText())
         {
             setParameterValue("WEATHER_WIND_SPEED", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordT[3].text)
+        else if (x.first == keywordTP[3].getText())
         {
             setParameterValue("WEATHER_WIND_GUST", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordT[4].text)
+        else if (x.first == keywordTP[4].getText())
         {
             setParameterValue("WEATHER_CLOUDS", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordT[5].text)
+        else if (x.first == keywordTP[5].getText())
         {
             setParameterValue("WEATHER_HUMIDITY", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordT[6].text)
+        else if (x.first == keywordTP[6].getText())
         {
             setParameterValue("WEATHER_PRESSURE", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordT[7].text)
+        else if (x.first == keywordTP[7].getText())
         {
             setParameterValue("WEATHER_FORECAST", std::strtod(x.second.c_str(), nullptr));
         }
@@ -346,10 +346,10 @@ bool WeatherWatcher::readWatchFile()
 
     AutoCNumeric locale;
 
-    if (std::string(watchFileT[0].text).find("http") == 0)
-        snprintf(requestURL, MAXRBUF, "%s", watchFileT[0].text);
+    if (std::string(watchFileTP[0].getText()).find("http") == 0)
+        snprintf(requestURL, MAXRBUF, "%s", watchFileTP[0].getText());
     else
-        snprintf(requestURL, MAXRBUF, "file://%s", watchFileT[0].text);
+        snprintf(requestURL, MAXRBUF, "file://%s", watchFileTP[0].getText());
 
     curl = curl_easy_init();
 
@@ -375,9 +375,9 @@ bool WeatherWatcher::saveConfigItems(FILE *fp)
 {
     INDI::Weather::saveConfigItems(fp);
 
-    IUSaveConfigText(fp, &watchFileTP);
-    IUSaveConfigText(fp, &keywordTP);
-    IUSaveConfigText(fp, &separatorTP);
+    watchFileTP.save(fp);
+    keywordTP.save(fp);
+    separatorTP.save(fp);
 
     return true;
 }
@@ -389,7 +389,7 @@ std::map<std::string, std::string> WeatherWatcher::createMap(std::string const &
     std::string key, val;
     std::istringstream iss(s);
 
-    while(std::getline(std::getline(iss, key, separatorT[0].text[0]) >> std::ws, val))
+    while(std::getline(std::getline(iss, key, separatorTP[0].text[0]) >> std::ws, val))
         m[key] = val;
 
     return m;

--- a/drivers/weather/weatherwatcher.h
+++ b/drivers/weather/weatherwatcher.h
@@ -28,6 +28,9 @@
 
 #include <map>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+
 class WeatherWatcher : public INDI::Weather
 {
   public:
@@ -46,19 +49,16 @@ class WeatherWatcher : public INDI::Weather
     virtual IPState updateWeather() override;
     virtual bool saveConfigItems(FILE *fp) override;
 
-    IText keywordT[8] {};
-    ITextVectorProperty keywordTP;
+    INDI::PropertyText keywordTP {8};
 
-    IText separatorT[1] {};
-    ITextVectorProperty separatorTP;
+    INDI::PropertyText separatorTP {1};
 
   private:
     std::map<std::string, std::string> createMap(std::string const& s);
     bool readWatchFile();
     bool createPropertiesFromMap();
 
-    IText watchFileT[1] {};
-    ITextVectorProperty watchFileTP;
+    INDI::PropertyText watchFileTP {1};
 
     bool initialParse { false };
     std::string readBuffer;

--- a/examples/tutorial_eight/simple_spectrograph.cpp
+++ b/examples/tutorial_eight/simple_spectrograph.cpp
@@ -25,7 +25,7 @@
 #include <memory>
 
 /* Macro shortcut to Spectrograph temperature value */
-#define currentSpectrographTemperature TemperatureN[0].value
+#define currentSpectrographTemperature TemperatureNP[0].value
 
 std::unique_ptr<SimpleSpectrograph> simpleSpectrograph(new SimpleSpectrograph());
 
@@ -219,7 +219,7 @@ void SimpleSpectrograph::TimerHit()
     }
 
     // TemperatureNP is defined in INDI::Spectrograph
-    switch (TemperatureNP.s)
+    switch (TemperatureNP.getState())
     {
         case IPS_IDLE:
         case IPS_OK:
@@ -235,13 +235,13 @@ void SimpleSpectrograph::TimerHit()
             /* If they're equal, stop updating */
             else
             {
-                TemperatureNP.s = IPS_OK;
-                IDSetNumber(&TemperatureNP, "Target temperature reached.");
+                TemperatureNP.setState(IPS_OK);
+                TemperatureNP.apply("Target temperature reached.");
 
                 break;
             }
 
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP.apply();
 
             break;
 

--- a/examples/tutorial_three/simpleccd.cpp
+++ b/examples/tutorial_three/simpleccd.cpp
@@ -25,7 +25,7 @@
 #include <memory>
 
 /* Macro shortcut to CCD temperature value */
-#define currentCCDTemperature TemperatureN[0].value
+#define currentCCDTemperature TemperatureNP[0].value
 
 std::unique_ptr<SimpleCCD> simpleCCD(new SimpleCCD());
 
@@ -206,7 +206,7 @@ void SimpleCCD::TimerHit()
     }
 
     // TemperatureNP is defined in INDI::CCD
-    switch (TemperatureNP.s)
+    switch (TemperatureNP.getState())
     {
         case IPS_IDLE:
         case IPS_OK:
@@ -222,13 +222,13 @@ void SimpleCCD::TimerHit()
             /* If they're equal, stop updating */
             else
             {
-                TemperatureNP.s = IPS_OK;
-                IDSetNumber(&TemperatureNP, "Target temperature reached.");
+                TemperatureNP.setState(IPS_OK);
+                TemperatureNP.apply("Target temperature reached.");
 
                 break;
             }
 
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP.apply();
 
             break;
 

--- a/libs/indibase/connectionplugins/connectionserial.h
+++ b/libs/indibase/connectionplugins/connectionserial.h
@@ -24,6 +24,9 @@
 
 #include <string>
 
+/* Smart Widget-Property */
+#include "indipropertyswitch.h"
+
 namespace Connection
 {
 /**
@@ -134,17 +137,14 @@ protected:
     ITextVectorProperty PortTP;
     IText PortT[1] {};
 
-    ISwitch BaudRateS[6];
-    ISwitchVectorProperty BaudRateSP;
+    INDI::PropertySwitch BaudRateSP {6};
 
-    ISwitch AutoSearchS[2];
-    ISwitchVectorProperty AutoSearchSP;
+    INDI::PropertySwitch AutoSearchSP {2};
 
     ISwitch *SystemPortS = nullptr;
     ISwitchVectorProperty SystemPortSP;
 
-    ISwitch RefreshS[1];
-    ISwitchVectorProperty RefreshSP;
+    INDI::PropertySwitch RefreshSP {1};
 
     int PortFD = -1;
 

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -129,8 +129,8 @@ bool CCD::initProperties()
     DefaultDevice::initProperties(); //  let the base class flesh in what it wants
 
     // CCD Temperature
-    IUFillNumber(&TemperatureN[0], "CCD_TEMPERATURE_VALUE", "Temperature (C)", "%5.2f", -50.0, 50.0, 0., 0.);
-    IUFillNumberVector(&TemperatureNP, TemperatureN, 1, getDeviceName(), "CCD_TEMPERATURE", "Temperature",
+    TemperatureNP[0].fill("CCD_TEMPERATURE_VALUE", "Temperature (C)", "%5.2f", -50.0, 50.0, 0., 0.);
+    TemperatureNP.fill(getDeviceName(), "CCD_TEMPERATURE", "Temperature",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     /**********************************************/
@@ -138,49 +138,49 @@ bool CCD::initProperties()
     /**********************************************/
 
     // Primary CCD Region-Of-Interest (ROI)
-    IUFillNumber(&PrimaryCCD.ImageFrameN[CCDChip::FRAME_X], "X", "Left ", "%4.0f", 0, 0.0, 0, 0);
-    IUFillNumber(&PrimaryCCD.ImageFrameN[CCDChip::FRAME_Y], "Y", "Top", "%4.0f", 0, 0, 0, 0);
-    IUFillNumber(&PrimaryCCD.ImageFrameN[CCDChip::FRAME_W], "WIDTH", "Width", "%4.0f", 0, 0.0, 0, 0.0);
-    IUFillNumber(&PrimaryCCD.ImageFrameN[CCDChip::FRAME_H], "HEIGHT", "Height", "%4.0f", 0, 0, 0, 0.0);
-    IUFillNumberVector(&PrimaryCCD.ImageFrameNP, PrimaryCCD.ImageFrameN, 4, getDeviceName(), "CCD_FRAME", "Frame",
+    IUFillNumber(&PrimaryCCD.ImageFrameNP[CCDChip::FRAME_X], "X", "Left ", "%4.0f", 0, 0.0, 0, 0);
+    IUFillNumber(&PrimaryCCD.ImageFrameNP[CCDChip::FRAME_Y], "Y", "Top", "%4.0f", 0, 0, 0, 0);
+    IUFillNumber(&PrimaryCCD.ImageFrameNP[CCDChip::FRAME_W], "WIDTH", "Width", "%4.0f", 0, 0.0, 0, 0.0);
+    IUFillNumber(&PrimaryCCD.ImageFrameNP[CCDChip::FRAME_H], "HEIGHT", "Height", "%4.0f", 0, 0, 0, 0.0);
+    PrimaryCCD.ImageFrameNP.fill(getDeviceName(), "CCD_FRAME", "Frame",
                        IMAGE_SETTINGS_TAB, IP_RW, 60, IPS_IDLE);
 
     // Primary CCD Frame Type
-    IUFillSwitch(&PrimaryCCD.FrameTypeS[CCDChip::LIGHT_FRAME], "FRAME_LIGHT", "Light", ISS_ON);
-    IUFillSwitch(&PrimaryCCD.FrameTypeS[CCDChip::BIAS_FRAME], "FRAME_BIAS", "Bias", ISS_OFF);
-    IUFillSwitch(&PrimaryCCD.FrameTypeS[CCDChip::DARK_FRAME], "FRAME_DARK", "Dark", ISS_OFF);
-    IUFillSwitch(&PrimaryCCD.FrameTypeS[CCDChip::FLAT_FRAME], "FRAME_FLAT", "Flat", ISS_OFF);
-    IUFillSwitchVector(&PrimaryCCD.FrameTypeSP, PrimaryCCD.FrameTypeS, 4, getDeviceName(), "CCD_FRAME_TYPE",
+    IUFillSwitch(&PrimaryCCD.FrameTypeSP[CCDChip::LIGHT_FRAME], "FRAME_LIGHT", "Light", ISS_ON);
+    IUFillSwitch(&PrimaryCCD.FrameTypeSP[CCDChip::BIAS_FRAME], "FRAME_BIAS", "Bias", ISS_OFF);
+    IUFillSwitch(&PrimaryCCD.FrameTypeSP[CCDChip::DARK_FRAME], "FRAME_DARK", "Dark", ISS_OFF);
+    IUFillSwitch(&PrimaryCCD.FrameTypeSP[CCDChip::FLAT_FRAME], "FRAME_FLAT", "Flat", ISS_OFF);
+    PrimaryCCD.FrameTypeSP.fill(getDeviceName(), "CCD_FRAME_TYPE",
                        "Frame Type", IMAGE_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Primary CCD Exposure
-    IUFillNumber(&PrimaryCCD.ImageExposureN[0], "CCD_EXPOSURE_VALUE", "Duration (s)", "%5.2f", 0.01, 3600, 1.0, 1.0);
-    IUFillNumberVector(&PrimaryCCD.ImageExposureNP, PrimaryCCD.ImageExposureN, 1, getDeviceName(), "CCD_EXPOSURE",
+    IUFillNumber(&PrimaryCCD.ImageExposureNP[0], "CCD_EXPOSURE_VALUE", "Duration (s)", "%5.2f", 0.01, 3600, 1.0, 1.0);
+    PrimaryCCD.ImageExposureNP.fill(getDeviceName(), "CCD_EXPOSURE",
                        "Expose", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     // Primary CCD Abort
-    IUFillSwitch(&PrimaryCCD.AbortExposureS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&PrimaryCCD.AbortExposureSP, PrimaryCCD.AbortExposureS, 1, getDeviceName(), "CCD_ABORT_EXPOSURE",
+    IUFillSwitch(&PrimaryCCD.AbortExposureSP[0], "ABORT", "Abort", ISS_OFF);
+    PrimaryCCD.AbortExposureSP.fill(getDeviceName(), "CCD_ABORT_EXPOSURE",
                        "Expose Abort", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Primary CCD Binning
-    IUFillNumber(&PrimaryCCD.ImageBinN[0], "HOR_BIN", "X", "%2.0f", 1, 4, 1, 1);
-    IUFillNumber(&PrimaryCCD.ImageBinN[1], "VER_BIN", "Y", "%2.0f", 1, 4, 1, 1);
-    IUFillNumberVector(&PrimaryCCD.ImageBinNP, PrimaryCCD.ImageBinN, 2, getDeviceName(), "CCD_BINNING", "Binning",
+    IUFillNumber(&PrimaryCCD.ImageBinNP[0], "HOR_BIN", "X", "%2.0f", 1, 4, 1, 1);
+    IUFillNumber(&PrimaryCCD.ImageBinNP[1], "VER_BIN", "Y", "%2.0f", 1, 4, 1, 1);
+    PrimaryCCD.ImageBinNP.fill(getDeviceName(), "CCD_BINNING", "Binning",
                        IMAGE_SETTINGS_TAB, IP_RW, 60, IPS_IDLE);
 
     // Primary CCD Info
-    IUFillNumber(&PrimaryCCD.ImagePixelSizeN[CCDChip::CCD_MAX_X], "CCD_MAX_X", "Max. Width", "%.f", 1, 16000, 0, 0);
-    IUFillNumber(&PrimaryCCD.ImagePixelSizeN[CCDChip::CCD_MAX_Y], "CCD_MAX_Y", "Max. Height", "%.f", 1, 16000, 0, 0);
-    IUFillNumber(&PrimaryCCD.ImagePixelSizeN[CCDChip::CCD_PIXEL_SIZE], "CCD_PIXEL_SIZE", "Pixel size (um)", "%.2f", 1,
+    IUFillNumber(&PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_X], "CCD_MAX_X", "Max. Width", "%.f", 1, 16000, 0, 0);
+    IUFillNumber(&PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_Y], "CCD_MAX_Y", "Max. Height", "%.f", 1, 16000, 0, 0);
+    IUFillNumber(&PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE], "CCD_PIXEL_SIZE", "Pixel size (um)", "%.2f", 1,
                  40, 0, 0);
-    IUFillNumber(&PrimaryCCD.ImagePixelSizeN[CCDChip::CCD_PIXEL_SIZE_X], "CCD_PIXEL_SIZE_X", "Pixel size X", "%.2f", 1,
+    IUFillNumber(&PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_X], "CCD_PIXEL_SIZE_X", "Pixel size X", "%.2f", 1,
                  40, 0, 0);
-    IUFillNumber(&PrimaryCCD.ImagePixelSizeN[CCDChip::CCD_PIXEL_SIZE_Y], "CCD_PIXEL_SIZE_Y", "Pixel size Y", "%.2f", 1,
+    IUFillNumber(&PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_Y], "CCD_PIXEL_SIZE_Y", "Pixel size Y", "%.2f", 1,
                  40, 0, 0);
-    IUFillNumber(&PrimaryCCD.ImagePixelSizeN[CCDChip::CCD_BITSPERPIXEL], "CCD_BITSPERPIXEL", "Bits per pixel", "%.f",
+    IUFillNumber(&PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_BITSPERPIXEL], "CCD_BITSPERPIXEL", "Bits per pixel", "%.f",
                  8, 64, 0, 0);
-    IUFillNumberVector(&PrimaryCCD.ImagePixelSizeNP, PrimaryCCD.ImagePixelSizeN, 6, getDeviceName(), "CCD_INFO",
+    PrimaryCCD.ImagePixelSizeNP.fill(getDeviceName(), "CCD_INFO",
                        "CCD Information", IMAGE_INFO_TAB, IP_RO, 60, IPS_IDLE);
 
     // Primary CCD Compression Options
@@ -196,36 +196,36 @@ bool CCD::initProperties()
                      IP_RO, 60, IPS_IDLE);
 
     // Bayer
-    IUFillText(&BayerT[0], "CFA_OFFSET_X", "X Offset", "0");
-    IUFillText(&BayerT[1], "CFA_OFFSET_Y", "Y Offset", "0");
-    IUFillText(&BayerT[2], "CFA_TYPE", "Filter", nullptr);
-    IUFillTextVector(&BayerTP, BayerT, 3, getDeviceName(), "CCD_CFA", "Bayer Info", IMAGE_INFO_TAB, IP_RW, 60,
+    BayerTP[0].fill("CFA_OFFSET_X", "X Offset", "0");
+    BayerTP[1].fill("CFA_OFFSET_Y", "Y Offset", "0");
+    BayerTP[2].fill("CFA_TYPE", "Filter", nullptr);
+    BayerTP.fill(getDeviceName(), "CCD_CFA", "Bayer Info", IMAGE_INFO_TAB, IP_RW, 60,
                      IPS_IDLE);
 
     // Reset Frame Settings
-    IUFillSwitch(&PrimaryCCD.ResetS[0], "RESET", "Reset", ISS_OFF);
-    IUFillSwitchVector(&PrimaryCCD.ResetSP, PrimaryCCD.ResetS, 1, getDeviceName(), "CCD_FRAME_RESET", "Frame Values",
+    IUFillSwitch(&PrimaryCCD.ResetSP[0], "RESET", "Reset", ISS_OFF);
+    PrimaryCCD.ResetSP.fill(getDeviceName(), "CCD_FRAME_RESET", "Frame Values",
                        IMAGE_SETTINGS_TAB, IP_WO, ISR_1OFMANY, 0, IPS_IDLE);
 
     /**********************************************/
     /********* Primary Chip Rapid Guide  **********/
     /**********************************************/
 #if 0
-    IUFillSwitch(&PrimaryCCD.RapidGuideS[0], "ENABLE", "Enable", ISS_OFF);
-    IUFillSwitch(&PrimaryCCD.RapidGuideS[1], "DISABLE", "Disable", ISS_ON);
-    IUFillSwitchVector(&PrimaryCCD.RapidGuideSP, PrimaryCCD.RapidGuideS, 2, getDeviceName(), "CCD_RAPID_GUIDE",
+    IUFillSwitch(&PrimaryCCD.RapidGuideSP[0], "ENABLE", "Enable", ISS_OFF);
+    IUFillSwitch(&PrimaryCCD.RapidGuideSP[1], "DISABLE", "Disable", ISS_ON);
+    PrimaryCCD.RapidGuideSP.fill(getDeviceName(), "CCD_RAPID_GUIDE",
                        "Rapid Guide", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&PrimaryCCD.RapidGuideSetupS[0], "AUTO_LOOP", "Auto loop", ISS_ON);
-    IUFillSwitch(&PrimaryCCD.RapidGuideSetupS[1], "SEND_IMAGE", "Send image", ISS_OFF);
-    IUFillSwitch(&PrimaryCCD.RapidGuideSetupS[2], "SHOW_MARKER", "Show marker", ISS_OFF);
-    IUFillSwitchVector(&PrimaryCCD.RapidGuideSetupSP, PrimaryCCD.RapidGuideSetupS, 3, getDeviceName(),
+    IUFillSwitch(&PrimaryCCD.RapidGuideSetupSP[0], "AUTO_LOOP", "Auto loop", ISS_ON);
+    IUFillSwitch(&PrimaryCCD.RapidGuideSetupSP[1], "SEND_IMAGE", "Send image", ISS_OFF);
+    IUFillSwitch(&PrimaryCCD.RapidGuideSetupSP[2], "SHOW_MARKER", "Show marker", ISS_OFF);
+    PrimaryCCD.RapidGuideSetupSP.fill(getDeviceName(),
                        "CCD_RAPID_GUIDE_SETUP", "Rapid Guide Setup", RAPIDGUIDE_TAB, IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&PrimaryCCD.RapidGuideDataN[0], "GUIDESTAR_X", "Guide star position X", "%5.2f", 0, 1024, 0, 0);
-    IUFillNumber(&PrimaryCCD.RapidGuideDataN[1], "GUIDESTAR_Y", "Guide star position Y", "%5.2f", 0, 1024, 0, 0);
-    IUFillNumber(&PrimaryCCD.RapidGuideDataN[2], "GUIDESTAR_FIT", "Guide star fit", "%5.2f", 0, 1024, 0, 0);
-    IUFillNumberVector(&PrimaryCCD.RapidGuideDataNP, PrimaryCCD.RapidGuideDataN, 3, getDeviceName(),
+    IUFillNumber(&PrimaryCCD.RapidGuideDataNP[0], "GUIDESTAR_X", "Guide star position X", "%5.2f", 0, 1024, 0, 0);
+    IUFillNumber(&PrimaryCCD.RapidGuideDataNP[1], "GUIDESTAR_Y", "Guide star position Y", "%5.2f", 0, 1024, 0, 0);
+    IUFillNumber(&PrimaryCCD.RapidGuideDataNP[2], "GUIDESTAR_FIT", "Guide star fit", "%5.2f", 0, 1024, 0, 0);
+    PrimaryCCD.RapidGuideDataNP.fill(getDeviceName(),
                        "CCD_RAPID_GUIDE_DATA", "Rapid Guide Data", RAPIDGUIDE_TAB, IP_RO, 60, IPS_IDLE);
 #endif
 
@@ -233,44 +233,44 @@ bool CCD::initProperties()
     /***************** Guide Chip *****************/
     /**********************************************/
 
-    IUFillNumber(&GuideCCD.ImageFrameN[CCDChip::FRAME_X], "X", "Left ", "%4.0f", 0, 0, 0, 0);
-    IUFillNumber(&GuideCCD.ImageFrameN[CCDChip::FRAME_Y], "Y", "Top", "%4.0f", 0, 0, 0, 0);
-    IUFillNumber(&GuideCCD.ImageFrameN[CCDChip::FRAME_W], "WIDTH", "Width", "%4.0f", 0, 0, 0, 0);
-    IUFillNumber(&GuideCCD.ImageFrameN[CCDChip::FRAME_H], "HEIGHT", "Height", "%4.0f", 0, 0, 0, 0);
-    IUFillNumberVector(&GuideCCD.ImageFrameNP, GuideCCD.ImageFrameN, 4, getDeviceName(), "GUIDER_FRAME", "Frame",
+    IUFillNumber(&GuideCCD.ImageFrameNP[CCDChip::FRAME_X], "X", "Left ", "%4.0f", 0, 0, 0, 0);
+    IUFillNumber(&GuideCCD.ImageFrameNP[CCDChip::FRAME_Y], "Y", "Top", "%4.0f", 0, 0, 0, 0);
+    IUFillNumber(&GuideCCD.ImageFrameNP[CCDChip::FRAME_W], "WIDTH", "Width", "%4.0f", 0, 0, 0, 0);
+    IUFillNumber(&GuideCCD.ImageFrameNP[CCDChip::FRAME_H], "HEIGHT", "Height", "%4.0f", 0, 0, 0, 0);
+    GuideCCD.ImageFrameNP.fill(getDeviceName(), "GUIDER_FRAME", "Frame",
                        GUIDE_HEAD_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillNumber(&GuideCCD.ImageBinN[0], "HOR_BIN", "X", "%2.0f", 1, 4, 1, 1);
-    IUFillNumber(&GuideCCD.ImageBinN[1], "VER_BIN", "Y", "%2.0f", 1, 4, 1, 1);
-    IUFillNumberVector(&GuideCCD.ImageBinNP, GuideCCD.ImageBinN, 2, getDeviceName(), "GUIDER_BINNING", "Binning",
+    IUFillNumber(&GuideCCD.ImageBinNP[0], "HOR_BIN", "X", "%2.0f", 1, 4, 1, 1);
+    IUFillNumber(&GuideCCD.ImageBinNP[1], "VER_BIN", "Y", "%2.0f", 1, 4, 1, 1);
+    GuideCCD.ImageBinNP.fill(getDeviceName(), "GUIDER_BINNING", "Binning",
                        GUIDE_HEAD_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillNumber(&GuideCCD.ImagePixelSizeN[CCDChip::CCD_MAX_X], "CCD_MAX_X", "Max. Width", "%4.0f", 1, 16000, 0, 0);
-    IUFillNumber(&GuideCCD.ImagePixelSizeN[CCDChip::CCD_MAX_Y], "CCD_MAX_Y", "Max. Height", "%4.0f", 1, 16000, 0, 0);
-    IUFillNumber(&GuideCCD.ImagePixelSizeN[CCDChip::CCD_PIXEL_SIZE], "CCD_PIXEL_SIZE", "Pixel size (um)", "%5.2f", 1,
+    IUFillNumber(&GuideCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_X], "CCD_MAX_X", "Max. Width", "%4.0f", 1, 16000, 0, 0);
+    IUFillNumber(&GuideCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_Y], "CCD_MAX_Y", "Max. Height", "%4.0f", 1, 16000, 0, 0);
+    IUFillNumber(&GuideCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE], "CCD_PIXEL_SIZE", "Pixel size (um)", "%5.2f", 1,
                  40, 0, 0);
-    IUFillNumber(&GuideCCD.ImagePixelSizeN[CCDChip::CCD_PIXEL_SIZE_X], "CCD_PIXEL_SIZE_X", "Pixel size X", "%5.2f", 1,
+    IUFillNumber(&GuideCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_X], "CCD_PIXEL_SIZE_X", "Pixel size X", "%5.2f", 1,
                  40, 0, 0);
-    IUFillNumber(&GuideCCD.ImagePixelSizeN[CCDChip::CCD_PIXEL_SIZE_Y], "CCD_PIXEL_SIZE_Y", "Pixel size Y", "%5.2f", 1,
+    IUFillNumber(&GuideCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_Y], "CCD_PIXEL_SIZE_Y", "Pixel size Y", "%5.2f", 1,
                  40, 0, 0);
-    IUFillNumber(&GuideCCD.ImagePixelSizeN[CCDChip::CCD_BITSPERPIXEL], "CCD_BITSPERPIXEL", "Bits per pixel", "%3.0f", 8,
+    IUFillNumber(&GuideCCD.ImagePixelSizeNP[CCDChip::CCD_BITSPERPIXEL], "CCD_BITSPERPIXEL", "Bits per pixel", "%3.0f", 8,
                  64, 0, 0);
-    IUFillNumberVector(&GuideCCD.ImagePixelSizeNP, GuideCCD.ImagePixelSizeN, 6, getDeviceName(), "GUIDER_INFO",
+    GuideCCD.ImagePixelSizeNP.fill(getDeviceName(), "GUIDER_INFO",
                        "Guide Info", IMAGE_INFO_TAB, IP_RO, 60, IPS_IDLE);
 
-    IUFillSwitch(&GuideCCD.FrameTypeS[0], "FRAME_LIGHT", "Light", ISS_ON);
-    IUFillSwitch(&GuideCCD.FrameTypeS[1], "FRAME_BIAS", "Bias", ISS_OFF);
-    IUFillSwitch(&GuideCCD.FrameTypeS[2], "FRAME_DARK", "Dark", ISS_OFF);
-    IUFillSwitch(&GuideCCD.FrameTypeS[3], "FRAME_FLAT", "Flat", ISS_OFF);
-    IUFillSwitchVector(&GuideCCD.FrameTypeSP, GuideCCD.FrameTypeS, 4, getDeviceName(), "GUIDER_FRAME_TYPE",
+    IUFillSwitch(&GuideCCD.FrameTypeSP[0], "FRAME_LIGHT", "Light", ISS_ON);
+    IUFillSwitch(&GuideCCD.FrameTypeSP[1], "FRAME_BIAS", "Bias", ISS_OFF);
+    IUFillSwitch(&GuideCCD.FrameTypeSP[2], "FRAME_DARK", "Dark", ISS_OFF);
+    IUFillSwitch(&GuideCCD.FrameTypeSP[3], "FRAME_FLAT", "Flat", ISS_OFF);
+    GuideCCD.FrameTypeSP.fill(getDeviceName(), "GUIDER_FRAME_TYPE",
                        "Frame Type", GUIDE_HEAD_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&GuideCCD.ImageExposureN[0], "GUIDER_EXPOSURE_VALUE", "Duration (s)", "%5.2f", 0.01, 3600, 1.0, 1.0);
-    IUFillNumberVector(&GuideCCD.ImageExposureNP, GuideCCD.ImageExposureN, 1, getDeviceName(), "GUIDER_EXPOSURE",
+    IUFillNumber(&GuideCCD.ImageExposureNP[0], "GUIDER_EXPOSURE_VALUE", "Duration (s)", "%5.2f", 0.01, 3600, 1.0, 1.0);
+    GuideCCD.ImageExposureNP.fill(getDeviceName(), "GUIDER_EXPOSURE",
                        "Guide Head", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillSwitch(&GuideCCD.AbortExposureS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&GuideCCD.AbortExposureSP, GuideCCD.AbortExposureS, 1, getDeviceName(), "GUIDER_ABORT_EXPOSURE",
+    IUFillSwitch(&GuideCCD.AbortExposureSP[0], "ABORT", "Abort", ISS_OFF);
+    GuideCCD.AbortExposureSP.fill(getDeviceName(), "GUIDER_ABORT_EXPOSURE",
                        "Guide Abort", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     IUFillSwitch(&GuideCCD.CompressS[0], "GUIDER_COMPRESS", "Compress", ISS_OFF);
@@ -288,22 +288,22 @@ bool CCD::initProperties()
     /**********************************************/
 
 #if 0
-    IUFillSwitch(&GuideCCD.RapidGuideS[0], "ENABLE", "Enable", ISS_OFF);
-    IUFillSwitch(&GuideCCD.RapidGuideS[1], "DISABLE", "Disable", ISS_ON);
-    IUFillSwitchVector(&GuideCCD.RapidGuideSP, GuideCCD.RapidGuideS, 2, getDeviceName(), "GUIDER_RAPID_GUIDE",
+    IUFillSwitch(&GuideCCD.RapidGuideSP[0], "ENABLE", "Enable", ISS_OFF);
+    IUFillSwitch(&GuideCCD.RapidGuideSP[1], "DISABLE", "Disable", ISS_ON);
+    GuideCCD.RapidGuideSP.fill(getDeviceName(), "GUIDER_RAPID_GUIDE",
                        "Guider Head Rapid Guide", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillSwitch(&GuideCCD.RapidGuideSetupS[0], "AUTO_LOOP", "Auto loop", ISS_ON);
-    IUFillSwitch(&GuideCCD.RapidGuideSetupS[1], "SEND_IMAGE", "Send image", ISS_OFF);
-    IUFillSwitch(&GuideCCD.RapidGuideSetupS[2], "SHOW_MARKER", "Show marker", ISS_OFF);
-    IUFillSwitchVector(&GuideCCD.RapidGuideSetupSP, GuideCCD.RapidGuideSetupS, 3, getDeviceName(),
+    IUFillSwitch(&GuideCCD.RapidGuideSetupSP[0], "AUTO_LOOP", "Auto loop", ISS_ON);
+    IUFillSwitch(&GuideCCD.RapidGuideSetupSP[1], "SEND_IMAGE", "Send image", ISS_OFF);
+    IUFillSwitch(&GuideCCD.RapidGuideSetupSP[2], "SHOW_MARKER", "Show marker", ISS_OFF);
+    GuideCCD.RapidGuideSetupSP.fill(getDeviceName(),
                        "GUIDER_RAPID_GUIDE_SETUP", "Rapid Guide Setup", RAPIDGUIDE_TAB, IP_RW, ISR_NOFMANY, 0,
                        IPS_IDLE);
 
-    IUFillNumber(&GuideCCD.RapidGuideDataN[0], "GUIDESTAR_X", "Guide star position X", "%5.2f", 0, 1024, 0, 0);
-    IUFillNumber(&GuideCCD.RapidGuideDataN[1], "GUIDESTAR_Y", "Guide star position Y", "%5.2f", 0, 1024, 0, 0);
-    IUFillNumber(&GuideCCD.RapidGuideDataN[2], "GUIDESTAR_FIT", "Guide star fit", "%5.2f", 0, 1024, 0, 0);
-    IUFillNumberVector(&GuideCCD.RapidGuideDataNP, GuideCCD.RapidGuideDataN, 3, getDeviceName(),
+    IUFillNumber(&GuideCCD.RapidGuideDataNP[0], "GUIDESTAR_X", "Guide star position X", "%5.2f", 0, 1024, 0, 0);
+    IUFillNumber(&GuideCCD.RapidGuideDataNP[1], "GUIDESTAR_Y", "Guide star position Y", "%5.2f", 0, 1024, 0, 0);
+    IUFillNumber(&GuideCCD.RapidGuideDataNP[2], "GUIDESTAR_FIT", "Guide star fit", "%5.2f", 0, 1024, 0, 0);
+    GuideCCD.RapidGuideDataNP.fill(getDeviceName(),
                        "GUIDER_RAPID_GUIDE_DATA", "Rapid Guide Data", RAPIDGUIDE_TAB, IP_RO, 60, IPS_IDLE);
 
 #endif
@@ -313,18 +313,18 @@ bool CCD::initProperties()
     /**********************************************/
 
     // WCS Enable/Disable
-    IUFillSwitch(&WorldCoordS[0], "WCS_ENABLE", "Enable", ISS_OFF);
-    IUFillSwitch(&WorldCoordS[1], "WCS_DISABLE", "Disable", ISS_ON);
-    IUFillSwitchVector(&WorldCoordSP, WorldCoordS, 2, getDeviceName(), "WCS_CONTROL", "WCS", WCS_TAB, IP_RW,
+    WorldCoordSP[0].fill("WCS_ENABLE", "Enable", ISS_OFF);
+    WorldCoordSP[1].fill("WCS_DISABLE", "Disable", ISS_ON);
+    WorldCoordSP.fill(getDeviceName(), "WCS_CONTROL", "WCS", WCS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&CCDRotationN[0], "CCD_ROTATION_VALUE", "Rotation", "%g", -360, 360, 1, 0);
-    IUFillNumberVector(&CCDRotationNP, CCDRotationN, 1, getDeviceName(), "CCD_ROTATION", "CCD FOV", WCS_TAB, IP_RW, 60,
+    CCDRotationNP[0].fill("CCD_ROTATION_VALUE", "Rotation", "%g", -360, 360, 1, 0);
+    CCDRotationNP.fill(getDeviceName(), "CCD_ROTATION", "CCD FOV", WCS_TAB, IP_RW, 60,
                        IPS_IDLE);
 
-    IUFillSwitch(&TelescopeTypeS[TELESCOPE_PRIMARY], "TELESCOPE_PRIMARY", "Primary", ISS_ON);
-    IUFillSwitch(&TelescopeTypeS[TELESCOPE_GUIDE], "TELESCOPE_GUIDE", "Guide", ISS_OFF);
-    IUFillSwitchVector(&TelescopeTypeSP, TelescopeTypeS, 2, getDeviceName(), "TELESCOPE_TYPE", "Telescope", OPTIONS_TAB,
+    TelescopeTypeSP[TELESCOPE_PRIMARY].fill("TELESCOPE_PRIMARY", "Primary", ISS_ON);
+    TelescopeTypeSP[TELESCOPE_GUIDE].fill("TELESCOPE_GUIDE", "Guide", ISS_OFF);
+    TelescopeTypeSP.fill(getDeviceName(), "TELESCOPE_TYPE", "Telescope", OPTIONS_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     /**********************************************/
@@ -332,57 +332,57 @@ bool CCD::initProperties()
     /**********************************************/
 
     // Upload Mode
-    IUFillSwitch(&UploadS[UPLOAD_CLIENT], "UPLOAD_CLIENT", "Client", ISS_ON);
-    IUFillSwitch(&UploadS[UPLOAD_LOCAL], "UPLOAD_LOCAL", "Local", ISS_OFF);
-    IUFillSwitch(&UploadS[UPLOAD_BOTH], "UPLOAD_BOTH", "Both", ISS_OFF);
-    IUFillSwitchVector(&UploadSP, UploadS, 3, getDeviceName(), "UPLOAD_MODE", "Upload", OPTIONS_TAB, IP_RW, ISR_1OFMANY,
+    UploadSP[UPLOAD_CLIENT].fill("UPLOAD_CLIENT", "Client", ISS_ON);
+    UploadSP[UPLOAD_LOCAL].fill("UPLOAD_LOCAL", "Local", ISS_OFF);
+    UploadSP[UPLOAD_BOTH].fill("UPLOAD_BOTH", "Both", ISS_OFF);
+    UploadSP.fill(getDeviceName(), "UPLOAD_MODE", "Upload", OPTIONS_TAB, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
     // Upload Settings
-    IUFillText(&UploadSettingsT[UPLOAD_DIR], "UPLOAD_DIR", "Dir", "");
-    IUFillText(&UploadSettingsT[UPLOAD_PREFIX], "UPLOAD_PREFIX", "Prefix", "IMAGE_XXX");
-    IUFillTextVector(&UploadSettingsTP, UploadSettingsT, 2, getDeviceName(), "UPLOAD_SETTINGS", "Upload Settings",
+    UploadSettingsTP[UPLOAD_DIR].fill("UPLOAD_DIR", "Dir", "");
+    UploadSettingsTP[UPLOAD_PREFIX].fill("UPLOAD_PREFIX", "Prefix", "IMAGE_XXX");
+    UploadSettingsTP.fill(getDeviceName(), "UPLOAD_SETTINGS", "Upload Settings",
                      OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
 
     // Upload File Path
-    IUFillText(&FileNameT[0], "FILE_PATH", "Path", "");
-    IUFillTextVector(&FileNameTP, FileNameT, 1, getDeviceName(), "CCD_FILE_PATH", "Filename", IMAGE_INFO_TAB, IP_RO, 60,
+    FileNameTP[0].fill("FILE_PATH", "Path", "");
+    FileNameTP.fill(getDeviceName(), "CCD_FILE_PATH", "Filename", IMAGE_INFO_TAB, IP_RO, 60,
                      IPS_IDLE);
 
     /**********************************************/
     /****************** FITS Header****************/
     /**********************************************/
 
-    IUFillText(&FITSHeaderT[FITS_OBSERVER], "FITS_OBSERVER", "Observer", "Unknown");
-    IUFillText(&FITSHeaderT[FITS_OBJECT], "FITS_OBJECT", "Object", "Unknown");
-    IUFillTextVector(&FITSHeaderTP, FITSHeaderT, 2, getDeviceName(), "FITS_HEADER", "FITS Header", INFO_TAB, IP_RW, 60,
+    FITSHeaderTP[FITS_OBSERVER].fill("FITS_OBSERVER", "Observer", "Unknown");
+    FITSHeaderTP[FITS_OBJECT].fill("FITS_OBJECT", "Object", "Unknown");
+    FITSHeaderTP.fill(getDeviceName(), "FITS_HEADER", "FITS Header", INFO_TAB, IP_RW, 60,
                      IPS_IDLE);
 
     /**********************************************/
     /****************** Exposure Looping **********/
     /***************** Primary CCD Only ***********/
 #ifdef WITH_EXPOSURE_LOOPING
-    IUFillSwitch(&ExposureLoopS[EXPOSURE_LOOP_ON], "LOOP_ON", "Enabled", ISS_OFF);
-    IUFillSwitch(&ExposureLoopS[EXPOSURE_LOOP_OFF], "LOOP_OFF", "Disabled", ISS_ON);
-    IUFillSwitchVector(&ExposureLoopSP, ExposureLoopS, 2, getDeviceName(), "CCD_EXPOSURE_LOOP", "Rapid Looping", OPTIONS_TAB,
+    ExposureLoopSP[EXPOSURE_LOOP_ON].fill("LOOP_ON", "Enabled", ISS_OFF);
+    ExposureLoopSP[EXPOSURE_LOOP_OFF].fill("LOOP_OFF", "Disabled", ISS_ON);
+    ExposureLoopSP.fill(getDeviceName(), "CCD_EXPOSURE_LOOP", "Rapid Looping", OPTIONS_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // CCD Should loop until the number of frames specified in this property is completed
-    IUFillNumber(&ExposureLoopCountN[0], "FRAMES", "Frames", "%.f", 0, 100000, 1, 1);
-    IUFillNumberVector(&ExposureLoopCountNP, ExposureLoopCountN, 1, getDeviceName(), "CCD_EXPOSURE_LOOP_COUNT", "Rapid Count",
+    ExposureLoopCountNP[0].fill("FRAMES", "Frames", "%.f", 0, 100000, 1, 1);
+    ExposureLoopCountNP.fill(getDeviceName(), "CCD_EXPOSURE_LOOP_COUNT", "Rapid Count",
                        OPTIONS_TAB, IP_RW, 0, IPS_IDLE);
 #endif
 
     /**********************************************/
     /**************** Web Socket ******************/
     /**********************************************/
-    IUFillSwitch(&WebSocketS[WEBSOCKET_ENABLED], "WEBSOCKET_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&WebSocketS[WEBSOCKET_DISABLED], "WEBSOCKET_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&WebSocketSP, WebSocketS, 2, getDeviceName(), "CCD_WEBSOCKET", "Websocket", OPTIONS_TAB,
+    WebSocketSP[WEBSOCKET_ENABLED].fill("WEBSOCKET_ENABLED", "Enabled", ISS_OFF);
+    WebSocketSP[WEBSOCKET_DISABLED].fill("WEBSOCKET_DISABLED", "Disabled", ISS_ON);
+    WebSocketSP.fill(getDeviceName(), "CCD_WEBSOCKET", "Websocket", OPTIONS_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
-    IUFillNumber(&WebSocketSettingsN[WS_SETTINGS_PORT], "WS_SETTINGS_PORT", "Port", "%.f", 0, 50000, 0, 0);
-    IUFillNumberVector(&WebSocketSettingsNP, WebSocketSettingsN, 1, getDeviceName(), "CCD_WEBSOCKET_SETTINGS", "WS Settings",
+    WebSocketSettingsNP[WS_SETTINGS_PORT].fill("WS_SETTINGS_PORT", "Port", "%.f", 0, 50000, 0, 0);
+    WebSocketSettingsNP.fill(getDeviceName(), "CCD_WEBSOCKET_SETTINGS", "WS Settings",
                        OPTIONS_TAB, IP_RW,
                        60, IPS_IDLE);
 
@@ -392,44 +392,44 @@ bool CCD::initProperties()
 
     // Snooped Devices
 
-    IUFillText(&ActiveDeviceT[ACTIVE_TELESCOPE], "ACTIVE_TELESCOPE", "Telescope", "Telescope Simulator");
-    IUFillText(&ActiveDeviceT[ACTIVE_ROTATOR], "ACTIVE_ROTATOR", "Rotator", "Rotator Simulator");
-    IUFillText(&ActiveDeviceT[ACTIVE_FOCUSER], "ACTIVE_FOCUSER", "Focuser", "Focuser Simulator");
-    IUFillText(&ActiveDeviceT[ACTIVE_FILTER], "ACTIVE_FILTER", "Filter", "CCD Simulator");
-    IUFillText(&ActiveDeviceT[ACTIVE_SKYQUALITY], "ACTIVE_SKYQUALITY", "Sky Quality", "SQM");
-    IUFillTextVector(&ActiveDeviceTP, ActiveDeviceT, 5, getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
+    ActiveDeviceTP[ACTIVE_TELESCOPE].fill("ACTIVE_TELESCOPE", "Telescope", "Telescope Simulator");
+    ActiveDeviceTP[ACTIVE_ROTATOR].fill("ACTIVE_ROTATOR", "Rotator", "Rotator Simulator");
+    ActiveDeviceTP[ACTIVE_FOCUSER].fill("ACTIVE_FOCUSER", "Focuser", "Focuser Simulator");
+    ActiveDeviceTP[ACTIVE_FILTER].fill("ACTIVE_FILTER", "Filter", "CCD Simulator");
+    ActiveDeviceTP[ACTIVE_SKYQUALITY].fill("ACTIVE_SKYQUALITY", "Sky Quality", "SQM");
+    ActiveDeviceTP.fill(getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
                      IP_RW, 60, IPS_IDLE);
 
     // Snooped RA/DEC Property
-    IUFillNumber(&EqN[0], "RA", "Ra (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-    IUFillNumber(&EqN[1], "DEC", "Dec (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-    IUFillNumberVector(&EqNP, EqN, 2, ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD", "EQ Coord", "Main Control",
+    EqNP[0].fill("RA", "Ra (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+    EqNP[1].fill("DEC", "Dec (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+    EqNP.fill(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD", "EQ Coord", "Main Control",
                        IP_RW,
                        60, IPS_IDLE);
 
     // Snoop properties of interest
 
     // Snoop mount
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD");
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "TELESCOPE_INFO");
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "GEOGRAPHIC_COORD");
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "TELESCOPE_PIER_SIDE");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "TELESCOPE_INFO");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "GEOGRAPHIC_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "TELESCOPE_PIER_SIDE");
 
     // Snoop Rotator
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_ROTATOR].text, "ABS_ROTATOR_ANGLE");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_ROTATOR].getText(), "ABS_ROTATOR_ANGLE");
 
     // JJ ed 2019-12-10
     // Snoop Focuser
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "ABS_FOCUS_POSITION");
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FOCUS_TEMPERATURE");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "ABS_FOCUS_POSITION");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FOCUS_TEMPERATURE");
     //
 
     // Snoop Filter Wheel
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FILTER].text, "FILTER_SLOT");
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_FILTER].text, "FILTER_NAME");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FILTER].getText(), "FILTER_SLOT");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_FILTER].getText(), "FILTER_NAME");
 
     // Snoop Sky Quality Meter
-    IDSnoopDevice(ActiveDeviceT[ACTIVE_SKYQUALITY].text, "SKY_QUALITY");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_SKYQUALITY].getText(), "SKY_QUALITY");
 
     // Guider Interface
     initGuiderProperties(getDeviceName(), GUIDE_CONTROL_TAB);
@@ -445,7 +445,7 @@ void CCD::ISGetProperties(const char * dev)
 {
     DefaultDevice::ISGetProperties(dev);
 
-    defineProperty(&ActiveDeviceTP);
+    defineProperty(ActiveDeviceTP);
     loadConfig(true, "ACTIVE_DEVICES");
 
     if (HasStreaming())
@@ -460,38 +460,38 @@ bool CCD::updateProperties()
     //IDLog("CCD UpdateProperties isConnected returns %d %d\n",isConnected(),Connected);
     if (isConnected())
     {
-        defineProperty(&PrimaryCCD.ImageExposureNP);
+        defineProperty(PrimaryCCD.ImageExposureNP);
 
         if (CanAbort())
-            defineProperty(&PrimaryCCD.AbortExposureSP);
+            defineProperty(PrimaryCCD.AbortExposureSP);
         if (CanSubFrame() == false)
-            PrimaryCCD.ImageFrameNP.p = IP_RO;
+            PrimaryCCD.ImageFrameNP.setPermission(IP_RO);
 
-        defineProperty(&PrimaryCCD.ImageFrameNP);
+        defineProperty(PrimaryCCD.ImageFrameNP);
         if (CanBin())
-            defineProperty(&PrimaryCCD.ImageBinNP);
+            defineProperty(PrimaryCCD.ImageBinNP);
 
-        defineProperty(&FITSHeaderTP);
+        defineProperty(FITSHeaderTP);
 
         if (HasGuideHead())
         {
-            defineProperty(&GuideCCD.ImageExposureNP);
+            defineProperty(GuideCCD.ImageExposureNP);
             if (CanAbort())
-                defineProperty(&GuideCCD.AbortExposureSP);
+                defineProperty(GuideCCD.AbortExposureSP);
             if (CanSubFrame() == false)
-                GuideCCD.ImageFrameNP.p = IP_RO;
-            defineProperty(&GuideCCD.ImageFrameNP);
+                GuideCCD.ImageFrameNP.setPermission(IP_RO);
+            defineProperty(GuideCCD.ImageFrameNP);
         }
 
         if (HasCooler())
-            defineProperty(&TemperatureNP);
+            defineProperty(TemperatureNP);
 
-        defineProperty(&PrimaryCCD.ImagePixelSizeNP);
+        defineProperty(PrimaryCCD.ImagePixelSizeNP);
         if (HasGuideHead())
         {
-            defineProperty(&GuideCCD.ImagePixelSizeNP);
+            defineProperty(GuideCCD.ImagePixelSizeNP);
             if (CanBin())
-                defineProperty(&GuideCCD.ImageBinNP);
+                defineProperty(GuideCCD.ImageBinNP);
         }
         defineProperty(&PrimaryCCD.CompressSP);
         defineProperty(&PrimaryCCD.FitsBP);
@@ -505,133 +505,133 @@ bool CCD::updateProperties()
             defineProperty(&GuideNSNP);
             defineProperty(&GuideWENP);
         }
-        defineProperty(&PrimaryCCD.FrameTypeSP);
+        defineProperty(PrimaryCCD.FrameTypeSP);
 
         if (CanBin() || CanSubFrame())
-            defineProperty(&PrimaryCCD.ResetSP);
+            defineProperty(PrimaryCCD.ResetSP);
 
         if (HasGuideHead())
-            defineProperty(&GuideCCD.FrameTypeSP);
+            defineProperty(GuideCCD.FrameTypeSP);
 
         if (HasBayer())
-            defineProperty(&BayerTP);
+            defineProperty(BayerTP);
 
 #if 0
-        defineProperty(&PrimaryCCD.RapidGuideSP);
+        defineProperty(PrimaryCCD.RapidGuideSP);
 
         if (HasGuideHead())
-            defineProperty(&GuideCCD.RapidGuideSP);
+            defineProperty(GuideCCD.RapidGuideSP);
 
         if (RapidGuideEnabled)
         {
-            defineProperty(&PrimaryCCD.RapidGuideSetupSP);
-            defineProperty(&PrimaryCCD.RapidGuideDataNP);
+            defineProperty(PrimaryCCD.RapidGuideSetupSP);
+            defineProperty(PrimaryCCD.RapidGuideDataNP);
         }
         if (GuiderRapidGuideEnabled)
         {
-            defineProperty(&GuideCCD.RapidGuideSetupSP);
-            defineProperty(&GuideCCD.RapidGuideDataNP);
+            defineProperty(GuideCCD.RapidGuideSetupSP);
+            defineProperty(GuideCCD.RapidGuideDataNP);
         }
 #endif
-        defineProperty(&TelescopeTypeSP);
+        defineProperty(TelescopeTypeSP);
 
-        defineProperty(&WorldCoordSP);
-        defineProperty(&UploadSP);
+        defineProperty(WorldCoordSP);
+        defineProperty(UploadSP);
 
-        if (UploadSettingsT[UPLOAD_DIR].text == nullptr)
-            IUSaveText(&UploadSettingsT[UPLOAD_DIR], getenv("HOME"));
-        defineProperty(&UploadSettingsTP);
+        if (UploadSettingsTP[UPLOAD_DIR].text == nullptr)
+            UploadSettingsTP[UPLOAD_DIR].setText(getenv("HOME"));
+        defineProperty(UploadSettingsTP);
 
 #ifdef HAVE_WEBSOCKET
         if (HasWebSocket())
-            defineProperty(&WebSocketSP);
+            defineProperty(WebSocketSP);
 #endif
 
 #ifdef WITH_EXPOSURE_LOOPING
-        defineProperty(&ExposureLoopSP);
-        defineProperty(&ExposureLoopCountNP);
+        defineProperty(ExposureLoopSP);
+        defineProperty(ExposureLoopCountNP);
 #endif
     }
     else
     {
-        deleteProperty(PrimaryCCD.ImageFrameNP.name);
-        deleteProperty(PrimaryCCD.ImagePixelSizeNP.name);
+        deleteProperty(PrimaryCCD.ImageFrameNP.getName());
+        deleteProperty(PrimaryCCD.ImagePixelSizeNP.getName());
 
         if (CanBin())
-            deleteProperty(PrimaryCCD.ImageBinNP.name);
+            deleteProperty(PrimaryCCD.ImageBinNP.getName());
 
-        deleteProperty(PrimaryCCD.ImageExposureNP.name);
+        deleteProperty(PrimaryCCD.ImageExposureNP.getName());
         if (CanAbort())
-            deleteProperty(PrimaryCCD.AbortExposureSP.name);
+            deleteProperty(PrimaryCCD.AbortExposureSP.getName());
         deleteProperty(PrimaryCCD.FitsBP.name);
         deleteProperty(PrimaryCCD.CompressSP.name);
 
 #if 0
-        deleteProperty(PrimaryCCD.RapidGuideSP.name);
+        deleteProperty(PrimaryCCD.RapidGuideSP.getName());
         if (RapidGuideEnabled)
         {
-            deleteProperty(PrimaryCCD.RapidGuideSetupSP.name);
-            deleteProperty(PrimaryCCD.RapidGuideDataNP.name);
+            deleteProperty(PrimaryCCD.RapidGuideSetupSP.getName());
+            deleteProperty(PrimaryCCD.RapidGuideDataNP.getName());
         }
 #endif
 
-        deleteProperty(FITSHeaderTP.name);
+        deleteProperty(FITSHeaderTP.getName());
 
         if (HasGuideHead())
         {
-            deleteProperty(GuideCCD.ImageExposureNP.name);
+            deleteProperty(GuideCCD.ImageExposureNP.getName());
             if (CanAbort())
-                deleteProperty(GuideCCD.AbortExposureSP.name);
-            deleteProperty(GuideCCD.ImageFrameNP.name);
-            deleteProperty(GuideCCD.ImagePixelSizeNP.name);
+                deleteProperty(GuideCCD.AbortExposureSP.getName());
+            deleteProperty(GuideCCD.ImageFrameNP.getName());
+            deleteProperty(GuideCCD.ImagePixelSizeNP.getName());
 
             deleteProperty(GuideCCD.FitsBP.name);
             if (CanBin())
-                deleteProperty(GuideCCD.ImageBinNP.name);
+                deleteProperty(GuideCCD.ImageBinNP.getName());
             deleteProperty(GuideCCD.CompressSP.name);
-            deleteProperty(GuideCCD.FrameTypeSP.name);
+            deleteProperty(GuideCCD.FrameTypeSP.getName());
 
 #if 0
-            deleteProperty(GuideCCD.RapidGuideSP.name);
+            deleteProperty(GuideCCD.RapidGuideSP.getName());
             if (GuiderRapidGuideEnabled)
             {
-                deleteProperty(GuideCCD.RapidGuideSetupSP.name);
-                deleteProperty(GuideCCD.RapidGuideDataNP.name);
+                deleteProperty(GuideCCD.RapidGuideSetupSP.getName());
+                deleteProperty(GuideCCD.RapidGuideDataNP.getName());
             }
 #endif
         }
         if (HasCooler())
-            deleteProperty(TemperatureNP.name);
+            deleteProperty(TemperatureNP.getName());
         if (HasST4Port())
         {
             deleteProperty(GuideNSNP.name);
             deleteProperty(GuideWENP.name);
         }
-        deleteProperty(PrimaryCCD.FrameTypeSP.name);
+        deleteProperty(PrimaryCCD.FrameTypeSP.getName());
         if (CanBin() || CanSubFrame())
-            deleteProperty(PrimaryCCD.ResetSP.name);
+            deleteProperty(PrimaryCCD.ResetSP.getName());
         if (HasBayer())
-            deleteProperty(BayerTP.name);
-        deleteProperty(TelescopeTypeSP.name);
+            deleteProperty(BayerTP.getName());
+        deleteProperty(TelescopeTypeSP.getName());
 
-        if (WorldCoordS[0].s == ISS_ON)
+        if (WorldCoordSP[0].getState() == ISS_ON)
         {
-            deleteProperty(CCDRotationNP.name);
+            deleteProperty(CCDRotationNP.getName());
         }
-        deleteProperty(WorldCoordSP.name);
-        deleteProperty(UploadSP.name);
-        deleteProperty(UploadSettingsTP.name);
+        deleteProperty(WorldCoordSP.getName());
+        deleteProperty(UploadSP.getName());
+        deleteProperty(UploadSettingsTP.getName());
 
 #ifdef HAVE_WEBSOCKET
         if (HasWebSocket())
         {
-            deleteProperty(WebSocketSP.name);
-            deleteProperty(WebSocketSettingsNP.name);
+            deleteProperty(WebSocketSP.getName());
+            deleteProperty(WebSocketSettingsNP.getName());
         }
 #endif
 #ifdef WITH_EXPOSURE_LOOPING
-        deleteProperty(ExposureLoopSP.name);
-        deleteProperty(ExposureLoopCountNP.name);
+        deleteProperty(ExposureLoopSP.getName());
+        deleteProperty(ExposureLoopCountNP.getName());
 #endif
     }
 
@@ -651,11 +651,11 @@ bool CCD::ISSnoopDevice(XMLEle * root)
     XMLEle * ep           = nullptr;
     const char * propName = findXMLAttValu(root, "name");
 
-    if (IUSnoopNumber(root, &EqNP) == 0)
+    if (IUSnoopNumber(root, EqNP.getNumber()) == 0) // #PS: refactor needed
     {
         double newra, newdec;
-        newra  = EqN[0].value;
-        newdec = EqN[1].value;
+        newra  = EqNP[0].getValue();
+        newdec = EqNP[1].getValue();
         if ((newra != RA) || (newdec != Dec))
         {
             //IDLog("RA %4.2f  Dec %4.2f Snooped RA %4.2f  Dec %4.2f\n",RA,Dec,newra,newdec);
@@ -800,19 +800,19 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
     {
         //  This is for our device
         //  Now lets see if it's something we process here
-        if (!strcmp(name, ActiveDeviceTP.name))
+        if (ActiveDeviceTP.isNameMatch(name))
         {
-            ActiveDeviceTP.s = IPS_OK;
-            IUUpdateText(&ActiveDeviceTP, texts, names, n);
-            IDSetText(&ActiveDeviceTP, nullptr);
+            ActiveDeviceTP.setState(IPS_OK);
+            ActiveDeviceTP.update(texts, names, n);
+            ActiveDeviceTP.apply();
 
             // Update the property name!
-            strncpy(EqNP.device, ActiveDeviceT[ACTIVE_TELESCOPE].text, MAXINDIDEVICE);
-            if (strlen(ActiveDeviceT[ACTIVE_TELESCOPE].text) > 0)
+            EqNP.setDeviceName(ActiveDeviceTP[ACTIVE_TELESCOPE].getText());
+            if (strlen(ActiveDeviceTP[ACTIVE_TELESCOPE].getText()) > 0)
             {
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD");
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "TELESCOPE_INFO");
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_TELESCOPE].text, "GEOGRAPHIC_COORD");
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "TELESCOPE_INFO");
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "GEOGRAPHIC_COORD");
             }
             else
             {
@@ -825,16 +825,16 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
                 Airmass = std::numeric_limits<double>::quiet_NaN();
             }
 
-            if (strlen(ActiveDeviceT[ACTIVE_ROTATOR].text) > 0)
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_ROTATOR].text, "ABS_ROTATOR_ANGLE");
+            if (strlen(ActiveDeviceTP[ACTIVE_ROTATOR].getText()) > 0)
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_ROTATOR].getText(), "ABS_ROTATOR_ANGLE");
             else
                 MPSAS = std::numeric_limits<double>::quiet_NaN();
 
             // JJ ed 2019-12-10
-            if (strlen(ActiveDeviceT[ACTIVE_FOCUSER].text) > 0)
+            if (strlen(ActiveDeviceTP[ACTIVE_FOCUSER].getText()) > 0)
             {
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "ABS_FOCUS_POSITION");
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_FOCUSER].text, "FOCUS_TEMPERATURE");
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "ABS_FOCUS_POSITION");
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FOCUS_TEMPERATURE");
             }
             else
             {
@@ -844,17 +844,17 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
             //
 
 
-            if (strlen(ActiveDeviceT[ACTIVE_FILTER].text) > 0)
+            if (strlen(ActiveDeviceTP[ACTIVE_FILTER].getText()) > 0)
             {
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_FILTER].text, "FILTER_SLOT");
-                IDSnoopDevice(ActiveDeviceT[ACTIVE_FILTER].text, "FILTER_NAME");
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_FILTER].getText(), "FILTER_SLOT");
+                IDSnoopDevice(ActiveDeviceTP[ACTIVE_FILTER].getText(), "FILTER_NAME");
             }
             else
             {
                 CurrentFilterSlot = -1;
             }
 
-            IDSnoopDevice(ActiveDeviceT[ACTIVE_SKYQUALITY].text, "SKY_QUALITY");
+            IDSnoopDevice(ActiveDeviceTP[ACTIVE_SKYQUALITY].getText(), "SKY_QUALITY");
 
             // Tell children active devices was updated.
             activeDevicesUpdated();
@@ -863,27 +863,27 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
             return true;
         }
 
-        if (!strcmp(name, BayerTP.name))
+        if (BayerTP.isNameMatch(name))
         {
-            IUUpdateText(&BayerTP, texts, names, n);
-            BayerTP.s = IPS_OK;
-            IDSetText(&BayerTP, nullptr);
+            BayerTP.update(texts, names, n);
+            BayerTP.setState(IPS_OK);
+            BayerTP.apply();
             return true;
         }
 
-        if (!strcmp(name, FITSHeaderTP.name))
+        if (FITSHeaderTP.isNameMatch(name))
         {
-            IUUpdateText(&FITSHeaderTP, texts, names, n);
-            FITSHeaderTP.s = IPS_OK;
-            IDSetText(&FITSHeaderTP, nullptr);
+            FITSHeaderTP.update(texts, names, n);
+            FITSHeaderTP.setState(IPS_OK);
+            FITSHeaderTP.apply();
             return true;
         }
 
-        if (!strcmp(name, UploadSettingsTP.name))
+        if (UploadSettingsTP.isNameMatch(name))
         {
-            IUUpdateText(&UploadSettingsTP, texts, names, n);
-            UploadSettingsTP.s = IPS_OK;
-            IDSetText(&UploadSettingsTP, nullptr);
+            UploadSettingsTP.update(texts, names, n);
+            UploadSettingsTP.setState(IPS_OK);
+            UploadSettingsTP.apply();
             return true;
         }
     }
@@ -908,23 +908,23 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
         if (!strcmp(name, "CCD_EXPOSURE"))
         {
             if (PrimaryCCD.getFrameType() != CCDChip::BIAS_FRAME &&
-                    (values[0] < PrimaryCCD.ImageExposureN[0].min || values[0] > PrimaryCCD.ImageExposureN[0].max))
+                    (values[0] < PrimaryCCD.ImageExposureNP[0].min || values[0] > PrimaryCCD.ImageExposureNP[0].max))
             {
                 LOGF_ERROR("Requested exposure value (%g) seconds out of bounds [%g,%g].",
-                           values[0], PrimaryCCD.ImageExposureN[0].min, PrimaryCCD.ImageExposureN[0].max);
-                PrimaryCCD.ImageExposureNP.s = IPS_ALERT;
-                IDSetNumber(&PrimaryCCD.ImageExposureNP, nullptr);
+                           values[0], PrimaryCCD.ImageExposureNP[0].min, PrimaryCCD.ImageExposureNP[0].max);
+                PrimaryCCD.ImageExposureNP.setState(IPS_ALERT);
+                PrimaryCCD.ImageExposureNP.apply();
                 return false;
             }
 
             if (PrimaryCCD.getFrameType() == CCDChip::BIAS_FRAME)
-                PrimaryCCD.ImageExposureN[0].value = ExposureTime = PrimaryCCD.ImageExposureN[0].min;
+                PrimaryCCD.ImageExposureNP[0].setValue(ExposureTime = PrimaryCCD.ImageExposureNP[0].min);
             else
-                PrimaryCCD.ImageExposureN[0].value = ExposureTime = values[0];
+                PrimaryCCD.ImageExposureNP[0].setValue(ExposureTime = values[0]);
 
             // Only abort when busy if we are not already in an exposure loops
-            //if (PrimaryCCD.ImageExposureNP.s == IPS_BUSY && ExposureLoopS[EXPOSURE_LOOP_OFF].s == ISS_ON)
-            if (PrimaryCCD.ImageExposureNP.s == IPS_BUSY)
+            //if (PrimaryCCD.ImageExposureNP.getState() == IPS_BUSY && ExposureLoopSP[EXPOSURE_LOOP_OFF].s == ISS_ON)
+            if (PrimaryCCD.ImageExposureNP.getState() == IPS_BUSY)
             {
                 if (CanAbort() && AbortExposure() == false)
                     DEBUG(Logger::DBG_WARNING, "Warning: Aborting exposure failed.");
@@ -958,50 +958,50 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
                     }
                 }
 
-                PrimaryCCD.ImageExposureNP.s = IPS_BUSY;
+                PrimaryCCD.ImageExposureNP.setState(IPS_BUSY);
                 if (ExposureTime * 1000 < getCurrentPollingPeriod())
                     setCurrentPollingPeriod(ExposureTime * 950);
             }
             else
-                PrimaryCCD.ImageExposureNP.s = IPS_ALERT;
-            IDSetNumber(&PrimaryCCD.ImageExposureNP, nullptr);
+                PrimaryCCD.ImageExposureNP.setState(IPS_ALERT);
+            PrimaryCCD.ImageExposureNP.apply();
             return true;
         }
 
         if (!strcmp(name, "GUIDER_EXPOSURE"))
         {
             if (GuideCCD.getFrameType() != CCDChip::BIAS_FRAME &&
-                    (values[0] < GuideCCD.ImageExposureN[0].min || values[0] > GuideCCD.ImageExposureN[0].max))
+                    (values[0] < GuideCCD.ImageExposureNP[0].min || values[0] > GuideCCD.ImageExposureNP[0].max))
             {
                 LOGF_ERROR("Requested guide exposure value (%g) seconds out of bounds [%g,%g].",
-                           values[0], GuideCCD.ImageExposureN[0].min, GuideCCD.ImageExposureN[0].max);
-                GuideCCD.ImageExposureNP.s = IPS_ALERT;
-                IDSetNumber(&GuideCCD.ImageExposureNP, nullptr);
+                           values[0], GuideCCD.ImageExposureNP[0].min, GuideCCD.ImageExposureNP[0].max);
+                GuideCCD.ImageExposureNP.setState(IPS_ALERT);
+                GuideCCD.ImageExposureNP.apply();
                 return false;
             }
 
             if (GuideCCD.getFrameType() == CCDChip::BIAS_FRAME)
-                GuideCCD.ImageExposureN[0].value = GuiderExposureTime = GuideCCD.ImageExposureN[0].min;
+                GuideCCD.ImageExposureNP[0].setValue(GuiderExposureTime = GuideCCD.ImageExposureNP[0].min);
             else
-                GuideCCD.ImageExposureN[0].value = GuiderExposureTime = values[0];
+                GuideCCD.ImageExposureNP[0].setValue(GuiderExposureTime = values[0]);
 
-            GuideCCD.ImageExposureNP.s = IPS_BUSY;
+            GuideCCD.ImageExposureNP.setState(IPS_BUSY);
             if (StartGuideExposure(GuiderExposureTime))
-                GuideCCD.ImageExposureNP.s = IPS_BUSY;
+                GuideCCD.ImageExposureNP.setState(IPS_BUSY);
             else
-                GuideCCD.ImageExposureNP.s = IPS_ALERT;
-            IDSetNumber(&GuideCCD.ImageExposureNP, nullptr);
+                GuideCCD.ImageExposureNP.setState(IPS_ALERT);
+            GuideCCD.ImageExposureNP.apply();
             return true;
         }
 
         if (!strcmp(name, "CCD_BINNING"))
         {
             //  We are being asked to set camera binning
-            INumber * np = IUFindNumber(&PrimaryCCD.ImageBinNP, names[0]);
+            INumber * np = PrimaryCCD.ImageBinNP.findWidgetByName(names[0]);
             if (np == nullptr)
             {
-                PrimaryCCD.ImageBinNP.s = IPS_ALERT;
-                IDSetNumber(&PrimaryCCD.ImageBinNP, nullptr);
+                PrimaryCCD.ImageBinNP.setState(IPS_ALERT);
+                PrimaryCCD.ImageBinNP.apply();
                 return false;
             }
 
@@ -1019,13 +1019,13 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
 
             if (UpdateCCDBin(binx, biny))
             {
-                IUUpdateNumber(&PrimaryCCD.ImageBinNP, values, names, n);
-                PrimaryCCD.ImageBinNP.s = IPS_OK;
+                PrimaryCCD.ImageBinNP.update(values, names, n);
+                PrimaryCCD.ImageBinNP.setState(IPS_OK);
             }
             else
-                PrimaryCCD.ImageBinNP.s = IPS_ALERT;
+                PrimaryCCD.ImageBinNP.setState(IPS_ALERT);
 
-            IDSetNumber(&PrimaryCCD.ImageBinNP, nullptr);
+            PrimaryCCD.ImageBinNP.apply();
 
             return true;
         }
@@ -1033,11 +1033,11 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
         if (!strcmp(name, "GUIDER_BINNING"))
         {
             //  We are being asked to set camera binning
-            INumber * np = IUFindNumber(&GuideCCD.ImageBinNP, names[0]);
+            INumber * np = GuideCCD.ImageBinNP.findWidgetByName(names[0]);
             if (np == nullptr)
             {
-                GuideCCD.ImageBinNP.s = IPS_ALERT;
-                IDSetNumber(&GuideCCD.ImageBinNP, nullptr);
+                GuideCCD.ImageBinNP.setState(IPS_ALERT);
+                GuideCCD.ImageBinNP.apply();
                 return false;
             }
 
@@ -1055,13 +1055,13 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
 
             if (UpdateGuiderBin(binx, biny))
             {
-                IUUpdateNumber(&GuideCCD.ImageBinNP, values, names, n);
-                GuideCCD.ImageBinNP.s = IPS_OK;
+                GuideCCD.ImageBinNP.update(values, names, n);
+                GuideCCD.ImageBinNP.setState(IPS_OK);
             }
             else
-                GuideCCD.ImageBinNP.s = IPS_ALERT;
+                GuideCCD.ImageBinNP.setState(IPS_ALERT);
 
-            IDSetNumber(&GuideCCD.ImageBinNP, nullptr);
+            GuideCCD.ImageBinNP.apply();
 
             return true;
         }
@@ -1086,39 +1086,39 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
             if (x < 0 || y < 0 || w <= 0 || h <= 0)
             {
                 LOGF_ERROR("Invalid frame requested (%d,%d) (%d x %d)", x, y, w, h);
-                PrimaryCCD.ImageFrameNP.s = IPS_ALERT;
-                IDSetNumber(&PrimaryCCD.ImageFrameNP, nullptr);
+                PrimaryCCD.ImageFrameNP.setState(IPS_ALERT);
+                PrimaryCCD.ImageFrameNP.apply();
                 return true;
             }
 
             if (UpdateCCDFrame(x, y, w, h))
             {
-                PrimaryCCD.ImageFrameNP.s = IPS_OK;
-                IUUpdateNumber(&PrimaryCCD.ImageFrameNP, values, names, n);
+                PrimaryCCD.ImageFrameNP.setState(IPS_OK);
+                PrimaryCCD.ImageFrameNP.update(values, names, n);
             }
             else
-                PrimaryCCD.ImageFrameNP.s = IPS_ALERT;
+                PrimaryCCD.ImageFrameNP.setState(IPS_ALERT);
 
-            IDSetNumber(&PrimaryCCD.ImageFrameNP, nullptr);
+            PrimaryCCD.ImageFrameNP.apply();
             return true;
         }
 
         if (!strcmp(name, "GUIDER_FRAME"))
         {
             //  We are being asked to set guide frame
-            if (IUUpdateNumber(&GuideCCD.ImageFrameNP, values, names, n) < 0)
+            if (!GuideCCD.ImageFrameNP.update(values, names, n))
                 return false;
 
-            GuideCCD.ImageFrameNP.s = IPS_OK;
+            GuideCCD.ImageFrameNP.setState(IPS_OK);
 
             DEBUGF(Logger::DBG_DEBUG, "Requested Guide Frame is %4.0f,%4.0f %4.0f x %4.0f", values[0], values[1],
                    values[2], values[4]);
 
-            if (UpdateGuiderFrame(GuideCCD.ImageFrameN[0].value, GuideCCD.ImageFrameN[1].value,
-                                  GuideCCD.ImageFrameN[2].value, GuideCCD.ImageFrameN[3].value) == false)
-                GuideCCD.ImageFrameNP.s = IPS_ALERT;
+            if (UpdateGuiderFrame(GuideCCD.ImageFrameNP[0].getValue(), GuideCCD.ImageFrameNP[1].getValue(),
+                                  GuideCCD.ImageFrameNP[2].getValue(), GuideCCD.ImageFrameNP[3].getValue()) == false)
+                GuideCCD.ImageFrameNP.setState(IPS_ALERT);
 
-            IDSetNumber(&GuideCCD.ImageFrameNP, nullptr);
+            GuideCCD.ImageFrameNP.apply();
 
             return true;
         }
@@ -1126,17 +1126,17 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
 #if 0
         if (!strcmp(name, "CCD_GUIDESTAR"))
         {
-            PrimaryCCD.RapidGuideDataNP.s = IPS_OK;
-            IUUpdateNumber(&PrimaryCCD.RapidGuideDataNP, values, names, n);
-            IDSetNumber(&PrimaryCCD.RapidGuideDataNP, nullptr);
+            PrimaryCCD.RapidGuideDataNP.setState(IPS_OK);
+            PrimaryCCD.RapidGuideDataNP.update(values, names, n);
+            PrimaryCCD.RapidGuideDataNP.apply();
             return true;
         }
 
         if (!strcmp(name, "GUIDER_GUIDESTAR"))
         {
-            GuideCCD.RapidGuideDataNP.s = IPS_OK;
-            IUUpdateNumber(&GuideCCD.RapidGuideDataNP, values, names, n);
-            IDSetNumber(&GuideCCD.RapidGuideDataNP, nullptr);
+            GuideCCD.RapidGuideDataNP.setState(IPS_OK);
+            GuideCCD.RapidGuideDataNP.update(values, names, n);
+            GuideCCD.RapidGuideDataNP.apply();
             return true;
         }
 #endif
@@ -1148,83 +1148,83 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
         }
 
 #ifdef WITH_EXPOSURE_LOOPING
-        if (!strcmp(name, ExposureLoopCountNP.name))
+        if (ExposureLoopCountNP.isNameMatch(name))
         {
-            IUUpdateNumber(&ExposureLoopCountNP, values, names, n);
-            ExposureLoopCountNP.s = IPS_OK;
-            IDSetNumber(&ExposureLoopCountNP, nullptr);
+            ExposureLoopCountNP.update(values, names, n);
+            ExposureLoopCountNP.setState(IPS_OK);
+            ExposureLoopCountNP.apply();
             return true;
         }
 #endif
 
         // CCD TEMPERATURE:
-        if (!strcmp(name, TemperatureNP.name))
+        if (TemperatureNP.isNameMatch(name))
         {
-            if (values[0] < TemperatureN[0].min || values[0] > TemperatureN[0].max)
+            if (values[0] < TemperatureNP[0].min || values[0] > TemperatureNP[0].max)
             {
-                TemperatureNP.s = IPS_ALERT;
+                TemperatureNP.setState(IPS_ALERT);
                 LOGF_ERROR("Error: Bad temperature value! Range is [%.1f, %.1f] [C].",
-                           TemperatureN[0].min, TemperatureN[0].max);
-                IDSetNumber(&TemperatureNP, nullptr);
+                           TemperatureNP[0].min, TemperatureNP[0].max);
+                TemperatureNP.apply();
                 return false;
             }
 
             int rc = SetTemperature(values[0]);
 
             if (rc == 0)
-                TemperatureNP.s = IPS_BUSY;
+                TemperatureNP.setState(IPS_BUSY);
             else if (rc == 1)
-                TemperatureNP.s = IPS_OK;
+                TemperatureNP.setState(IPS_OK);
             else
-                TemperatureNP.s = IPS_ALERT;
+                TemperatureNP.setState(IPS_ALERT);
 
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP.apply();
             return true;
         }
 
         // Primary CCD Info
-        if (!strcmp(name, PrimaryCCD.ImagePixelSizeNP.name))
+        if (PrimaryCCD.ImagePixelSizeNP.isNameMatch(name))
         {
-            if (IUUpdateNumber(&PrimaryCCD.ImagePixelSizeNP, values, names, n) == 0)
+            if (PrimaryCCD.ImagePixelSizeNP.update(values, names, n) == 0)
             {
-                PrimaryCCD.ImagePixelSizeNP.s = IPS_OK;
-                SetCCDParams(PrimaryCCD.ImagePixelSizeNP.np[CCDChip::CCD_MAX_X].value,
-                             PrimaryCCD.ImagePixelSizeNP.np[CCDChip::CCD_MAX_Y].value,
+                PrimaryCCD.ImagePixelSizeNP.setState(IPS_OK);
+                SetCCDParams(PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_X].getValue(),
+                             PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_Y].getValue(),
                              PrimaryCCD.getBPP(),
-                             PrimaryCCD.ImagePixelSizeNP.np[CCDChip::CCD_PIXEL_SIZE_X].value,
-                             PrimaryCCD.ImagePixelSizeNP.np[CCDChip::CCD_PIXEL_SIZE_Y].value);
-                saveConfig(true, PrimaryCCD.ImagePixelSizeNP.name);
+                             PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_X].getValue(),
+                             PrimaryCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_Y].getValue());
+                saveConfig(true, PrimaryCCD.ImagePixelSizeNP.getName());
             }
             else
-                PrimaryCCD.ImagePixelSizeNP.s = IPS_ALERT;
+                PrimaryCCD.ImagePixelSizeNP.setState(IPS_ALERT);
 
-            IDSetNumber(&PrimaryCCD.ImagePixelSizeNP, nullptr);
+            PrimaryCCD.ImagePixelSizeNP.apply();
             return true;
         }
 
         // Guide CCD Info
-        if (!strcmp(name, GuideCCD.ImagePixelSizeNP.name))
+        if (GuideCCD.ImagePixelSizeNP.isNameMatch(name))
         {
-            IUUpdateNumber(&GuideCCD.ImagePixelSizeNP, values, names, n);
-            GuideCCD.ImagePixelSizeNP.s = IPS_OK;
-            SetGuiderParams(GuideCCD.ImagePixelSizeNP.np[CCDChip::CCD_MAX_X].value,
-                            GuideCCD.ImagePixelSizeNP.np[CCDChip::CCD_MAX_Y].value, GuideCCD.getBPP(),
-                            GuideCCD.ImagePixelSizeNP.np[CCDChip::CCD_PIXEL_SIZE_X].value,
-                            GuideCCD.ImagePixelSizeNP.np[CCDChip::CCD_PIXEL_SIZE_Y].value);
-            IDSetNumber(&GuideCCD.ImagePixelSizeNP, nullptr);
+            GuideCCD.ImagePixelSizeNP.update(values, names, n);
+            GuideCCD.ImagePixelSizeNP.setState(IPS_OK);
+            SetGuiderParams(GuideCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_X].getValue(),
+                            GuideCCD.ImagePixelSizeNP[CCDChip::CCD_MAX_Y].getValue(), GuideCCD.getBPP(),
+                            GuideCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_X].getValue(),
+                            GuideCCD.ImagePixelSizeNP[CCDChip::CCD_PIXEL_SIZE_Y].getValue());
+            GuideCCD.ImagePixelSizeNP.apply();
             saveConfig(true);
             return true;
         }
 
         // CCD Rotation
-        if (!strcmp(name, CCDRotationNP.name))
+        if (CCDRotationNP.isNameMatch(name))
         {
-            IUUpdateNumber(&CCDRotationNP, values, names, n);
-            CCDRotationNP.s = IPS_OK;
-            IDSetNumber(&CCDRotationNP, nullptr);
+            CCDRotationNP.update(values, names, n);
+            CCDRotationNP.setState(IPS_OK);
+            CCDRotationNP.apply();
             m_ValidCCDRotation = true;
 
-            DEBUGF(Logger::DBG_SESSION, "CCD FOV rotation updated to %g degrees.", CCDRotationN[0].value);
+            DEBUGF(Logger::DBG_SESSION, "CCD FOV rotation updated to %g degrees.", CCDRotationNP[0].getValue());
 
             return true;
         }
@@ -1246,177 +1246,177 @@ bool CCD::ISNewSwitch(const char * dev, const char * name, ISState * states, cha
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Upload Mode
-        if (!strcmp(name, UploadSP.name))
+        if (UploadSP.isNameMatch(name))
         {
-            int prevMode = IUFindOnSwitchIndex(&UploadSP);
-            IUUpdateSwitch(&UploadSP, states, names, n);
+            int prevMode = UploadSP.findOnSwitchIndex();
+            UploadSP.update(states, names, n);
 
-            if (UpdateCCDUploadMode(static_cast<CCD_UPLOAD_MODE>(IUFindOnSwitchIndex(&UploadSP))))
+            if (UpdateCCDUploadMode(static_cast<CCD_UPLOAD_MODE>(UploadSP.findOnSwitchIndex())))
             {
-                if (UploadS[UPLOAD_CLIENT].s == ISS_ON)
+                if (UploadSP[UPLOAD_CLIENT].getState() == ISS_ON)
                 {
                     DEBUG(Logger::DBG_SESSION, "Upload settings set to client only.");
                     if (prevMode != 0)
-                        deleteProperty(FileNameTP.name);
+                        deleteProperty(FileNameTP.getName());
                 }
-                else if (UploadS[UPLOAD_LOCAL].s == ISS_ON)
+                else if (UploadSP[UPLOAD_LOCAL].getState() == ISS_ON)
                 {
                     DEBUG(Logger::DBG_SESSION, "Upload settings set to local only.");
-                    defineProperty(&FileNameTP);
+                    defineProperty(FileNameTP);
                 }
                 else
                 {
                     DEBUG(Logger::DBG_SESSION, "Upload settings set to client and local.");
-                    defineProperty(&FileNameTP);
+                    defineProperty(FileNameTP);
                 }
 
-                UploadSP.s = IPS_OK;
+                UploadSP.setState(IPS_OK);
             }
             else
             {
-                IUResetSwitch(&UploadSP);
-                UploadS[prevMode].s = ISS_ON;
-                UploadSP.s = IPS_ALERT;
+                UploadSP.reset();
+                UploadSP[prevMode].setState(ISS_ON);
+                UploadSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&UploadSP, nullptr);
+            UploadSP.apply();
 
             return true;
         }
 
-        if (!strcmp(name, TelescopeTypeSP.name))
+        if (TelescopeTypeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&TelescopeTypeSP, states, names, n);
-            TelescopeTypeSP.s = IPS_OK;
-            IDSetSwitch(&TelescopeTypeSP, nullptr);
+            TelescopeTypeSP.update(states, names, n);
+            TelescopeTypeSP.setState(IPS_OK);
+            TelescopeTypeSP.apply();
             return true;
         }
 
 #ifdef WITH_EXPOSURE_LOOPING
         // Exposure Looping
-        if (!strcmp(name, ExposureLoopSP.name))
+        if (ExposureLoopSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ExposureLoopSP, states, names, n);
-            ExposureLoopSP.s = IPS_OK;
-            IDSetSwitch(&ExposureLoopSP, nullptr);
+            ExposureLoopSP.update(states, names, n);
+            ExposureLoopSP.setState(IPS_OK);
+            ExposureLoopSP.apply();
             return true;
         }
 #endif
 
 #ifdef HAVE_WEBSOCKET
         // Websocket Enable/Disable
-        if (!strcmp(name, WebSocketSP.name))
+        if (WebSocketSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&WebSocketSP, states, names, n);
-            WebSocketSP.s = IPS_OK;
+            WebSocketSP.update(states, names, n);
+            WebSocketSP.setState(IPS_OK);
 
-            if (WebSocketS[WEBSOCKET_ENABLED].s == ISS_ON)
+            if (WebSocketSP[WEBSOCKET_ENABLED].getState() == ISS_ON)
             {
                 wsThread = std::thread(&wsThreadHelper, this);
-                WebSocketSettingsN[WS_SETTINGS_PORT].value = wsServer.generatePort();
-                WebSocketSettingsNP.s = IPS_OK;
-                defineProperty(&WebSocketSettingsNP);
+                WebSocketSettingsNP[WS_SETTINGS_PORT].setValue(wsServer.generatePort());
+                WebSocketSettingsNP.setState(IPS_OK);
+                defineProperty(WebSocketSettingsNP);
             }
             else if (wsServer.is_running())
             {
                 wsServer.stop();
                 wsThread.join();
-                deleteProperty(WebSocketSettingsNP.name);
+                deleteProperty(WebSocketSettingsNP.getName());
             }
 
-            IDSetSwitch(&WebSocketSP, nullptr);
+            WebSocketSP.apply();
             return true;
         }
 #endif
 
         // WCS Enable/Disable
-        if (!strcmp(name, WorldCoordSP.name))
+        if (WorldCoordSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&WorldCoordSP, states, names, n);
-            WorldCoordSP.s = IPS_OK;
+            WorldCoordSP.update(states, names, n);
+            WorldCoordSP.setState(IPS_OK);
 
-            if (WorldCoordS[0].s == ISS_ON)
+            if (WorldCoordSP[0].getState() == ISS_ON)
             {
                 LOG_INFO("World Coordinate System is enabled.");
-                defineProperty(&CCDRotationNP);
+                defineProperty(CCDRotationNP);
             }
             else
             {
                 LOG_INFO("World Coordinate System is disabled.");
-                deleteProperty(CCDRotationNP.name);
+                deleteProperty(CCDRotationNP.getName());
             }
 
             m_ValidCCDRotation = false;
-            IDSetSwitch(&WorldCoordSP, nullptr);
+            WorldCoordSP.apply();
         }
 
         // Primary Chip Frame Reset
-        if (strcmp(name, PrimaryCCD.ResetSP.name) == 0)
+        if (PrimaryCCD.ResetSP.isNameMatch(name))
         {
-            IUResetSwitch(&PrimaryCCD.ResetSP);
-            PrimaryCCD.ResetSP.s = IPS_OK;
+            PrimaryCCD.ResetSP.reset();
+            PrimaryCCD.ResetSP.setState(IPS_OK);
             if (CanBin())
                 UpdateCCDBin(1, 1);
             if (CanSubFrame())
                 UpdateCCDFrame(0, 0, PrimaryCCD.getXRes(), PrimaryCCD.getYRes());
 
-            IDSetSwitch(&PrimaryCCD.ResetSP, nullptr);
+            PrimaryCCD.ResetSP.apply();
             return true;
         }
 
         // Primary Chip Abort Expsoure
-        if (strcmp(name, PrimaryCCD.AbortExposureSP.name) == 0)
+        if (PrimaryCCD.AbortExposureSP.isNameMatch(name))
         {
-            IUResetSwitch(&PrimaryCCD.AbortExposureSP);
+            PrimaryCCD.AbortExposureSP.reset();
 
             if (AbortExposure())
             {
-                PrimaryCCD.AbortExposureSP.s       = IPS_OK;
-                PrimaryCCD.ImageExposureNP.s       = IPS_IDLE;
-                PrimaryCCD.ImageExposureN[0].value = 0;
+                PrimaryCCD.AbortExposureSP.setState(IPS_OK);
+                PrimaryCCD.ImageExposureNP.setState(IPS_IDLE);
+                PrimaryCCD.ImageExposureNP[0].setValue(0);
             }
             else
             {
-                PrimaryCCD.AbortExposureSP.s = IPS_ALERT;
-                PrimaryCCD.ImageExposureNP.s = IPS_ALERT;
+                PrimaryCCD.AbortExposureSP.setState(IPS_ALERT);
+                PrimaryCCD.ImageExposureNP.setState(IPS_ALERT);
             }
 
             setCurrentPollingPeriod(getPollingPeriod());
 
 #ifdef WITH_EXPOSURE_LOOPING
-            if (ExposureLoopCountNP.s == IPS_BUSY)
+            if (ExposureLoopCountNP.getState() == IPS_BUSY)
             {
                 uploadTime = 0;
-                ExposureLoopCountNP.s = IPS_IDLE;
-                ExposureLoopCountN[0].value = 1;
-                IDSetNumber(&ExposureLoopCountNP, nullptr);
+                ExposureLoopCountNP.setState(IPS_IDLE);
+                ExposureLoopCountNP[0].setValue(1);
+                ExposureLoopCountNP.apply();
             }
 #endif
-            IDSetSwitch(&PrimaryCCD.AbortExposureSP, nullptr);
-            IDSetNumber(&PrimaryCCD.ImageExposureNP, nullptr);
+            PrimaryCCD.AbortExposureSP.apply();
+            PrimaryCCD.ImageExposureNP.apply();
 
             return true;
         }
 
         // Guide Chip Abort Exposure
-        if (strcmp(name, GuideCCD.AbortExposureSP.name) == 0)
+        if (GuideCCD.AbortExposureSP.isNameMatch(name))
         {
-            IUResetSwitch(&GuideCCD.AbortExposureSP);
+            GuideCCD.AbortExposureSP.reset();
 
             if (AbortGuideExposure())
             {
-                GuideCCD.AbortExposureSP.s       = IPS_OK;
-                GuideCCD.ImageExposureNP.s       = IPS_IDLE;
-                GuideCCD.ImageExposureN[0].value = 0;
+                GuideCCD.AbortExposureSP.setState(IPS_OK);
+                GuideCCD.ImageExposureNP.setState(IPS_IDLE);
+                GuideCCD.ImageExposureNP[0].setValue(0);
             }
             else
             {
-                GuideCCD.AbortExposureSP.s = IPS_ALERT;
-                GuideCCD.ImageExposureNP.s = IPS_ALERT;
+                GuideCCD.AbortExposureSP.setState(IPS_ALERT);
+                GuideCCD.ImageExposureNP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&GuideCCD.AbortExposureSP, nullptr);
-            IDSetNumber(&GuideCCD.ImageExposureNP, nullptr);
+            GuideCCD.AbortExposureSP.apply();
+            GuideCCD.ImageExposureNP.apply();
 
             return true;
         }
@@ -1458,140 +1458,140 @@ bool CCD::ISNewSwitch(const char * dev, const char * name, ISState * states, cha
         }
 
         // Primary Chip Frame Type
-        if (strcmp(name, PrimaryCCD.FrameTypeSP.name) == 0)
+        if (PrimaryCCD.FrameTypeSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PrimaryCCD.FrameTypeSP, states, names, n);
-            PrimaryCCD.FrameTypeSP.s = IPS_OK;
-            if (PrimaryCCD.FrameTypeS[0].s == ISS_ON)
+            PrimaryCCD.FrameTypeSP.update(states, names, n);
+            PrimaryCCD.FrameTypeSP.setState(IPS_OK);
+            if (PrimaryCCD.FrameTypeSP[0].getState() == ISS_ON)
                 PrimaryCCD.setFrameType(CCDChip::LIGHT_FRAME);
-            else if (PrimaryCCD.FrameTypeS[1].s == ISS_ON)
+            else if (PrimaryCCD.FrameTypeSP[1].getState() == ISS_ON)
             {
                 PrimaryCCD.setFrameType(CCDChip::BIAS_FRAME);
                 if (HasShutter() == false)
                     DEBUG(Logger::DBG_WARNING,
                           "The CCD does not have a shutter. Cover the camera in order to take a bias frame.");
             }
-            else if (PrimaryCCD.FrameTypeS[2].s == ISS_ON)
+            else if (PrimaryCCD.FrameTypeSP[2].getState() == ISS_ON)
             {
                 PrimaryCCD.setFrameType(CCDChip::DARK_FRAME);
                 if (HasShutter() == false)
                     DEBUG(Logger::DBG_WARNING,
                           "The CCD does not have a shutter. Cover the camera in order to take a dark frame.");
             }
-            else if (PrimaryCCD.FrameTypeS[3].s == ISS_ON)
+            else if (PrimaryCCD.FrameTypeSP[3].getState() == ISS_ON)
                 PrimaryCCD.setFrameType(CCDChip::FLAT_FRAME);
 
             if (UpdateCCDFrameType(PrimaryCCD.getFrameType()) == false)
-                PrimaryCCD.FrameTypeSP.s = IPS_ALERT;
+                PrimaryCCD.FrameTypeSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&PrimaryCCD.FrameTypeSP, nullptr);
+            PrimaryCCD.FrameTypeSP.apply();
 
             return true;
         }
 
         // Guide Chip Frame Type
-        if (strcmp(name, GuideCCD.FrameTypeSP.name) == 0)
+        if (GuideCCD.FrameTypeSP.isNameMatch(name))
         {
             //  Compression Update
-            IUUpdateSwitch(&GuideCCD.FrameTypeSP, states, names, n);
-            GuideCCD.FrameTypeSP.s = IPS_OK;
-            if (GuideCCD.FrameTypeS[0].s == ISS_ON)
+            GuideCCD.FrameTypeSP.update(states, names, n);
+            GuideCCD.FrameTypeSP.setState(IPS_OK);
+            if (GuideCCD.FrameTypeSP[0].getState() == ISS_ON)
                 GuideCCD.setFrameType(CCDChip::LIGHT_FRAME);
-            else if (GuideCCD.FrameTypeS[1].s == ISS_ON)
+            else if (GuideCCD.FrameTypeSP[1].getState() == ISS_ON)
             {
                 GuideCCD.setFrameType(CCDChip::BIAS_FRAME);
                 if (HasShutter() == false)
                     DEBUG(Logger::DBG_WARNING,
                           "The CCD does not have a shutter. Cover the camera in order to take a bias frame.");
             }
-            else if (GuideCCD.FrameTypeS[2].s == ISS_ON)
+            else if (GuideCCD.FrameTypeSP[2].getState() == ISS_ON)
             {
                 GuideCCD.setFrameType(CCDChip::DARK_FRAME);
                 if (HasShutter() == false)
                     DEBUG(Logger::DBG_WARNING,
                           "The CCD does not have a shutter. Cover the camera in order to take a dark frame.");
             }
-            else if (GuideCCD.FrameTypeS[3].s == ISS_ON)
+            else if (GuideCCD.FrameTypeSP[3].getState() == ISS_ON)
                 GuideCCD.setFrameType(CCDChip::FLAT_FRAME);
 
             if (UpdateGuiderFrameType(GuideCCD.getFrameType()) == false)
-                GuideCCD.FrameTypeSP.s = IPS_ALERT;
+                GuideCCD.FrameTypeSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&GuideCCD.FrameTypeSP, nullptr);
+            GuideCCD.FrameTypeSP.apply();
 
             return true;
         }
 
 #if 0
         // Primary Chip Rapid Guide Enable/Disable
-        if (strcmp(name, PrimaryCCD.RapidGuideSP.name) == 0)
+        if (PrimaryCCD.RapidGuideSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PrimaryCCD.RapidGuideSP, states, names, n);
-            PrimaryCCD.RapidGuideSP.s = IPS_OK;
-            RapidGuideEnabled         = (PrimaryCCD.RapidGuideS[0].s == ISS_ON);
+            PrimaryCCD.RapidGuideSP.update(states, names, n);
+            PrimaryCCD.RapidGuideSP.setState(IPS_OK);
+            RapidGuideEnabled         = (PrimaryCCD.RapidGuideSP[0].getState() == ISS_ON);
 
             if (RapidGuideEnabled)
             {
-                defineProperty(&PrimaryCCD.RapidGuideSetupSP);
-                defineProperty(&PrimaryCCD.RapidGuideDataNP);
+                defineProperty(PrimaryCCD.RapidGuideSetupSP);
+                defineProperty(PrimaryCCD.RapidGuideDataNP);
             }
             else
             {
-                deleteProperty(PrimaryCCD.RapidGuideSetupSP.name);
-                deleteProperty(PrimaryCCD.RapidGuideDataNP.name);
+                deleteProperty(PrimaryCCD.RapidGuideSetupSP.getName());
+                deleteProperty(PrimaryCCD.RapidGuideDataNP.getName());
             }
 
-            IDSetSwitch(&PrimaryCCD.RapidGuideSP, nullptr);
+            PrimaryCCD.RapidGuideSP.apply();
             return true;
         }
 
         // Guide Chip Rapid Guide Enable/Disable
-        if (strcmp(name, GuideCCD.RapidGuideSP.name) == 0)
+        if (GuideCCD.RapidGuideSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&GuideCCD.RapidGuideSP, states, names, n);
-            GuideCCD.RapidGuideSP.s = IPS_OK;
-            GuiderRapidGuideEnabled = (GuideCCD.RapidGuideS[0].s == ISS_ON);
+            GuideCCD.RapidGuideSP.update(states, names, n);
+            GuideCCD.RapidGuideSP.setState(IPS_OK);
+            GuiderRapidGuideEnabled = (GuideCCD.RapidGuideSP[0].getState() == ISS_ON);
 
             if (GuiderRapidGuideEnabled)
             {
-                defineProperty(&GuideCCD.RapidGuideSetupSP);
-                defineProperty(&GuideCCD.RapidGuideDataNP);
+                defineProperty(GuideCCD.RapidGuideSetupSP);
+                defineProperty(GuideCCD.RapidGuideDataNP);
             }
             else
             {
-                deleteProperty(GuideCCD.RapidGuideSetupSP.name);
-                deleteProperty(GuideCCD.RapidGuideDataNP.name);
+                deleteProperty(GuideCCD.RapidGuideSetupSP.getName());
+                deleteProperty(GuideCCD.RapidGuideDataNP.getName());
             }
 
-            IDSetSwitch(&GuideCCD.RapidGuideSP, nullptr);
+            GuideCCD.RapidGuideSP.apply();
             return true;
         }
 
         // Primary CCD Rapid Guide Setup
-        if (strcmp(name, PrimaryCCD.RapidGuideSetupSP.name) == 0)
+        if (PrimaryCCD.RapidGuideSetupSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PrimaryCCD.RapidGuideSetupSP, states, names, n);
-            PrimaryCCD.RapidGuideSetupSP.s = IPS_OK;
+            PrimaryCCD.RapidGuideSetupSP.update(states, names, n);
+            PrimaryCCD.RapidGuideSetupSP.setState(IPS_OK);
 
-            AutoLoop   = (PrimaryCCD.RapidGuideSetupS[0].s == ISS_ON);
-            SendImage  = (PrimaryCCD.RapidGuideSetupS[1].s == ISS_ON);
-            ShowMarker = (PrimaryCCD.RapidGuideSetupS[2].s == ISS_ON);
+            AutoLoop   = (PrimaryCCD.RapidGuideSetupSP[0].getState() == ISS_ON);
+            SendImage  = (PrimaryCCD.RapidGuideSetupSP[1].getState() == ISS_ON);
+            ShowMarker = (PrimaryCCD.RapidGuideSetupSP[2].getState() == ISS_ON);
 
-            IDSetSwitch(&PrimaryCCD.RapidGuideSetupSP, nullptr);
+            PrimaryCCD.RapidGuideSetupSP.apply();
             return true;
         }
 
         // Guide Chip Rapid Guide Setup
-        if (strcmp(name, GuideCCD.RapidGuideSetupSP.name) == 0)
+        if (GuideCCD.RapidGuideSetupSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&GuideCCD.RapidGuideSetupSP, states, names, n);
-            GuideCCD.RapidGuideSetupSP.s = IPS_OK;
+            GuideCCD.RapidGuideSetupSP.update(states, names, n);
+            GuideCCD.RapidGuideSetupSP.setState(IPS_OK);
 
-            GuiderAutoLoop   = (GuideCCD.RapidGuideSetupS[0].s == ISS_ON);
-            GuiderSendImage  = (GuideCCD.RapidGuideSetupS[1].s == ISS_ON);
-            GuiderShowMarker = (GuideCCD.RapidGuideSetupS[2].s == ISS_ON);
+            GuiderAutoLoop   = (GuideCCD.RapidGuideSetupSP[0].getState() == ISS_ON);
+            GuiderSendImage  = (GuideCCD.RapidGuideSetupSP[1].getState() == ISS_ON);
+            GuiderShowMarker = (GuideCCD.RapidGuideSetupSP[2].getState() == ISS_ON);
 
-            IDSetSwitch(&GuideCCD.RapidGuideSetupSP, nullptr);
+            GuideCCD.RapidGuideSetupSP.apply();
             return true;
         }
 #endif
@@ -1710,21 +1710,21 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
     fits_update_key_str(fptr, "INSTRUME", getDeviceName(), "CCD Name", &status);
 
     // Telescope
-    if (strlen(ActiveDeviceT[ACTIVE_TELESCOPE].text) > 0)
+    if (strlen(ActiveDeviceTP[ACTIVE_TELESCOPE].getText()) > 0)
     {
-        fits_update_key_str(fptr, "TELESCOP", ActiveDeviceT[0].text, "Telescope name", &status);
+        fits_update_key_str(fptr, "TELESCOP", ActiveDeviceTP[0].getText(), "Telescope name", &status);
     }
 
     // Which scope is in effect
     // TODO: Support N-telescopes
-    if (TelescopeTypeS[TELESCOPE_PRIMARY].s == ISS_ON)
+    if (TelescopeTypeSP[TELESCOPE_PRIMARY].getState() == ISS_ON)
     {
         if (primaryFocalLength > 0)
             effectiveFocalLength = primaryFocalLength;
         if (primaryAperture > 0)
             effectiveAperture = primaryAperture;
     }
-    else if (TelescopeTypeS[TELESCOPE_GUIDE].s == ISS_ON)
+    else if (TelescopeTypeSP[TELESCOPE_GUIDE].getState() == ISS_ON)
     {
         if (guiderFocalLength > 0)
             effectiveFocalLength = guiderFocalLength;
@@ -1738,10 +1738,10 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
         LOG_WARN("Telescope aperture is missing.");
 
     // Observer
-    fits_update_key_str(fptr, "OBSERVER", FITSHeaderT[FITS_OBSERVER].text, "Observer name", &status);
+    fits_update_key_str(fptr, "OBSERVER", FITSHeaderTP[FITS_OBSERVER].getText(), "Observer name", &status);
 
     // Object
-    fits_update_key_str(fptr, "OBJECT", FITSHeaderT[FITS_OBJECT].text, "Object name", &status);
+    fits_update_key_str(fptr, "OBJECT", FITSHeaderTP[FITS_OBJECT].getText(), "Object name", &status);
 
     double subPixSize1 = static_cast<double>(targetChip->getPixelSizeX());
     double subPixSize2 = static_cast<double>(targetChip->getPixelSizeY());
@@ -1759,8 +1759,8 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
         fits_update_key_dbl(fptr, "DARKTIME", targetChip->getExposureDuration(), 6, "Total Dark Exposure Time (s)", &status);
 
     // If the camera has a cooler OR if the temperature permission was explicitly set to Read-Only, then record the temperature
-    if (HasCooler() || TemperatureNP.p == IP_RO)
-        fits_update_key_dbl(fptr, "CCD-TEMP", TemperatureN[0].value, 2, "CCD Temperature (Celsius)", &status);
+    if (HasCooler() || TemperatureNP.getPermission() == IP_RO)
+        fits_update_key_dbl(fptr, "CCD-TEMP", TemperatureNP[0].getValue(), 2, "CCD Temperature (Celsius)", &status);
 
     fits_update_key_dbl(fptr, "PIXSIZE1", subPixSize1, 6, "Pixel Size 1 (microns)", &status);
     fits_update_key_dbl(fptr, "PIXSIZE2", subPixSize2, 6, "Pixel Size 2 (microns)", &status);
@@ -1810,9 +1810,9 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
 
     if (HasBayer() && targetChip->getNAxis() == 2)
     {
-        fits_update_key_lng(fptr, "XBAYROFF", atoi(BayerT[0].text), "X offset of Bayer array", &status);
-        fits_update_key_lng(fptr, "YBAYROFF", atoi(BayerT[1].text), "Y offset of Bayer array", &status);
-        fits_update_key_str(fptr, "BAYERPAT", BayerT[2].text, "Bayer color pattern", &status);
+        fits_update_key_lng(fptr, "XBAYROFF", atoi(BayerTP[0].getText()), "X offset of Bayer array", &status);
+        fits_update_key_lng(fptr, "YBAYROFF", atoi(BayerTP[1].getText()), "Y offset of Bayer array", &status);
+        fits_update_key_str(fptr, "BAYERPAT", BayerTP[2].getText(), "Bayer color pattern", &status);
     }
 
     if (!std::isnan(effectiveFocalLength))
@@ -1901,7 +1901,7 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
         fits_update_key_lng(fptr, "EQUINOX", 2000, "Equinox", &status);
 
         // Add WCS Info
-        if (WorldCoordS[0].s == ISS_ON && m_ValidCCDRotation && !std::isnan(effectiveFocalLength))
+        if (WorldCoordSP[0].getState() == ISS_ON && m_ValidCCDRotation && !std::isnan(effectiveFocalLength))
         {
             double J2000RAHours = J2000RA * 15;
             fits_update_key_dbl(fptr, "CRVAL1", J2000RAHours, 10, "CRVAL1", &status);
@@ -1934,7 +1934,7 @@ void CCD::addFITSKeywords(fitsfile * fptr, CCDChip * targetChip)
             fits_update_key_dbl(fptr, "CDELT2", degpix2, 10, "CDELT2", &status);
 
             // Rotation is CW, we need to convert it to CCW per CROTA1 definition
-            double rotation = 360 - CCDRotationN[0].value;
+            double rotation = 360 - CCDRotationNP[0].getValue();
             if (rotation > 360)
                 rotation -= 360;
 
@@ -1988,13 +1988,13 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
     }
 #ifdef WITH_EXPOSURE_LOOPING
     // If looping is on, let's immediately take another capture
-    if (ExposureLoopS[EXPOSURE_LOOP_ON].s == ISS_ON)
+    if (ExposureLoopSP[EXPOSURE_LOOP_ON].getState() == ISS_ON)
     {
         double duration = targetChip->getExposureDuration();
 
-        if (ExposureLoopCountN[0].value > 1)
+        if (ExposureLoopCountNP[0].value > 1)
         {
-            if (ExposureLoopCountNP.s != IPS_BUSY)
+            if (ExposureLoopCountNP.getState() != IPS_BUSY)
             {
                 exposureLoopStartup = std::chrono::system_clock::now();
             }
@@ -2008,15 +2008,15 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
                 exposureLoopStartup = end;
             }
 
-            ExposureLoopCountNP.s = IPS_BUSY;
-            ExposureLoopCountN[0].value--;
-            IDSetNumber(&ExposureLoopCountNP, nullptr);
+            ExposureLoopCountNP.setState(IPS_BUSY);
+            ExposureLoopCountNP[0].getValue()--;
+            ExposureLoopCountNP.apply();
 
             if (uploadTime < duration)
             {
                 StartExposure(duration);
-                PrimaryCCD.ImageExposureNP.s = IPS_BUSY;
-                IDSetNumber(&PrimaryCCD.ImageExposureNP, nullptr);
+                PrimaryCCD.ImageExposureNP.setState(IPS_BUSY);
+                PrimaryCCD.ImageExposureNP.apply();
                 if (duration * 1000 < getCurrentPollingPeriod())
                     setCurrentPollingPeriod(duration * 950);
             }
@@ -2024,11 +2024,11 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
             {
                 LOGF_ERROR("Rapid exposure not possible since upload time is %.2f seconds while exposure time is %.2f seconds.", uploadTime,
                            duration);
-                PrimaryCCD.ImageExposureNP.s = IPS_ALERT;
-                IDSetNumber(&PrimaryCCD.ImageExposureNP, nullptr);
-                ExposureLoopCountN[0].value = 1;
-                ExposureLoopCountNP.s = IPS_IDLE;
-                IDSetNumber(&ExposureLoopCountNP, nullptr);
+                PrimaryCCD.ImageExposureNP.setState(IPS_ALERT);
+                PrimaryCCD.ImageExposureNP.apply();
+                ExposureLoopCountNP[0].setValue(1);
+                ExposureLoopCountNP.setState(IPS_IDLE);
+                ExposureLoopCountNP.apply();
                 uploadTime = 0;
                 return false;
             }
@@ -2036,14 +2036,14 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
         else
         {
             uploadTime = 0;
-            ExposureLoopCountNP.s = IPS_IDLE;
-            IDSetNumber(&ExposureLoopCountNP, nullptr);
+            ExposureLoopCountNP.setState(IPS_IDLE);
+            ExposureLoopCountNP.apply();
         }
     }
 #endif
 
-    bool sendImage = (UploadS[0].s == ISS_ON || UploadS[2].s == ISS_ON);
-    bool saveImage = (UploadS[1].s == ISS_ON || UploadS[2].s == ISS_ON);
+    bool sendImage = (UploadSP[0].getState() == ISS_ON || UploadSP[2].getState() == ISS_ON);
+    bool saveImage = (UploadSP[1].getState() == ISS_ON || UploadSP[2].getState() == ISS_ON);
 
 #if 0
     bool showMarker = false;
@@ -2072,7 +2072,7 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
     {
         static double P0 = 0.906, P1 = 0.584, P2 = 0.365, P3 = 0.117, P4 = 0.049, P5 = -0.05, P6 = -0.064, P7 = -0.074,
                       P8               = -0.094;
-        targetChip->RapidGuideDataNP.s = IPS_BUSY;
+        targetChip->RapidGuideDataNP.setState(IPS_BUSY);
         int width                      = targetChip->getSubW() / targetChip->getBinX();
         int height                     = targetChip->getSubH() / targetChip->getBinY();
         void * src                      = (unsigned short *)targetChip->getFrameBuffer();
@@ -2312,9 +2312,9 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
                 }
         }
 
-        targetChip->RapidGuideDataN[0].value = ix;
-        targetChip->RapidGuideDataN[1].value = iy;
-        targetChip->RapidGuideDataN[2].value = bestFit;
+        targetChip->RapidGuideDataNP[0].setValue(ix);
+        targetChip->RapidGuideDataNP[1].setValue(iy);
+        targetChip->RapidGuideDataNP[2].setValue(bestFit);
         targetChip->lastRapidX               = ix;
         targetChip->lastRapidY               = iy;
         if (bestFit > 50)
@@ -2386,25 +2386,25 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
 
             if (total > 0)
             {
-                targetChip->RapidGuideDataN[0].value = ((double)sumX) / total;
-                targetChip->RapidGuideDataN[1].value = ((double)sumY) / total;
-                targetChip->RapidGuideDataNP.s       = IPS_OK;
+                targetChip->RapidGuideDataNP[0].setValue(((double)sumX) / total);
+                targetChip->RapidGuideDataNP[1].setValue(((double)sumY) / total);
+                targetChip->RapidGuideDataNP.setState(IPS_OK);
 
-                DEBUGF(Logger::DBG_DEBUG, "Guide Star X: %g Y: %g FIT: %g", targetChip->RapidGuideDataN[0].value,
-                       targetChip->RapidGuideDataN[1].value, targetChip->RapidGuideDataN[2].value);
+                DEBUGF(Logger::DBG_DEBUG, "Guide Star X: %g Y: %g FIT: %g", targetChip->RapidGuideDataNP[0].getValue(),
+                       targetChip->RapidGuideDataNP[1].getValue(), targetChip->RapidGuideDataNP[2].getValue());
             }
             else
             {
-                targetChip->RapidGuideDataNP.s = IPS_ALERT;
+                targetChip->RapidGuideDataNP.setState(IPS_ALERT);
                 targetChip->lastRapidX = targetChip->lastRapidY = -1;
             }
         }
         else
         {
-            targetChip->RapidGuideDataNP.s = IPS_ALERT;
+            targetChip->RapidGuideDataNP.setState(IPS_ALERT);
             targetChip->lastRapidX = targetChip->lastRapidY = -1;
         }
-        IDSetNumber(&targetChip->RapidGuideDataNP, nullptr);
+        targetChip->RapidGuideDataNP.apply();
 
         if (showMarker)
         {
@@ -2618,15 +2618,15 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
         }
     }
 
-    targetChip->ImageExposureNP.s = IPS_OK;
-    IDSetNumber(&targetChip->ImageExposureNP, nullptr);
+    targetChip->ImageExposureNP.setState(IPS_OK);
+    targetChip->ImageExposureNP.apply();
 
 #if 0
     if (autoLoop)
     {
         if (targetChip == &PrimaryCCD)
         {
-            PrimaryCCD.ImageExposureN[0].value = ExposureTime;
+            PrimaryCCD.ImageExposureNP[0].setValue(ExposureTime);
             if (StartExposure(ExposureTime))
             {
                 // Record information required later in creation of FITS header
@@ -2655,29 +2655,29 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
                     }
                 }
 
-                PrimaryCCD.ImageExposureNP.s = IPS_BUSY;
+                PrimaryCCD.ImageExposureNP.setState(IPS_BUSY);
             }
             else
             {
                 DEBUG(Logger::DBG_DEBUG, "Autoloop: Primary CCD Exposure Error!");
-                PrimaryCCD.ImageExposureNP.s = IPS_ALERT;
+                PrimaryCCD.ImageExposureNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&PrimaryCCD.ImageExposureNP, nullptr);
+            PrimaryCCD.ImageExposureNP.apply();
         }
         else
         {
-            GuideCCD.ImageExposureN[0].value = GuiderExposureTime;
-            GuideCCD.ImageExposureNP.s       = IPS_BUSY;
+            GuideCCD.ImageExposureNP[0].setValue(GuiderExposureTime);
+            GuideCCD.ImageExposureNP.setState(IPS_BUSY);
             if (StartGuideExposure(GuiderExposureTime))
-                GuideCCD.ImageExposureNP.s = IPS_BUSY;
+                GuideCCD.ImageExposureNP.setState(IPS_BUSY);
             else
             {
                 DEBUG(Logger::DBG_DEBUG, "Autoloop: Guide CCD Exposure Error!");
-                GuideCCD.ImageExposureNP.s = IPS_ALERT;
+                GuideCCD.ImageExposureNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&GuideCCD.ImageExposureNP, nullptr);
+            GuideCCD.ImageExposureNP.apply();
         }
     }
 #endif
@@ -2701,13 +2701,13 @@ bool CCD::uploadFile(CCDChip * targetChip, const void * fitsData, size_t totalBy
         FILE * fp = nullptr;
         char imageFileName[MAXRBUF];
 
-        std::string prefix = UploadSettingsT[UPLOAD_PREFIX].text;
-        int maxIndex       = getFileIndex(UploadSettingsT[UPLOAD_DIR].text, UploadSettingsT[UPLOAD_PREFIX].text,
+        std::string prefix = UploadSettingsTP[UPLOAD_PREFIX].getText();
+        int maxIndex       = getFileIndex(UploadSettingsTP[UPLOAD_DIR].getText(), UploadSettingsTP[UPLOAD_PREFIX].getText(),
                                           targetChip->FitsB.format);
 
         if (maxIndex < 0)
         {
-            LOGF_ERROR("Error iterating directory %s. %s", UploadSettingsT[0].text,
+            LOGF_ERROR("Error iterating directory %s. %s", UploadSettingsTP[0].getText(),
                        strerror(errno));
             return false;
         }
@@ -2730,7 +2730,7 @@ bool CCD::uploadFile(CCDChip * targetChip, const void * fitsData, size_t totalBy
             prefix = std::regex_replace(prefix, std::regex("XXX"), prefixIndex);
         }
 
-        snprintf(imageFileName, MAXRBUF, "%s/%s%s", UploadSettingsT[0].text, prefix.c_str(), targetChip->FitsB.format);
+        snprintf(imageFileName, MAXRBUF, "%s/%s%s", UploadSettingsTP[0].getText(), prefix.c_str(), targetChip->FitsB.format);
 
         fp = fopen(imageFileName, "w");
         if (fp == nullptr)
@@ -2746,11 +2746,11 @@ bool CCD::uploadFile(CCDChip * targetChip, const void * fitsData, size_t totalBy
         fclose(fp);
 
         // Save image file path
-        IUSaveText(&FileNameT[0], imageFileName);
+        FileNameTP[0].setText(imageFileName);
 
         DEBUGF(Logger::DBG_SESSION, "Image saved to %s", imageFileName);
-        FileNameTP.s = IPS_OK;
-        IDSetText(&FileNameTP, nullptr);
+        FileNameTP.setState(IPS_OK);
+        FileNameTP.apply();
     }
 
     if (targetChip->SendCompressed)
@@ -2868,7 +2868,7 @@ bool CCD::uploadFile(CCDChip * targetChip, const void * fitsData, size_t totalBy
     if (sendImage)
     {
 #ifdef HAVE_WEBSOCKET
-        if (HasWebSocket() && WebSocketS[WEBSOCKET_ENABLED].s == ISS_ON)
+        if (HasWebSocket() && WebSocketSP[WEBSOCKET_ENABLED].s == ISS_ON)
         {
             auto start = std::chrono::high_resolution_clock::now();
 
@@ -2923,12 +2923,12 @@ bool CCD::saveConfigItems(FILE * fp)
 {
     DefaultDevice::saveConfigItems(fp);
 
-    IUSaveConfigText(fp, &ActiveDeviceTP);
-    IUSaveConfigSwitch(fp, &UploadSP);
-    IUSaveConfigText(fp, &UploadSettingsTP);
-    IUSaveConfigSwitch(fp, &TelescopeTypeSP);
+    ActiveDeviceTP.save(fp);
+    UploadSP.save(fp);
+    UploadSettingsTP.save(fp);
+    TelescopeTypeSP.save(fp);
 #ifdef WITH_EXPOSURE_LOOPING
-    IUSaveConfigSwitch(fp, &ExposureLoopSP);
+    ExposureLoopSP.save(fp);
 #endif
 
     IUSaveConfigSwitch(fp, &PrimaryCCD.CompressSP);
@@ -2936,17 +2936,17 @@ bool CCD::saveConfigItems(FILE * fp)
     if (HasGuideHead())
     {
         IUSaveConfigSwitch(fp, &GuideCCD.CompressSP);
-        IUSaveConfigNumber(fp, &GuideCCD.ImageBinNP);
+        GuideCCD.ImageBinNP.save(fp);
     }
 
-    if (CanSubFrame() && PrimaryCCD.ImageFrameN[2].value > 0)
-        IUSaveConfigNumber(fp, &PrimaryCCD.ImageFrameNP);
+    if (CanSubFrame() && PrimaryCCD.ImageFrameNP[2].getValue() > 0)
+        PrimaryCCD.ImageFrameNP.save(fp);
 
     if (CanBin())
-        IUSaveConfigNumber(fp, &PrimaryCCD.ImageBinNP);
+        PrimaryCCD.ImageBinNP.save(fp);
 
     if (HasBayer())
-        IUSaveConfigText(fp, &BayerTP);
+        BayerTP.save(fp);
 
     if (HasStreaming())
         Streamer->saveConfigItems(fp);

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -45,6 +45,11 @@
 #include <mutex>
 #include <thread>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 //JM 2019-01-17: Disabled until further notice
 //#define WITH_EXPOSURE_LOOPING
 
@@ -572,8 +577,7 @@ class CCD : public DefaultDevice, GuiderInterface
          * ActiveDeviceTP defines snoop devices and the driver listens to this property emitted
          * by the mount driver if specified. It is important to generate a proper FITS header.
          */
-        INumberVectorProperty EqNP;
-        INumber EqN[2];
+        INDI::PropertyNumber EqNP {2};
 
         /**
          * @brief ActiveDeviceTP defines 4 devices the camera driver can listen to (snoop) for
@@ -583,10 +587,9 @@ class CCD : public DefaultDevice, GuiderInterface
          * + **Filter Wheel**: Listens for FILTER_SLOT and FILTER_NAME properties.
          * + **SQM**: Listens for sky quality meter magnitude.
          */
-        ITextVectorProperty ActiveDeviceTP;
 
         // JJ ed 2019-12-10
-        IText ActiveDeviceT[5] {};
+        INDI::PropertyText ActiveDeviceTP {5};
         enum
         {
             ACTIVE_TELESCOPE,
@@ -599,36 +602,30 @@ class CCD : public DefaultDevice, GuiderInterface
         /**
          * @brief TemperatureNP Read-Only Temperature in Celcius.
          */
-        INumberVectorProperty TemperatureNP;
-        INumber TemperatureN[1];
+        INDI::PropertyNumber TemperatureNP {1};
 
         /**
          *@brief BayerTP Bayer pattern offset and type
          */
-        ITextVectorProperty BayerTP;
-        IText BayerT[3] {};
+        INDI::PropertyText BayerTP {3};
 
         /**
          *@brief FileNameTP File name of locally-saved images. By default, images are uploaded to the client
          * but when upload option is set to either @a Both or @a Local, then they are saved on the local disk with
          * this name.
          */
-        ITextVectorProperty FileNameTP;
-        IText FileNameT[1] {};
+        INDI::PropertyText FileNameTP {1};
 
-        ISwitch UploadS[3];
-        ISwitchVectorProperty UploadSP;
+        INDI::PropertySwitch UploadSP {3};
 
-        IText UploadSettingsT[2] {};
-        ITextVectorProperty UploadSettingsTP;
+        INDI::PropertyText UploadSettingsTP {2};
         enum
         {
             UPLOAD_DIR,
             UPLOAD_PREFIX
         };
 
-        ISwitch TelescopeTypeS[2];
-        ISwitchVectorProperty TelescopeTypeSP;
+        INDI::PropertySwitch TelescopeTypeSP {2};
         enum
         {
             TELESCOPE_PRIMARY,
@@ -636,8 +633,7 @@ class CCD : public DefaultDevice, GuiderInterface
         };
 
         // Websocket Support
-        ISwitch WebSocketS[2];
-        ISwitchVectorProperty WebSocketSP;
+        INDI::PropertySwitch WebSocketSP {2};
         enum
         {
             WEBSOCKET_ENABLED,
@@ -646,25 +642,21 @@ class CCD : public DefaultDevice, GuiderInterface
 
 
         // Websocket Settings
-        INumber WebSocketSettingsN[1];
-        INumberVectorProperty WebSocketSettingsNP;
+        INDI::PropertyNumber WebSocketSettingsNP {1};
         enum
         {
             WS_SETTINGS_PORT,
         };
 
         // WCS
-        ISwitch WorldCoordS[2];
-        ISwitchVectorProperty WorldCoordSP;
+        INDI::PropertySwitch WorldCoordSP {2};
 
         // WCS CCD Rotation
-        INumber CCDRotationN[1];
-        INumberVectorProperty CCDRotationNP;
+        INDI::PropertyNumber CCDRotationNP {1};
 
 #ifdef WITH_EXPOSURE_LOOPING
         // Exposure Looping
-        ISwitch ExposureLoopS[2];
-        ISwitchVectorProperty ExposureLoopSP;
+        INDI::PropertySwitch ExposureLoopSP {2};
         enum
         {
             EXPOSURE_LOOP_ON,
@@ -672,15 +664,13 @@ class CCD : public DefaultDevice, GuiderInterface
         };
 
         // Exposure Looping Count
-        INumber ExposureLoopCountN[1];
-        INumberVectorProperty ExposureLoopCountNP;
+        INDI::PropertyNumber ExposureLoopCountNP {1};
         double uploadTime = { 0 };
         std::chrono::system_clock::time_point exposureLoopStartup;
 #endif
 
         // FITS Header
-        IText FITSHeaderT[2] {};
-        ITextVectorProperty FITSHeaderTP;
+        INDI::PropertyText FITSHeaderTP {2};
         enum
         {
             FITS_OBSERVER,

--- a/libs/indibase/indiccdchip.cpp
+++ b/libs/indibase/indiccdchip.cpp
@@ -46,21 +46,21 @@ void CCDChip::setResolution(uint32_t x, uint32_t y)
     XRes = x;
     YRes = y;
 
-    ImagePixelSizeN[0].value = x;
-    ImagePixelSizeN[1].value = y;
+    ImagePixelSizeNP[0].setValue(x);
+    ImagePixelSizeNP[1].setValue(y);
 
-    IDSetNumber(&ImagePixelSizeNP, nullptr);
+    ImagePixelSizeNP.apply();
 
-    ImageFrameN[FRAME_X].min = 0;
-    ImageFrameN[FRAME_X].max = x - 1;
-    ImageFrameN[FRAME_Y].min = 0;
-    ImageFrameN[FRAME_Y].max = y - 1;
+    ImageFrameNP[FRAME_X].setMin(0);
+    ImageFrameNP[FRAME_X].setMax(x - 1);
+    ImageFrameNP[FRAME_Y].setMin(0);
+    ImageFrameNP[FRAME_Y].setMax(y - 1);
 
-    ImageFrameN[FRAME_W].min = 1;
-    ImageFrameN[FRAME_W].max = x;
-    ImageFrameN[FRAME_H].min = 1;
-    ImageFrameN[FRAME_H].max = y;
-    IUUpdateMinMax(&ImageFrameNP);
+    ImageFrameNP[FRAME_W].setMin(1);
+    ImageFrameNP[FRAME_W].setMax(x);
+    ImageFrameNP[FRAME_H].setMin(1);
+    ImageFrameNP[FRAME_H].setMax(y);
+    ImageFrameNP.updateMinMax();
 }
 
 void CCDChip::setFrame(uint32_t subx, uint32_t suby, uint32_t subw, uint32_t subh)
@@ -70,12 +70,12 @@ void CCDChip::setFrame(uint32_t subx, uint32_t suby, uint32_t subw, uint32_t sub
     SubW = subw;
     SubH = subh;
 
-    ImageFrameN[FRAME_X].value = SubX;
-    ImageFrameN[FRAME_Y].value = SubY;
-    ImageFrameN[FRAME_W].value = SubW;
-    ImageFrameN[FRAME_H].value = SubH;
+    ImageFrameNP[FRAME_X].setValue(SubX);
+    ImageFrameNP[FRAME_Y].setValue(SubY);
+    ImageFrameNP[FRAME_W].setValue(SubW);
+    ImageFrameNP[FRAME_H].setValue(SubH);
 
-    IDSetNumber(&ImageFrameNP, nullptr);
+    ImageFrameNP.apply();
 }
 
 void CCDChip::setBin(uint8_t hor, uint8_t ver)
@@ -83,10 +83,10 @@ void CCDChip::setBin(uint8_t hor, uint8_t ver)
     BinX = hor;
     BinY = ver;
 
-    ImageBinN[BIN_W].value = BinX;
-    ImageBinN[BIN_H].value = BinY;
+    ImageBinNP[BIN_W].setValue(BinX);
+    ImageBinNP[BIN_H].setValue(BinY);
 
-    IDSetNumber(&ImageBinNP, nullptr);
+    ImageBinNP.apply();
 }
 
 void CCDChip::setMinMaxStep(const char *property, const char *element, double min, double max, double step,
@@ -94,16 +94,16 @@ void CCDChip::setMinMaxStep(const char *property, const char *element, double mi
 {
     INumberVectorProperty *nvp = nullptr;
 
-    if (!strcmp(property, ImageExposureNP.name))
-        nvp = &ImageExposureNP;
-    else if (!strcmp(property, ImageFrameNP.name))
-        nvp = &ImageFrameNP;
-    else if (!strcmp(property, ImageBinNP.name))
-        nvp = &ImageBinNP;
-    else if (!strcmp(property, ImagePixelSizeNP.name))
-        nvp = &ImagePixelSizeNP;
-    //    else if (!strcmp(property, RapidGuideDataNP.name))
-    //        nvp = &RapidGuideDataNP;
+    if (ImageExposureNP.isNameMatch(property))
+        nvp = ImageExposureNP.getNumber(); // #PS: refactor needed
+    else if (ImageFrameNP.isNameMatch(property))
+        nvp = ImageFrameNP.getNumber(); // #PS: refactor needed
+    else if (ImageBinNP.isNameMatch(property))
+        nvp = ImageBinNP.getNumber(); // #PS: refactor needed
+    else if (ImagePixelSizeNP.isNameMatch(property))
+        nvp = ImagePixelSizeNP.getNumber(); // #PS: refactor needed
+    //    else if (RapidGuideDataNP.isNameMatch(property))
+    //        nvp = RapidGuideDataNP.getNumber(); // #PS: refactor needed
     else
         return;
 
@@ -124,20 +124,20 @@ void CCDChip::setPixelSize(double x, double y)
     PixelSizeX = x;
     PixelSizeY = y;
 
-    ImagePixelSizeN[2].value = x;
-    ImagePixelSizeN[3].value = x;
-    ImagePixelSizeN[4].value = y;
+    ImagePixelSizeNP[2].setValue(x);
+    ImagePixelSizeNP[3].setValue(x);
+    ImagePixelSizeNP[4].setValue(y);
 
-    IDSetNumber(&ImagePixelSizeNP, nullptr);
+    ImagePixelSizeNP.apply();
 }
 
 void CCDChip::setBPP(uint8_t bbp)
 {
     BitsPerPixel = bbp;
 
-    ImagePixelSizeN[5].value = BitsPerPixel;
+    ImagePixelSizeNP[5].setValue(BitsPerPixel);
 
-    IDSetNumber(&ImagePixelSizeNP, nullptr);
+    ImagePixelSizeNP.apply();
 }
 
 void CCDChip::setFrameBufferSize(uint32_t nbuf, bool allocMem)
@@ -162,10 +162,10 @@ void CCDChip::setFrameBufferSize(uint32_t nbuf, bool allocMem)
 
 void CCDChip::setExposureLeft(double duration)
 {
-    ImageExposureNP.s = IPS_BUSY;
-    ImageExposureN[0].value = duration;
+    ImageExposureNP.setState(IPS_BUSY);
+    ImageExposureNP[0].setValue(duration);
 
-    IDSetNumber(&ImageExposureNP, nullptr);
+    ImageExposureNP.apply();
 }
 
 void CCDChip::setExposureDuration(double duration)
@@ -176,7 +176,7 @@ void CCDChip::setExposureDuration(double duration)
 
 const char *CCDChip::getFrameTypeName(CCD_FRAME fType)
 {
-    return FrameTypeS[fType].name;
+    return FrameTypeSP[fType].getName();
 }
 
 const char *CCDChip::getExposureStartTime()
@@ -208,8 +208,8 @@ const char *CCDChip::getExposureStartTime()
 
 void CCDChip::setExposureFailed()
 {
-    ImageExposureNP.s = IPS_ALERT;
-    IDSetNumber(&ImageExposureNP, nullptr);
+    ImageExposureNP.setState(IPS_ALERT);
+    ImageExposureNP.apply();
 }
 
 int CCDChip::getNAxis() const

--- a/libs/indibase/indiccdchip.h
+++ b/libs/indibase/indiccdchip.h
@@ -23,6 +23,10 @@
 #include <sys/time.h>
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 namespace INDI
 {
 
@@ -162,7 +166,7 @@ class CCDChip
          */
         inline double getExposureLeft()
         {
-            return ImageExposureN[0].value;
+            return ImageExposureNP[0].getValue();
         }
 
         /**
@@ -241,7 +245,7 @@ class CCDChip
          */
         INumberVectorProperty *getCCDInfo()
         {
-            return &ImagePixelSizeNP;
+            return ImagePixelSizeNP.getNumber(); // #PS: refactor needed
         }
 
         /**
@@ -371,7 +375,7 @@ class CCDChip
          */
         bool isExposing()
         {
-            return (ImageExposureNP.s == IPS_BUSY);
+            return (ImageExposureNP.getState() == IPS_BUSY);
         }
 
         /**
@@ -434,38 +438,32 @@ class CCDChip
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Image Exposure Duration
         /////////////////////////////////////////////////////////////////////////////////////////
-        INumberVectorProperty ImageExposureNP;
-        INumber ImageExposureN[1];
+        INDI::PropertyNumber ImageExposureNP {1};
 
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Abort Exposure
         /////////////////////////////////////////////////////////////////////////////////////////
-        ISwitchVectorProperty AbortExposureSP;
-        ISwitch AbortExposureS[1];
+        INDI::PropertySwitch AbortExposureSP {1};
 
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Image Frame ROI
         /////////////////////////////////////////////////////////////////////////////////////////
-        INumberVectorProperty ImageFrameNP;
-        INumber ImageFrameN[4];
+        INDI::PropertyNumber ImageFrameNP {4};
 
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Image Binning
         /////////////////////////////////////////////////////////////////////////////////////////
-        INumberVectorProperty ImageBinNP;
-        INumber ImageBinN[2];
+        INDI::PropertyNumber ImageBinNP {2};
 
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Image Resolution & Pixel Size data
         /////////////////////////////////////////////////////////////////////////////////////////
-        INumberVectorProperty ImagePixelSizeNP;
-        INumber ImagePixelSizeN[6];
+        INDI::PropertyNumber ImagePixelSizeNP {6};
 
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Frame Type (Light, Bias..etc)
         /////////////////////////////////////////////////////////////////////////////////////////
-        ISwitchVectorProperty FrameTypeSP;
-        ISwitch FrameTypeS[4];
+        INDI::PropertySwitch FrameTypeSP {4};
 
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Compression Toggle
@@ -482,21 +480,17 @@ class CCDChip
         /////////////////////////////////////////////////////////////////////////////////////////
         /// Reset ROI Frame to Full Resolution
         /////////////////////////////////////////////////////////////////////////////////////////
-        ISwitchVectorProperty ResetSP;
-        ISwitch ResetS[1];
+        INDI::PropertySwitch ResetSP {1};
 
         friend class CCD;
         friend class StreamRecoder;
 
 #if 0
-        ISwitch RapidGuideS[2];
-        ISwitchVectorProperty RapidGuideSP;
+        INDI::PropertySwitch RapidGuideSP {2};
 
-        ISwitch RapidGuideSetupS[3];
-        ISwitchVectorProperty RapidGuideSetupSP;
+        INDI::PropertySwitch RapidGuideSetupSP {3};
 
-        INumber RapidGuideDataN[3];
-        INumberVectorProperty RapidGuideDataNP;
+        INDI::PropertyNumber RapidGuideDataNP {3};
 #endif
 
 };

--- a/libs/indibase/indicorrelator.cpp
+++ b/libs/indibase/indicorrelator.cpp
@@ -53,12 +53,12 @@ Correlator::~Correlator()
 bool Correlator::initProperties()
 {
     // PrimaryCorrelator Info
-    IUFillNumber(&CorrelatorSettingsN[CORRELATOR_BASELINE_X], "CORRELATOR_BASELINE_X", "Baseline X size (m)", "%16.12f", 1.0e-12, 1.0e+6, 1.0e-12, 10.0);
-    IUFillNumber(&CorrelatorSettingsN[CORRELATOR_BASELINE_X], "CORRELATOR_BASELINE_Y", "Baseline Y size (m)", "%16.12f", 1.0e-12, 1.0e+6, 1.0e-12, 10.0);
-    IUFillNumber(&CorrelatorSettingsN[CORRELATOR_BASELINE_X], "CORRELATOR_BASELINE_Z", "Baseline Z size (m)", "%16.12f", 1.0e-12, 1.0e+6, 1.0e-12, 10.0);
-    IUFillNumber(&CorrelatorSettingsN[CORRELATOR_WAVELENGTH], "CORRELATOR_WAVELENGTH", "Wavelength (m)", "%7.12f", 3.0e-12, 3.0e+6, 3.0e-12, 350.0e-9);
-    IUFillNumber(&CorrelatorSettingsN[CORRELATOR_BANDWIDTH], "CORRELATOR_BANDWIDTH", "Bandwidth (Hz)", "%12.0f", 1.0, 100.0e+9, 1.0, 1.42e+9);
-    IUFillNumberVector(&CorrelatorSettingsNP, CorrelatorSettingsN, 5, getDeviceName(), "CORRELATOR_SETTINGS", "Correlator Settings", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    CorrelatorSettingsNP[CORRELATOR_BASELINE_X].fill("CORRELATOR_BASELINE_X", "Baseline X size (m)", "%16.12f", 1.0e-12, 1.0e+6, 1.0e-12, 10.0);
+    CorrelatorSettingsNP[CORRELATOR_BASELINE_X].fill("CORRELATOR_BASELINE_Y", "Baseline Y size (m)", "%16.12f", 1.0e-12, 1.0e+6, 1.0e-12, 10.0);
+    CorrelatorSettingsNP[CORRELATOR_BASELINE_X].fill("CORRELATOR_BASELINE_Z", "Baseline Z size (m)", "%16.12f", 1.0e-12, 1.0e+6, 1.0e-12, 10.0);
+    CorrelatorSettingsNP[CORRELATOR_WAVELENGTH].fill("CORRELATOR_WAVELENGTH", "Wavelength (m)", "%7.12f", 3.0e-12, 3.0e+6, 3.0e-12, 350.0e-9);
+    CorrelatorSettingsNP[CORRELATOR_BANDWIDTH].fill("CORRELATOR_BANDWIDTH", "Bandwidth (Hz)", "%12.0f", 1.0, 100.0e+9, 1.0, 1.42e+9);
+    CorrelatorSettingsNP.fill(getDeviceName(), "CORRELATOR_SETTINGS", "Correlator Settings", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     setDriverInterface(CORRELATOR_INTERFACE);
 
@@ -74,17 +74,17 @@ bool Correlator::updateProperties()
 {
     if (isConnected())
     {
-        defineProperty(&CorrelatorSettingsNP);
+        defineProperty(CorrelatorSettingsNP);
 
         if (HasCooler())
-            defineProperty(&TemperatureNP);
+            defineProperty(TemperatureNP);
     }
     else
     {
-        deleteProperty(CorrelatorSettingsNP.name);
+        deleteProperty(CorrelatorSettingsNP.getName());
 
         if (HasCooler())
-            deleteProperty(TemperatureNP.name);
+            deleteProperty(TemperatureNP.getName());
     }
     return SensorInterface::updateProperties();
 }
@@ -101,8 +101,8 @@ bool Correlator::ISNewText(const char *dev, const char *name, char *values[], ch
 
 bool Correlator::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
 {
-    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, CorrelatorSettingsNP.name)) {
-        IDSetNumber(&CorrelatorSettingsNP, nullptr);
+    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, CorrelatorSettingsNP.getName())) {
+        CorrelatorSettingsNP.apply();
     }
     return processNumber(dev, name, values, names, n);
 }
@@ -122,29 +122,29 @@ void Correlator::setBaseline(Baseline bl)
 {
     baseline = bl;
 
-    CorrelatorSettingsN[Correlator::CORRELATOR_BASELINE_X].value = baseline.x;
-    CorrelatorSettingsN[Correlator::CORRELATOR_BASELINE_Y].value = baseline.y;
-    CorrelatorSettingsN[Correlator::CORRELATOR_BASELINE_Z].value = baseline.z;
+    CorrelatorSettingsNP[Correlator::CORRELATOR_BASELINE_X].setValue(baseline.x);
+    CorrelatorSettingsNP[Correlator::CORRELATOR_BASELINE_Y].setValue(baseline.y);
+    CorrelatorSettingsNP[Correlator::CORRELATOR_BASELINE_Z].setValue(baseline.z);
 
-    IDSetNumber(&CorrelatorSettingsNP, nullptr);
+    CorrelatorSettingsNP.apply();
 }
 
 void Correlator::setWavelength(double wl)
 {
     wavelength = wl;
 
-    CorrelatorSettingsN[Correlator::CORRELATOR_WAVELENGTH].value = wl;
+    CorrelatorSettingsNP[Correlator::CORRELATOR_WAVELENGTH].setValue(wl);
 
-    IDSetNumber(&CorrelatorSettingsNP, nullptr);
+    CorrelatorSettingsNP.apply();
 }
 
 void Correlator::setBandwidth(double bw)
 {
     bandwidth = bw;
 
-    CorrelatorSettingsN[Correlator::CORRELATOR_BANDWIDTH].value = bw;
+    CorrelatorSettingsNP[Correlator::CORRELATOR_BANDWIDTH].setValue(bw);
 
-    IDSetNumber(&CorrelatorSettingsNP, nullptr);
+    CorrelatorSettingsNP.apply();
 }
 
 void Correlator::SetCorrelatorCapability(uint32_t cap)
@@ -207,8 +207,8 @@ void Correlator::setMinMaxStep(const char *property, const char *element, double
 {
     INumberVectorProperty *vp = nullptr;
 
-    if (!strcmp(property, CorrelatorSettingsNP.name)) {
-        vp = &FramedIntegrationNP;
+    if (CorrelatorSettingsNP.isNameMatch(property)) {
+        vp = FramedIntegrationNP.getNumber(); // #PS: refactor needed
 
         INumber *np = IUFindNumber(vp, element);
         if (np)

--- a/libs/indibase/indicorrelator.h
+++ b/libs/indibase/indicorrelator.h
@@ -35,6 +35,9 @@
 #include <mutex>
 #include <thread>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 //JM 2019-01-17: Disabled until further notice
 //#define WITH_EXPOSURE_LOOPING
 
@@ -220,7 +223,7 @@ class Correlator : public SensorInterface
          */
         inline INumberVectorProperty *getCorrelatorSettings()
         {
-            return &CorrelatorSettingsNP;
+            return CorrelatorSettingsNP.getNumber(); // #PS: refactor needed
         }
 
         /**
@@ -257,12 +260,11 @@ class Correlator : public SensorInterface
             CORRELATOR_WAVELENGTH,
             CORRELATOR_BANDWIDTH,
         } CORRELATOR_INFO_INDEX;
-        INumberVectorProperty CorrelatorSettingsNP;
 
       private:
         Baseline baseline;
         double wavelength;
         double bandwidth;
-        INumber CorrelatorSettingsN[5];
+        INDI::PropertyNumber CorrelatorSettingsNP {5};
 };
 }

--- a/libs/indibase/indidetector.cpp
+++ b/libs/indibase/indidetector.cpp
@@ -54,9 +54,9 @@ Detector::~Detector()
 bool Detector::initProperties()
 {
     // PrimaryDetector Info
-    IUFillNumber(&DetectorSettingsN[DETECTOR_RESOLUTION], "DETECTOR_RESOLUTION", "Resolution (ns)", "%16.3f", 0.01, 1.0e+8, 0.01, 1.0e+6);
-    IUFillNumber(&DetectorSettingsN[DETECTOR_TRIGGER], "DETECTOR_TRIGGER", "Trigger pulse (%)", "%3.2f", 0.01, 1.0e+15, 0.01, 1.42e+9);
-    IUFillNumberVector(&DetectorSettingsNP, DetectorSettingsN, 2, getDeviceName(), "DETECTOR_SETTINGS", "Detector Settings", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    DetectorSettingsNP[DETECTOR_RESOLUTION].fill("DETECTOR_RESOLUTION", "Resolution (ns)", "%16.3f", 0.01, 1.0e+8, 0.01, 1.0e+6);
+    DetectorSettingsNP[DETECTOR_TRIGGER].fill("DETECTOR_TRIGGER", "Trigger pulse (%)", "%3.2f", 0.01, 1.0e+15, 0.01, 1.42e+9);
+    DetectorSettingsNP.fill(getDeviceName(), "DETECTOR_SETTINGS", "Detector Settings", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     setDriverInterface(DETECTOR_INTERFACE);
 
@@ -72,17 +72,17 @@ bool Detector::updateProperties()
 {
     if (isConnected())
     {
-        defineProperty(&DetectorSettingsNP);
+        defineProperty(DetectorSettingsNP);
 
         if (HasCooler())
-            defineProperty(&TemperatureNP);
+            defineProperty(TemperatureNP);
     }
     else
     {
-        deleteProperty(DetectorSettingsNP.name);
+        deleteProperty(DetectorSettingsNP.getName());
 
         if (HasCooler())
-            deleteProperty(TemperatureNP.name);
+            deleteProperty(TemperatureNP.getName());
     }
     return SensorInterface::updateProperties();
 }
@@ -99,8 +99,8 @@ bool Detector::ISNewText(const char *dev, const char *name, char *values[], char
 
 bool Detector::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
 {
-    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, DetectorSettingsNP.name)) {
-        IDSetNumber(&DetectorSettingsNP, nullptr);
+    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, DetectorSettingsNP.getName())) {
+        DetectorSettingsNP.apply();
     }
     return processNumber(dev, name, values, names, n);
 }
@@ -120,18 +120,18 @@ void Detector::setTriggerLevel(double level)
 {
     TriggerLevel = level;
 
-    DetectorSettingsN[Detector::DETECTOR_TRIGGER].value = level;
+    DetectorSettingsNP[Detector::DETECTOR_TRIGGER].setValue(level);
 
-    IDSetNumber(&DetectorSettingsNP, nullptr);
+    DetectorSettingsNP.apply();
 }
 
 void Detector::setResolution(double res)
 {
     Resolution = res;
 
-    DetectorSettingsN[Detector::DETECTOR_RESOLUTION].value = res;
+    DetectorSettingsNP[Detector::DETECTOR_RESOLUTION].setValue(res);
 
-    IDSetNumber(&DetectorSettingsNP, nullptr);
+    DetectorSettingsNP.apply();
 }
 
 void Detector::SetDetectorCapability(uint32_t cap)
@@ -152,8 +152,8 @@ void Detector::setMinMaxStep(const char *property, const char *element, double m
 {
     INumberVectorProperty *vp = nullptr;
 
-    if (!strcmp(property, DetectorSettingsNP.name)) {
-        vp = &FramedIntegrationNP;
+    if (DetectorSettingsNP.isNameMatch(property)) {
+        vp = FramedIntegrationNP.getNumber(); // #PS: refactor needed
 
         INumber *np = IUFindNumber(vp, element);
         if (np)

--- a/libs/indibase/indidetector.h
+++ b/libs/indibase/indidetector.h
@@ -35,6 +35,9 @@
 #include <mutex>
 #include <thread>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 //JM 2019-01-17: Disabled until further notice
 //#define WITH_EXPOSURE_LOOPING
 
@@ -124,7 +127,7 @@ class Detector : public SensorInterface
          */
         inline INumberVectorProperty *getDetectorSettings()
         {
-            return &DetectorSettingsNP;
+            return DetectorSettingsNP.getNumber(); // #PS: refactor needed
         }
 
         /**
@@ -158,11 +161,10 @@ class Detector : public SensorInterface
             DETECTOR_RESOLUTION = 0,
             DETECTOR_TRIGGER,
         } DETECTOR_INFO_INDEX;
-        INumberVectorProperty DetectorSettingsNP;
 
       private:
         double TriggerLevel;
         double Resolution;
-        INumber DetectorSettingsN[2];
+        INDI::PropertyNumber DetectorSettingsNP {2};
 };
 }

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -92,122 +92,122 @@ bool Dome::initProperties()
     DefaultDevice::initProperties(); //  let the base class flesh in what it wants
 
     // Presets
-    IUFillNumber(&PresetN[0], "Preset 1", "", "%6.2f", 0, 360.0, 1.0, 0);
-    IUFillNumber(&PresetN[1], "Preset 2", "", "%6.2f", 0, 360.0, 1.0, 0);
-    IUFillNumber(&PresetN[2], "Preset 3", "", "%6.2f", 0, 360.0, 1.0, 0);
-    IUFillNumberVector(&PresetNP, PresetN, 3, getDeviceName(), "Presets", "", "Presets", IP_RW, 0, IPS_IDLE);
+    PresetNP[0].fill("Preset 1", "", "%6.2f", 0, 360.0, 1.0, 0);
+    PresetNP[1].fill("Preset 2", "", "%6.2f", 0, 360.0, 1.0, 0);
+    PresetNP[2].fill("Preset 3", "", "%6.2f", 0, 360.0, 1.0, 0);
+    PresetNP.fill(getDeviceName(), "Presets", "", "Presets", IP_RW, 0, IPS_IDLE);
 
     //Preset GOTO
-    IUFillSwitch(&PresetGotoS[0], "Preset 1", "", ISS_OFF);
-    IUFillSwitch(&PresetGotoS[1], "Preset 2", "", ISS_OFF);
-    IUFillSwitch(&PresetGotoS[2], "Preset 3", "", ISS_OFF);
-    IUFillSwitchVector(&PresetGotoSP, PresetGotoS, 3, getDeviceName(), "Goto", "", "Presets", IP_RW, ISR_1OFMANY, 0,
+    PresetGotoSP[0].fill("Preset 1", "", ISS_OFF);
+    PresetGotoSP[1].fill("Preset 2", "", ISS_OFF);
+    PresetGotoSP[2].fill("Preset 3", "", ISS_OFF);
+    PresetGotoSP.fill(getDeviceName(), "Goto", "", "Presets", IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
-    //    IUFillSwitch(&AutoParkS[0], "INDI_ENABLED", "Enable", ISS_OFF);
-    //    IUFillSwitch(&AutoParkS[1], "INDI_DISABLED", "Disable", ISS_ON);
-    //    IUFillSwitchVector(&AutoParkSP, AutoParkS, 2, getDeviceName(), "DOME_AUTOPARK", "Auto Park", OPTIONS_TAB, IP_RW,
+    //    AutoParkSP[0].fill("INDI_ENABLED", "Enable", ISS_OFF);
+    //    AutoParkSP[1].fill("INDI_DISABLED", "Disable", ISS_ON);
+    //    AutoParkSP.fill(getDeviceName(), "DOME_AUTOPARK", "Auto Park", OPTIONS_TAB, IP_RW,
     //                       ISR_1OFMANY, 0, IPS_IDLE);
 
     // Active Devices
-    IUFillText(&ActiveDeviceT[0], "ACTIVE_TELESCOPE", "Telescope", "Telescope Simulator");
-    //IUFillText(&ActiveDeviceT[1], "ACTIVE_WEATHER", "Weather", "WunderGround");
-    IUFillTextVector(&ActiveDeviceTP, ActiveDeviceT, 1, getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
+    ActiveDeviceTP[0].fill("ACTIVE_TELESCOPE", "Telescope", "Telescope Simulator");
+    //ActiveDeviceTP[1].fill("ACTIVE_WEATHER", "Weather", "WunderGround");
+    ActiveDeviceTP.fill(getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
                      IP_RW, 60, IPS_IDLE);
 
     // Use locking if telescope is unparked
-    IUFillSwitch(&MountPolicyS[MOUNT_IGNORED], "MOUNT_IGNORED", "Mount ignored", ISS_ON);
-    IUFillSwitch(&MountPolicyS[MOUNT_LOCKS], "MOUNT_LOCKS", "Mount locks", ISS_OFF);
-    IUFillSwitchVector(&MountPolicySP, MountPolicyS, 2, getDeviceName(), "MOUNT_POLICY", "Mount Policy", OPTIONS_TAB, IP_RW,
+    MountPolicySP[MOUNT_IGNORED].fill("MOUNT_IGNORED", "Mount ignored", ISS_ON);
+    MountPolicySP[MOUNT_LOCKS].fill("MOUNT_LOCKS", "Mount locks", ISS_OFF);
+    MountPolicySP.fill(getDeviceName(), "MOUNT_POLICY", "Mount Policy", OPTIONS_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
     // Shutter Policy
-    IUFillSwitch(&ShutterParkPolicyS[SHUTTER_CLOSE_ON_PARK], "SHUTTER_CLOSE_ON_PARK", "Close On Park", ISS_OFF);
-    IUFillSwitch(&ShutterParkPolicyS[SHUTTER_OPEN_ON_UNPARK], "SHUTTER_OPEN_ON_UNPARK", "Open On UnPark", ISS_OFF);
-    IUFillSwitchVector(&ShutterParkPolicySP, ShutterParkPolicyS, 2, getDeviceName(), "DOME_SHUTTER_PARK_POLICY", "Shutter",
+    ShutterParkPolicySP[SHUTTER_CLOSE_ON_PARK].fill("SHUTTER_CLOSE_ON_PARK", "Close On Park", ISS_OFF);
+    ShutterParkPolicySP[SHUTTER_OPEN_ON_UNPARK].fill("SHUTTER_OPEN_ON_UNPARK", "Open On UnPark", ISS_OFF);
+    ShutterParkPolicySP.fill(getDeviceName(), "DOME_SHUTTER_PARK_POLICY", "Shutter",
                        OPTIONS_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
     // Measurements
-    IUFillNumber(&DomeMeasurementsN[DM_DOME_RADIUS], "DM_DOME_RADIUS", "Radius (m)", "%6.2f", 0.0, 50.0, 1.0, 0.0);
-    IUFillNumber(&DomeMeasurementsN[DM_SHUTTER_WIDTH], "DM_SHUTTER_WIDTH", "Shutter width (m)", "%6.2f", 0.0, 10.0, 1.0,
+    DomeMeasurementsNP[DM_DOME_RADIUS].fill("DM_DOME_RADIUS", "Radius (m)", "%6.2f", 0.0, 50.0, 1.0, 0.0);
+    DomeMeasurementsNP[DM_SHUTTER_WIDTH].fill("DM_SHUTTER_WIDTH", "Shutter width (m)", "%6.2f", 0.0, 10.0, 1.0,
                  0.0);
-    IUFillNumber(&DomeMeasurementsN[DM_NORTH_DISPLACEMENT], "DM_NORTH_DISPLACEMENT", "N displacement (m)", "%6.2f",
+    DomeMeasurementsNP[DM_NORTH_DISPLACEMENT].fill("DM_NORTH_DISPLACEMENT", "N displacement (m)", "%6.2f",
                  -10.0, 10.0, 1.0, 0.0);
-    IUFillNumber(&DomeMeasurementsN[DM_EAST_DISPLACEMENT], "DM_EAST_DISPLACEMENT", "E displacement (m)", "%6.2f", -10.0,
+    DomeMeasurementsNP[DM_EAST_DISPLACEMENT].fill("DM_EAST_DISPLACEMENT", "E displacement (m)", "%6.2f", -10.0,
                  10.0, 1.0, 0.0);
-    IUFillNumber(&DomeMeasurementsN[DM_UP_DISPLACEMENT], "DM_UP_DISPLACEMENT", "Up displacement (m)", "%6.2f", -10,
+    DomeMeasurementsNP[DM_UP_DISPLACEMENT].fill("DM_UP_DISPLACEMENT", "Up displacement (m)", "%6.2f", -10,
                  10.0, 1.0, 0.0);
-    IUFillNumber(&DomeMeasurementsN[DM_OTA_OFFSET], "DM_OTA_OFFSET", "OTA offset (m)", "%6.2f", -10.0, 10.0, 1.0, 0.0);
-    IUFillNumberVector(&DomeMeasurementsNP, DomeMeasurementsN, 6, getDeviceName(), "DOME_MEASUREMENTS", "Measurements",
+    DomeMeasurementsNP[DM_OTA_OFFSET].fill("DM_OTA_OFFSET", "OTA offset (m)", "%6.2f", -10.0, 10.0, 1.0, 0.0);
+    DomeMeasurementsNP.fill(getDeviceName(), "DOME_MEASUREMENTS", "Measurements",
                        DOME_SLAVING_TAB, IP_RW, 60, IPS_OK);
 
-    IUFillSwitch(&OTASideS[0], "DM_OTA_SIDE_EAST", "East", ISS_OFF);
-    IUFillSwitch(&OTASideS[1], "DM_OTA_SIDE_WEST", "West", ISS_OFF);
-    IUFillSwitchVector(&OTASideSP, OTASideS, 2, getDeviceName(), "DM_OTA_SIDE", "Meridian side", DOME_SLAVING_TAB,
+    OTASideSP[0].fill("DM_OTA_SIDE_EAST", "East", ISS_OFF);
+    OTASideSP[1].fill("DM_OTA_SIDE_WEST", "West", ISS_OFF);
+    OTASideSP.fill(getDeviceName(), "DM_OTA_SIDE", "Meridian side", DOME_SLAVING_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_OK);
 
-    IUFillSwitch(&DomeAutoSyncS[0], "DOME_AUTOSYNC_ENABLE", "Enable", ISS_OFF);
-    IUFillSwitch(&DomeAutoSyncS[1], "DOME_AUTOSYNC_DISABLE", "Disable", ISS_ON);
-    IUFillSwitchVector(&DomeAutoSyncSP, DomeAutoSyncS, 2, getDeviceName(), "DOME_AUTOSYNC", "Slaving", DOME_SLAVING_TAB,
+    DomeAutoSyncSP[0].fill("DOME_AUTOSYNC_ENABLE", "Enable", ISS_OFF);
+    DomeAutoSyncSP[1].fill("DOME_AUTOSYNC_DISABLE", "Disable", ISS_ON);
+    DomeAutoSyncSP.fill(getDeviceName(), "DOME_AUTOSYNC", "Slaving", DOME_SLAVING_TAB,
                        IP_RW, ISR_1OFMANY, 60, IPS_OK);
 
-    IUFillNumber(&DomeSpeedN[0], "DOME_SPEED_VALUE", "RPM", "%6.2f", 0.0, 10, 0.1, 1.0);
-    IUFillNumberVector(&DomeSpeedNP, DomeSpeedN, 1, getDeviceName(), "DOME_SPEED", "Speed", MAIN_CONTROL_TAB, IP_RW, 60,
+    DomeSpeedNP[0].fill("DOME_SPEED_VALUE", "RPM", "%6.2f", 0.0, 10, 0.1, 1.0);
+    DomeSpeedNP.fill(getDeviceName(), "DOME_SPEED", "Speed", MAIN_CONTROL_TAB, IP_RW, 60,
                        IPS_OK);
 
-    IUFillNumber(&DomeSyncN[0], "DOME_SYNC_VALUE", "Az", "%.2f", 0.0, 360, 10, 0.0);
-    IUFillNumberVector(&DomeSyncNP, DomeSyncN, 1, getDeviceName(), "DOME_SYNC", "Sync", MAIN_CONTROL_TAB, IP_RW, 60,
+    DomeSyncNP[0].fill("DOME_SYNC_VALUE", "Az", "%.2f", 0.0, 360, 10, 0.0);
+    DomeSyncNP.fill(getDeviceName(), "DOME_SYNC", "Sync", MAIN_CONTROL_TAB, IP_RW, 60,
                        IPS_OK);
 
-    IUFillSwitch(&DomeMotionS[0], "DOME_CW", "Dome CW", ISS_OFF);
-    IUFillSwitch(&DomeMotionS[1], "DOME_CCW", "Dome CCW", ISS_OFF);
-    IUFillSwitchVector(&DomeMotionSP, DomeMotionS, 2, getDeviceName(), "DOME_MOTION", "Motion", MAIN_CONTROL_TAB, IP_RW,
+    DomeMotionSP[0].fill("DOME_CW", "Dome CW", ISS_OFF);
+    DomeMotionSP[1].fill("DOME_CCW", "Dome CCW", ISS_OFF);
+    DomeMotionSP.fill(getDeviceName(), "DOME_MOTION", "Motion", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 60, IPS_OK);
 
     // Driver can define those to clients if there is support
-    IUFillNumber(&DomeAbsPosN[0], "DOME_ABSOLUTE_POSITION", "Degrees", "%6.2f", 0.0, 360.0, 1.0, 0.0);
-    IUFillNumberVector(&DomeAbsPosNP, DomeAbsPosN, 1, getDeviceName(), "ABS_DOME_POSITION", "Absolute Position",
+    DomeAbsPosNP[0].fill("DOME_ABSOLUTE_POSITION", "Degrees", "%6.2f", 0.0, 360.0, 1.0, 0.0);
+    DomeAbsPosNP.fill(getDeviceName(), "ABS_DOME_POSITION", "Absolute Position",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_OK);
 
-    IUFillNumber(&DomeRelPosN[0], "DOME_RELATIVE_POSITION", "Degrees", "%6.2f", -180, 180.0, 10.0, 0.0);
-    IUFillNumberVector(&DomeRelPosNP, DomeRelPosN, 1, getDeviceName(), "REL_DOME_POSITION", "Relative Position",
+    DomeRelPosNP[0].fill("DOME_RELATIVE_POSITION", "Degrees", "%6.2f", -180, 180.0, 10.0, 0.0);
+    DomeRelPosNP.fill(getDeviceName(), "REL_DOME_POSITION", "Relative Position",
                        MAIN_CONTROL_TAB, IP_RW, 60, IPS_OK);
 
-    IUFillSwitch(&AbortS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&AbortSP, AbortS, 1, getDeviceName(), "DOME_ABORT_MOTION", "Abort Motion", MAIN_CONTROL_TAB,
+    AbortSP[0].fill("ABORT", "Abort", ISS_OFF);
+    AbortSP.fill(getDeviceName(), "DOME_ABORT_MOTION", "Abort Motion", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillNumber(&DomeParamN[0], "AUTOSYNC_THRESHOLD", "Autosync threshold (deg)", "%6.2f", 0.0, 360.0, 1.0, 0.5);
-    IUFillNumberVector(&DomeParamNP, DomeParamN, 1, getDeviceName(), "DOME_PARAMS", "Params", DOME_SLAVING_TAB, IP_RW,
+    DomeParamNP[0].fill("AUTOSYNC_THRESHOLD", "Autosync threshold (deg)", "%6.2f", 0.0, 360.0, 1.0, 0.5);
+    DomeParamNP.fill(getDeviceName(), "DOME_PARAMS", "Params", DOME_SLAVING_TAB, IP_RW,
                        60, IPS_OK);
 
-    IUFillSwitch(&ParkS[0], "PARK", "Park(ed)", ISS_OFF);
-    IUFillSwitch(&ParkS[1], "UNPARK", "UnPark(ed)", ISS_OFF);
-    IUFillSwitchVector(&ParkSP, ParkS, 2, getDeviceName(), "DOME_PARK", "Parking", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY,
+    ParkSP[0].fill("PARK", "Park(ed)", ISS_OFF);
+    ParkSP[1].fill("UNPARK", "UnPark(ed)", ISS_OFF);
+    ParkSP.fill(getDeviceName(), "DOME_PARK", "Parking", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY,
                        60, IPS_OK);
 
     // Backlash Compensation
-    IUFillSwitch(&DomeBacklashS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&DomeBacklashS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&DomeBacklashSP, DomeBacklashS, 2, getDeviceName(), "DOME_BACKLASH_TOGGLE", "Backlash", OPTIONS_TAB,
+    DomeBacklashSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    DomeBacklashSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    DomeBacklashSP.fill(getDeviceName(), "DOME_BACKLASH_TOGGLE", "Backlash", OPTIONS_TAB,
                        IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
 
     // Backlash Compensation Value
-    IUFillNumber(&DomeBacklashN[0], "DOME_BACKLASH_VALUE", "Steps", "%.f", 0, 1e6, 100, 0);
-    IUFillNumberVector(&DomeBacklashNP, DomeBacklashN, 1, getDeviceName(), "DOME_BACKLASH_STEPS", "Backlash",
+    DomeBacklashNP[0].fill("DOME_BACKLASH_VALUE", "Steps", "%.f", 0, 1e6, 100, 0);
+    DomeBacklashNP.fill(getDeviceName(), "DOME_BACKLASH_STEPS", "Backlash",
                        OPTIONS_TAB, IP_RW, 60, IPS_OK);
 
 
-    IUFillSwitch(&DomeShutterS[0], "SHUTTER_OPEN", "Open", ISS_OFF);
-    IUFillSwitch(&DomeShutterS[1], "SHUTTER_CLOSE", "Close", ISS_ON);
-    IUFillSwitchVector(&DomeShutterSP, DomeShutterS, 2, getDeviceName(), "DOME_SHUTTER", "Shutter", MAIN_CONTROL_TAB,
+    DomeShutterSP[0].fill("SHUTTER_OPEN", "Open", ISS_OFF);
+    DomeShutterSP[1].fill("SHUTTER_CLOSE", "Close", ISS_ON);
+    DomeShutterSP.fill(getDeviceName(), "DOME_SHUTTER", "Shutter", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_OK);
 
-    IUFillSwitch(&ParkOptionS[0], "PARK_CURRENT", "Current", ISS_OFF);
-    IUFillSwitch(&ParkOptionS[1], "PARK_DEFAULT", "Default", ISS_OFF);
-    IUFillSwitch(&ParkOptionS[2], "PARK_WRITE_DATA", "Write Data", ISS_OFF);
-    IUFillSwitchVector(&ParkOptionSP, ParkOptionS, 3, getDeviceName(), "DOME_PARK_OPTION", "Park Options", SITE_TAB,
+    ParkOptionSP[0].fill("PARK_CURRENT", "Current", ISS_OFF);
+    ParkOptionSP[1].fill("PARK_DEFAULT", "Default", ISS_OFF);
+    ParkOptionSP[2].fill("PARK_WRITE_DATA", "Write Data", ISS_OFF);
+    ParkOptionSP.fill(getDeviceName(), "DOME_PARK_OPTION", "Park Options", SITE_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     addDebugControl();
@@ -217,13 +217,13 @@ bool Dome::initProperties()
 
     controller->initProperties();
 
-    IDSnoopDevice(ActiveDeviceT[0].text, "EQUATORIAL_EOD_COORD");
-    IDSnoopDevice(ActiveDeviceT[0].text, "GEOGRAPHIC_COORD");
-    IDSnoopDevice(ActiveDeviceT[0].text, "TELESCOPE_PARK");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "GEOGRAPHIC_COORD");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "TELESCOPE_PARK");
     if (CanAbsMove())
-        IDSnoopDevice(ActiveDeviceT[0].text, "TELESCOPE_PIER_SIDE");
+        IDSnoopDevice(ActiveDeviceTP[0].getText(), "TELESCOPE_PIER_SIDE");
 
-    //IDSnoopDevice(ActiveDeviceT[1].text, "WEATHER_STATUS");
+    //IDSnoopDevice(ActiveDeviceTP[1].getText(), "WEATHER_STATUS");
 
     setDriverInterface(DOME_INTERFACE);
 
@@ -255,16 +255,16 @@ void Dome::ISGetProperties(const char * dev)
     //  First we let our parent populate
     DefaultDevice::ISGetProperties(dev);
 
-    defineProperty(&ActiveDeviceTP);
+    defineProperty(ActiveDeviceTP);
     loadConfig(true, "ACTIVE_DEVICES");
 
     ISState isMountIgnored = ISS_OFF;
-    if (IUGetConfigSwitch(getDeviceName(), MountPolicySP.name, MountPolicyS[MOUNT_IGNORED].name, &isMountIgnored) == 0)
+    if (IUGetConfigSwitch(getDeviceName(), MountPolicySP.getName(), MountPolicySP[MOUNT_IGNORED].getName(), &isMountIgnored) == 0)
     {
-        MountPolicyS[MOUNT_IGNORED].s = isMountIgnored;
-        MountPolicyS[MOUNT_LOCKS].s = (isMountIgnored == ISS_ON) ? ISS_OFF : ISS_ON;
+        MountPolicySP[MOUNT_IGNORED].setState(isMountIgnored);
+        MountPolicySP[MOUNT_LOCKS].setState((isMountIgnored == ISS_ON) ? ISS_OFF : ISS_ON);
     }
-    defineProperty(&MountPolicySP);
+    defineProperty(MountPolicySP);
 
     controller->ISGetProperties(dev);
     return;
@@ -276,107 +276,107 @@ bool Dome::updateProperties()
     {
         if (HasShutter())
         {
-            defineProperty(&DomeShutterSP);
-            defineProperty(&ShutterParkPolicySP);
+            defineProperty(DomeShutterSP);
+            defineProperty(ShutterParkPolicySP);
         }
 
         //  Now we add our Dome specific stuff
-        defineProperty(&DomeMotionSP);
+        defineProperty(DomeMotionSP);
 
         if (HasVariableSpeed())
         {
-            defineProperty(&DomeSpeedNP);
+            defineProperty(DomeSpeedNP);
             //defineProperty(&DomeTimerNP);
         }
         if (CanRelMove())
-            defineProperty(&DomeRelPosNP);
+            defineProperty(DomeRelPosNP);
         if (CanAbsMove())
-            defineProperty(&DomeAbsPosNP);
+            defineProperty(DomeAbsPosNP);
         if (CanAbort())
-            defineProperty(&AbortSP);
+            defineProperty(AbortSP);
         if (CanAbsMove())
         {
-            defineProperty(&PresetNP);
-            defineProperty(&PresetGotoSP);
+            defineProperty(PresetNP);
+            defineProperty(PresetGotoSP);
 
-            defineProperty(&DomeAutoSyncSP);
-            defineProperty(&OTASideSP);
-            defineProperty(&DomeParamNP);
-            defineProperty(&DomeMeasurementsNP);
+            defineProperty(DomeAutoSyncSP);
+            defineProperty(OTASideSP);
+            defineProperty(DomeParamNP);
+            defineProperty(DomeMeasurementsNP);
         }
         if (CanSync())
-            defineProperty(&DomeSyncNP);
+            defineProperty(DomeSyncNP);
 
         if (CanPark())
         {
-            defineProperty(&ParkSP);
+            defineProperty(ParkSP);
             if (parkDataType != PARK_NONE)
             {
-                defineProperty(&ParkPositionNP);
-                defineProperty(&ParkOptionSP);
+                defineProperty(ParkPositionNP);
+                defineProperty(ParkOptionSP);
             }
         }
 
         if (HasBacklash())
         {
-            defineProperty(&DomeBacklashSP);
-            defineProperty(&DomeBacklashNP);
+            defineProperty(DomeBacklashSP);
+            defineProperty(DomeBacklashNP);
         }
 
-        //defineProperty(&AutoParkSP);
+        //defineProperty(AutoParkSP);
     }
     else
     {
         if (HasShutter())
         {
-            deleteProperty(DomeShutterSP.name);
-            deleteProperty(ShutterParkPolicySP.name);
+            deleteProperty(DomeShutterSP.getName());
+            deleteProperty(ShutterParkPolicySP.getName());
         }
 
-        deleteProperty(DomeMotionSP.name);
+        deleteProperty(DomeMotionSP.getName());
 
         if (HasVariableSpeed())
         {
-            deleteProperty(DomeSpeedNP.name);
+            deleteProperty(DomeSpeedNP.getName());
             //deleteProperty(DomeTimerNP.name);
         }
         if (CanRelMove())
-            deleteProperty(DomeRelPosNP.name);
+            deleteProperty(DomeRelPosNP.getName());
         if (CanAbsMove())
-            deleteProperty(DomeAbsPosNP.name);
+            deleteProperty(DomeAbsPosNP.getName());
         if (CanAbort())
-            deleteProperty(AbortSP.name);
+            deleteProperty(AbortSP.getName());
         if (CanAbsMove())
         {
-            deleteProperty(PresetNP.name);
-            deleteProperty(PresetGotoSP.name);
+            deleteProperty(PresetNP.getName());
+            deleteProperty(PresetGotoSP.getName());
 
-            deleteProperty(DomeAutoSyncSP.name);
-            deleteProperty(OTASideSP.name);
-            deleteProperty(DomeParamNP.name);
-            deleteProperty(DomeMeasurementsNP.name);
+            deleteProperty(DomeAutoSyncSP.getName());
+            deleteProperty(OTASideSP.getName());
+            deleteProperty(DomeParamNP.getName());
+            deleteProperty(DomeMeasurementsNP.getName());
         }
 
         if (CanSync())
-            deleteProperty(DomeSyncNP.name);
+            deleteProperty(DomeSyncNP.getName());
 
         if (CanPark())
         {
-            deleteProperty(ParkSP.name);
+            deleteProperty(ParkSP.getName());
             if (parkDataType != PARK_NONE)
             {
-                deleteProperty(ParkPositionNP.name);
-                deleteProperty(ParkOptionSP.name);
+                deleteProperty(ParkPositionNP.getName());
+                deleteProperty(ParkOptionSP.getName());
             }
         }
 
         if (HasBacklash())
         {
-            deleteProperty(DomeBacklashSP.name);
-            deleteProperty(DomeBacklashNP.name);
+            deleteProperty(DomeBacklashSP.getName());
+            deleteProperty(DomeBacklashNP.getName());
         }
 
-        //deleteProperty(AutoParkSP.name);
+        //deleteProperty(AutoParkSP.getName());
     }
 
     controller->updateProperties();
@@ -388,82 +388,82 @@ bool Dome::ISNewNumber(const char * dev, const char * name, double values[], cha
     //  first check if it's for our device
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, PresetNP.name))
+        if (PresetNP.isNameMatch(name))
         {
-            IUUpdateNumber(&PresetNP, values, names, n);
-            PresetNP.s = IPS_OK;
-            IDSetNumber(&PresetNP, nullptr);
+            PresetNP.update(values, names, n);
+            PresetNP.setState(IPS_OK);
+            PresetNP.apply();
 
             return true;
         }
         // Dome Sync
-        else if (!strcmp(name, DomeSyncNP.name))
+        else if (DomeSyncNP.isNameMatch(name))
         {
             if (Sync(values[0]))
             {
-                IUUpdateNumber(&DomeSyncNP, values, names, n);
-                DomeSyncNP.s = IPS_OK;
-                DomeAbsPosN[0].value = values[0];
-                IDSetNumber(&DomeAbsPosNP, nullptr);
+                DomeSyncNP.update(values, names, n);
+                DomeSyncNP.setState(IPS_OK);
+                DomeAbsPosNP[0].setValue(values[0]);
+                DomeAbsPosNP.apply();
             }
             else
             {
-                DomeSyncNP.s = IPS_ALERT;
+                DomeSyncNP.setState(IPS_ALERT);
             }
 
-            IDSetNumber(&DomeSyncNP, nullptr);
+            DomeSyncNP.apply();
             return true;
         }
-        else if (!strcmp(name, DomeParamNP.name))
+        else if (DomeParamNP.isNameMatch(name))
         {
-            IUUpdateNumber(&DomeParamNP, values, names, n);
-            DomeParamNP.s = IPS_OK;
-            IDSetNumber(&DomeParamNP, nullptr);
+            DomeParamNP.update(values, names, n);
+            DomeParamNP.setState(IPS_OK);
+            DomeParamNP.apply();
             return true;
         }
-        else if (!strcmp(name, DomeSpeedNP.name))
+        else if (DomeSpeedNP.isNameMatch(name))
         {
             double newSpeed = values[0];
             Dome::SetSpeed(newSpeed);
             return true;
         }
-        else if (!strcmp(name, DomeAbsPosNP.name))
+        else if (DomeAbsPosNP.isNameMatch(name))
         {
             double newPos = values[0];
             Dome::MoveAbs(newPos);
             return true;
         }
-        else if (!strcmp(name, DomeRelPosNP.name))
+        else if (DomeRelPosNP.isNameMatch(name))
         {
             double newPos = values[0];
             Dome::MoveRel(newPos);
             return true;
         }
-        else if (!strcmp(name, DomeMeasurementsNP.name))
+        else if (DomeMeasurementsNP.isNameMatch(name))
         {
-            IUUpdateNumber(&DomeMeasurementsNP, values, names, n);
-            DomeMeasurementsNP.s = IPS_OK;
-            IDSetNumber(&DomeMeasurementsNP, nullptr);
+            DomeMeasurementsNP.update(values, names, n);
+            DomeMeasurementsNP.setState(IPS_OK);
+            DomeMeasurementsNP.apply();
 
             return true;
         }
-        else if (strcmp(name, ParkPositionNP.name) == 0)
+        else if (ParkPositionNP.isNameMatch(name))
         {
-            IUUpdateNumber(&ParkPositionNP, values, names, n);
-            ParkPositionNP.s = IPS_OK;
+            ParkPositionNP.update(values, names, n);
+            ParkPositionNP.setState(IPS_OK);
 
-            Axis1ParkPosition = ParkPositionN[AXIS_RA].value;
-            IDSetNumber(&ParkPositionNP, nullptr);
+            Axis1ParkPosition = ParkPositionNP[AXIS_RA].getValue();
+            ParkPositionNP.apply();
             return true;
         }
         ////////////////////////////////////////////
         // Backlash value
         ////////////////////////////////////////////
-        else if (!strcmp(name, DomeBacklashNP.name))
+        else if (DomeBacklashNP.isNameMatch(name))
         {
-            if (DomeBacklashS[INDI_ENABLED].s != ISS_ON)
+            if (DomeBacklashSP[INDI_ENABLED].getState() != ISS_ON)
             {
-                DomeBacklashNP.s = IPS_IDLE;
+                DomeBacklashNP.setState(IPS_IDLE);
                 DEBUGDEVICE(dev, Logger::DBG_WARNING, "Dome backlash must be enabled first.");
             }
             else
@@ -471,13 +471,13 @@ bool Dome::ISNewNumber(const char * dev, const char * name, double values[], cha
                 uint32_t steps = static_cast<uint32_t>(values[0]);
                 if (SetBacklash(steps))
                 {
-                    DomeBacklashN[0].value = values[0];
-                    DomeBacklashNP.s = IPS_OK;
+                    DomeBacklashNP[0].setValue(values[0]);
+                    DomeBacklashNP.setState(IPS_OK);
                 }
                 else
-                    DomeBacklashNP.s = IPS_ALERT;
+                    DomeBacklashNP.setState(IPS_ALERT);
             }
-            IDSetNumber(&DomeBacklashNP, nullptr);
+            DomeBacklashNP.apply();
             return true;
         }
     }
@@ -492,56 +492,56 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // GOTO Presets
         ////////////////////////////////////////////
-        if (!strcmp(PresetGotoSP.name, name))
+        if (PresetGotoSP.isNameMatch(name))
         {
             if (m_DomeState == DOME_PARKED)
             {
                 DEBUGDEVICE(getDeviceName(), Logger::DBG_ERROR,
                             "Please unpark before issuing any motion commands.");
-                PresetGotoSP.s = IPS_ALERT;
-                IDSetSwitch(&PresetGotoSP, nullptr);
+                PresetGotoSP.setState(IPS_ALERT);
+                PresetGotoSP.apply();
                 return false;
             }
 
-            IUUpdateSwitch(&PresetGotoSP, states, names, n);
-            int index  = IUFindOnSwitchIndex(&PresetGotoSP);
-            IPState rc = Dome::MoveAbs(PresetN[index].value);
+            PresetGotoSP.update(states, names, n);
+            int index  = PresetGotoSP.findOnSwitchIndex();
+            IPState rc = Dome::MoveAbs(PresetNP[index].value);
             if (rc == IPS_OK || rc == IPS_BUSY)
             {
-                PresetGotoSP.s = IPS_OK;
-                LOGF_INFO("Moving to Preset %d (%.2f degrees).", index + 1, PresetN[index].value);
-                IDSetSwitch(&PresetGotoSP, nullptr);
+                PresetGotoSP.setState(IPS_OK);
+                LOGF_INFO("Moving to Preset %d (%.2f degrees).", index + 1, PresetNP[index].getValue());
+                PresetGotoSP.apply();
                 return true;
             }
 
-            PresetGotoSP.s = IPS_ALERT;
-            IDSetSwitch(&PresetGotoSP, nullptr);
+            PresetGotoSP.setState(IPS_ALERT);
+            PresetGotoSP.apply();
             return false;
         }
         ////////////////////////////////////////////
         // Dome Auto Sync
         ////////////////////////////////////////////
-        else if (!strcmp(name, DomeAutoSyncSP.name))
+        else if (DomeAutoSyncSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&DomeAutoSyncSP, states, names, n);
-            DomeAutoSyncSP.s = IPS_OK;
+            DomeAutoSyncSP.update(states, names, n);
+            DomeAutoSyncSP.setState(IPS_OK);
 
-            if (DomeAutoSyncS[0].s == ISS_ON)
+            if (DomeAutoSyncSP[0].getState() == ISS_ON)
             {
-                IDSetSwitch(&DomeAutoSyncSP, "Dome will now be synced to mount azimuth position.");
+                DomeAutoSyncSP.apply("Dome will now be synced to mount azimuth position.");
                 //UpdateAutoSync();
                 m_HorizontalUpdateTimerID = IEAddTimer(10, &Dome::updateMountCoordsHelper, this);
             }
             else
             {
-                IDSetSwitch(&DomeAutoSyncSP, "Dome is no longer synced to mount azimuth position.");
+                DomeAutoSyncSP.apply("Dome is no longer synced to mount azimuth position.");
                 if (m_HorizontalUpdateTimerID > 0)
                 {
                     IERmTimer(m_HorizontalUpdateTimerID);
                     m_HorizontalUpdateTimerID = -1;
                 }
 
-                if (DomeAbsPosNP.s == IPS_BUSY || DomeRelPosNP.s == IPS_BUSY /* || DomeTimerNP.s == IPS_BUSY*/)
+                if (DomeAbsPosNP.getState() == IPS_BUSY || DomeRelPosNP.getState() == IPS_BUSY /* || DomeTimerNP.s == IPS_BUSY*/)
                     Dome::Abort();
             }
 
@@ -550,19 +550,19 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // OTA Side
         ////////////////////////////////////////////
-        else if (!strcmp(name, OTASideSP.name))
+        else if (OTASideSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&OTASideSP, states, names, n);
-            OTASideSP.s = IPS_OK;
+            OTASideSP.update(states, names, n);
+            OTASideSP.setState(IPS_OK);
 
-            if (OTASideS[0].s == ISS_ON)
+            if (OTASideSP[0].getState() == ISS_ON)
             {
-                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at east of meridian");
+                OTASideSP.apply("Dome will be synced for telescope been at east of meridian");
                 UpdateAutoSync();
             }
             else
             {
-                IDSetSwitch(&OTASideSP, "Dome will be synced for telescope been at west of meridian");
+                OTASideSP.apply("Dome will be synced for telescope been at west of meridian");
                 UpdateAutoSync();
             }
 
@@ -571,14 +571,14 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // Dome Motion
         ////////////////////////////////////////////
-        else if (!strcmp(name, DomeMotionSP.name))
+        else if (DomeMotionSP.isNameMatch(name))
         {
             // Check if any switch is ON
             for (int i = 0; i < n; i++)
             {
                 if (states[i] == ISS_ON)
                 {
-                    if (!strcmp(DomeMotionS[DOME_CW].name, names[i]))
+                    if (!strcmp(DomeMotionSP[DOME_CW].getName(), names[i]))
                         Dome::Move(DOME_CW, MOTION_START);
                     else
                         Dome::Move(DOME_CCW, MOTION_START);
@@ -588,12 +588,12 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             }
 
             // All switches are off, so let's turn off last motion
-            int current_direction = IUFindOnSwitchIndex(&DomeMotionSP);
+            int current_direction = DomeMotionSP.findOnSwitchIndex();
             // Shouldn't happen
             if (current_direction < 0)
             {
-                DomeMotionSP.s = IPS_IDLE;
-                IDSetSwitch(&DomeMotionSP, nullptr);
+                DomeMotionSP.setState(IPS_IDLE);
+                DomeMotionSP.apply();
                 return false;
             }
 
@@ -604,7 +604,7 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // Abort Motion
         ////////////////////////////////////////////
-        else if (!strcmp(name, AbortSP.name))
+        else if (AbortSP.isNameMatch(name))
         {
             Dome::Abort();
             return true;
@@ -612,7 +612,7 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // Shutter
         ////////////////////////////////////////////
-        else if (!strcmp(name, DomeShutterSP.name))
+        else if (DomeShutterSP.isNameMatch(name))
         {
             // Check if any switch is ON
             for (int i = 0; i < n; i++)
@@ -620,7 +620,7 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
                 if (states[i] == ISS_ON)
                 {
                     // Open
-                    if (!strcmp(DomeShutterS[0].name, names[i]))
+                    if (!strcmp(DomeShutterSP[0].getName(), names[i]))
                     {
                         return (Dome::ControlShutter(SHUTTER_OPEN) != IPS_ALERT);
                     }
@@ -634,14 +634,14 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // Parking Switch
         ////////////////////////////////////////////
-        else if (!strcmp(name, ParkSP.name))
+        else if (ParkSP.isNameMatch(name))
         {
             // Check if any switch is ON
             for (int i = 0; i < n; i++)
             {
                 if (states[i] == ISS_ON)
                 {
-                    if (!strcmp(ParkS[0].name, names[i]))
+                    if (!strcmp(ParkSP[0].getName(), names[i]))
                     {
                         if (m_DomeState == DOME_PARKING)
                             return false;
@@ -661,16 +661,16 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // Parking Option
         ////////////////////////////////////////////
-        else if (!strcmp(name, ParkOptionSP.name))
+        else if (ParkOptionSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ParkOptionSP, states, names, n);
-            ISwitch * sp = IUFindOnSwitch(&ParkOptionSP);
+            ParkOptionSP.update(states, names, n);
+            ISwitch * sp = ParkOptionSP.findOnSwitch();
             if (!sp)
                 return false;
 
             bool rc = false;
 
-            IUResetSwitch(&ParkOptionSP);
+            ParkOptionSP.reset();
 
             if (!strcmp(sp->name, "PARK_CURRENT"))
             {
@@ -689,8 +689,8 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
                     LOG_WARN( "Can not save Park Status/Position.");
             }
 
-            ParkOptionSP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&ParkOptionSP, nullptr);
+            ParkOptionSP.setState(rc ? IPS_OK : IPS_ALERT);
+            ParkOptionSP.apply();
 
             return true;
         }
@@ -698,13 +698,13 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         // Auto Park
         ////////////////////////////////////////////
 #if 0
-        else if (!strcmp(name, AutoParkSP.name))
+        else if (AutoParkSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&AutoParkSP, states, names, n);
+            AutoParkSP.update(states, names, n);
 
-            AutoParkSP.s = IPS_OK;
+            AutoParkSP.setState(IPS_OK);
 
-            if (AutoParkS[0].s == ISS_ON)
+            if (AutoParkSP[0].getState() == ISS_ON)
                 LOG_WARN( "Warning: Auto park is enabled. If weather conditions are in the "
                           "danger zone, the dome will be automatically parked. Only enable this "
                           "option is parking the dome at any time will not cause damage to any "
@@ -712,7 +712,7 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
             else
                 DEBUG(Logger::DBG_SESSION, "Auto park is disabled.");
 
-            IDSetSwitch(&AutoParkSP, nullptr);
+            AutoParkSP.apply();
 
             return true;
         }
@@ -720,52 +720,52 @@ bool Dome::ISNewSwitch(const char * dev, const char * name, ISState * states, ch
         ////////////////////////////////////////////
         // Telescope Parking Policy
         ////////////////////////////////////////////
-        else if (!strcmp(name, MountPolicySP.name))
+        else if (MountPolicySP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MountPolicySP, states, names, n);
-            MountPolicySP.s = IPS_OK;
-            if (MountPolicyS[MOUNT_IGNORED].s == ISS_ON)
+            MountPolicySP.update(states, names, n);
+            MountPolicySP.setState(IPS_OK);
+            if (MountPolicySP[MOUNT_IGNORED].getState() == ISS_ON)
                 LOG_INFO("Mount Policy set to: Mount ignored. Dome can park regardless of mount parking state.");
             else
                 LOG_WARN("Mount Policy set to: Mount locks. This prevents the dome from parking when mount is unparked.");
-            IDSetSwitch(&MountPolicySP, nullptr);
-            triggerSnoop(ActiveDeviceT[0].text, "TELESCOPE_PARK");
+            MountPolicySP.apply();
+            triggerSnoop(ActiveDeviceTP[0].getText(), "TELESCOPE_PARK");
             return true;
         }
         ////////////////////////////////////////////
         // Shutter Parking Policy
         ////////////////////////////////////////////
-        else if (!strcmp(name, ShutterParkPolicySP.name))
+        else if (ShutterParkPolicySP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ShutterParkPolicySP, states, names, n);
-            ShutterParkPolicySP.s = IPS_OK;
-            IDSetSwitch(&ShutterParkPolicySP, nullptr);
+            ShutterParkPolicySP.update(states, names, n);
+            ShutterParkPolicySP.setState(IPS_OK);
+            ShutterParkPolicySP.apply();
             return true;
         }
         ////////////////////////////////////////////
         // Backlash enable/disable
         ////////////////////////////////////////////
-        else if (strcmp(name, DomeBacklashSP.name) == 0)
+        else if (DomeBacklashSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&DomeBacklashSP);
-            IUUpdateSwitch(&DomeBacklashSP, states, names, n);
-            const bool enabled = IUFindOnSwitchIndex(&DomeBacklashSP) == INDI_ENABLED;
+            int prevIndex = DomeBacklashSP.findOnSwitchIndex();
+            DomeBacklashSP.update(states, names, n);
+            const bool enabled = DomeBacklashSP.findOnSwitchIndex() == INDI_ENABLED;
 
             if (SetBacklashEnabled(enabled))
             {
-                IUUpdateSwitch(&DomeBacklashSP, states, names, n);
-                DomeBacklashSP.s = IPS_OK;
+                DomeBacklashSP.update(states, names, n);
+                DomeBacklashSP.setState(IPS_OK);
                 LOGF_INFO("Dome backlash is %s.", (enabled ? "enabled" : "disabled"));
             }
             else
             {
-                IUResetSwitch(&DomeBacklashSP);
-                DomeBacklashS[prevIndex].s = ISS_ON;
-                DomeBacklashSP.s = IPS_ALERT;
+                DomeBacklashSP.reset();
+                DomeBacklashSP[prevIndex].setState(ISS_ON);
+                DomeBacklashSP.setState(IPS_ALERT);
                 LOG_ERROR("Failed to set trigger Dome backlash.");
             }
 
-            IDSetSwitch(&DomeBacklashSP, nullptr);
+            DomeBacklashSP.apply();
             return true;
         }
     }
@@ -780,19 +780,19 @@ bool Dome::ISNewText(const char * dev, const char * name, char * texts[], char *
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, ActiveDeviceTP.name) == 0)
+        if (ActiveDeviceTP.isNameMatch(name))
         {
-            ActiveDeviceTP.s = IPS_OK;
-            IUUpdateText(&ActiveDeviceTP, texts, names, n);
-            IDSetText(&ActiveDeviceTP, nullptr);
+            ActiveDeviceTP.setState(IPS_OK);
+            ActiveDeviceTP.update(texts, names, n);
+            ActiveDeviceTP.apply();
 
-            IDSnoopDevice(ActiveDeviceT[0].text, "EQUATORIAL_EOD_COORD");
-            IDSnoopDevice(ActiveDeviceT[0].text, "TARGET_EOD_COORD");
-            IDSnoopDevice(ActiveDeviceT[0].text, "GEOGRAPHIC_COORD");
-            IDSnoopDevice(ActiveDeviceT[0].text, "TELESCOPE_PARK");
+            IDSnoopDevice(ActiveDeviceTP[0].getText(), "EQUATORIAL_EOD_COORD");
+            IDSnoopDevice(ActiveDeviceTP[0].getText(), "TARGET_EOD_COORD");
+            IDSnoopDevice(ActiveDeviceTP[0].getText(), "GEOGRAPHIC_COORD");
+            IDSnoopDevice(ActiveDeviceTP[0].getText(), "TELESCOPE_PARK");
             if (CanAbsMove())
-                IDSnoopDevice(ActiveDeviceT[0].text, "TELESCOPE_PIER_SIDE");
-            //IDSnoopDevice(ActiveDeviceT[1].text, "WEATHER_STATUS");
+                IDSnoopDevice(ActiveDeviceTP[0].getText(), "TELESCOPE_PIER_SIDE");
+            //IDSnoopDevice(ActiveDeviceTP[1].getText(), "WEATHER_STATUS");
 
             return true;
         }
@@ -833,8 +833,8 @@ bool Dome::ISSnoopDevice(XMLEle * root)
                 //  If this slew involves a meridian flip, then the slaving calcs will end up using
                 //  the wrong OTA side.  Lets set things up so our slaving code will calculate the side
                 //  for the target slew instead of using mount pier side info
-                OTASideSP.s = IPS_IDLE;
-                IDSetSwitch(&OTASideSP, nullptr);
+                OTASideSP.setState(IPS_IDLE);
+                OTASideSP.apply();
                 //  and see if we can get there at the same time as the mount
                 mountEquatorialCoords.ra  = ra * 15.0;
                 mountEquatorialCoords.dec = de;
@@ -948,7 +948,7 @@ bool Dome::ISSnoopDevice(XMLEle * root)
                 else if (!IsLocked && !strcmp(elemName, "UNPARK") && !strcmp(pcdataXMLEle(ep), "On"))
                     IsLocked = true;
             }
-            if (prevState != IsLocked && MountPolicyS[1].s == ISS_ON)
+            if (prevState != IsLocked && MountPolicySP[1].s == ISS_ON)
                 LOGF_INFO("Telescope status changed. Lock is set to: %s",
                           IsLocked ? "locked" : "unlocked");
         }
@@ -969,7 +969,7 @@ bool Dome::ISSnoopDevice(XMLEle * root)
             {
                 if (!isParked())
                 {
-                    if (AutoParkS[0].s == ISS_ON)
+                    if (AutoParkSP[0].getState() == ISS_ON)
                     {
                         LOG_WARN("Weather conditions in the danger zone! Parking dome...");
                         Dome::Park();
@@ -992,9 +992,9 @@ bool Dome::ISSnoopDevice(XMLEle * root)
         // set defaults to say we have no valid information from mount
         bool isEast = false;
         bool isWest = false;
-        OTASideS[0].s = ISS_OFF;
-        OTASideS[1].s = ISS_OFF;
-        OTASideSP.s = IPS_IDLE;
+        OTASideSP[0].setState(ISS_OFF);
+        OTASideSP[1].setState(ISS_OFF);
+        OTASideSP.setState(IPS_IDLE);
         //  crack the message
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
         {
@@ -1006,11 +1006,11 @@ bool Dome::ISSnoopDevice(XMLEle * root)
                 isWest = true;
         }
         //  update the switch
-        if(isEast) OTASideS[0].s = ISS_ON;
-        if(isWest) OTASideS[1].s = ISS_ON;
-        if(isWest || isEast) OTASideSP.s = IPS_OK;
+        if(isEast) OTASideSP[0].setState(ISS_ON);
+        if(isWest) OTASideSP[1].setState(ISS_ON);
+        if(isWest || isEast) OTASideSP.setState(IPS_OK);
         //  and set it.  If we didn't get valid info, it'll be set to idle and neither 'button' pressed in the ui
-        IDSetSwitch(&OTASideSP, nullptr);
+        OTASideSP.apply();
         return true;
     }
 
@@ -1030,7 +1030,7 @@ bool Dome::SetBacklashEnabled(bool enabled)
 {
     // If disabled, set the Domeer backlash to zero.
     if (enabled)
-        return SetBacklash(static_cast<int32_t>(DomeBacklashN[0].value));
+        return SetBacklash(static_cast<int32_t>(DomeBacklashNP[0].value));
     else
         return SetBacklash(0);
 }
@@ -1039,23 +1039,23 @@ bool Dome::saveConfigItems(FILE * fp)
 {
     DefaultDevice::saveConfigItems(fp);
 
-    IUSaveConfigText(fp, &ActiveDeviceTP);
-    IUSaveConfigSwitch(fp, &MountPolicySP);
-    IUSaveConfigNumber(fp, &PresetNP);
-    IUSaveConfigNumber(fp, &DomeParamNP);
-    IUSaveConfigNumber(fp, &DomeMeasurementsNP);
-    //IUSaveConfigSwitch(fp, &AutoParkSP);
-    IUSaveConfigSwitch(fp, &DomeAutoSyncSP);
+    ActiveDeviceTP.save(fp);
+    MountPolicySP.save(fp);
+    PresetNP.save(fp);
+    DomeParamNP.save(fp);
+    DomeMeasurementsNP.save(fp);
+    //AutoParkSP.save(fp);
+    DomeAutoSyncSP.save(fp);
 
     if (HasBacklash())
     {
-        IUSaveConfigSwitch(fp, &DomeBacklashSP);
-        IUSaveConfigNumber(fp, &DomeBacklashNP);
+        DomeBacklashSP.save(fp);
+        DomeBacklashNP.save(fp);
     }
 
     if (HasShutter())
     {
-        IUSaveConfigSwitch(fp, &ShutterParkPolicySP);
+        ShutterParkPolicySP.save(fp);
     }
 
     controller->saveConfigItems(fp);
@@ -1071,7 +1071,7 @@ void Dome::triggerSnoop(const char * driverName, const char * snoopedProp)
 
 bool Dome::isLocked()
 {
-    return MountPolicyS[1].s == ISS_ON && IsLocked;
+    return MountPolicySP[1].getState() == ISS_ON && IsLocked;
 }
 
 void Dome::buttonHelper(const char * button_n, ISState state, void * context)
@@ -1088,14 +1088,14 @@ void Dome::processButton(const char * button_n, ISState state)
     // Dome In
     if (!strcmp(button_n, "Dome CW"))
     {
-        if (DomeMotionSP.s != IPS_BUSY)
+        if (DomeMotionSP.getState() != IPS_BUSY)
             Dome::Move(DOME_CW, MOTION_START);
         else
             Dome::Move(DOME_CW, MOTION_STOP);
     }
     else if (!strcmp(button_n, "Dome CCW"))
     {
-        if (DomeMotionSP.s != IPS_BUSY)
+        if (DomeMotionSP.getState() != IPS_BUSY)
             Dome::Move(DOME_CCW, MOTION_START);
         else
             Dome::Move(DOME_CCW, MOTION_STOP);
@@ -1116,35 +1116,35 @@ void Dome::setShutterState(const Dome::ShutterState &value)
     switch (value)
     {
         case SHUTTER_OPENED:
-            IUResetSwitch(&DomeShutterSP);
-            DomeShutterS[SHUTTER_OPEN].s = ISS_ON;
-            DomeShutterSP.s = IPS_OK;
+            DomeShutterSP.reset();
+            DomeShutterSP[SHUTTER_OPEN].setState(ISS_ON);
+            DomeShutterSP.setState(IPS_OK);
             break;
 
         case SHUTTER_CLOSED:
-            IUResetSwitch(&DomeShutterSP);
-            DomeShutterS[SHUTTER_CLOSE].s = ISS_ON;
-            DomeShutterSP.s = IPS_OK;
+            DomeShutterSP.reset();
+            DomeShutterSP[SHUTTER_CLOSE].setState(ISS_ON);
+            DomeShutterSP.setState(IPS_OK);
             break;
 
 
         case SHUTTER_MOVING:
-            DomeShutterSP.s = IPS_BUSY;
+            DomeShutterSP.setState(IPS_BUSY);
             break;
 
         case SHUTTER_ERROR:
-            DomeShutterSP.s = IPS_ALERT;
+            DomeShutterSP.setState(IPS_ALERT);
             LOG_WARN("Shutter failure.");
             break;
 
         case SHUTTER_UNKNOWN:
-            IUResetSwitch(&DomeShutterSP);
-            DomeShutterSP.s = IPS_IDLE;
+            DomeShutterSP.reset();
+            DomeShutterSP.setState(IPS_IDLE);
             LOG_WARN("Unknown shutter status.");
             break;
     }
 
-    IDSetSwitch(&DomeShutterSP, nullptr);
+    DomeShutterSP.apply();
     m_ShutterState = value;
 }
 
@@ -1153,99 +1153,99 @@ void Dome::setDomeState(const Dome::DomeState &value)
     switch (value)
     {
         case DOME_IDLE:
-            if (DomeMotionSP.s == IPS_BUSY)
+            if (DomeMotionSP.getState() == IPS_BUSY)
             {
-                IUResetSwitch(&DomeMotionSP);
-                DomeMotionSP.s = IPS_IDLE;
-                IDSetSwitch(&DomeMotionSP, nullptr);
+                DomeMotionSP.reset();
+                DomeMotionSP.setState(IPS_IDLE);
+                DomeMotionSP.apply();
             }
-            if (DomeAbsPosNP.s == IPS_BUSY)
+            if (DomeAbsPosNP.getState() == IPS_BUSY)
             {
-                DomeAbsPosNP.s = IPS_IDLE;
-                IDSetNumber(&DomeAbsPosNP, nullptr);
+                DomeAbsPosNP.setState(IPS_IDLE);
+                DomeAbsPosNP.apply();
             }
-            if (DomeRelPosNP.s == IPS_BUSY)
+            if (DomeRelPosNP.getState() == IPS_BUSY)
             {
-                DomeRelPosNP.s = IPS_IDLE;
-                IDSetNumber(&DomeRelPosNP, nullptr);
+                DomeRelPosNP.setState(IPS_IDLE);
+                DomeRelPosNP.apply();
             }
             break;
 
         case DOME_SYNCED:
-            if (DomeMotionSP.s == IPS_BUSY)
+            if (DomeMotionSP.getState() == IPS_BUSY)
             {
-                IUResetSwitch(&DomeMotionSP);
-                DomeMotionSP.s = IPS_OK;
-                IDSetSwitch(&DomeMotionSP, nullptr);
+                DomeMotionSP.reset();
+                DomeMotionSP.setState(IPS_OK);
+                DomeMotionSP.apply();
             }
-            if (DomeAbsPosNP.s == IPS_BUSY)
+            if (DomeAbsPosNP.getState() == IPS_BUSY)
             {
-                DomeAbsPosNP.s = IPS_OK;
-                IDSetNumber(&DomeAbsPosNP, nullptr);
+                DomeAbsPosNP.setState(IPS_OK);
+                DomeAbsPosNP.apply();
             }
-            if (DomeRelPosNP.s == IPS_BUSY)
+            if (DomeRelPosNP.getState() == IPS_BUSY)
             {
-                DomeRelPosNP.s = IPS_OK;
-                IDSetNumber(&DomeRelPosNP, nullptr);
+                DomeRelPosNP.setState(IPS_OK);
+                DomeRelPosNP.apply();
             }
             break;
 
         case DOME_PARKED:
-            if (DomeMotionSP.s == IPS_BUSY)
+            if (DomeMotionSP.getState() == IPS_BUSY)
             {
-                IUResetSwitch(&DomeMotionSP);
-                DomeMotionSP.s = IPS_IDLE;
-                IDSetSwitch(&DomeMotionSP, nullptr);
+                DomeMotionSP.reset();
+                DomeMotionSP.setState(IPS_IDLE);
+                DomeMotionSP.apply();
             }
-            if (DomeAbsPosNP.s == IPS_BUSY)
+            if (DomeAbsPosNP.getState() == IPS_BUSY)
             {
-                DomeAbsPosNP.s = IPS_IDLE;
-                IDSetNumber(&DomeAbsPosNP, nullptr);
+                DomeAbsPosNP.setState(IPS_IDLE);
+                DomeAbsPosNP.apply();
             }
-            if (DomeRelPosNP.s == IPS_BUSY)
+            if (DomeRelPosNP.getState() == IPS_BUSY)
             {
-                DomeRelPosNP.s = IPS_IDLE;
-                IDSetNumber(&DomeRelPosNP, nullptr);
+                DomeRelPosNP.setState(IPS_IDLE);
+                DomeRelPosNP.apply();
             }
-            IUResetSwitch(&ParkSP);
-            ParkSP.s   = IPS_OK;
-            ParkS[0].s = ISS_ON;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.reset();
+            ParkSP.setState(IPS_OK);
+            ParkSP[0].setState(ISS_ON);
+            ParkSP.apply();
             IsParked = true;
             break;
 
         case DOME_PARKING:
-            IUResetSwitch(&ParkSP);
-            ParkSP.s   = IPS_BUSY;
-            ParkS[0].s = ISS_ON;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.reset();
+            ParkSP.setState(IPS_BUSY);
+            ParkSP[0].setState(ISS_ON);
+            ParkSP.apply();
             break;
 
         case DOME_UNPARKING:
-            IUResetSwitch(&ParkSP);
-            ParkSP.s   = IPS_BUSY;
-            ParkS[1].s = ISS_ON;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.reset();
+            ParkSP.setState(IPS_BUSY);
+            ParkSP[1].setState(ISS_ON);
+            ParkSP.apply();
             break;
 
         case DOME_UNPARKED:
-            IUResetSwitch(&ParkSP);
-            ParkSP.s   = IPS_OK;
-            ParkS[1].s = ISS_ON;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.reset();
+            ParkSP.setState(IPS_OK);
+            ParkSP[1].setState(ISS_ON);
+            ParkSP.apply();
             IsParked = false;
             break;
 
         case DOME_UNKNOWN:
-            IUResetSwitch(&ParkSP);
-            ParkSP.s = IPS_IDLE;
+            ParkSP.reset();
+            ParkSP.setState(IPS_IDLE);
             IsParked = false;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.apply();
             break;
 
         case DOME_ERROR:
-            ParkSP.s = IPS_ALERT;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.setState(IPS_ALERT);
+            ParkSP.apply();
             break;
 
         case DOME_MOVING:
@@ -1274,7 +1274,7 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
 
     if (HaveLatLong == false)
     {
-        triggerSnoop(ActiveDeviceT[0].text, "GEOGRAPHIC_COORD");
+        triggerSnoop(ActiveDeviceTP[0].getText(), "GEOGRAPHIC_COORD");
         LOG_WARN( "Geographic coordinates are not yet defined, triggering snoop...");
         return false;
     }
@@ -1284,9 +1284,9 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
 
     LOGF_DEBUG("JD: %g - MSD: %g", JD, MSD);
 
-    MountCenter.x = DomeMeasurementsN[DM_EAST_DISPLACEMENT].value; // Positive to East
-    MountCenter.y = DomeMeasurementsN[DM_NORTH_DISPLACEMENT].value;  // Positive to North
-    MountCenter.z = DomeMeasurementsN[DM_UP_DISPLACEMENT].value;    // Positive Up
+    MountCenter.x = DomeMeasurementsNP[DM_EAST_DISPLACEMENT].getValue(); // Positive to East
+    MountCenter.y = DomeMeasurementsNP[DM_NORTH_DISPLACEMENT].getValue();  // Positive to North
+    MountCenter.z = DomeMeasurementsNP[DM_UP_DISPLACEMENT].getValue();    // Positive Up
 
     LOGF_DEBUG("MC.x: %g - MC.y: %g MC.z: %g", MountCenter.x, MountCenter.y, MountCenter.z);
 
@@ -1297,10 +1297,10 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
 
     //  this will have state OK if the mount sent us information
     //  and it will be IDLE if not
-    if(CanAbsMove() && OTASideSP.s == IPS_OK)
+    if(CanAbsMove() && OTASideSP.getState() == IPS_OK)
     {
         // process info from the mount
-        if(OTASideS[0].s == ISS_ON) OTASide = -1;
+        if(OTASideSP[0].getState() == ISS_ON) OTASide = -1;
         else OTASide = 1;
     }
     else
@@ -1311,14 +1311,14 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
         //  if we got here because we turned off the PIER_SIDE switches in a target goto
         //  lets try get it back on
         if (CanAbsMove())
-            triggerSnoop(ActiveDeviceT[0].text, "TELESCOPE_PIER_SIDE");
+            triggerSnoop(ActiveDeviceTP[0].getText(), "TELESCOPE_PIER_SIDE");
 
     }
 
-    OpticalCenter(MountCenter, OTASide * DomeMeasurementsN[DM_OTA_OFFSET].value, observer.lat, hourAngle, OptCenter);
+    OpticalCenter(MountCenter, OTASide * DomeMeasurementsNP[DM_OTA_OFFSET].getValue(), observer.lat, hourAngle, OptCenter);
 
     LOGF_DEBUG("OTA_SIDE: %d", OTASide);
-    LOGF_DEBUG("OTA_OFFSET: %g  Lat: %g", DomeMeasurementsN[DM_OTA_OFFSET].value, observer.lat);
+    LOGF_DEBUG("OTA_OFFSET: %g  Lat: %g", DomeMeasurementsNP[DM_OTA_OFFSET].getValue(), observer.lat);
     LOGF_DEBUG("OC.x: %g - OC.y: %g OC.z: %g", OptCenter.x, OptCenter.y, OptCenter.z);
 
     // To be sure mountHoriztonalCoords is up to date.
@@ -1335,7 +1335,7 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
     LOGF_DEBUG("Mount Az: %g  Alt: %g", mountHoriztonalCoords.az, mountHoriztonalCoords.alt);
     LOGF_DEBUG("OV.x: %g - OV.y: %g OV.z: %g", OptVector.x, OptVector.y, OptVector.z);
 
-    if (Intersection(OptCenter, OptVector, DomeMeasurementsN[DM_DOME_RADIUS].value, mu1, mu2))
+    if (Intersection(OptCenter, OptVector, DomeMeasurementsNP[DM_DOME_RADIUS].getValue(), mu1, mu2))
     {
         // If telescope is pointing over the horizon, the solution is mu1, else is mu2
         if (mu1 < 0)
@@ -1380,11 +1380,11 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
             Alt = 90; // Dome Zenith
 
         // Calculate the Azimuth range in the given Altitude of the dome
-        RadiusAtAlt = DomeMeasurementsN[DM_DOME_RADIUS].value * cos(M_PI * Alt / 180); // Radius alt the given altitude
+        RadiusAtAlt = DomeMeasurementsNP[DM_DOME_RADIUS].value * cos(M_PI * Alt / 180); // Radius alt the given altitude
 
-        if (DomeMeasurementsN[DM_SHUTTER_WIDTH].value < (2 * RadiusAtAlt))
+        if (DomeMeasurementsNP[DM_SHUTTER_WIDTH].value < (2 * RadiusAtAlt))
         {
-            HalfApertureChordAngle = 180 * asin(DomeMeasurementsN[DM_SHUTTER_WIDTH].value / (2 * RadiusAtAlt)) /
+            HalfApertureChordAngle = 180 * asin(DomeMeasurementsNP[DM_SHUTTER_WIDTH].value / (2 * RadiusAtAlt)) /
                                      M_PI; // Angle of a chord of half aperture length
             minAz = Az - HalfApertureChordAngle;
             if (minAz < 0)
@@ -1526,7 +1526,7 @@ void Dome::UpdateMountCoords()
 
 void Dome::UpdateAutoSync()
 {
-    if ((m_MountState == IPS_OK || m_MountState == IPS_IDLE) && DomeAbsPosNP.s != IPS_BUSY && DomeAutoSyncS[0].s == ISS_ON)
+    if ((m_MountState == IPS_OK || m_MountState == IPS_IDLE) && DomeAbsPosNP.getState() != IPS_BUSY && DomeAutoSyncSP[0].s == ISS_ON)
     {
         if (CanPark())
         {
@@ -1553,7 +1553,7 @@ void Dome::UpdateAutoSync()
         LOGF_DEBUG("Calculated target azimuth is %.2f. MinAz: %.2f, MaxAz: %.2f", targetAz, minAz,
                    maxAz);
 
-        if (fabs(targetAz - DomeAbsPosN[0].value) > DomeParamN[0].value)
+        if (fabs(targetAz - DomeAbsPosNP[0].getValue()) > DomeParamNP[0].getValue())
         {
             IPState ret = Dome::MoveAbs(targetAz);
             if (ret == IPS_OK)
@@ -1563,8 +1563,8 @@ void Dome::UpdateAutoSync()
             else
                 LOG_ERROR("Dome failed to sync to new requested position.");
 
-            DomeAbsPosNP.s = ret;
-            IDSetNumber(&DomeAbsPosNP, nullptr);
+            DomeAbsPosNP.setState(ret);
+            DomeAbsPosNP.apply();
         }
     }
 }
@@ -1602,19 +1602,19 @@ void Dome::SetParkDataType(Dome::DomeParkData type)
     switch (parkDataType)
     {
         case PARK_NONE:
-            strncpy(DomeMotionS[DOME_CW].label, "Open", MAXINDILABEL);
-            strncpy(DomeMotionS[DOME_CCW].label, "Close", MAXINDILABEL);
+            DomeMotionSP[DOME_CW].setLabel("Open");
+            DomeMotionSP[DOME_CCW].setLabel("Close");
             break;
 
         case PARK_AZ:
-            IUFillNumber(&ParkPositionN[AXIS_AZ], "PARK_AZ", "AZ D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
-            IUFillNumberVector(&ParkPositionNP, ParkPositionN, 1, getDeviceName(), "DOME_PARK_POSITION", "Park Position",
+            ParkPositionNP[AXIS_AZ].fill("PARK_AZ", "AZ D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
+            ParkPositionNP.fill(getDeviceName(), "DOME_PARK_POSITION", "Park Position",
                                SITE_TAB, IP_RW, 60, IPS_IDLE);
             break;
 
         case PARK_AZ_ENCODER:
-            IUFillNumber(&ParkPositionN[AXIS_AZ], "PARK_AZ", "AZ Encoder", "%.0f", 0, 16777215, 1, 0);
-            IUFillNumberVector(&ParkPositionNP, ParkPositionN, 1, getDeviceName(), "DOME_PARK_POSITION", "Park Position",
+            ParkPositionNP[AXIS_AZ].fill("PARK_AZ", "AZ Encoder", "%.0f", 0, 16777215, 1, 0);
+            ParkPositionNP.fill(getDeviceName(), "DOME_PARK_POSITION", "Park Position",
                                SITE_TAB, IP_RW, 60, IPS_IDLE);
             break;
 
@@ -1667,14 +1667,14 @@ bool Dome::InitPark()
     if (parkDataType != PARK_NONE)
     {
         LOGF_DEBUG("InitPark Axis1 %.2f", Axis1ParkPosition);
-        ParkPositionN[AXIS_AZ].value = Axis1ParkPosition;
-        IDSetNumber(&ParkPositionNP, nullptr);
+        ParkPositionNP[AXIS_AZ].setValue(Axis1ParkPosition);
+        ParkPositionNP.apply();
 
         // If parked, store the position as current azimuth angle or encoder ticks
         if (isParked() && CanAbsMove())
         {
-            DomeAbsPosN[0].value = ParkPositionN[AXIS_AZ].value;
-            IDSetNumber(&DomeAbsPosNP, nullptr);
+            DomeAbsPosNP[0].setValue(ParkPositionNP[AXIS_AZ].value);
+            DomeAbsPosNP.apply();
         }
     }
 
@@ -1872,8 +1872,8 @@ double Dome::GetAxis1ParkDefault()
 void Dome::SetAxis1Park(double value)
 {
     Axis1ParkPosition            = value;
-    ParkPositionN[AXIS_RA].value = value;
-    IDSetNumber(&ParkPositionNP, nullptr);
+    ParkPositionNP[AXIS_RA].setValue(value);
+    ParkPositionNP.apply();
 }
 
 void Dome::SetAxis1ParkDefault(double value)
@@ -1893,32 +1893,32 @@ IPState Dome::Move(DomeDirection dir, DomeMotionCommand operation)
         }
     }
 
-    if ((DomeMotionSP.s != IPS_BUSY && (DomeAbsPosNP.s == IPS_BUSY || DomeRelPosNP.s == IPS_BUSY)) ||
+    if ((DomeMotionSP.getState() != IPS_BUSY && (DomeAbsPosNP.getState() == IPS_BUSY || DomeRelPosNP.getState() == IPS_BUSY)) ||
             (m_DomeState == DOME_PARKING))
     {
         LOG_WARN( "Please stop dome before issuing any further motion commands.");
         return IPS_ALERT;
     }
 
-    int current_direction = IUFindOnSwitchIndex(&DomeMotionSP);
+    int current_direction = DomeMotionSP.findOnSwitchIndex();
 
     // if same move requested, return
-    if (DomeMotionSP.s == IPS_BUSY && current_direction == dir && operation == MOTION_START)
+    if (DomeMotionSP.getState() == IPS_BUSY && current_direction == dir && operation == MOTION_START)
         return IPS_BUSY;
 
-    DomeMotionSP.s = Move(dir, operation);
+    DomeMotionSP.setState(Move(dir, operation));
 
-    if (DomeMotionSP.s == IPS_BUSY || DomeMotionSP.s == IPS_OK)
+    if (DomeMotionSP.getState() == IPS_BUSY || DomeMotionSP.getState() == IPS_OK)
     {
         m_DomeState = (operation == MOTION_START) ? DOME_MOVING : DOME_IDLE;
-        IUResetSwitch(&DomeMotionSP);
+        DomeMotionSP.reset();
         if (operation == MOTION_START)
-            DomeMotionS[dir].s = ISS_ON;
+            DomeMotionSP[dir].setState(ISS_ON);
     }
 
-    IDSetSwitch(&DomeMotionSP, nullptr);
+    DomeMotionSP.apply();
 
-    return DomeMotionSP.s;
+    return DomeMotionSP.getState();
 }
 
 IPState Dome::MoveRel(double azDiff)
@@ -1932,16 +1932,16 @@ IPState Dome::MoveRel(double azDiff)
     if (m_DomeState == DOME_PARKED)
     {
         LOG_ERROR( "Please unpark before issuing any motion commands.");
-        DomeRelPosNP.s = IPS_ALERT;
-        IDSetNumber(&DomeRelPosNP, nullptr);
+        DomeRelPosNP.setState(IPS_ALERT);
+        DomeRelPosNP.apply();
         return IPS_ALERT;
     }
 
-    if ((DomeRelPosNP.s != IPS_BUSY && DomeMotionSP.s == IPS_BUSY) || (m_DomeState == DOME_PARKING))
+    if ((DomeRelPosNP.getState() != IPS_BUSY && DomeMotionSP.getState() == IPS_BUSY) || (m_DomeState == DOME_PARKING))
     {
         LOG_WARN( "Please stop dome before issuing any further motion commands.");
-        DomeRelPosNP.s = IPS_IDLE;
-        IDSetNumber(&DomeRelPosNP, nullptr);
+        DomeRelPosNP.setState(IPS_IDLE);
+        DomeRelPosNP.apply();
         return IPS_ALERT;
     }
 
@@ -1950,42 +1950,42 @@ IPState Dome::MoveRel(double azDiff)
     if ((rc = MoveRel(azDiff)) == IPS_OK)
     {
         m_DomeState            = DOME_IDLE;
-        DomeRelPosNP.s       = IPS_OK;
-        DomeRelPosN[0].value = azDiff;
-        IDSetNumber(&DomeRelPosNP, "Dome moved %.2f degrees %s.", azDiff,
+        DomeRelPosNP.setState(IPS_OK);
+        DomeRelPosNP[0].setValue(azDiff);
+        DomeRelPosNP.apply("Dome moved %.2f degrees %s.", azDiff,
                     (azDiff > 0) ? "clockwise" : "counter clockwise");
         if (CanAbsMove())
         {
-            DomeAbsPosNP.s = IPS_OK;
-            IDSetNumber(&DomeAbsPosNP, nullptr);
+            DomeAbsPosNP.setState(IPS_OK);
+            DomeAbsPosNP.apply();
         }
         return IPS_OK;
     }
     else if (rc == IPS_BUSY)
     {
         m_DomeState = DOME_MOVING;
-        DomeRelPosN[0].value = azDiff;
-        DomeRelPosNP.s = IPS_BUSY;
-        IDSetNumber(&DomeRelPosNP, "Dome is moving %.2f degrees %s...", azDiff,
+        DomeRelPosNP[0].setValue(azDiff);
+        DomeRelPosNP.setState(IPS_BUSY);
+        DomeRelPosNP.apply("Dome is moving %.2f degrees %s...", azDiff,
                     (azDiff > 0) ? "clockwise" : "counter clockwise");
         if (CanAbsMove())
         {
-            DomeAbsPosNP.s = IPS_BUSY;
-            IDSetNumber(&DomeAbsPosNP, nullptr);
+            DomeAbsPosNP.setState(IPS_BUSY);
+            DomeAbsPosNP.apply();
         }
 
-        DomeMotionSP.s = IPS_BUSY;
-        IUResetSwitch(&DomeMotionSP);
-        DomeMotionS[DOME_CW].s  = (azDiff > 0) ? ISS_ON : ISS_OFF;
-        DomeMotionS[DOME_CCW].s = (azDiff < 0) ? ISS_ON : ISS_OFF;
-        IDSetSwitch(&DomeMotionSP, nullptr);
+        DomeMotionSP.setState(IPS_BUSY);
+        DomeMotionSP.reset();
+        DomeMotionSP[DOME_CW].setState((azDiff > 0) ? ISS_ON : ISS_OFF);
+        DomeMotionSP[DOME_CCW].setState((azDiff < 0) ? ISS_ON : ISS_OFF);
+        DomeMotionSP.apply();
         return IPS_BUSY;
     }
 
     m_DomeState      = DOME_IDLE;
-    DomeRelPosNP.s = IPS_ALERT;
+    DomeRelPosNP.setState(IPS_ALERT);
     LOG_WARN("Dome failed to move to new requested position.");
-    IDSetNumber(&DomeRelPosNP, nullptr);
+    DomeRelPosNP.apply();
     return IPS_ALERT;
 }
 
@@ -2000,12 +2000,12 @@ IPState Dome::MoveAbs(double az)
     if (m_DomeState == DOME_PARKED)
     {
         LOG_ERROR( "Please unpark before issuing any motion commands.");
-        DomeAbsPosNP.s = IPS_ALERT;
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.setState(IPS_ALERT);
+        DomeAbsPosNP.apply();
         return IPS_ALERT;
     }
 
-    if ((DomeRelPosNP.s != IPS_BUSY && DomeMotionSP.s == IPS_BUSY) || (m_DomeState == DOME_PARKING))
+    if ((DomeRelPosNP.getState() != IPS_BUSY && DomeMotionSP.getState() == IPS_BUSY) || (m_DomeState == DOME_PARKING))
     {
         LOG_WARN( "Please stop dome before issuing any further motion commands.");
         return IPS_ALERT;
@@ -2013,43 +2013,43 @@ IPState Dome::MoveAbs(double az)
 
     IPState rc;
 
-    if (az < DomeAbsPosN[0].min || az > DomeAbsPosN[0].max)
+    if (az < DomeAbsPosNP[0].min || az > DomeAbsPosNP[0].max)
     {
         LOGF_ERROR( "Error: requested azimuth angle %.2f is out of range.", az);
-        DomeAbsPosNP.s = IPS_ALERT;
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.setState(IPS_ALERT);
+        DomeAbsPosNP.apply();
         return IPS_ALERT;
     }
 
     if ((rc = MoveAbs(az)) == IPS_OK)
     {
         m_DomeState            = DOME_IDLE;
-        DomeAbsPosNP.s       = IPS_OK;
-        DomeAbsPosN[0].value = az;
+        DomeAbsPosNP.setState(IPS_OK);
+        DomeAbsPosNP[0].setValue(az);
         LOGF_INFO("Dome moved to position %.2f degrees azimuth.", az);
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
 
         return IPS_OK;
     }
     else if (rc == IPS_BUSY)
     {
         m_DomeState      = DOME_MOVING;
-        DomeAbsPosNP.s = IPS_BUSY;
+        DomeAbsPosNP.setState(IPS_BUSY);
         LOGF_INFO("Dome is moving to position %.2f degrees azimuth...", az);
-        IDSetNumber(&DomeAbsPosNP, nullptr);
+        DomeAbsPosNP.apply();
 
-        DomeMotionSP.s = IPS_BUSY;
-        IUResetSwitch(&DomeMotionSP);
-        DomeMotionS[DOME_CW].s  = (az > DomeAbsPosN[0].value) ? ISS_ON : ISS_OFF;
-        DomeMotionS[DOME_CCW].s = (az < DomeAbsPosN[0].value) ? ISS_ON : ISS_OFF;
-        IDSetSwitch(&DomeMotionSP, nullptr);
+        DomeMotionSP.setState(IPS_BUSY);
+        DomeMotionSP.reset();
+        DomeMotionSP[DOME_CW].setState((az > DomeAbsPosNP[0].getValue()) ? ISS_ON : ISS_OFF);
+        DomeMotionSP[DOME_CCW].setState((az < DomeAbsPosNP[0].getValue()) ? ISS_ON : ISS_OFF);
+        DomeMotionSP.apply();
 
         return IPS_BUSY;
     }
 
     m_DomeState      = DOME_IDLE;
-    DomeAbsPosNP.s = IPS_ALERT;
-    IDSetNumber(&DomeAbsPosNP, "Dome failed to move to new requested position.");
+    DomeAbsPosNP.setState(IPS_ALERT);
+    DomeAbsPosNP.apply("Dome failed to move to new requested position.");
     return IPS_ALERT;
 }
 
@@ -2068,50 +2068,50 @@ bool Dome::Abort()
         return false;
     }
 
-    IUResetSwitch(&AbortSP);
+    AbortSP.reset();
 
     if (Abort())
     {
-        AbortSP.s = IPS_OK;
+        AbortSP.setState(IPS_OK);
 
         if (m_DomeState == DOME_PARKING || m_DomeState == DOME_UNPARKING)
         {
-            IUResetSwitch(&ParkSP);
+            ParkSP.reset();
             if (m_DomeState == DOME_PARKING)
             {
                 DEBUG(Logger::DBG_SESSION, "Parking aborted.");
                 // If parking was aborted then it was UNPARKED before
-                ParkS[1].s = ISS_ON;
+                ParkSP[1].setState(ISS_ON);
             }
             else
             {
                 DEBUG(Logger::DBG_SESSION, "UnParking aborted.");
                 // If unparking aborted then it was PARKED before
-                ParkS[0].s = ISS_ON;
+                ParkSP[0].setState(ISS_ON);
             }
 
-            ParkSP.s = IPS_ALERT;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.setState(IPS_ALERT);
+            ParkSP.apply();
         }
 
         setDomeState(DOME_IDLE);
     }
     else
     {
-        AbortSP.s = IPS_ALERT;
+        AbortSP.setState(IPS_ALERT);
 
         // If alert was aborted during parking or unparking, the parking state is unknown
         if (m_DomeState == DOME_PARKING || m_DomeState == DOME_UNPARKING)
         {
-            IUResetSwitch(&ParkSP);
-            ParkSP.s = IPS_IDLE;
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.reset();
+            ParkSP.setState(IPS_IDLE);
+            ParkSP.apply();
         }
     }
 
-    IDSetSwitch(&AbortSP, nullptr);
+    AbortSP.apply();
 
-    return (AbortSP.s == IPS_OK);
+    return (AbortSP.getState() == IPS_OK);
 }
 
 bool Dome::SetSpeed(double speed)
@@ -2124,15 +2124,15 @@ bool Dome::SetSpeed(double speed)
 
     if (SetSpeed(speed))
     {
-        DomeSpeedNP.s       = IPS_OK;
-        DomeSpeedN[0].value = speed;
+        DomeSpeedNP.setState(IPS_OK);
+        DomeSpeedNP[0].setValue(speed);
     }
     else
-        DomeSpeedNP.s = IPS_ALERT;
+        DomeSpeedNP.setState(IPS_ALERT);
 
-    IDSetNumber(&DomeSpeedNP, nullptr);
+    DomeSpeedNP.apply();
 
-    return (DomeSpeedNP.s == IPS_OK);
+    return (DomeSpeedNP.getState() == IPS_OK);
 }
 
 IPState Dome::ControlShutter(ShutterOperation operation)
@@ -2149,33 +2149,33 @@ IPState Dome::ControlShutter(ShutterOperation operation)
     //        return IPS_ALERT;
     //    }
 
-    int currentStatus = IUFindOnSwitchIndex(&DomeShutterSP);
+    int currentStatus = DomeShutterSP.findOnSwitchIndex();
 
     // No change of status, let's return
-    if (DomeShutterSP.s == IPS_BUSY && currentStatus == operation)
+    if (DomeShutterSP.getState() == IPS_BUSY && currentStatus == operation)
     {
-        IDSetSwitch(&DomeShutterSP, nullptr);
-        return DomeShutterSP.s;
+        DomeShutterSP.apply();
+        return DomeShutterSP.getState();
     }
 
-    DomeShutterSP.s = ControlShutter(operation);
+    DomeShutterSP.setState(ControlShutter(operation));
 
-    if (DomeShutterSP.s == IPS_OK)
+    if (DomeShutterSP.getState() == IPS_OK)
     {
-        IDSetSwitch(&DomeShutterSP, "Shutter is %s.", (operation == SHUTTER_OPEN ? "open" : "closed"));
+        DomeShutterSP.apply("Shutter is %s.", (operation == SHUTTER_OPEN ? "open" : "closed"));
         setShutterState(operation == SHUTTER_OPEN ? SHUTTER_OPENED : SHUTTER_CLOSED);
-        return DomeShutterSP.s;
+        return DomeShutterSP.getState();
     }
-    else if (DomeShutterSP.s == IPS_BUSY)
+    else if (DomeShutterSP.getState() == IPS_BUSY)
     {
-        IUResetSwitch(&DomeShutterSP);
-        DomeShutterS[operation].s = ISS_ON;
-        IDSetSwitch(&DomeShutterSP, "Shutter is %s...", (operation == 0 ? "opening" : "closing"));
+        DomeShutterSP.reset();
+        DomeShutterSP[operation].setState(ISS_ON);
+        DomeShutterSP.apply("Shutter is %s...", (operation == 0 ? "opening" : "closing"));
         setShutterState(SHUTTER_MOVING);
-        return DomeShutterSP.s;
+        return DomeShutterSP.getState();
     }
 
-    IDSetSwitch(&DomeShutterSP, "Shutter failed to %s.", (operation == 0 ? "open" : "close"));
+    DomeShutterSP.apply("Shutter failed to %s.", (operation == 0 ? "open" : "close"));
     return IPS_ALERT;
 }
 
@@ -2191,46 +2191,46 @@ IPState Dome::Park()
     // No need to park if parked already.
     if (m_DomeState == DOME_PARKED)
     {
-        IUResetSwitch(&ParkSP);
-        ParkS[0].s = ISS_ON;
+        ParkSP.reset();
+        ParkSP[0].setState(ISS_ON);
         LOG_INFO("Dome already parked.");
-        IDSetSwitch(&ParkSP, nullptr);
+        ParkSP.apply();
         return IPS_OK;
     }
 
     // Check if dome is locked due to Mount Policy
     if (isLocked())
     {
-        IUResetSwitch(&ParkSP);
-        ParkS[1].s = ISS_ON;
-        ParkSP.s = IPS_ALERT;
-        IDSetSwitch(&ParkSP, nullptr);
+        ParkSP.reset();
+        ParkSP[1].setState(ISS_ON);
+        ParkSP.setState(IPS_ALERT);
+        ParkSP.apply();
         LOG_INFO("Cannot Park Dome when mount is locking. See: Mount Policy in options tab.");
         return IPS_ALERT;
     }
 
     // Now ask child driver to start the actual parking process.
-    ParkSP.s = Park();
+    ParkSP.setState(Park());
 
     // IPS_OK is when it is immediately parked so realisticly this does not happen
     // unless dome is physically parked but just needed a state change.
-    if (ParkSP.s == IPS_OK)
+    if (ParkSP.getState() == IPS_OK)
         SetParked(true);
     // Dome is moving to parking position
-    else if (ParkSP.s == IPS_BUSY)
+    else if (ParkSP.getState() == IPS_BUSY)
     {
         setDomeState(DOME_PARKING);
 
         if (CanAbsMove())
-            DomeAbsPosNP.s = IPS_BUSY;
+            DomeAbsPosNP.setState(IPS_BUSY);
 
-        IUResetSwitch(&ParkSP);
-        ParkS[0].s = ISS_ON;
+        ParkSP.reset();
+        ParkSP[0].setState(ISS_ON);
     }
     else
-        IDSetSwitch(&ParkSP, nullptr);
+        ParkSP.apply();
 
-    return ParkSP.s;
+    return ParkSP.getState();
 }
 
 IPState Dome::UnPark()
@@ -2243,31 +2243,31 @@ IPState Dome::UnPark()
 
     if (m_DomeState != DOME_PARKED)
     {
-        IUResetSwitch(&ParkSP);
-        ParkS[1].s = ISS_ON;
+        ParkSP.reset();
+        ParkSP[1].setState(ISS_ON);
         DEBUG(Logger::DBG_SESSION, "Dome already unparked.");
-        IDSetSwitch(&ParkSP, nullptr);
+        ParkSP.apply();
         return IPS_OK;
     }
 
     //    if (weatherState == IPS_ALERT)
     //    {
     //        LOG_WARN( "Weather is in the danger zone! Cannot unpark dome.");
-    //        ParkSP.s = IPS_OK;
-    //        IDSetSwitch(&ParkSP, nullptr);
+    //        ParkSP.setState(IPS_OK);
+    //        ParkSP.apply();
     //        return IPS_ALERT;
     //    }
 
-    ParkSP.s = UnPark();
+    ParkSP.setState(UnPark());
 
-    if (ParkSP.s == IPS_OK)
+    if (ParkSP.getState() == IPS_OK)
         SetParked(false);
-    else if (ParkSP.s == IPS_BUSY)
+    else if (ParkSP.getState() == IPS_BUSY)
         setDomeState(DOME_UNPARKING);
     else
-        IDSetSwitch(&ParkSP, nullptr);
+        ParkSP.apply();
 
-    return ParkSP.s;
+    return ParkSP.getState();
 }
 
 bool Dome::SetCurrentPark()

--- a/libs/indibase/indidome.h
+++ b/libs/indibase/indidome.h
@@ -28,6 +28,11 @@
 
 #include <string>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 // Defines a point in a 3 dimension space
 typedef struct
 {
@@ -524,80 +529,49 @@ class Dome : public DefaultDevice
 
         double Csc(double x);
         double Sec(double x);
+        INDI::PropertyNumber DomeSpeedNP {1};
+        INDI::PropertySwitch DomeMotionSP {2};
+        INDI::PropertyNumber DomeAbsPosNP {1};
+        INDI::PropertyNumber DomeRelPosNP {1};
+        INDI::PropertySwitch AbortSP {1};
+        INDI::PropertyNumber DomeParamNP {1};
+        INDI::PropertyNumber DomeSyncNP {1};
+        INDI::PropertySwitch DomeShutterSP {2};
+        INDI::PropertySwitch ParkSP {2};
 
-        INumberVectorProperty DomeSpeedNP;
-        INumber DomeSpeedN[1];
+        INDI::PropertyNumber ParkPositionNP {1};
 
-        ISwitchVectorProperty DomeMotionSP;
-        ISwitch DomeMotionS[2];
+        INDI::PropertySwitch ParkOptionSP {3};
 
-        INumberVectorProperty DomeAbsPosNP;
-        INumber DomeAbsPosN[1];
-
-        INumberVectorProperty DomeRelPosNP;
-        INumber DomeRelPosN[1];
-
-        ISwitchVectorProperty AbortSP;
-        ISwitch AbortS[1];
-
-        INumberVectorProperty DomeParamNP;
-        INumber DomeParamN[1];
-
-        INumberVectorProperty DomeSyncNP;
-        INumber DomeSyncN[1];
-
-        ISwitchVectorProperty DomeShutterSP;
-        ISwitch DomeShutterS[2];
-
-        ISwitchVectorProperty ParkSP;
-        ISwitch ParkS[2];
-
-        INumber ParkPositionN[1];
-        INumberVectorProperty ParkPositionNP;
-
-        ISwitch ParkOptionS[3];
-        ISwitchVectorProperty ParkOptionSP;
-
-        //        ISwitch AutoParkS[2];
-        //        ISwitchVectorProperty AutoParkSP;
+        //        INDI::PropertySwitch AutoParkSP {2};
+        //
 
         uint32_t capability;
         DomeParkData parkDataType;
-
-        ITextVectorProperty ActiveDeviceTP;
-        IText ActiveDeviceT[1] {};
+        INDI::PropertyText ActiveDeviceTP {1};
 
         // Switch to lock id mount is unparked
-        ISwitchVectorProperty MountPolicySP;
-        ISwitch MountPolicyS[2];
+        INDI::PropertySwitch MountPolicySP {2};
 
         // Shutter control on Park/Unpark
-        ISwitchVectorProperty ShutterParkPolicySP;
-        ISwitch ShutterParkPolicyS[2];
+        INDI::PropertySwitch ShutterParkPolicySP {2};
         enum
         {
             SHUTTER_CLOSE_ON_PARK,
             SHUTTER_OPEN_ON_UNPARK,
         };
 
-        INumber PresetN[3];
-        INumberVectorProperty PresetNP;
-        ISwitch PresetGotoS[3];
-        ISwitchVectorProperty PresetGotoSP;
-        INumber DomeMeasurementsN[6];
-        INumberVectorProperty DomeMeasurementsNP;
-        ISwitchVectorProperty OTASideSP;
-        ISwitch OTASideS[2];
-        ISwitchVectorProperty DomeAutoSyncSP;
-        ISwitch DomeAutoSyncS[2];
+        INDI::PropertyNumber PresetNP {3};
+        INDI::PropertySwitch PresetGotoSP {3};
+        INDI::PropertyNumber DomeMeasurementsNP {6};
+        INDI::PropertySwitch OTASideSP {2};
+        INDI::PropertySwitch DomeAutoSyncSP {2};
 
         // Backlash toogle
-        ISwitchVectorProperty DomeBacklashSP;
-        ISwitch DomeBacklashS[2];
+        INDI::PropertySwitch DomeBacklashSP {2};
 
         // Backlash steps
-        INumberVectorProperty DomeBacklashNP;
-        INumber DomeBacklashN[1];
+        INDI::PropertyNumber DomeBacklashNP {1};
 
         double prev_az, prev_alt, prev_ra, prev_dec;
 

--- a/libs/indibase/indifilterinterface.h
+++ b/libs/indibase/indifilterinterface.h
@@ -24,6 +24,9 @@
 #include <vector>
 #include "indibase.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 /**
  * \class FilterInterface
    \brief Provides interface to implement Filter Wheel functionality.
@@ -118,8 +121,7 @@ class FilterInterface
         bool saveConfigItems(FILE *fp);
 
         //  A number vector for filter slot
-        INumberVectorProperty FilterSlotNP;
-        INumber FilterSlotN[1];
+        INDI::PropertyNumber FilterSlotNP {1};
 
         //  A text vector that stores out physical port name
         ITextVectorProperty *FilterNameTP { nullptr };

--- a/libs/indibase/indifilterwheel.cpp
+++ b/libs/indibase/indifilterwheel.cpp
@@ -172,10 +172,10 @@ void FilterWheel::processJoystick(const char *joystick_n, double mag, double ang
             if (angle > 0 && angle < 180)
             {
                 // Previous switch
-                if (FilterSlotN[0].value == FilterSlotN[0].min)
-                    TargetFilter = FilterSlotN[0].max;
+                if (FilterSlotNP[0].value == FilterSlotNP[0].min)
+                    TargetFilter = FilterSlotNP[0].getMax();
                 else
-                    TargetFilter = FilterSlotN[0].value - 1;
+                    TargetFilter = FilterSlotNP[0].getValue() - 1;
 
                 SelectFilter(TargetFilter);
             }
@@ -183,10 +183,10 @@ void FilterWheel::processJoystick(const char *joystick_n, double mag, double ang
             if (angle > 180 && angle < 360)
             {
                 // Next Switch
-                if (FilterSlotN[0].value == FilterSlotN[0].max)
-                    TargetFilter = FilterSlotN[0].min;
+                if (FilterSlotNP[0].value == FilterSlotNP[0].max)
+                    TargetFilter = FilterSlotNP[0].min;
                 else
-                    TargetFilter = FilterSlotN[0].value + 1;
+                    TargetFilter = FilterSlotNP[0].getValue() + 1;
 
                 SelectFilter(TargetFilter);
             }
@@ -203,7 +203,7 @@ void FilterWheel::processButton(const char *button_n, ISState state)
     // Reset
     if (!strcmp(button_n, "Reset"))
     {
-        TargetFilter = FilterSlotN[0].min;
+        TargetFilter = FilterSlotNP[0].min;
         SelectFilter(TargetFilter);
     }
 }

--- a/libs/indibase/indifocuser.cpp
+++ b/libs/indibase/indifocuser.cpp
@@ -46,16 +46,16 @@ bool Focuser::initProperties()
     FI::initProperties(MAIN_CONTROL_TAB);
 
     // Presets
-    IUFillNumber(&PresetN[0], "PRESET_1", "Preset 1", "%.f", 0, 100000, 1000, 0);
-    IUFillNumber(&PresetN[1], "PRESET_2", "Preset 2", "%.f", 0, 100000, 1000, 0);
-    IUFillNumber(&PresetN[2], "PRESET_3", "Preset 3", "%.f", 0, 100000, 1000, 0);
-    IUFillNumberVector(&PresetNP, PresetN, 3, getDeviceName(), "Presets", "", "Presets", IP_RW, 0, IPS_IDLE);
+    PresetNP[0].fill("PRESET_1", "Preset 1", "%.f", 0, 100000, 1000, 0);
+    PresetNP[1].fill("PRESET_2", "Preset 2", "%.f", 0, 100000, 1000, 0);
+    PresetNP[2].fill("PRESET_3", "Preset 3", "%.f", 0, 100000, 1000, 0);
+    PresetNP.fill(getDeviceName(), "Presets", "", "Presets", IP_RW, 0, IPS_IDLE);
 
     //Preset GOTO
-    IUFillSwitch(&PresetGotoS[0], "Preset 1", "", ISS_OFF);
-    IUFillSwitch(&PresetGotoS[1], "Preset 2", "", ISS_OFF);
-    IUFillSwitch(&PresetGotoS[2], "Preset 3", "", ISS_OFF);
-    IUFillSwitchVector(&PresetGotoSP, PresetGotoS, 3, getDeviceName(), "Goto", "", "Presets", IP_RW, ISR_1OFMANY, 0,
+    PresetGotoSP[0].fill("Preset 1", "", ISS_OFF);
+    PresetGotoSP[1].fill("Preset 2", "", ISS_OFF);
+    PresetGotoSP[2].fill("Preset 3", "", ISS_OFF);
+    PresetGotoSP.fill(getDeviceName(), "Goto", "", "Presets", IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     addDebugControl();
@@ -109,16 +109,16 @@ bool Focuser::updateProperties()
     {
         if (CanAbsMove())
         {
-            defineProperty(&PresetNP);
-            defineProperty(&PresetGotoSP);
+            defineProperty(PresetNP);
+            defineProperty(PresetGotoSP);
         }
     }
     else
     {
         if (CanAbsMove())
         {
-            deleteProperty(PresetNP.name);
-            deleteProperty(PresetGotoSP.name);
+            deleteProperty(PresetNP.getName());
+            deleteProperty(PresetGotoSP.getName());
         }
     }
 
@@ -131,11 +131,11 @@ bool Focuser::ISNewNumber(const char *dev, const char *name, double values[], ch
     //  first check if it's for our device
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, PresetNP.name))
+        if (PresetNP.isNameMatch(name))
         {
-            IUUpdateNumber(&PresetNP, values, names, n);
-            PresetNP.s = IPS_OK;
-            IDSetNumber(&PresetNP, nullptr);
+            PresetNP.update(values, names, n);
+            PresetNP.setState(IPS_OK);
+            PresetNP.apply();
 
             //saveConfig();
 
@@ -153,43 +153,43 @@ bool Focuser::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(PresetGotoSP.name, name))
+        if (PresetGotoSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&PresetGotoSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&PresetGotoSP);
+            PresetGotoSP.update(states, names, n);
+            int index = PresetGotoSP.findOnSwitchIndex();
 
-            if (PresetN[index].value < FocusAbsPosN[0].min)
+            if (PresetNP[index].value < FocusAbsPosNP[0].min)
             {
-                PresetGotoSP.s = IPS_ALERT;
-                IDSetSwitch(&PresetGotoSP, nullptr);
+                PresetGotoSP.setState(IPS_ALERT);
+                PresetGotoSP.apply();
                 DEBUGFDEVICE(dev, Logger::DBG_ERROR,
-                             "Requested position out of bound. Focus minimum position is %g", FocusAbsPosN[0].min);
+                             "Requested position out of bound. Focus minimum position is %g", FocusAbsPosNP[0].min);
                 return true;
             }
-            else if (PresetN[index].value > FocusAbsPosN[0].max)
+            else if (PresetNP[index].value > FocusAbsPosNP[0].max)
             {
-                PresetGotoSP.s = IPS_ALERT;
-                IDSetSwitch(&PresetGotoSP, nullptr);
+                PresetGotoSP.setState(IPS_ALERT);
+                PresetGotoSP.apply();
                 DEBUGFDEVICE(dev, Logger::DBG_ERROR,
-                             "Requested position out of bound. Focus maximum position is %g", FocusAbsPosN[0].max);
+                             "Requested position out of bound. Focus maximum position is %g", FocusAbsPosNP[0].max);
                 return true;
             }
 
-            IPState rc = MoveAbsFocuser(PresetN[index].value);
+            IPState rc = MoveAbsFocuser(PresetNP[index].value);
             if (rc != IPS_ALERT)
             {
-                PresetGotoSP.s = IPS_OK;
+                PresetGotoSP.setState(IPS_OK);
                 DEBUGF(Logger::DBG_SESSION, "Moving to Preset %d with position %g.", index + 1,
-                       PresetN[index].value);
-                IDSetSwitch(&PresetGotoSP, nullptr);
+                       PresetNP[index].getValue());
+                PresetGotoSP.apply();
 
-                FocusAbsPosNP.s = IPS_BUSY;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusAbsPosNP.setState(IPS_BUSY);
+                FocusAbsPosNP.apply();
                 return true;
             }
 
-            PresetGotoSP.s = IPS_ALERT;
-            IDSetSwitch(&PresetGotoSP, nullptr);
+            PresetGotoSP.setState(IPS_ALERT);
+            PresetGotoSP.apply();
             return true;
         }
 
@@ -228,7 +228,7 @@ bool Focuser::saveConfigItems(FILE *fp)
 
     FI::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &PresetNP);
+    PresetNP.save(fp);
     controller->saveConfigItems(fp);
 
     return true;
@@ -245,7 +245,7 @@ void Focuser::processButton(const char *button_n, ISState state)
     if (state == ISS_OFF)
         return;
 
-    FocusTimerN[0].value = lastTimerValue;
+    FocusTimerNP[0].setValue(lastTimerValue);
 
     IPState rc = IPS_IDLE;
 
@@ -254,89 +254,89 @@ void Focuser::processButton(const char *button_n, ISState state)
     {
         if (AbortFocuser())
         {
-            FocusAbortSP.s = IPS_OK;
+            FocusAbortSP.setState(IPS_OK);
             DEBUG(Logger::DBG_SESSION, "Focuser aborted.");
-            if (CanAbsMove() && FocusAbsPosNP.s != IPS_IDLE)
+            if (CanAbsMove() && FocusAbsPosNP.getState() != IPS_IDLE)
             {
-                FocusAbsPosNP.s = IPS_IDLE;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusAbsPosNP.setState(IPS_IDLE);
+                FocusAbsPosNP.apply();
             }
-            if (CanRelMove() && FocusRelPosNP.s != IPS_IDLE)
+            if (CanRelMove() && FocusRelPosNP.getState() != IPS_IDLE)
             {
-                FocusRelPosNP.s = IPS_IDLE;
-                IDSetNumber(&FocusRelPosNP, nullptr);
+                FocusRelPosNP.setState(IPS_IDLE);
+                FocusRelPosNP.apply();
             }
         }
         else
         {
-            FocusAbortSP.s = IPS_ALERT;
+            FocusAbortSP.setState(IPS_ALERT);
             DEBUG(Logger::DBG_ERROR, "Aborting focuser failed.");
         }
 
-        IDSetSwitch(&FocusAbortSP, nullptr);
+        FocusAbortSP.apply();
     }
     // Focus In
     else if (!strcmp(button_n, "Focus In"))
     {
-        if (FocusMotionS[FOCUS_INWARD].s != ISS_ON)
+        if (FocusMotionSP[FOCUS_INWARD].getState() != ISS_ON)
         {
-            FocusMotionS[FOCUS_INWARD].s  = ISS_ON;
-            FocusMotionS[FOCUS_OUTWARD].s = ISS_OFF;
-            IDSetSwitch(&FocusMotionSP, nullptr);
+            FocusMotionSP[FOCUS_INWARD].setState(ISS_ON);
+            FocusMotionSP[FOCUS_OUTWARD].setState(ISS_OFF);
+            FocusMotionSP.apply();
         }
 
         if (CanRelMove())
         {
-            rc = MoveRelFocuser(FOCUS_INWARD, FocusRelPosN[0].value);
+            rc = MoveRelFocuser(FOCUS_INWARD, FocusRelPosNP[0].getValue());
             if (rc == IPS_OK)
             {
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusRelPosNP, "Focuser moved %d steps inward", (int)FocusRelPosN[0].value);
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusRelPosNP.apply("Focuser moved %d steps inward", (int)FocusRelPosNP[0].getValue());
+                FocusAbsPosNP.apply();
             }
             else if (rc == IPS_BUSY)
             {
-                FocusRelPosNP.s = IPS_BUSY;
-                IDSetNumber(&FocusAbsPosNP, "Focuser is moving %d steps inward...", (int)FocusRelPosN[0].value);
+                FocusRelPosNP.setState(IPS_BUSY);
+                FocusAbsPosNP.apply("Focuser is moving %d steps inward...", (int)FocusRelPosNP[0].getValue());
             }
         }
         else if (HasVariableSpeed())
         {
-            rc             = MoveFocuser(FOCUS_INWARD, FocusSpeedN[0].value, FocusTimerN[0].value);
-            FocusTimerNP.s = rc;
-            IDSetNumber(&FocusTimerNP, nullptr);
+            rc             = MoveFocuser(FOCUS_INWARD, FocusSpeedNP[0].getValue(), FocusTimerNP[0].getValue());
+            FocusTimerNP.setState(rc);
+            FocusTimerNP.apply();
         }
 
     }
     else if (!strcmp(button_n, "Focus Out"))
     {
-        if (FocusMotionS[FOCUS_OUTWARD].s != ISS_ON)
+        if (FocusMotionSP[FOCUS_OUTWARD].getState() != ISS_ON)
         {
-            FocusMotionS[FOCUS_INWARD].s  = ISS_OFF;
-            FocusMotionS[FOCUS_OUTWARD].s = ISS_ON;
-            IDSetSwitch(&FocusMotionSP, nullptr);
+            FocusMotionSP[FOCUS_INWARD].setState(ISS_OFF);
+            FocusMotionSP[FOCUS_OUTWARD].setState(ISS_ON);
+            FocusMotionSP.apply();
         }
 
         if (CanRelMove())
         {
-            rc = MoveRelFocuser(FOCUS_OUTWARD, FocusRelPosN[0].value);
+            rc = MoveRelFocuser(FOCUS_OUTWARD, FocusRelPosNP[0].getValue());
             if (rc == IPS_OK)
             {
-                FocusRelPosNP.s = IPS_OK;
-                IDSetNumber(&FocusRelPosNP, "Focuser moved %d steps outward", (int)FocusRelPosN[0].value);
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusRelPosNP.setState(IPS_OK);
+                FocusRelPosNP.apply("Focuser moved %d steps outward", (int)FocusRelPosNP[0].getValue());
+                FocusAbsPosNP.apply();
             }
             else if (rc == IPS_BUSY)
             {
-                FocusRelPosNP.s = IPS_BUSY;
-                IDSetNumber(&FocusAbsPosNP, "Focuser is moving %d steps outward...", (int)FocusRelPosN[0].value);
+                FocusRelPosNP.setState(IPS_BUSY);
+                FocusAbsPosNP.apply("Focuser is moving %d steps outward...", (int)FocusRelPosNP[0].getValue());
             }
         }
         else if (HasVariableSpeed())
         {
-            rc             = MoveFocuser(FOCUS_OUTWARD, FocusSpeedN[0].value, FocusTimerN[0].value);
-            FocusTimerNP.s = rc;
-            IDSetNumber(&FocusTimerNP, nullptr);
+            rc             = MoveFocuser(FOCUS_OUTWARD, FocusSpeedNP[0].getValue(), FocusTimerNP[0].getValue());
+            FocusTimerNP.setState(rc);
+            FocusTimerNP.apply();
         }
     }
 }
@@ -375,12 +375,12 @@ bool Focuser::SetFocuserMaxPosition(uint32_t ticks)
 
 void Focuser::SyncPresets(uint32_t ticks)
 {
-    PresetN[0].max = ticks;
-    PresetN[0].step = PresetN[0].max / 50.0;
-    PresetN[1].max = ticks;
-    PresetN[1].step = PresetN[0].max / 50.0;
-    PresetN[2].max = ticks;
-    PresetN[2].step = PresetN[0].max / 50.0;
-    IUUpdateMinMax(&PresetNP);
+    PresetNP[0].setMax(ticks);
+    PresetNP[0].setStep(PresetNP[0].getMax() / 50.0);
+    PresetNP[1].setMax(ticks);
+    PresetNP[1].setStep(PresetNP[0].getMax() / 50.0);
+    PresetNP[2].setMax(ticks);
+    PresetNP[2].setStep(PresetNP[0].getMax() / 50.0);
+    PresetNP.updateMinMax();
 }
 }

--- a/libs/indibase/indifocuser.h
+++ b/libs/indibase/indifocuser.h
@@ -21,6 +21,10 @@
 #include "defaultdevice.h"
 #include "indifocuserinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 namespace Connection
 {
 class Serial;
@@ -101,10 +105,8 @@ class Focuser : public DefaultDevice, public FocuserInterface
      */
     virtual void SyncPresets(uint32_t ticks);
 
-    INumber PresetN[3];
-    INumberVectorProperty PresetNP;
-    ISwitch PresetGotoS[3];
-    ISwitchVectorProperty PresetGotoSP;
+    INDI::PropertyNumber PresetNP {3};
+    INDI::PropertySwitch PresetGotoSP {3};
 
     void processButton(const char *button_n, ISState state);
 

--- a/libs/indibase/indifocuserinterface.cpp
+++ b/libs/indibase/indifocuserinterface.cpp
@@ -34,66 +34,66 @@ FocuserInterface::FocuserInterface(DefaultDevice * defaultDevice) : m_defaultDev
 
 void FocuserInterface::initProperties(const char * groupName)
 {
-    IUFillNumber(&FocusSpeedN[0], "FOCUS_SPEED_VALUE", "Focus Speed", "%3.0f", 0.0, 255.0, 1.0, 255.0);
-    IUFillNumberVector(&FocusSpeedNP, FocusSpeedN, 1, m_defaultDevice->getDeviceName(), "FOCUS_SPEED", "Speed", groupName,
+    FocusSpeedNP[0].fill("FOCUS_SPEED_VALUE", "Focus Speed", "%3.0f", 0.0, 255.0, 1.0, 255.0);
+    FocusSpeedNP.fill(m_defaultDevice->getDeviceName(), "FOCUS_SPEED", "Speed", groupName,
                        IP_RW, 60, IPS_OK);
 
-    IUFillNumber(&FocusTimerN[0], "FOCUS_TIMER_VALUE", "Focus Timer (ms)", "%4.0f", 0.0, 5000.0, 50.0, 1000.0);
-    IUFillNumberVector(&FocusTimerNP, FocusTimerN, 1, m_defaultDevice->getDeviceName(), "FOCUS_TIMER", "Timer", groupName,
+    FocusTimerNP[0].fill("FOCUS_TIMER_VALUE", "Focus Timer (ms)", "%4.0f", 0.0, 5000.0, 50.0, 1000.0);
+    FocusTimerNP.fill(m_defaultDevice->getDeviceName(), "FOCUS_TIMER", "Timer", groupName,
                        IP_RW, 60, IPS_OK);
     lastTimerValue = 1000.0;
 
-    IUFillSwitch(&FocusMotionS[0], "FOCUS_INWARD", "Focus In", ISS_ON);
-    IUFillSwitch(&FocusMotionS[1], "FOCUS_OUTWARD", "Focus Out", ISS_OFF);
-    IUFillSwitchVector(&FocusMotionSP, FocusMotionS, 2, m_defaultDevice->getDeviceName(), "FOCUS_MOTION", "Direction",
+    FocusMotionSP[0].fill("FOCUS_INWARD", "Focus In", ISS_ON);
+    FocusMotionSP[1].fill("FOCUS_OUTWARD", "Focus Out", ISS_OFF);
+    FocusMotionSP.fill(m_defaultDevice->getDeviceName(), "FOCUS_MOTION", "Direction",
                        groupName, IP_RW,
                        ISR_1OFMANY, 60, IPS_OK);
 
     // Absolute Position
-    IUFillNumber(&FocusAbsPosN[0], "FOCUS_ABSOLUTE_POSITION", "Steps", "%.f", 0.0, 100000.0, 1000.0, 0);
-    IUFillNumberVector(&FocusAbsPosNP, FocusAbsPosN, 1, m_defaultDevice->getDeviceName(), "ABS_FOCUS_POSITION",
+    FocusAbsPosNP[0].fill("FOCUS_ABSOLUTE_POSITION", "Steps", "%.f", 0.0, 100000.0, 1000.0, 0);
+    FocusAbsPosNP.fill(m_defaultDevice->getDeviceName(), "ABS_FOCUS_POSITION",
                        "Absolute Position",
                        groupName, IP_RW, 60, IPS_OK);
 
     // Relative Position
-    IUFillNumber(&FocusRelPosN[0], "FOCUS_RELATIVE_POSITION", "Steps", "%.f", 0.0, 100000.0, 1000.0, 0);
-    IUFillNumberVector(&FocusRelPosNP, FocusRelPosN, 1, m_defaultDevice->getDeviceName(), "REL_FOCUS_POSITION",
+    FocusRelPosNP[0].fill("FOCUS_RELATIVE_POSITION", "Steps", "%.f", 0.0, 100000.0, 1000.0, 0);
+    FocusRelPosNP.fill(m_defaultDevice->getDeviceName(), "REL_FOCUS_POSITION",
                        "Relative Position",
                        groupName, IP_RW, 60, IPS_OK);
 
     // Sync
-    IUFillNumber(&FocusSyncN[0], "FOCUS_SYNC_VALUE", "Steps", "%.f", 0.0, 100000.0, 1000.0, 0);
-    IUFillNumberVector(&FocusSyncNP, FocusSyncN, 1, m_defaultDevice->getDeviceName(), "FOCUS_SYNC", "Sync",
+    FocusSyncNP[0].fill("FOCUS_SYNC_VALUE", "Steps", "%.f", 0.0, 100000.0, 1000.0, 0);
+    FocusSyncNP.fill(m_defaultDevice->getDeviceName(), "FOCUS_SYNC", "Sync",
                        groupName, IP_RW, 60, IPS_OK);
 
     // Maximum Position
-    IUFillNumber(&FocusMaxPosN[0], "FOCUS_MAX_VALUE", "Steps", "%.f", 1e3, 1e6, 1e4, 1e5);
-    IUFillNumberVector(&FocusMaxPosNP, FocusMaxPosN, 1, m_defaultDevice->getDeviceName(), "FOCUS_MAX", "Max. Position",
+    FocusMaxPosNP[0].fill("FOCUS_MAX_VALUE", "Steps", "%.f", 1e3, 1e6, 1e4, 1e5);
+    FocusMaxPosNP.fill(m_defaultDevice->getDeviceName(), "FOCUS_MAX", "Max. Position",
                        groupName, IP_RW, 60, IPS_OK);
 
     // Abort
-    IUFillSwitch(&FocusAbortS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&FocusAbortSP, FocusAbortS, 1, m_defaultDevice->getDeviceName(), "FOCUS_ABORT_MOTION", "Abort Motion",
+    FocusAbortSP[0].fill("ABORT", "Abort", ISS_OFF);
+    FocusAbortSP.fill(m_defaultDevice->getDeviceName(), "FOCUS_ABORT_MOTION", "Abort Motion",
                        groupName, IP_RW,
                        ISR_ATMOST1, 60, IPS_IDLE);
 
     // Revese
-    IUFillSwitch(&FocusReverseS[DefaultDevice::INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&FocusReverseS[DefaultDevice::INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&FocusReverseSP, FocusReverseS, 2, m_defaultDevice->getDeviceName(), "FOCUS_REVERSE_MOTION",
+    FocusReverseSP[DefaultDevice::INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    FocusReverseSP[DefaultDevice::INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    FocusReverseSP.fill(m_defaultDevice->getDeviceName(), "FOCUS_REVERSE_MOTION",
                        "Reverse Motion", groupName, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
     // Backlash Compensation
-    IUFillSwitch(&FocusBacklashS[DefaultDevice::INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&FocusBacklashS[DefaultDevice::INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&FocusBacklashSP, FocusBacklashS, 2, m_defaultDevice->getDeviceName(), "FOCUS_BACKLASH_TOGGLE",
+    FocusBacklashSP[DefaultDevice::INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    FocusBacklashSP[DefaultDevice::INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    FocusBacklashSP.fill(m_defaultDevice->getDeviceName(), "FOCUS_BACKLASH_TOGGLE",
                        "Backlash", groupName, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
     // Backlash Compensation Value
-    IUFillNumber(&FocusBacklashN[0], "FOCUS_BACKLASH_VALUE", "Steps", "%.f", 0, 1e6, 100, 0);
-    IUFillNumberVector(&FocusBacklashNP, FocusBacklashN, 1, m_defaultDevice->getDeviceName(), "FOCUS_BACKLASH_STEPS",
+    FocusBacklashNP[0].fill("FOCUS_BACKLASH_VALUE", "Steps", "%.f", 0, 1e6, 100, 0);
+    FocusBacklashNP.fill(m_defaultDevice->getDeviceName(), "FOCUS_BACKLASH_STEPS",
                        "Backlash",
                        groupName, IP_RW, 60, IPS_OK);
 }
@@ -103,62 +103,62 @@ bool FocuserInterface::updateProperties()
     if (m_defaultDevice->isConnected())
     {
         //  Now we add our focusser specific stuff
-        m_defaultDevice->defineProperty(&FocusMotionSP);
+        m_defaultDevice->defineProperty(FocusMotionSP);
 
         if (HasVariableSpeed())
         {
-            m_defaultDevice->defineProperty(&FocusSpeedNP);
+            m_defaultDevice->defineProperty(FocusSpeedNP);
 
             // We only define Focus Timer if we can not absolute move
             if (CanAbsMove() == false)
-                m_defaultDevice->defineProperty(&FocusTimerNP);
+                m_defaultDevice->defineProperty(FocusTimerNP);
         }
         if (CanRelMove())
-            m_defaultDevice->defineProperty(&FocusRelPosNP);
+            m_defaultDevice->defineProperty(FocusRelPosNP);
         if (CanAbsMove())
         {
-            m_defaultDevice->defineProperty(&FocusAbsPosNP);
-            m_defaultDevice->defineProperty(&FocusMaxPosNP);
+            m_defaultDevice->defineProperty(FocusAbsPosNP);
+            m_defaultDevice->defineProperty(FocusMaxPosNP);
         }
         if (CanAbort())
-            m_defaultDevice->defineProperty(&FocusAbortSP);
+            m_defaultDevice->defineProperty(FocusAbortSP);
         if (CanSync())
-            m_defaultDevice->defineProperty(&FocusSyncNP);
+            m_defaultDevice->defineProperty(FocusSyncNP);
         if (CanReverse())
-            m_defaultDevice->defineProperty(&FocusReverseSP);
+            m_defaultDevice->defineProperty(FocusReverseSP);
         if (HasBacklash())
         {
-            m_defaultDevice->defineProperty(&FocusBacklashSP);
-            m_defaultDevice->defineProperty(&FocusBacklashNP);
+            m_defaultDevice->defineProperty(FocusBacklashSP);
+            m_defaultDevice->defineProperty(FocusBacklashNP);
         }
     }
     else
     {
-        m_defaultDevice->deleteProperty(FocusMotionSP.name);
+        m_defaultDevice->deleteProperty(FocusMotionSP.getName());
         if (HasVariableSpeed())
         {
-            m_defaultDevice->deleteProperty(FocusSpeedNP.name);
+            m_defaultDevice->deleteProperty(FocusSpeedNP.getName());
 
             if (CanAbsMove() == false)
-                m_defaultDevice->deleteProperty(FocusTimerNP.name);
+                m_defaultDevice->deleteProperty(FocusTimerNP.getName());
         }
         if (CanRelMove())
-            m_defaultDevice->deleteProperty(FocusRelPosNP.name);
+            m_defaultDevice->deleteProperty(FocusRelPosNP.getName());
         if (CanAbsMove())
         {
-            m_defaultDevice->deleteProperty(FocusAbsPosNP.name);
-            m_defaultDevice->deleteProperty(FocusMaxPosNP.name);
+            m_defaultDevice->deleteProperty(FocusAbsPosNP.getName());
+            m_defaultDevice->deleteProperty(FocusMaxPosNP.getName());
         }
         if (CanAbort())
-            m_defaultDevice->deleteProperty(FocusAbortSP.name);
+            m_defaultDevice->deleteProperty(FocusAbortSP.getName());
         if (CanSync())
-            m_defaultDevice->deleteProperty(FocusSyncNP.name);
+            m_defaultDevice->deleteProperty(FocusSyncNP.getName());
         if (CanReverse())
-            m_defaultDevice->deleteProperty(FocusReverseSP.name);
+            m_defaultDevice->deleteProperty(FocusReverseSP.getName());
         if (HasBacklash())
         {
-            m_defaultDevice->deleteProperty(FocusBacklashSP.name);
-            m_defaultDevice->deleteProperty(FocusBacklashNP.name);
+            m_defaultDevice->deleteProperty(FocusBacklashSP.getName());
+            m_defaultDevice->deleteProperty(FocusBacklashNP.getName());
         }
     }
 
@@ -168,108 +168,108 @@ bool FocuserInterface::updateProperties()
 bool FocuserInterface::processNumber(const char * dev, const char * name, double values[], char * names[], int n)
 {
     // Move focuser based on requested timeout
-    if (!strcmp(name, FocusTimerNP.name))
+    if (FocusTimerNP.isNameMatch(name))
     {
         FocusDirection dir;
         int speed;
         int t;
 
         //  first we get all the numbers just sent to us
-        IUUpdateNumber(&FocusTimerNP, values, names, n);
+        FocusTimerNP.update(values, names, n);
 
         //  Now lets find what we need for this move
-        speed = FocusSpeedN[0].value;
+        speed = FocusSpeedNP[0].getValue();
 
-        if (FocusMotionS[0].s == ISS_ON)
+        if (FocusMotionSP[0].getState() == ISS_ON)
             dir = FOCUS_INWARD;
         else
             dir = FOCUS_OUTWARD;
 
-        t              = FocusTimerN[0].value;
+        t              = FocusTimerNP[0].getValue();
         lastTimerValue = t;
 
-        FocusTimerNP.s = MoveFocuser(dir, speed, t);
-        IDSetNumber(&FocusTimerNP, nullptr);
+        FocusTimerNP.setState(MoveFocuser(dir, speed, t));
+        FocusTimerNP.apply();
         return true;
     }
 
     // Set variable focus speed
-    if (!strcmp(name, FocusSpeedNP.name))
+    if (FocusSpeedNP.isNameMatch(name))
     {
-        FocusSpeedNP.s    = IPS_OK;
-        int current_speed = FocusSpeedN[0].value;
-        IUUpdateNumber(&FocusSpeedNP, values, names, n);
+        FocusSpeedNP.setState(IPS_OK);
+        int current_speed = FocusSpeedNP[0].getValue();
+        FocusSpeedNP.update(values, names, n);
 
-        if (SetFocuserSpeed(FocusSpeedN[0].value) == false)
+        if (SetFocuserSpeed(FocusSpeedNP[0].value) == false)
         {
-            FocusSpeedN[0].value = current_speed;
-            FocusSpeedNP.s       = IPS_ALERT;
+            FocusSpeedNP[0].setValue(current_speed);
+            FocusSpeedNP.setState(IPS_ALERT);
         }
 
         //  Update client display
-        IDSetNumber(&FocusSpeedNP, nullptr);
+        FocusSpeedNP.apply();
         return true;
     }
 
     // Update Maximum Position allowed
-    if (!strcmp(name, FocusMaxPosNP.name))
+    if (FocusMaxPosNP.isNameMatch(name))
     {
         uint32_t maxTravel = rint(values[0]);
         if (SetFocuserMaxPosition(maxTravel))
         {
-            IUUpdateNumber(&FocusMaxPosNP, values, names, n);
+            FocusMaxPosNP.update(values, names, n);
 
-            FocusAbsPosN[0].max = FocusMaxPosN[0].value;
-            FocusSyncN[0].max = FocusMaxPosN[0].value;
+            FocusAbsPosNP[0].setMax(FocusMaxPosNP[0].value);
+            FocusSyncNP[0].setMax(FocusMaxPosNP[0].value);
 
-            FocusAbsPosN[0].step = FocusMaxPosN[0].value / 50.0;
-            FocusSyncN[0].step = FocusMaxPosN[0].value / 50.0;
+            FocusAbsPosNP[0].setStep(FocusMaxPosNP[0].value / 50.0);
+            FocusSyncNP[0].setStep(FocusMaxPosNP[0].value / 50.0);
 
-            FocusAbsPosN[0].min = 0;
-            FocusSyncN[0].min = 0;
+            FocusAbsPosNP[0].setMin(0);
+            FocusSyncNP[0].setMin(0);
 
-            FocusRelPosN[0].max  = FocusMaxPosN[0].value / 2;
-            FocusRelPosN[0].step = FocusMaxPosN[0].value / 100.0;
-            FocusRelPosN[0].min  = 0;
+            FocusRelPosNP[0].setMax(FocusMaxPosNP[0].value / 2);
+            FocusRelPosNP[0].setStep(FocusMaxPosNP[0].value / 100.0);
+            FocusRelPosNP[0].setMin(0);
 
-            IUUpdateMinMax(&FocusAbsPosNP);
-            IUUpdateMinMax(&FocusRelPosNP);
-            IUUpdateMinMax(&FocusSyncNP);
+            FocusAbsPosNP.updateMinMax();
+            FocusRelPosNP.updateMinMax();
+            FocusSyncNP.updateMinMax();
 
-            FocusMaxPosNP.s = IPS_OK;
+            FocusMaxPosNP.setState(IPS_OK);
         }
         else
-            FocusMaxPosNP.s = IPS_ALERT;
+            FocusMaxPosNP.setState(IPS_ALERT);
 
-        IDSetNumber(&FocusMaxPosNP, nullptr);
+        FocusMaxPosNP.apply();
         return true;
     }
 
     // Sync
-    if (!strcmp(name, FocusSyncNP.name))
+    if (FocusSyncNP.isNameMatch(name))
     {
         if (SyncFocuser(rint(values[0])))
         {
-            FocusSyncN[0].value = rint(values[0]);
-            FocusAbsPosN[0].value = rint(values[0]);
-            FocusSyncNP.s = IPS_OK;
-            IDSetNumber(&FocusSyncNP, nullptr);
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusSyncNP[0].setValue(rint(values[0]));
+            FocusAbsPosNP[0].setValue(rint(values[0]));
+            FocusSyncNP.setState(IPS_OK);
+            FocusSyncNP.apply();
+            FocusAbsPosNP.apply();
         }
         else
         {
-            FocusSyncNP.s = IPS_ALERT;
-            IDSetNumber(&FocusSyncNP, nullptr);
+            FocusSyncNP.setState(IPS_ALERT);
+            FocusSyncNP.apply();
         }
         return true;
     }
 
     // Set backlash value
-    if (!strcmp(name, FocusBacklashNP.name))
+    if (FocusBacklashNP.isNameMatch(name))
     {
-        if (FocusBacklashS[DefaultDevice::INDI_ENABLED].s != ISS_ON)
+        if (FocusBacklashSP[DefaultDevice::INDI_ENABLED].getState() != ISS_ON)
         {
-            FocusBacklashNP.s = IPS_IDLE;
+            FocusBacklashNP.setState(IPS_IDLE);
 
             // Only warn if there is non-zero backlash value.
             if (values[0] > 0)
@@ -280,35 +280,35 @@ bool FocuserInterface::processNumber(const char * dev, const char * name, double
             uint32_t steps = static_cast<uint32_t>(values[0]);
             if (SetFocuserBacklash(steps))
             {
-                FocusBacklashN[0].value = values[0];
-                FocusBacklashNP.s = IPS_OK;
+                FocusBacklashNP[0].setValue(values[0]);
+                FocusBacklashNP.setState(IPS_OK);
             }
             else
-                FocusBacklashNP.s = IPS_ALERT;
+                FocusBacklashNP.setState(IPS_ALERT);
         }
-        IDSetNumber(&FocusBacklashNP, nullptr);
+        FocusBacklashNP.apply();
         return true;
     }
 
     // Update Absolute Focuser Position
-    if (!strcmp(name, FocusAbsPosNP.name))
+    if (FocusAbsPosNP.isNameMatch(name))
     {
         int newPos = rint(values[0]);
 
-        if (newPos < FocusAbsPosN[0].min)
+        if (newPos < FocusAbsPosNP[0].min)
         {
-            FocusAbsPosNP.s = IPS_ALERT;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP.setState(IPS_ALERT);
+            FocusAbsPosNP.apply();
             DEBUGFDEVICE(dev, Logger::DBG_ERROR, "Requested position out of bound. Focus minimum position is %g",
-                         FocusAbsPosN[0].min);
+                         FocusAbsPosNP[0].min);
             return false;
         }
-        else if (newPos > FocusAbsPosN[0].max)
+        else if (newPos > FocusAbsPosNP[0].max)
         {
-            FocusAbsPosNP.s = IPS_ALERT;
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP.setState(IPS_ALERT);
+            FocusAbsPosNP.apply();
             DEBUGFDEVICE(dev, Logger::DBG_ERROR, "Requested position out of bound. Focus maximum position is %g",
-                         FocusAbsPosN[0].max);
+                         FocusAbsPosNP[0].max);
             return false;
         }
 
@@ -316,36 +316,36 @@ bool FocuserInterface::processNumber(const char * dev, const char * name, double
 
         if ((ret = MoveAbsFocuser(newPos)) == IPS_OK)
         {
-            FocusAbsPosNP.s = IPS_OK;
-            IUUpdateNumber(&FocusAbsPosNP, values, names, n);
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusAbsPosNP.update(values, names, n);
             DEBUGFDEVICE(dev, Logger::DBG_SESSION, "Focuser moved to position %d", newPos);
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP.apply();
             return true;
         }
         else if (ret == IPS_BUSY)
         {
-            FocusAbsPosNP.s = IPS_BUSY;
+            FocusAbsPosNP.setState(IPS_BUSY);
             DEBUGFDEVICE(dev, Logger::DBG_SESSION, "Focuser is moving to position %d", newPos);
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusAbsPosNP.apply();
             return true;
         }
 
-        FocusAbsPosNP.s = IPS_ALERT;
+        FocusAbsPosNP.setState(IPS_ALERT);
         DEBUGDEVICE(dev, Logger::DBG_ERROR, "Focuser failed to move to new requested position.");
-        IDSetNumber(&FocusAbsPosNP, nullptr);
+        FocusAbsPosNP.apply();
         return false;
     }
 
     // Update Relative focuser steps. This moves the focuser CW/CCW by this number of steps.
-    if (!strcmp(name, FocusRelPosNP.name))
+    if (FocusRelPosNP.isNameMatch(name))
     {
         int newPos = rint(values[0]);
 
         if (newPos <= 0)
         {
             DEBUGDEVICE(dev, Logger::DBG_ERROR, "Relative ticks value must be greater than zero.");
-            FocusRelPosNP.s = IPS_ALERT;
-            IDSetNumber(&FocusRelPosNP, nullptr);
+            FocusRelPosNP.setState(IPS_ALERT);
+            FocusRelPosNP.apply();
             return false;
         }
 
@@ -353,54 +353,54 @@ bool FocuserInterface::processNumber(const char * dev, const char * name, double
 
         if (CanAbsMove())
         {
-            if (FocusMotionS[0].s == ISS_ON)
+            if (FocusMotionSP[0].getState() == ISS_ON)
             {
-                if (FocusAbsPosN[0].value - newPos < FocusAbsPosN[0].min)
+                if (FocusAbsPosNP[0].value - newPos < FocusAbsPosNP[0].min)
                 {
-                    FocusRelPosNP.s = IPS_ALERT;
-                    IDSetNumber(&FocusRelPosNP, nullptr);
+                    FocusRelPosNP.setState(IPS_ALERT);
+                    FocusRelPosNP.apply();
                     DEBUGFDEVICE(dev, Logger::DBG_ERROR,
-                                 "Requested position out of bound. Focus minimum position is %g", FocusAbsPosN[0].min);
+                                 "Requested position out of bound. Focus minimum position is %g", FocusAbsPosNP[0].min);
                     return false;
                 }
             }
             else
             {
-                if (FocusAbsPosN[0].value + newPos > FocusAbsPosN[0].max)
+                if (FocusAbsPosNP[0].value + newPos > FocusAbsPosNP[0].max)
                 {
-                    FocusRelPosNP.s = IPS_ALERT;
-                    IDSetNumber(&FocusRelPosNP, nullptr);
+                    FocusRelPosNP.setState(IPS_ALERT);
+                    FocusRelPosNP.apply();
                     DEBUGFDEVICE(dev, Logger::DBG_ERROR,
-                                 "Requested position out of bound. Focus maximum position is %g", FocusAbsPosN[0].max);
+                                 "Requested position out of bound. Focus maximum position is %g", FocusAbsPosNP[0].max);
                     return false;
                 }
             }
         }
 
-        if ((ret = MoveRelFocuser((FocusMotionS[0].s == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD), newPos)) == IPS_OK)
+        if ((ret = MoveRelFocuser((FocusMotionSP[0].getState() == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD), newPos)) == IPS_OK)
         {
-            FocusRelPosNP.s = IPS_OK;
-            FocusAbsPosNP.s = IPS_OK;
-            IUUpdateNumber(&FocusRelPosNP, values, names, n);
-            IDSetNumber(&FocusRelPosNP, "Focuser moved %d steps %s", newPos,
-                        FocusMotionS[0].s == ISS_ON ? "inward" : "outward");
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusRelPosNP.setState(IPS_OK);
+            FocusAbsPosNP.setState(IPS_OK);
+            FocusRelPosNP.update(values, names, n);
+            FocusRelPosNP.apply("Focuser moved %d steps %s", newPos,
+                        FocusMotionSP[0].getState() == ISS_ON ? "inward" : "outward");
+            FocusAbsPosNP.apply();
             return true;
         }
         else if (ret == IPS_BUSY)
         {
-            IUUpdateNumber(&FocusRelPosNP, values, names, n);
-            FocusRelPosNP.s = IPS_BUSY;
-            FocusAbsPosNP.s = IPS_BUSY;
-            IDSetNumber(&FocusAbsPosNP, "Focuser is moving %d steps %s...", newPos,
-                        FocusMotionS[0].s == ISS_ON ? "inward" : "outward");
-            IDSetNumber(&FocusAbsPosNP, nullptr);
+            FocusRelPosNP.update(values, names, n);
+            FocusRelPosNP.setState(IPS_BUSY);
+            FocusAbsPosNP.setState(IPS_BUSY);
+            FocusAbsPosNP.apply("Focuser is moving %d steps %s...", newPos,
+                        FocusMotionSP[0].getState() == ISS_ON ? "inward" : "outward");
+            FocusAbsPosNP.apply();
             return true;
         }
 
-        FocusRelPosNP.s = IPS_ALERT;
+        FocusRelPosNP.setState(IPS_ALERT);
         DEBUGDEVICE(dev, Logger::DBG_ERROR, "Focuser failed to move to new requested position.");
-        IDSetNumber(&FocusRelPosNP, nullptr);
+        FocusRelPosNP.apply();
         return false;
     }
 
@@ -411,19 +411,19 @@ bool FocuserInterface::processSwitch(const char * dev, const char * name, ISStat
 {
     INDI_UNUSED(dev);
     //  This one is for focus motion
-    if (!strcmp(name, FocusMotionSP.name))
+    if (FocusMotionSP.isNameMatch(name))
     {
         // Record last direction and state.
-        FocusDirection prevDirection = FocusMotionS[FOCUS_INWARD].s == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD;
-        IPState prevState = FocusMotionSP.s;
+        FocusDirection prevDirection = FocusMotionSP[FOCUS_INWARD].getState() == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD;
+        IPState prevState = FocusMotionSP.getState();
 
-        IUUpdateSwitch(&FocusMotionSP, states, names, n);
+        FocusMotionSP.update(states, names, n);
 
-        FocusDirection targetDirection = FocusMotionS[FOCUS_INWARD].s == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD;
+        FocusDirection targetDirection = FocusMotionSP[FOCUS_INWARD].getState() == ISS_ON ? FOCUS_INWARD : FOCUS_OUTWARD;
 
         if (CanRelMove() || CanAbsMove() || HasVariableSpeed())
         {
-            FocusMotionSP.s = IPS_OK;
+            FocusMotionSP.setState(IPS_OK);
         }
         // If we are dealing with a simple dumb DC focuser, we move in a specific direction in an open-loop fashion until stopped.
         else
@@ -432,80 +432,80 @@ bool FocuserInterface::processSwitch(const char * dev, const char * name, ISStat
             if (prevDirection != targetDirection && prevState == IPS_BUSY)
                 AbortFocuser();
 
-            FocusMotionSP.s = MoveFocuser(targetDirection, 0, 0);
+            FocusMotionSP.setState(MoveFocuser(targetDirection, 0, 0));
         }
 
-        IDSetSwitch(&FocusMotionSP, nullptr);
+        FocusMotionSP.apply();
 
         return true;
     }
 
     // Backlash compensation
-    else if (!strcmp(name, FocusBacklashSP.name))
+    else if (FocusBacklashSP.isNameMatch(name))
     {
-        int prevIndex = IUFindOnSwitchIndex(&FocusBacklashSP);
-        IUUpdateSwitch(&FocusBacklashSP, states, names, n);
+        int prevIndex = FocusBacklashSP.findOnSwitchIndex();
+        FocusBacklashSP.update(states, names, n);
 
-        if (SetFocuserBacklashEnabled(IUFindOnSwitchIndex(&FocusBacklashSP) == DefaultDevice::INDI_ENABLED))
+        if (SetFocuserBacklashEnabled(FocusBacklashSP.findOnSwitchIndex() == DefaultDevice::INDI_ENABLED))
         {
-            IUUpdateSwitch(&FocusBacklashSP, states, names, n);
-            FocusBacklashSP.s = IPS_OK;
+            FocusBacklashSP.update(states, names, n);
+            FocusBacklashSP.setState(IPS_OK);
         }
         else
         {
-            IUResetSwitch(&FocusBacklashSP);
-            FocusBacklashS[prevIndex].s = ISS_ON;
-            FocusBacklashSP.s = IPS_ALERT;
+            FocusBacklashSP.reset();
+            FocusBacklashSP[prevIndex].setState(ISS_ON);
+            FocusBacklashSP.setState(IPS_ALERT);
         }
 
-        IDSetSwitch(&FocusBacklashSP, nullptr);
+        FocusBacklashSP.apply();
         return true;
     }
 
     // Abort Focuser
-    else if (!strcmp(name, FocusAbortSP.name))
+    else if (FocusAbortSP.isNameMatch(name))
     {
-        IUResetSwitch(&FocusAbortSP);
+        FocusAbortSP.reset();
 
         if (AbortFocuser())
         {
-            FocusAbortSP.s = IPS_OK;
-            if (CanAbsMove() && FocusAbsPosNP.s != IPS_IDLE)
+            FocusAbortSP.setState(IPS_OK);
+            if (CanAbsMove() && FocusAbsPosNP.getState() != IPS_IDLE)
             {
-                FocusAbsPosNP.s = IPS_IDLE;
-                IDSetNumber(&FocusAbsPosNP, nullptr);
+                FocusAbsPosNP.setState(IPS_IDLE);
+                FocusAbsPosNP.apply();
             }
-            if (CanRelMove() && FocusRelPosNP.s != IPS_IDLE)
+            if (CanRelMove() && FocusRelPosNP.getState() != IPS_IDLE)
             {
-                FocusRelPosNP.s = IPS_IDLE;
-                IDSetNumber(&FocusRelPosNP, nullptr);
+                FocusRelPosNP.setState(IPS_IDLE);
+                FocusRelPosNP.apply();
             }
         }
         else
-            FocusAbortSP.s = IPS_ALERT;
+            FocusAbortSP.setState(IPS_ALERT);
 
-        IDSetSwitch(&FocusAbortSP, nullptr);
+        FocusAbortSP.apply();
         return true;
     }
 
     // Reverse Motion
-    else if (!strcmp(name, FocusReverseSP.name))
+    else if (FocusReverseSP.isNameMatch(name))
     {
-        int prevIndex = IUFindOnSwitchIndex(&FocusReverseSP);
-        IUUpdateSwitch(&FocusReverseSP, states, names, n);
+        int prevIndex = FocusReverseSP.findOnSwitchIndex();
+        FocusReverseSP.update(states, names, n);
 
-        if (ReverseFocuser(IUFindOnSwitchIndex(&FocusReverseSP) == DefaultDevice::INDI_ENABLED))
+        if (ReverseFocuser(FocusReverseSP.findOnSwitchIndex() == DefaultDevice::INDI_ENABLED))
         {
-            FocusReverseSP.s = IPS_OK;
+            FocusReverseSP.setState(IPS_OK);
         }
         else
         {
-            IUResetSwitch(&FocusReverseSP);
-            FocusReverseS[prevIndex].s = ISS_ON;
-            FocusReverseSP.s = IPS_ALERT;
+            FocusReverseSP.reset();
+            FocusReverseSP[prevIndex].setState(ISS_ON);
+            FocusReverseSP.setState(IPS_ALERT);
         }
 
-        IDSetSwitch(&FocusReverseSP, nullptr);
+        FocusReverseSP.apply();
         return true;
     }
 
@@ -582,7 +582,7 @@ bool FocuserInterface::SetFocuserBacklashEnabled(bool enabled)
 {
     // If disabled, set the focuser backlash to zero.
     if (enabled)
-        return SetFocuserBacklash(static_cast<int32_t>(FocusBacklashN[0].value));
+        return SetFocuserBacklash(static_cast<int32_t>(FocusBacklashNP[0].value));
     else
         return SetFocuserBacklash(0);
 }
@@ -590,13 +590,13 @@ bool FocuserInterface::SetFocuserBacklashEnabled(bool enabled)
 bool FocuserInterface::saveConfigItems(FILE * fp)
 {
     if (CanAbsMove())
-        IUSaveConfigNumber(fp, &FocusMaxPosNP);
+        FocusMaxPosNP.save(fp);
     if (CanReverse())
-        IUSaveConfigSwitch(fp, &FocusReverseSP);
+        FocusReverseSP.save(fp);
     if (HasBacklash())
     {
-        IUSaveConfigSwitch(fp, &FocusBacklashSP);
-        IUSaveConfigNumber(fp, &FocusBacklashNP);
+        FocusBacklashSP.save(fp);
+        FocusBacklashNP.save(fp);
     }
 
     return true;

--- a/libs/indibase/indifocuserinterface.h
+++ b/libs/indibase/indifocuserinterface.h
@@ -24,6 +24,10 @@
 
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 // Alias
 using FI = INDI::FocuserInterface;
 
@@ -265,50 +269,39 @@ class FocuserInterface
         bool saveConfigItems(FILE * fp);
 
         // Focuser Speed (if variable speeds are supported)
-        INumberVectorProperty FocusSpeedNP;
-        INumber FocusSpeedN[1];
+        INDI::PropertyNumber FocusSpeedNP {1};
 
         // Focuser Motion switch.
         // For absolute focusers, this controls the directoin of FocusRelPos when updated.
         // For DC speed based focusers, this moves the focuser continues in the CW/CCW directions until stopped.
-        ISwitchVectorProperty FocusMotionSP;
-        ISwitch FocusMotionS[2];
+        INDI::PropertySwitch FocusMotionSP {2};
 
         // Timer for user with DC focusers to run focuser in specific direction for this duration
-        INumberVectorProperty FocusTimerNP;
-        INumber FocusTimerN[1];
+        INDI::PropertyNumber FocusTimerNP {1};
 
         // Absolute Focuser Position in steps
-        INumberVectorProperty FocusAbsPosNP;
-        INumber FocusAbsPosN[1];
+        INDI::PropertyNumber FocusAbsPosNP {1};
 
         // Relative Focuser position to be commanded
-        INumberVectorProperty FocusRelPosNP;
-        INumber FocusRelPosN[1];
+        INDI::PropertyNumber FocusRelPosNP {1};
 
         // Absolute Focuser position is 0 to this maximum limit. By Default, it is set to 200,000.
-        INumberVectorProperty FocusMaxPosNP;
-        INumber FocusMaxPosN[1];
+        INDI::PropertyNumber FocusMaxPosNP {1};
 
         // Sync
-        INumberVectorProperty FocusSyncNP;
-        INumber FocusSyncN[1];
+        INDI::PropertyNumber FocusSyncNP {1};
 
         // Abort Focuser
-        ISwitchVectorProperty FocusAbortSP;
-        ISwitch FocusAbortS[1];
+        INDI::PropertySwitch FocusAbortSP {1};
 
         // Reverse Focuser
-        ISwitchVectorProperty FocusReverseSP;
-        ISwitch FocusReverseS[2];
+        INDI::PropertySwitch FocusReverseSP {2};
 
         // Backlash toogle
-        ISwitchVectorProperty FocusBacklashSP;
-        ISwitch FocusBacklashS[2];
+        INDI::PropertySwitch FocusBacklashSP {2};
 
         // Backlash steps
-        INumberVectorProperty FocusBacklashNP;
-        INumber FocusBacklashN[1];
+        INDI::PropertyNumber FocusBacklashNP {1};
 
         uint32_t capability;
 

--- a/libs/indibase/indigps.cpp
+++ b/libs/indibase/indigps.cpp
@@ -33,22 +33,22 @@ bool GPS::initProperties()
 {
     DefaultDevice::initProperties();
 
-    IUFillNumber(&PeriodN[0], "PERIOD", "Period (s)", "%.f", 0, 3600, 60.0, 0);
-    IUFillNumberVector(&PeriodNP, PeriodN, 1, getDeviceName(), "GPS_REFRESH_PERIOD", "Refresh", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
+    PeriodNP[0].fill("PERIOD", "Period (s)", "%.f", 0, 3600, 60.0, 0);
+    PeriodNP.fill(getDeviceName(), "GPS_REFRESH_PERIOD", "Refresh", MAIN_CONTROL_TAB, IP_RW, 0, IPS_IDLE);
 
-    IUFillSwitch(&RefreshS[0], "REFRESH", "GPS", ISS_OFF);
-    IUFillSwitchVector(&RefreshSP, RefreshS, 1, getDeviceName(), "GPS_REFRESH", "Refresh", MAIN_CONTROL_TAB, IP_RW,
+    RefreshSP[0].fill("REFRESH", "GPS", ISS_OFF);
+    RefreshSP.fill(getDeviceName(), "GPS_REFRESH", "Refresh", MAIN_CONTROL_TAB, IP_RW,
                        ISR_ATMOST1, 0, IPS_IDLE);
 
-    IUFillNumber(&LocationN[LOCATION_LATITUDE], "LAT", "Lat (dd:mm:ss)", "%010.6m", -90, 90, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss)", "%010.6m", 0, 360, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_ELEVATION], "ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
-    IUFillNumberVector(&LocationNP, LocationN, 3, getDeviceName(), "GEOGRAPHIC_COORD", "Location", MAIN_CONTROL_TAB,
+    LocationNP[LOCATION_LATITUDE].fill("LAT", "Lat (dd:mm:ss)", "%010.6m", -90, 90, 0, 0.0);
+    LocationNP[LOCATION_LONGITUDE].fill("LONG", "Lon (dd:mm:ss)", "%010.6m", 0, 360, 0, 0.0);
+    LocationNP[LOCATION_ELEVATION].fill("ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
+    LocationNP.fill(getDeviceName(), "GEOGRAPHIC_COORD", "Location", MAIN_CONTROL_TAB,
                        IP_RO, 60, IPS_IDLE);
 
-    IUFillText(&TimeT[0], "UTC", "UTC Time", nullptr);
-    IUFillText(&TimeT[1], "OFFSET", "UTC Offset", nullptr);
-    IUFillTextVector(&TimeTP, TimeT, 2, getDeviceName(), "TIME_UTC", "UTC", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
+    TimeTP[0].fill("UTC", "UTC Time", nullptr);
+    TimeTP[1].fill("OFFSET", "UTC Offset", nullptr);
+    TimeTP.fill(getDeviceName(), "TIME_UTC", "UTC", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     setDefaultPollingPeriod(2000);
 
@@ -67,13 +67,13 @@ bool GPS::updateProperties()
         // Update GPS and send values to client
         IPState state = updateGPS();
 
-        LocationNP.s = state;
-        defineProperty(&LocationNP);
-        TimeTP.s = state;
-        defineProperty(&TimeTP);
-        RefreshSP.s = state;
-        defineProperty(&RefreshSP);
-        defineProperty(&PeriodNP);
+        LocationNP.setState(state);
+        defineProperty(LocationNP);
+        TimeTP.setState(state);
+        defineProperty(TimeTP);
+        RefreshSP.setState(state);
+        defineProperty(RefreshSP);
+        defineProperty(PeriodNP);
 
         if (state != IPS_OK)
         {
@@ -82,15 +82,15 @@ bool GPS::updateProperties()
 
             timerID = SetTimer(getCurrentPollingPeriod());
         }
-        else if (PeriodN[0].value > 0)
-            timerID = SetTimer(PeriodN[0].value);
+        else if (PeriodNP[0].value > 0)
+            timerID = SetTimer(PeriodNP[0].value);
     }
     else
     {
-        deleteProperty(LocationNP.name);
-        deleteProperty(TimeTP.name);
-        deleteProperty(RefreshSP.name);
-        deleteProperty(PeriodNP.name);
+        deleteProperty(LocationNP.getName());
+        deleteProperty(TimeTP.getName());
+        deleteProperty(RefreshSP.getName());
+        deleteProperty(PeriodNP.getName());
 
         if (timerID > 0)
         {
@@ -112,26 +112,26 @@ void GPS::TimerHit()
 
     IPState state = updateGPS();
 
-    LocationNP.s = state;
-    TimeTP.s = state;
-    RefreshSP.s = state;
+    LocationNP.setState(state);
+    TimeTP.setState(state);
+    RefreshSP.setState(state);
 
     switch (state)
     {
         // Ok
         case IPS_OK:        
-            IDSetNumber(&LocationNP, nullptr);
-            IDSetText(&TimeTP, nullptr);
+            LocationNP.apply();
+            TimeTP.apply();
             // We got data OK, but if we are required to update once in a while, we'll call it.
-            if (PeriodN[0].value > 0)
-                timerID = SetTimer(PeriodN[0].value*1000);
+            if (PeriodNP[0].value > 0)
+                timerID = SetTimer(PeriodNP[0].value*1000);
             return;
             break;
 
         // GPS fix is in progress or alert
         case IPS_ALERT:
-            IDSetNumber(&LocationNP, nullptr);
-            IDSetText(&TimeTP, nullptr);            
+            LocationNP.apply();
+            TimeTP.apply();            
             break;
 
         default:
@@ -152,11 +152,11 @@ bool GPS::ISNewSwitch(const char *dev, const char *name, ISState *states, char *
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, RefreshSP.name))
+        if (RefreshSP.isNameMatch(name))
         {
-            RefreshS[0].s = ISS_OFF;
-            RefreshSP.s   = IPS_OK;
-            IDSetSwitch(&RefreshSP, nullptr);
+            RefreshSP[0].setState(ISS_OFF);
+            RefreshSP.setState(IPS_OK);
+            RefreshSP.apply();
 
             // Manual trigger
             TimerHit();
@@ -170,30 +170,30 @@ bool GPS::ISNewNumber(const char *dev, const char *name, double values[], char *
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (strcmp(name, PeriodNP.name) == 0)
+        if (PeriodNP.isNameMatch(name))
         {
-            double prevPeriod = PeriodN[0].value;
-            IUUpdateNumber(&PeriodNP, values, names, n);
+            double prevPeriod = PeriodNP[0].getValue();
+            PeriodNP.update(values, names, n);
             // Do not remove timer if GPS update is still in progress
-            if (timerID > 0 && RefreshSP.s != IPS_BUSY)
+            if (timerID > 0 && RefreshSP.getState() != IPS_BUSY)
             {
                 RemoveTimer(timerID);
                 timerID = -1;
             }
 
-            if (PeriodN[0].value == 0)
+            if (PeriodNP[0].value == 0)
             {
                 DEBUG(Logger::DBG_SESSION, "GPS Update Timer disabled.");
             }
             else
             {
-                timerID = SetTimer(PeriodN[0].value*1000);
+                timerID = SetTimer(PeriodNP[0].value*1000);
                 if (prevPeriod == 0)
                     DEBUG(Logger::DBG_SESSION, "GPS Update Timer enabled.");
             }
 
-            PeriodNP.s = IPS_OK;
-            IDSetNumber(&PeriodNP, nullptr);
+            PeriodNP.setState(IPS_OK);
+            PeriodNP.apply();
 
             return true;
         }
@@ -206,7 +206,7 @@ bool GPS::saveConfigItems(FILE *fp)
 {
     DefaultDevice::saveConfigItems(fp);
 
-    IUSaveConfigNumber(fp, &PeriodNP);
+    PeriodNP.save(fp);
     return true;
 }
 }

--- a/libs/indibase/indigps.h
+++ b/libs/indibase/indigps.h
@@ -26,6 +26,11 @@
 
 #include "defaultdevice.h"
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * \class GPS
    \brief Class to provide general functionality of a GPS device.
@@ -82,20 +87,16 @@ class GPS : public DefaultDevice
     virtual bool saveConfigItems(FILE *fp);
 
     //  A number vector that stores lattitude and longitude
-    INumberVectorProperty LocationNP;
-    INumber LocationN[3];
+    INDI::PropertyNumber LocationNP {3};
 
     // UTC and UTC Offset
-    IText TimeT[2] {};
-    ITextVectorProperty TimeTP;
+    INDI::PropertyText TimeTP {2};
 
     // Refresh data
-    ISwitch RefreshS[1];
-    ISwitchVectorProperty RefreshSP;
+    INDI::PropertySwitch RefreshSP {1};
 
     // Refresh Period
-    INumber PeriodN[1];
-    INumberVectorProperty PeriodNP;
+    INDI::PropertyNumber PeriodNP {1};
 
     int timerID = -1;
 };

--- a/libs/indibase/indilightboxinterface.h
+++ b/libs/indibase/indilightboxinterface.h
@@ -24,6 +24,11 @@
 
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * \class LightBoxInterface
    \brief Provides interface to implement controllable light box/switch device.
@@ -96,16 +101,13 @@ class LightBoxInterface
     virtual bool EnableLightBox(bool enable);
 
     // Turn on/off light
-    ISwitchVectorProperty LightSP;
-    ISwitch LightS[2];
+    INDI::PropertySwitch LightSP {2};
 
     // Light Intensity
-    INumberVectorProperty LightIntensityNP;
-    INumber LightIntensityN[1];
+    INDI::PropertyNumber LightIntensityNP {1};
 
     // Active devices to snoop
-    ITextVectorProperty ActiveDeviceTP;
-    IText ActiveDeviceT[1] {};
+    INDI::PropertyText ActiveDeviceTP {1};
 
     INumberVectorProperty FilterIntensityNP;
     INumber *FilterIntensityN;

--- a/libs/indibase/indirotator.h
+++ b/libs/indibase/indirotator.h
@@ -21,6 +21,10 @@
 #include "defaultdevice.h"
 #include "indirotatorinterface.h"
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 namespace Connection
 {
 class Serial;
@@ -87,10 +91,8 @@ class Rotator : public DefaultDevice, public RotatorInterface
         /** \brief perform handshake with device to check communication */
         virtual bool Handshake();
 
-        INumber PresetN[3];
-        INumberVectorProperty PresetNP;
-        ISwitch PresetGotoS[3];
-        ISwitchVectorProperty PresetGotoSP;
+        INDI::PropertyNumber PresetNP {3};
+        INDI::PropertySwitch PresetGotoSP {3};
 
         Connection::Serial *serialConnection = nullptr;
         Connection::TCP *tcpConnection       = nullptr;

--- a/libs/indibase/indirotatorinterface.cpp
+++ b/libs/indibase/indirotatorinterface.cpp
@@ -35,43 +35,43 @@ RotatorInterface::RotatorInterface(DefaultDevice *defaultDevice) : m_defaultDevi
 void RotatorInterface::initProperties(const char *groupName)
 {
     // Rotator Angle
-    IUFillNumber(&GotoRotatorN[0], "ANGLE", "Angle", "%.2f", 0, 360., 10., 0.);
-    IUFillNumberVector(&GotoRotatorNP, GotoRotatorN, 1, m_defaultDevice->getDeviceName(), "ABS_ROTATOR_ANGLE", "Goto",
+    GotoRotatorNP[0].fill("ANGLE", "Angle", "%.2f", 0, 360., 10., 0.);
+    GotoRotatorNP.fill(m_defaultDevice->getDeviceName(), "ABS_ROTATOR_ANGLE", "Goto",
                        groupName, IP_RW, 0, IPS_IDLE );
 
     // Abort Rotator
-    IUFillSwitch(&AbortRotatorS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&AbortRotatorSP, AbortRotatorS, 1, m_defaultDevice->getDeviceName(), "ROTATOR_ABORT_MOTION",
+    AbortRotatorSP[0].fill("ABORT", "Abort", ISS_OFF);
+    AbortRotatorSP.fill(m_defaultDevice->getDeviceName(), "ROTATOR_ABORT_MOTION",
                        "Abort Motion", groupName, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Rotator Sync
-    IUFillNumber(&SyncRotatorN[0], "ANGLE", "Angle", "%.2f", 0, 360., 10., 0.);
-    IUFillNumberVector(&SyncRotatorNP, SyncRotatorN, 1, m_defaultDevice->getDeviceName(), "SYNC_ROTATOR_ANGLE", "Sync",
+    SyncRotatorNP[0].fill("ANGLE", "Angle", "%.2f", 0, 360., 10., 0.);
+    SyncRotatorNP.fill(m_defaultDevice->getDeviceName(), "SYNC_ROTATOR_ANGLE", "Sync",
                        groupName, IP_RW, 0, IPS_IDLE );
 
     // Home Rotator
-    IUFillSwitch(&HomeRotatorS[0], "HOME", "Start", ISS_OFF);
-    IUFillSwitchVector(&HomeRotatorSP, HomeRotatorS, 1, m_defaultDevice->getDeviceName(), "ROTATOR_HOME", "Homing", groupName,
+    HomeRotatorSP[0].fill("HOME", "Start", ISS_OFF);
+    HomeRotatorSP.fill(m_defaultDevice->getDeviceName(), "ROTATOR_HOME", "Homing", groupName,
                        IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
 
     // Reverse Direction
-    IUFillSwitch(&ReverseRotatorS[DefaultDevice::INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&ReverseRotatorS[DefaultDevice::INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&ReverseRotatorSP, ReverseRotatorS, 2, m_defaultDevice->getDeviceName(), "ROTATOR_REVERSE", "Reverse",
+    ReverseRotatorSP[DefaultDevice::INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    ReverseRotatorSP[DefaultDevice::INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    ReverseRotatorSP.fill(m_defaultDevice->getDeviceName(), "ROTATOR_REVERSE", "Reverse",
                        groupName, IP_RW, ISR_1OFMANY,
                        0, IPS_IDLE);
 
     // Backlash Compensation
-    IUFillSwitch(&RotatorBacklashS[DefaultDevice::INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&RotatorBacklashS[DefaultDevice::INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&RotatorBacklashSP, RotatorBacklashS, 2, m_defaultDevice->getDeviceName(), "ROTATOR_BACKLASH_TOGGLE",
+    RotatorBacklashSP[DefaultDevice::INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    RotatorBacklashSP[DefaultDevice::INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_ON);
+    RotatorBacklashSP.fill(m_defaultDevice->getDeviceName(), "ROTATOR_BACKLASH_TOGGLE",
                        "Backlash", groupName, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
 
     // Backlash Compensation Value
-    IUFillNumber(&RotatorBacklashN[0], "ROTATOR_BACKLASH_VALUE", "Steps", "%.f", 0, 1e6, 100, 0);
-    IUFillNumberVector(&RotatorBacklashNP, RotatorBacklashN, 1, m_defaultDevice->getDeviceName(), "ROTATOR_BACKLASH_STEPS",
+    RotatorBacklashNP[0].fill("ROTATOR_BACKLASH_VALUE", "Steps", "%.f", 0, 1e6, 100, 0);
+    RotatorBacklashNP.fill(m_defaultDevice->getDeviceName(), "ROTATOR_BACKLASH_STEPS",
                        "Backlash",
                        groupName, IP_RW, 60, IPS_OK);
 }
@@ -86,49 +86,49 @@ bool RotatorInterface::processNumber(const char *dev, const char *name, double v
         ////////////////////////////////////////////
         // Move Absolute Angle
         ////////////////////////////////////////////
-        if (strcmp(name, GotoRotatorNP.name) == 0)
+        if (GotoRotatorNP.isNameMatch(name))
         {
-            if (values[0] == GotoRotatorN[0].value)
+            if (values[0] == GotoRotatorNP[0].getValue())
             {
-                GotoRotatorNP.s = IPS_OK;
-                IDSetNumber(&GotoRotatorNP, nullptr);
+                GotoRotatorNP.setState(IPS_OK);
+                GotoRotatorNP.apply();
                 return true;
             }
 
-            GotoRotatorNP.s = MoveRotator(values[0]);
-            IDSetNumber(&GotoRotatorNP, nullptr);
-            if (GotoRotatorNP.s == IPS_BUSY)
+            GotoRotatorNP.setState(MoveRotator(values[0]));
+            GotoRotatorNP.apply();
+            if (GotoRotatorNP.getState() == IPS_BUSY)
                 DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_SESSION, "Rotator moving to %.2f degrees...", values[0]);
             return true;
         }
         ////////////////////////////////////////////
         // Sync
         ////////////////////////////////////////////
-        else if (strcmp(name, SyncRotatorNP.name) == 0)
+        else if (SyncRotatorNP.isNameMatch(name))
         {
-            if (values[0] == GotoRotatorN[0].value)
+            if (values[0] == GotoRotatorNP[0].getValue())
             {
-                SyncRotatorNP.s = IPS_OK;
-                IDSetNumber(&SyncRotatorNP, nullptr);
+                SyncRotatorNP.setState(IPS_OK);
+                SyncRotatorNP.apply();
                 return true;
             }
 
             bool rc = SyncRotator(values[0]);
-            SyncRotatorNP.s = rc ? IPS_OK : IPS_ALERT;
+            SyncRotatorNP.setState(rc ? IPS_OK : IPS_ALERT);
             if (rc)
-                SyncRotatorN[0].value = values[0];
+                SyncRotatorNP[0].setValue(values[0]);
 
-            IDSetNumber(&SyncRotatorNP, nullptr);
+            SyncRotatorNP.apply();
             return true;
         }
         ////////////////////////////////////////////
         // Backlash value
         ////////////////////////////////////////////
-        else if (!strcmp(name, RotatorBacklashNP.name))
+        else if (RotatorBacklashNP.isNameMatch(name))
         {
-            if (RotatorBacklashS[DefaultDevice::INDI_ENABLED].s != ISS_ON)
+            if (RotatorBacklashSP[DefaultDevice::INDI_ENABLED].getState() != ISS_ON)
             {
-                RotatorBacklashNP.s = IPS_IDLE;
+                RotatorBacklashNP.setState(IPS_IDLE);
                 DEBUGDEVICE(dev, Logger::DBG_WARNING, "Rotatorer backlash must be enabled first.");
             }
             else
@@ -136,13 +136,13 @@ bool RotatorInterface::processNumber(const char *dev, const char *name, double v
                 uint32_t steps = static_cast<uint32_t>(values[0]);
                 if (SetRotatorBacklash(steps))
                 {
-                    RotatorBacklashN[0].value = values[0];
-                    RotatorBacklashNP.s = IPS_OK;
+                    RotatorBacklashNP[0].setValue(values[0]);
+                    RotatorBacklashNP.setState(IPS_OK);
                 }
                 else
-                    RotatorBacklashNP.s = IPS_ALERT;
+                    RotatorBacklashNP.setState(IPS_ALERT);
             }
-            IDSetNumber(&RotatorBacklashNP, nullptr);
+            RotatorBacklashNP.apply();
             return true;
         }
     }
@@ -161,16 +161,16 @@ bool RotatorInterface::processSwitch(const char *dev, const char *name, ISState 
         ////////////////////////////////////////////
         // Abort
         ////////////////////////////////////////////
-        if (strcmp(name, AbortRotatorSP.name) == 0)
+        if (AbortRotatorSP.isNameMatch(name))
         {
-            AbortRotatorSP.s = AbortRotator() ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&AbortRotatorSP, nullptr);
-            if (AbortRotatorSP.s == IPS_OK)
+            AbortRotatorSP.setState(AbortRotator() ? IPS_OK : IPS_ALERT);
+            AbortRotatorSP.apply();
+            if (AbortRotatorSP.getState() == IPS_OK)
             {
-                if (GotoRotatorNP.s != IPS_OK)
+                if (GotoRotatorNP.getState() != IPS_OK)
                 {
-                    GotoRotatorNP.s = IPS_OK;
-                    IDSetNumber(&GotoRotatorNP, nullptr);
+                    GotoRotatorNP.setState(IPS_OK);
+                    GotoRotatorNP.apply();
                 }
             }
             return true;
@@ -178,66 +178,66 @@ bool RotatorInterface::processSwitch(const char *dev, const char *name, ISState 
         ////////////////////////////////////////////
         // Home
         ////////////////////////////////////////////
-        else if (strcmp(name, HomeRotatorSP.name) == 0)
+        else if (HomeRotatorSP.isNameMatch(name))
         {
-            HomeRotatorSP.s = HomeRotator();
-            IUResetSwitch(&HomeRotatorSP);
-            if (HomeRotatorSP.s == IPS_BUSY)
-                HomeRotatorS[0].s = ISS_ON;
-            IDSetSwitch(&HomeRotatorSP, nullptr);
+            HomeRotatorSP.setState(HomeRotator());
+            HomeRotatorSP.reset();
+            if (HomeRotatorSP.getState() == IPS_BUSY)
+                HomeRotatorSP[0].setState(ISS_ON);
+            HomeRotatorSP.apply();
             return true;
         }
         ////////////////////////////////////////////
         // Reverse Rotator
         ////////////////////////////////////////////
-        else if (strcmp(name, ReverseRotatorSP.name) == 0)
+        else if (ReverseRotatorSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&ReverseRotatorSP);
-            IUUpdateSwitch(&ReverseRotatorSP, states, names, n);
-            const bool enabled = IUFindOnSwitchIndex(&ReverseRotatorSP) == DefaultDevice::INDI_ENABLED;
+            int prevIndex = ReverseRotatorSP.findOnSwitchIndex();
+            ReverseRotatorSP.update(states, names, n);
+            const bool enabled = ReverseRotatorSP.findOnSwitchIndex() == DefaultDevice::INDI_ENABLED;
 
             if (ReverseRotator(enabled))
             {
-                IUUpdateSwitch(&ReverseRotatorSP, states, names, n);
-                ReverseRotatorSP.s = IPS_OK;
+                ReverseRotatorSP.update(states, names, n);
+                ReverseRotatorSP.setState(IPS_OK);
                 DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_SESSION, "Rotator direction is %s.",
                              (enabled ? "reversed" : "normal"));
             }
             else
             {
-                IUResetSwitch(&ReverseRotatorSP);
-                ReverseRotatorS[prevIndex].s = ISS_ON;
-                ReverseRotatorSP.s = IPS_ALERT;
+                ReverseRotatorSP.reset();
+                ReverseRotatorSP[prevIndex].setState(ISS_ON);
+                ReverseRotatorSP.setState(IPS_ALERT);
                 DEBUGDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_SESSION, "Rotator reverse direction failed.");
             }
 
-            IDSetSwitch(&ReverseRotatorSP, nullptr);
+            ReverseRotatorSP.apply();
             return true;
         }
         ////////////////////////////////////////////
         // Backlash enable/disable
         ////////////////////////////////////////////
-        else if (strcmp(name, RotatorBacklashSP.name) == 0)
+        else if (RotatorBacklashSP.isNameMatch(name))
         {
-            int prevIndex = IUFindOnSwitchIndex(&RotatorBacklashSP);
-            IUUpdateSwitch(&RotatorBacklashSP, states, names, n);
-            const bool enabled = IUFindOnSwitchIndex(&RotatorBacklashSP) == DefaultDevice::INDI_ENABLED;
+            int prevIndex = RotatorBacklashSP.findOnSwitchIndex();
+            RotatorBacklashSP.update(states, names, n);
+            const bool enabled = RotatorBacklashSP.findOnSwitchIndex() == DefaultDevice::INDI_ENABLED;
 
             if (SetRotatorBacklashEnabled(enabled))
             {
-                RotatorBacklashSP.s = IPS_OK;
+                RotatorBacklashSP.setState(IPS_OK);
                 DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_SESSION, "Rotator backlash is %s.",
                              (enabled ? "enabled" : "disabled"));
             }
             else
             {
-                IUResetSwitch(&RotatorBacklashSP);
-                RotatorBacklashS[prevIndex].s = ISS_ON;
-                RotatorBacklashSP.s = IPS_ALERT;
+                RotatorBacklashSP.reset();
+                RotatorBacklashSP[prevIndex].setState(ISS_ON);
+                RotatorBacklashSP.setState(IPS_ALERT);
                 DEBUGDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_ERROR, "Failed to set trigger rotator backlash.");
             }
 
-            IDSetSwitch(&RotatorBacklashSP, nullptr);
+            RotatorBacklashSP.apply();
             return true;
         }
     }
@@ -249,38 +249,38 @@ bool RotatorInterface::updateProperties()
 {
     if (m_defaultDevice->isConnected())
     {
-        m_defaultDevice->defineProperty(&GotoRotatorNP);
+        m_defaultDevice->defineProperty(GotoRotatorNP);
 
         if (CanAbort())
-            m_defaultDevice->defineProperty(&AbortRotatorSP);
+            m_defaultDevice->defineProperty(AbortRotatorSP);
         if (CanSync())
-            m_defaultDevice->defineProperty(&SyncRotatorNP);
+            m_defaultDevice->defineProperty(SyncRotatorNP);
         if (CanHome())
-            m_defaultDevice->defineProperty(&HomeRotatorSP);
+            m_defaultDevice->defineProperty(HomeRotatorSP);
         if (CanReverse())
-            m_defaultDevice->defineProperty(&ReverseRotatorSP);
+            m_defaultDevice->defineProperty(ReverseRotatorSP);
         if (HasBacklash())
         {
-            m_defaultDevice->defineProperty(&RotatorBacklashSP);
-            m_defaultDevice->defineProperty(&RotatorBacklashNP);
+            m_defaultDevice->defineProperty(RotatorBacklashSP);
+            m_defaultDevice->defineProperty(RotatorBacklashNP);
         }
     }
     else
     {
-        m_defaultDevice->deleteProperty(GotoRotatorNP.name);
+        m_defaultDevice->deleteProperty(GotoRotatorNP.getName());
 
         if (CanAbort())
-            m_defaultDevice->deleteProperty(AbortRotatorSP.name);
+            m_defaultDevice->deleteProperty(AbortRotatorSP.getName());
         if (CanSync())
-            m_defaultDevice->deleteProperty(SyncRotatorNP.name);
+            m_defaultDevice->deleteProperty(SyncRotatorNP.getName());
         if (CanHome())
-            m_defaultDevice->deleteProperty(HomeRotatorSP.name);
+            m_defaultDevice->deleteProperty(HomeRotatorSP.getName());
         if (CanReverse())
-            m_defaultDevice->deleteProperty(ReverseRotatorSP.name);
+            m_defaultDevice->deleteProperty(ReverseRotatorSP.getName());
         if (HasBacklash())
         {
-            m_defaultDevice->deleteProperty(RotatorBacklashSP.name);
-            m_defaultDevice->deleteProperty(RotatorBacklashNP.name);
+            m_defaultDevice->deleteProperty(RotatorBacklashSP.getName());
+            m_defaultDevice->deleteProperty(RotatorBacklashNP.getName());
         }
     }
 
@@ -324,7 +324,7 @@ bool RotatorInterface::SetRotatorBacklashEnabled(bool enabled)
 {
     // If disabled, set the Rotatorer backlash to zero.
     if (enabled)
-        return SetRotatorBacklash(static_cast<int32_t>(RotatorBacklashN[0].value));
+        return SetRotatorBacklash(static_cast<int32_t>(RotatorBacklashNP[0].value));
     else
         return SetRotatorBacklash(0);
 }
@@ -333,12 +333,12 @@ bool RotatorInterface::saveConfigItems(FILE *fp)
 {
     if (CanReverse())
     {
-        IUSaveConfigSwitch(fp, &ReverseRotatorSP);
+        ReverseRotatorSP.save(fp);
     }
     if (HasBacklash())
     {
-        IUSaveConfigSwitch(fp, &RotatorBacklashSP);
-        IUSaveConfigNumber(fp, &RotatorBacklashNP);
+        RotatorBacklashSP.save(fp);
+        RotatorBacklashNP.save(fp);
     }
 
     return true;

--- a/libs/indibase/indirotatorinterface.h
+++ b/libs/indibase/indirotatorinterface.h
@@ -23,6 +23,10 @@
 #include "indibase.h"
 #include <stdint.h>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 using RI = INDI::RotatorInterface;
 
 /**
@@ -194,28 +198,21 @@ class RotatorInterface
         bool saveConfigItems(FILE * fp);
 
 
-        INumber GotoRotatorN[1];
-        INumberVectorProperty GotoRotatorNP;
+        INDI::PropertyNumber GotoRotatorNP {1};
 
-        INumber SyncRotatorN[1];
-        INumberVectorProperty SyncRotatorNP;
+        INDI::PropertyNumber SyncRotatorNP {1};
 
-        ISwitch AbortRotatorS[1];
-        ISwitchVectorProperty AbortRotatorSP;
+        INDI::PropertySwitch AbortRotatorSP {1};
 
-        ISwitch HomeRotatorS[1];
-        ISwitchVectorProperty HomeRotatorSP;
+        INDI::PropertySwitch HomeRotatorSP {1};
 
-        ISwitch ReverseRotatorS[2];
-        ISwitchVectorProperty ReverseRotatorSP;
+        INDI::PropertySwitch ReverseRotatorSP {2};
 
         // Backlash toogle
-        ISwitchVectorProperty RotatorBacklashSP;
-        ISwitch RotatorBacklashS[2];
+        INDI::PropertySwitch RotatorBacklashSP {2};
 
         // Backlash steps
-        INumberVectorProperty RotatorBacklashNP;
-        INumber RotatorBacklashN[1];
+        INDI::PropertyNumber RotatorBacklashNP {1};
 
         uint32_t rotatorCapability = 0;
         DefaultDevice *m_defaultDevice { nullptr };

--- a/libs/indibase/indisensorinterface.h
+++ b/libs/indibase/indisensorinterface.h
@@ -38,6 +38,11 @@
 #include <thread>
 #include <stream/streammanager.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 //JM 2019-01-17: Disabled until further notice
 //#define WITH_EXPOSURE_LOOPING
 
@@ -121,7 +126,7 @@ class SensorInterface : public DefaultDevice
          */
         inline double getIntegrationLeft()
         {
-            return FramedIntegrationN[0].value;
+            return FramedIntegrationNP[0].getValue();
         }
 
         /**
@@ -249,7 +254,7 @@ class SensorInterface : public DefaultDevice
          */
         inline bool isCapturing()
         {
-            return (FramedIntegrationNP.s == IPS_BUSY);
+            return (FramedIntegrationNP.getState() == IPS_BUSY);
         }
 
         /**
@@ -416,47 +421,35 @@ protected:
         virtual bool AbortIntegration();
 
         uint32_t capability;
-
-        INumberVectorProperty FramedIntegrationNP;
-        INumber FramedIntegrationN[1];
-
-        ISwitchVectorProperty AbortIntegrationSP;
-        ISwitch AbortIntegrationS[1];
+        INDI::PropertyNumber FramedIntegrationNP {1};
+        INDI::PropertySwitch AbortIntegrationSP {1};
 
         IBLOB FitsB;
         IBLOBVectorProperty FitsBP;
+        INDI::PropertyText ActiveDeviceTP {4};
 
-        ITextVectorProperty ActiveDeviceTP;
-        IText ActiveDeviceT[4] {};
-
-        IText FileNameT[1] {};
-        ITextVectorProperty FileNameTP;
+        INDI::PropertyText FileNameTP {1};
         enum
         {
             TELESCOPE_PRIMARY
         };
 
-        ISwitch DatasetS[1];
-        ISwitchVectorProperty DatasetSP;
+        INDI::PropertySwitch DatasetSP {1};
 
 
-        ISwitch UploadS[3];
-        ISwitchVectorProperty UploadSP;
+        INDI::PropertySwitch UploadSP {3};
 
-        IText UploadSettingsT[2] {};
-        ITextVectorProperty UploadSettingsTP;
+        INDI::PropertyText UploadSettingsTP {2};
         enum
         {
             UPLOAD_DIR,
             UPLOAD_PREFIX
         };
 
-        ISwitch TelescopeTypeS[2];
-        ISwitchVectorProperty TelescopeTypeSP;
+        INDI::PropertySwitch TelescopeTypeSP {2};
 
         // FITS Header
-        IText FITSHeaderT[2] {};
-        ITextVectorProperty FITSHeaderTP;
+        INDI::PropertyText FITSHeaderTP {2};
         enum
         {
             FITS_OBSERVER,
@@ -471,17 +464,11 @@ protected:
         virtual bool saveConfigItems(FILE *fp);
 
         bool InIntegration;
-
-        INumberVectorProperty EqNP;
-        INumber EqN[2];
+        INDI::PropertyNumber EqNP {2};
         double RA, Dec;
-
-        INumberVectorProperty LocationNP;
-        INumber LocationN[3];
+        INDI::PropertyNumber LocationNP {3};
         double Lat, Lon, El;
-
-        INumberVectorProperty ScopeParametersNP;
-        INumber ScopeParametersN[4];
+        INDI::PropertyNumber ScopeParametersNP {4};
         double primaryAperture, primaryFocalLength;
 
         bool AutoLoop;
@@ -499,8 +486,7 @@ protected:
          */
         virtual void activeDevicesUpdated() {}
 
-        INumber TemperatureN[1];
-        INumberVectorProperty TemperatureNP;
+        INDI::PropertyNumber TemperatureNP {1};
 
         // Threading
         std::mutex detectorBufferLock;

--- a/libs/indibase/indispectrograph.cpp
+++ b/libs/indibase/indispectrograph.cpp
@@ -53,13 +53,13 @@ Spectrograph::~Spectrograph()
 bool Spectrograph::initProperties()
 {
     // PrimarySpectrograph Info
-    IUFillNumber(&SpectrographSettingsN[SPECTROGRAPH_SAMPLERATE], "SPECTROGRAPH_SAMPLERATE", "Sample rate (SPS)", "%16.2f", 0.01, 1.0e+8, 0.01, 1.0e+6);
-    IUFillNumber(&SpectrographSettingsN[SPECTROGRAPH_FREQUENCY], "SPECTROGRAPH_FREQUENCY", "Center frequency (Hz)", "%16.2f", 0.01, 1.0e+15, 0.01, 1.42e+9);
-    IUFillNumber(&SpectrographSettingsN[SPECTROGRAPH_BITSPERSAMPLE], "SPECTROGRAPH_BITSPERSAMPLE", "Bits per sample", "%3.0f", -64, 64, 8, 8);
-    IUFillNumber(&SpectrographSettingsN[SPECTROGRAPH_BANDWIDTH], "SPECTROGRAPH_BANDWIDTH", "Bandwidth (Hz)", "%16.2f", 0.01, 1.0e+8, 0.01, 1.0e+3);
-    IUFillNumber(&SpectrographSettingsN[SPECTROGRAPH_GAIN], "SPECTROGRAPH_GAIN", "Gain", "%3.2f", 0.01, 255.0, 0.01, 1.0);
-    IUFillNumber(&SpectrographSettingsN[SPECTROGRAPH_ANTENNA], "SPECTROGRAPH_ANTENNA", "Antenna", "%16.2f", 1, 4, 1, 1);
-    IUFillNumberVector(&SpectrographSettingsNP, SpectrographSettingsN, 6, getDeviceName(), "SPECTROGRAPH_SETTINGS", "Spectrograph Settings", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    SpectrographSettingsNP[SPECTROGRAPH_SAMPLERATE].fill("SPECTROGRAPH_SAMPLERATE", "Sample rate (SPS)", "%16.2f", 0.01, 1.0e+8, 0.01, 1.0e+6);
+    SpectrographSettingsNP[SPECTROGRAPH_FREQUENCY].fill("SPECTROGRAPH_FREQUENCY", "Center frequency (Hz)", "%16.2f", 0.01, 1.0e+15, 0.01, 1.42e+9);
+    SpectrographSettingsNP[SPECTROGRAPH_BITSPERSAMPLE].fill("SPECTROGRAPH_BITSPERSAMPLE", "Bits per sample", "%3.0f", -64, 64, 8, 8);
+    SpectrographSettingsNP[SPECTROGRAPH_BANDWIDTH].fill("SPECTROGRAPH_BANDWIDTH", "Bandwidth (Hz)", "%16.2f", 0.01, 1.0e+8, 0.01, 1.0e+3);
+    SpectrographSettingsNP[SPECTROGRAPH_GAIN].fill("SPECTROGRAPH_GAIN", "Gain", "%3.2f", 0.01, 255.0, 0.01, 1.0);
+    SpectrographSettingsNP[SPECTROGRAPH_ANTENNA].fill("SPECTROGRAPH_ANTENNA", "Antenna", "%16.2f", 1, 4, 1, 1);
+    SpectrographSettingsNP.fill(getDeviceName(), "SPECTROGRAPH_SETTINGS", "Spectrograph Settings", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     setDriverInterface(SPECTROGRAPH_INTERFACE);
 
@@ -75,17 +75,17 @@ bool Spectrograph::updateProperties()
 {
     if (isConnected())
     {
-        defineProperty(&SpectrographSettingsNP);
+        defineProperty(SpectrographSettingsNP);
 
         if (HasCooler())
-            defineProperty(&TemperatureNP);
+            defineProperty(TemperatureNP);
     }
     else
     {
-        deleteProperty(SpectrographSettingsNP.name);
+        deleteProperty(SpectrographSettingsNP.getName());
 
         if (HasCooler())
-            deleteProperty(TemperatureNP.name);
+            deleteProperty(TemperatureNP.getName());
     }
     return SensorInterface::updateProperties();
 }
@@ -102,8 +102,8 @@ bool Spectrograph::ISNewText(const char *dev, const char *name, char *values[], 
 
 bool Spectrograph::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
 {
-    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, SpectrographSettingsNP.name)) {
-        IDSetNumber(&SpectrographSettingsNP, nullptr);
+    if (dev && !strcmp(dev, getDeviceName()) && !strcmp(name, SpectrographSettingsNP.getName())) {
+        SpectrographSettingsNP.apply();
     }
     return processNumber(dev, name, values, names, n);
 }
@@ -123,36 +123,36 @@ void Spectrograph::setSampleRate(double sr)
 {
     Samplerate = sr;
 
-    SpectrographSettingsN[Spectrograph::SPECTROGRAPH_SAMPLERATE].value = sr;
+    SpectrographSettingsNP[Spectrograph::SPECTROGRAPH_SAMPLERATE].setValue(sr);
 
-    IDSetNumber(&SpectrographSettingsNP, nullptr);
+    SpectrographSettingsNP.apply();
 }
 
 void Spectrograph::setBandwidth(double bw)
 {
     Bandwidth = bw;
 
-    SpectrographSettingsN[Spectrograph::SPECTROGRAPH_BANDWIDTH].value = bw;
+    SpectrographSettingsNP[Spectrograph::SPECTROGRAPH_BANDWIDTH].setValue(bw);
 
-    IDSetNumber(&SpectrographSettingsNP, nullptr);
+    SpectrographSettingsNP.apply();
 }
 
 void Spectrograph::setGain(double gain)
 {
     Gain = gain;
 
-    SpectrographSettingsN[Spectrograph::SPECTROGRAPH_GAIN].value = gain;
+    SpectrographSettingsNP[Spectrograph::SPECTROGRAPH_GAIN].setValue(gain);
 
-    IDSetNumber(&SpectrographSettingsNP, nullptr);
+    SpectrographSettingsNP.apply();
 }
 
 void Spectrograph::setFrequency(double freq)
 {
     Frequency = freq;
 
-    SpectrographSettingsN[Spectrograph::SPECTROGRAPH_FREQUENCY].value = freq;
+    SpectrographSettingsNP[Spectrograph::SPECTROGRAPH_FREQUENCY].setValue(freq);
 
-    IDSetNumber(&SpectrographSettingsNP, nullptr);
+    SpectrographSettingsNP.apply();
 }
 
 void Spectrograph::SetSpectrographCapability(uint32_t cap)
@@ -173,8 +173,8 @@ void Spectrograph::setMinMaxStep(const char *property, const char *element, doub
 {
     INumberVectorProperty *vp = nullptr;
 
-    if (!strcmp(property, SpectrographSettingsNP.name)) {
-        vp = &FramedIntegrationNP;
+    if (SpectrographSettingsNP.isNameMatch(property)) {
+        vp = FramedIntegrationNP.getNumber(); // #PS: refactor needed
 
         INumber *np = IUFindNumber(vp, element);
         if (np)

--- a/libs/indibase/indispectrograph.h
+++ b/libs/indibase/indispectrograph.h
@@ -35,6 +35,9 @@
 #include <mutex>
 #include <thread>
 
+/* Smart Widget-Property */
+#include "indipropertynumber.h"
+
 //JM 2019-01-17: Disabled until further notice
 //#define WITH_EXPOSURE_LOOPING
 
@@ -147,7 +150,7 @@ class Spectrograph : public SensorInterface
          */
         inline INumberVectorProperty *getSpectrographSettings()
         {
-            return &SpectrographSettingsNP;
+            return SpectrographSettingsNP.getNumber(); // #PS: refactor needed
         }
 
         /**
@@ -186,8 +189,7 @@ class Spectrograph : public SensorInterface
             SPECTROGRAPH_SAMPLERATE,
             SPECTROGRAPH_ANTENNA,
         } SPECTROGRAPH_INFO_INDEX;
-        INumberVectorProperty SpectrographSettingsNP;
-        INumber SpectrographSettingsN[7];
+        INDI::PropertyNumber SpectrographSettingsNP {7};
 
 private:
         double Samplerate;

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -68,63 +68,63 @@ bool Telescope::initProperties()
     DefaultDevice::initProperties();
 
     // Active Devices
-    IUFillText(&ActiveDeviceT[0], "ACTIVE_GPS", "GPS", "GPS Simulator");
-    IUFillText(&ActiveDeviceT[1], "ACTIVE_DOME", "DOME", "Dome Simulator");
-    IUFillTextVector(&ActiveDeviceTP, ActiveDeviceT, 2, getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
+    ActiveDeviceTP[0].fill("ACTIVE_GPS", "GPS", "GPS Simulator");
+    ActiveDeviceTP[1].fill("ACTIVE_DOME", "DOME", "Dome Simulator");
+    ActiveDeviceTP.fill(getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
                      IP_RW, 60, IPS_IDLE);
 
     // Use locking if dome is closed (and or) park scope if dome is closing
-    IUFillSwitch(&DomePolicyS[DOME_IGNORED], "DOME_IGNORED", "Dome ignored", ISS_ON);
-    IUFillSwitch(&DomePolicyS[DOME_LOCKS], "DOME_LOCKS", "Dome locks", ISS_OFF);
+    DomePolicySP[DOME_IGNORED].fill("DOME_IGNORED", "Dome ignored", ISS_ON);
+    DomePolicySP[DOME_LOCKS].fill("DOME_LOCKS", "Dome locks", ISS_OFF);
     //    IUFillSwitch(&DomeClosedLockT[2], "FORCE_CLOSE", "Dome parks", ISS_OFF);
     //    IUFillSwitch(&DomeClosedLockT[3], "LOCK_AND_FORCE", "Both", ISS_OFF);
-    IUFillSwitchVector(&DomePolicySP, DomePolicyS, 2, getDeviceName(), "DOME_POLICY", "Dome Policy",  OPTIONS_TAB, IP_RW,
+    DomePolicySP.fill(getDeviceName(), "DOME_POLICY", "Dome Policy",  OPTIONS_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
-    IUFillNumber(&EqN[AXIS_RA], "RA", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-    IUFillNumber(&EqN[AXIS_DE], "DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-    IUFillNumberVector(&EqNP, EqN, 2, getDeviceName(), "EQUATORIAL_EOD_COORD", "Eq. Coordinates", MAIN_CONTROL_TAB,
+    EqNP[AXIS_RA].fill("RA", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+    EqNP[AXIS_DE].fill("DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+    EqNP.fill(getDeviceName(), "EQUATORIAL_EOD_COORD", "Eq. Coordinates", MAIN_CONTROL_TAB,
                        IP_RW, 60, IPS_IDLE);
     lastEqState = IPS_IDLE;
 
-    IUFillNumber(&TargetN[AXIS_RA], "RA", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-    IUFillNumber(&TargetN[AXIS_DE], "DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-    IUFillNumberVector(&TargetNP, TargetN, 2, getDeviceName(), "TARGET_EOD_COORD", "Slew Target", MOTION_TAB, IP_RO, 60,
+    TargetNP[AXIS_RA].fill("RA", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+    TargetNP[AXIS_DE].fill("DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+    TargetNP.fill(getDeviceName(), "TARGET_EOD_COORD", "Slew Target", MOTION_TAB, IP_RO, 60,
                        IPS_IDLE);
 
-    IUFillSwitch(&ParkOptionS[PARK_CURRENT], "PARK_CURRENT", "Current", ISS_OFF);
-    IUFillSwitch(&ParkOptionS[PARK_DEFAULT], "PARK_DEFAULT", "Default", ISS_OFF);
-    IUFillSwitch(&ParkOptionS[PARK_WRITE_DATA], "PARK_WRITE_DATA", "Write Data", ISS_OFF);
-    IUFillSwitch(&ParkOptionS[PARK_PURGE_DATA], "PARK_PURGE_DATA", "Purge Data", ISS_OFF);
-    IUFillSwitchVector(&ParkOptionSP, ParkOptionS, 4, getDeviceName(), "TELESCOPE_PARK_OPTION", "Park Options",
+    ParkOptionSP[PARK_CURRENT].fill("PARK_CURRENT", "Current", ISS_OFF);
+    ParkOptionSP[PARK_DEFAULT].fill("PARK_DEFAULT", "Default", ISS_OFF);
+    ParkOptionSP[PARK_WRITE_DATA].fill("PARK_WRITE_DATA", "Write Data", ISS_OFF);
+    ParkOptionSP[PARK_PURGE_DATA].fill("PARK_PURGE_DATA", "Purge Data", ISS_OFF);
+    ParkOptionSP.fill(getDeviceName(), "TELESCOPE_PARK_OPTION", "Park Options",
                        SITE_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillText(&TimeT[0], "UTC", "UTC Time", nullptr);
-    IUFillText(&TimeT[1], "OFFSET", "UTC Offset", nullptr);
-    IUFillTextVector(&TimeTP, TimeT, 2, getDeviceName(), "TIME_UTC", "UTC", SITE_TAB, IP_RW, 60, IPS_IDLE);
+    TimeTP[0].fill("UTC", "UTC Time", nullptr);
+    TimeTP[1].fill("OFFSET", "UTC Offset", nullptr);
+    TimeTP.fill(getDeviceName(), "TIME_UTC", "UTC", SITE_TAB, IP_RW, 60, IPS_IDLE);
 
-    IUFillNumber(&LocationN[LOCATION_LATITUDE], "LAT", "Lat (dd:mm:ss.s)", "%012.8m", -90, 90, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_LONGITUDE], "LONG", "Lon (dd:mm:ss.s)", "%012.8m", 0, 360, 0, 0.0);
-    IUFillNumber(&LocationN[LOCATION_ELEVATION], "ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
-    IUFillNumberVector(&LocationNP, LocationN, 3, getDeviceName(), "GEOGRAPHIC_COORD", "Scope Location", SITE_TAB,
+    LocationNP[LOCATION_LATITUDE].fill("LAT", "Lat (dd:mm:ss.s)", "%012.8m", -90, 90, 0, 0.0);
+    LocationNP[LOCATION_LONGITUDE].fill("LONG", "Lon (dd:mm:ss.s)", "%012.8m", 0, 360, 0, 0.0);
+    LocationNP[LOCATION_ELEVATION].fill("ELEV", "Elevation (m)", "%g", -200, 10000, 0, 0);
+    LocationNP.fill(getDeviceName(), "GEOGRAPHIC_COORD", "Scope Location", SITE_TAB,
                        IP_RW, 60, IPS_IDLE);
 
     // Pier Side
-    IUFillSwitch(&PierSideS[PIER_WEST], "PIER_WEST", "West (pointing east)", ISS_OFF);
-    IUFillSwitch(&PierSideS[PIER_EAST], "PIER_EAST", "East (pointing west)", ISS_OFF);
-    IUFillSwitchVector(&PierSideSP, PierSideS, 2, getDeviceName(), "TELESCOPE_PIER_SIDE", "Pier Side", MAIN_CONTROL_TAB,
+    PierSideSP[PIER_WEST].fill("PIER_WEST", "West (pointing east)", ISS_OFF);
+    PierSideSP[PIER_EAST].fill("PIER_EAST", "East (pointing west)", ISS_OFF);
+    PierSideSP.fill(getDeviceName(), "TELESCOPE_PIER_SIDE", "Pier Side", MAIN_CONTROL_TAB,
                        IP_RO, ISR_ATMOST1, 60, IPS_IDLE);
     // Pier Side Simulation
-    IUFillSwitch(&SimulatePierSideS[0], "SIMULATE_YES", "Yes", ISS_OFF);
-    IUFillSwitch(&SimulatePierSideS[1], "SIMULATE_NO", "No", ISS_ON);
-    IUFillSwitchVector(&SimulatePierSideSP, SimulatePierSideS, 2, getDeviceName(), "SIMULATE_PIER_SIDE", "Simulate Pier Side",
+    SimulatePierSideSP[0].fill("SIMULATE_YES", "Yes", ISS_OFF);
+    SimulatePierSideSP[1].fill("SIMULATE_NO", "No", ISS_ON);
+    SimulatePierSideSP.fill(getDeviceName(), "SIMULATE_PIER_SIDE", "Simulate Pier Side",
                        MAIN_CONTROL_TAB,
                        IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // PEC State
-    IUFillSwitch(&PECStateS[PEC_OFF], "PEC OFF", "PEC OFF", ISS_OFF);
-    IUFillSwitch(&PECStateS[PEC_ON], "PEC ON", "PEC ON", ISS_ON);
-    IUFillSwitchVector(&PECStateSP, PECStateS, 2, getDeviceName(), "PEC", "PEC Playback", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
+    PECStateSP[PEC_OFF].fill("PEC OFF", "PEC OFF", ISS_OFF);
+    PECStateSP[PEC_ON].fill("PEC ON", "PEC ON", ISS_ON);
+    PECStateSP.fill(getDeviceName(), "PEC", "PEC Playback", MOTION_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Track Mode. Child class must call AddTrackMode to add members
@@ -132,37 +132,37 @@ bool Telescope::initProperties()
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Track State
-    IUFillSwitch(&TrackStateS[TRACK_ON], "TRACK_ON", "On", ISS_OFF);
-    IUFillSwitch(&TrackStateS[TRACK_OFF], "TRACK_OFF", "Off", ISS_ON);
-    IUFillSwitchVector(&TrackStateSP, TrackStateS, 2, getDeviceName(), "TELESCOPE_TRACK_STATE", "Tracking", MAIN_CONTROL_TAB,
+    TrackStateSP[TRACK_ON].fill("TRACK_ON", "On", ISS_OFF);
+    TrackStateSP[TRACK_OFF].fill("TRACK_OFF", "Off", ISS_ON);
+    TrackStateSP.fill(getDeviceName(), "TELESCOPE_TRACK_STATE", "Tracking", MAIN_CONTROL_TAB,
                        IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
 
     // Track Rate
-    IUFillNumber(&TrackRateN[AXIS_RA], "TRACK_RATE_RA", "RA (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001,
+    TrackRateNP[AXIS_RA].fill("TRACK_RATE_RA", "RA (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001,
                  TRACKRATE_SIDEREAL);
-    IUFillNumber(&TrackRateN[AXIS_DE], "TRACK_RATE_DE", "DE (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001, 0.0);
-    IUFillNumberVector(&TrackRateNP, TrackRateN, 2, getDeviceName(), "TELESCOPE_TRACK_RATE", "Track Rates", MAIN_CONTROL_TAB,
+    TrackRateNP[AXIS_DE].fill("TRACK_RATE_DE", "DE (arcsecs/s)", "%.6f", -16384.0, 16384.0, 0.000001, 0.0);
+    TrackRateNP.fill(getDeviceName(), "TELESCOPE_TRACK_RATE", "Track Rates", MAIN_CONTROL_TAB,
                        IP_RW, 60, IPS_IDLE);
 
     // On Coord Set actions
-    IUFillSwitch(&CoordS[0], "TRACK", "Track", ISS_ON);
-    IUFillSwitch(&CoordS[1], "SLEW", "Slew", ISS_OFF);
-    IUFillSwitch(&CoordS[2], "SYNC", "Sync", ISS_OFF);
+    CoordSP[0].fill("TRACK", "Track", ISS_ON);
+    CoordSP[1].fill("SLEW", "Slew", ISS_OFF);
+    CoordSP[2].fill("SYNC", "Sync", ISS_OFF);
 
     // If both GOTO and SYNC are supported
     if (CanGOTO() && CanSync())
-        IUFillSwitchVector(&CoordSP, CoordS, 3, getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
+        CoordSP.fill(getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
                            ISR_1OFMANY, 60, IPS_IDLE);
     // If ONLY GOTO is supported
     else if (CanGOTO())
-        IUFillSwitchVector(&CoordSP, CoordS, 2, getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
+        CoordSP.fill(getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
                            ISR_1OFMANY, 60, IPS_IDLE);
     // If ONLY SYNC is supported
     else if (CanSync())
     {
-        IUFillSwitch(&CoordS[0], "SYNC", "Sync", ISS_ON);
-        IUFillSwitchVector(&CoordSP, CoordS, 1, getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
+        CoordSP[0].fill("SYNC", "Sync", ISS_ON);
+        CoordSP.fill(getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
                            ISR_1OFMANY, 60, IPS_IDLE);
     }
 
@@ -172,8 +172,8 @@ bool Telescope::initProperties()
 
     if (CanTrackSatellite())
     {
-        IUFillText(&TLEtoTrackT[0], "TLE", "TLE", "");
-        IUFillTextVector(&TLEtoTrackTP, TLEtoTrackT, 1, getDeviceName(), "SAT_TLE_TEXT", "Orbit Params", SATELLITE_TAB, 
+        TLEtoTrackTP[0].fill("TLE", "TLE", "");
+        TLEtoTrackTP.fill(getDeviceName(), "SAT_TLE_TEXT", "Orbit Params", SATELLITE_TAB, 
         IP_RW, 60, IPS_IDLE);
 
         char curTime[32] = {0};
@@ -181,46 +181,46 @@ bool Telescope::initProperties()
         struct std::tm *utctimeinfo = std::gmtime(&t);
         strftime(curTime, sizeof(curTime), "%Y-%m-%dT%H:%M:%S", utctimeinfo);
         
-        IUFillText(&SatPassWindowT[SAT_PASS_WINDOW_END], "SAT_PASS_WINDOW_END", "End UTC", curTime);
-        IUFillText(&SatPassWindowT[SAT_PASS_WINDOW_START], "SAT_PASS_WINDOW_START", "Start UTC", curTime);
-        IUFillTextVector(&SatPassWindowTP, SatPassWindowT, SAT_PASS_WINDOW_COUNT, getDeviceName(),
+        SatPassWindowTP[SAT_PASS_WINDOW_END].fill("SAT_PASS_WINDOW_END", "End UTC", curTime);
+        SatPassWindowTP[SAT_PASS_WINDOW_START].fill("SAT_PASS_WINDOW_START", "Start UTC", curTime);
+        SatPassWindowTP.fill(getDeviceName(),
         "SAT_PASS_WINDOW", "Pass Window", SATELLITE_TAB, IP_RW, 60, IPS_IDLE);
 
-        IUFillSwitch(&TrackSatS[SAT_TRACK], "SAT_TRACK", "Track", ISS_OFF);
-        IUFillSwitch(&TrackSatS[SAT_HALT], "SAT_HALT", "Halt", ISS_ON);
-        IUFillSwitchVector(&TrackSatSP, TrackSatS, SAT_TRACK_COUNT, getDeviceName(), "SAT_TRACKING_STAT",
+        TrackSatSP[SAT_TRACK].fill("SAT_TRACK", "Track", ISS_OFF);
+        TrackSatSP[SAT_HALT].fill("SAT_HALT", "Halt", ISS_ON);
+        TrackSatSP.fill(getDeviceName(), "SAT_TRACKING_STAT",
         "Sat tracking", SATELLITE_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
     }
 
-    IUFillSwitch(&ParkS[0], "PARK", "Park(ed)", ISS_OFF);
-    IUFillSwitch(&ParkS[1], "UNPARK", "UnPark(ed)", ISS_OFF);
-    IUFillSwitchVector(&ParkSP, ParkS, 2, getDeviceName(), "TELESCOPE_PARK", "Parking", MAIN_CONTROL_TAB, IP_RW,
+    ParkSP[0].fill("PARK", "Park(ed)", ISS_OFF);
+    ParkSP[1].fill("UNPARK", "UnPark(ed)", ISS_OFF);
+    ParkSP.fill(getDeviceName(), "TELESCOPE_PARK", "Parking", MAIN_CONTROL_TAB, IP_RW,
                        ISR_1OFMANY, 60, IPS_IDLE);
 
-    IUFillSwitch(&AbortS[0], "ABORT", "Abort", ISS_OFF);
-    IUFillSwitchVector(&AbortSP, AbortS, 1, getDeviceName(), "TELESCOPE_ABORT_MOTION", "Abort Motion", MAIN_CONTROL_TAB,
+    AbortSP[0].fill("ABORT", "Abort", ISS_OFF);
+    AbortSP.fill(getDeviceName(), "TELESCOPE_ABORT_MOTION", "Abort Motion", MAIN_CONTROL_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillSwitch(&MovementNSS[DIRECTION_NORTH], "MOTION_NORTH", "North", ISS_OFF);
-    IUFillSwitch(&MovementNSS[DIRECTION_SOUTH], "MOTION_SOUTH", "South", ISS_OFF);
-    IUFillSwitchVector(&MovementNSSP, MovementNSS, 2, getDeviceName(), "TELESCOPE_MOTION_NS", "Motion N/S", MOTION_TAB,
+    MovementNSSP[DIRECTION_NORTH].fill("MOTION_NORTH", "North", ISS_OFF);
+    MovementNSSP[DIRECTION_SOUTH].fill("MOTION_SOUTH", "South", ISS_OFF);
+    MovementNSSP.fill(getDeviceName(), "TELESCOPE_MOTION_NS", "Motion N/S", MOTION_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillSwitch(&MovementWES[DIRECTION_WEST], "MOTION_WEST", "West", ISS_OFF);
-    IUFillSwitch(&MovementWES[DIRECTION_EAST], "MOTION_EAST", "East", ISS_OFF);
-    IUFillSwitchVector(&MovementWESP, MovementWES, 2, getDeviceName(), "TELESCOPE_MOTION_WE", "Motion W/E", MOTION_TAB,
+    MovementWESP[DIRECTION_WEST].fill("MOTION_WEST", "West", ISS_OFF);
+    MovementWESP[DIRECTION_EAST].fill("MOTION_EAST", "East", ISS_OFF);
+    MovementWESP.fill(getDeviceName(), "TELESCOPE_MOTION_WE", "Motion W/E", MOTION_TAB,
                        IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
-    IUFillNumber(&ScopeParametersN[0], "TELESCOPE_APERTURE", "Aperture (mm)", "%g", 10, 5000, 0, 0.0);
-    IUFillNumber(&ScopeParametersN[1], "TELESCOPE_FOCAL_LENGTH", "Focal Length (mm)", "%g", 10, 10000, 0, 0.0);
-    IUFillNumber(&ScopeParametersN[2], "GUIDER_APERTURE", "Guider Aperture (mm)", "%g", 10, 5000, 0, 0.0);
-    IUFillNumber(&ScopeParametersN[3], "GUIDER_FOCAL_LENGTH", "Guider Focal Length (mm)", "%g", 10, 10000, 0, 0.0);
-    IUFillNumberVector(&ScopeParametersNP, ScopeParametersN, 4, getDeviceName(), "TELESCOPE_INFO", "Scope Properties",
+    ScopeParametersNP[0].fill("TELESCOPE_APERTURE", "Aperture (mm)", "%g", 10, 5000, 0, 0.0);
+    ScopeParametersNP[1].fill("TELESCOPE_FOCAL_LENGTH", "Focal Length (mm)", "%g", 10, 10000, 0, 0.0);
+    ScopeParametersNP[2].fill("GUIDER_APERTURE", "Guider Aperture (mm)", "%g", 10, 5000, 0, 0.0);
+    ScopeParametersNP[3].fill("GUIDER_FOCAL_LENGTH", "Guider Focal Length (mm)", "%g", 10, 10000, 0, 0.0);
+    ScopeParametersNP.fill(getDeviceName(), "TELESCOPE_INFO", "Scope Properties",
                        OPTIONS_TAB, IP_RW, 60, IPS_OK);
 
     // Scope config name
-    IUFillText(&ScopeConfigNameT[0], "SCOPE_CONFIG_NAME", "Config Name", "");
-    IUFillTextVector(&ScopeConfigNameTP, ScopeConfigNameT, 1, getDeviceName(), "SCOPE_CONFIG_NAME", "Scope Name",
+    ScopeConfigNameTP[0].fill("SCOPE_CONFIG_NAME", "Config Name", "");
+    ScopeConfigNameTP.fill(getDeviceName(), "SCOPE_CONFIG_NAME", "Scope Name",
                      OPTIONS_TAB, IP_RW, 60, IPS_OK);
 
     // Switch for aperture/focal length configs
@@ -236,15 +236,15 @@ bool Telescope::initProperties()
     controller->initProperties();
 
     // Joystick motion control
-    IUFillSwitch(&MotionControlModeT[0], "MOTION_CONTROL_MODE_JOYSTICK", "4-Way Joystick", ISS_ON);
-    IUFillSwitch(&MotionControlModeT[1], "MOTION_CONTROL_MODE_AXES", "Two Separate Axes", ISS_OFF);
-    IUFillSwitchVector(&MotionControlModeTP, MotionControlModeT, 2, getDeviceName(), "MOTION_CONTROL_MODE", "Motion Control",
+    MotionControlModeTP[0].fill("MOTION_CONTROL_MODE_JOYSTICK", "4-Way Joystick", ISS_ON);
+    MotionControlModeTP[1].fill("MOTION_CONTROL_MODE_AXES", "Two Separate Axes", ISS_OFF);
+    MotionControlModeTP.fill(getDeviceName(), "MOTION_CONTROL_MODE", "Motion Control",
                        "Joystick", IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
     // Lock Axis
-    IUFillSwitch(&LockAxisS[0], "LOCK_AXIS_1", "West/East", ISS_OFF);
-    IUFillSwitch(&LockAxisS[1], "LOCK_AXIS_2", "North/South", ISS_OFF);
-    IUFillSwitchVector(&LockAxisSP, LockAxisS, 2, getDeviceName(), "JOYSTICK_LOCK_AXIS", "Lock Axis", "Joystick", IP_RW,
+    LockAxisSP[0].fill("LOCK_AXIS_1", "West/East", ISS_OFF);
+    LockAxisSP[1].fill("LOCK_AXIS_2", "North/South", ISS_OFF);
+    LockAxisSP.fill(getDeviceName(), "JOYSTICK_LOCK_AXIS", "Lock Axis", "Joystick", IP_RW,
                        ISR_ATMOST1, 60, IPS_IDLE);
 
     TrackState = SCOPE_IDLE;
@@ -272,11 +272,11 @@ bool Telescope::initProperties()
         registerConnection(tcpConnection);
     }
 
-    IDSnoopDevice(ActiveDeviceT[0].text, "GEOGRAPHIC_COORD");
-    IDSnoopDevice(ActiveDeviceT[0].text, "TIME_UTC");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "GEOGRAPHIC_COORD");
+    IDSnoopDevice(ActiveDeviceTP[0].getText(), "TIME_UTC");
 
-    IDSnoopDevice(ActiveDeviceT[1].text, "DOME_PARK");
-    IDSnoopDevice(ActiveDeviceT[1].text, "DOME_SHUTTER");
+    IDSnoopDevice(ActiveDeviceTP[1].getText(), "DOME_PARK");
+    IDSnoopDevice(ActiveDeviceTP[1].getText(), "DOME_SHUTTER");
 
     addPollPeriodControl();
 
@@ -290,20 +290,20 @@ void Telescope::ISGetProperties(const char *dev)
 
     if (CanGOTO())
     {
-        defineProperty(&ActiveDeviceTP);
+        defineProperty(ActiveDeviceTP);
         loadConfig(true, "ACTIVE_DEVICES");
 
         ISState isDomeIgnored = ISS_OFF;
-        if (IUGetConfigSwitch(getDeviceName(), DomePolicySP.name, DomePolicyS[DOME_IGNORED].name, &isDomeIgnored) == 0)
+        if (IUGetConfigSwitch(getDeviceName(), DomePolicySP.getName(), DomePolicySP[DOME_IGNORED].getName(), &isDomeIgnored) == 0)
         {
-            DomePolicyS[DOME_IGNORED].s = isDomeIgnored;
-            DomePolicyS[DOME_LOCKS].s = (isDomeIgnored == ISS_ON) ? ISS_OFF : ISS_ON;
+            DomePolicySP[DOME_IGNORED].setState(isDomeIgnored);
+            DomePolicySP[DOME_LOCKS].setState((isDomeIgnored == ISS_ON) ? ISS_OFF : ISS_ON);
         }
-        defineProperty(&DomePolicySP);
+        defineProperty(DomePolicySP);
     }
 
-    defineProperty(&ScopeParametersNP);
-    defineProperty(&ScopeConfigNameTP);
+    defineProperty(ScopeParametersNP);
+    defineProperty(ScopeConfigNameTP);
 
     if (HasDefaultScopeConfig())
     {
@@ -344,48 +344,48 @@ bool Telescope::updateProperties()
 
         //  Now we add our telescope specific stuff
         if (CanGOTO() || CanSync())
-            defineProperty(&CoordSP);
-        defineProperty(&EqNP);
+            defineProperty(CoordSP);
+        defineProperty(EqNP);
         if (CanAbort())
-            defineProperty(&AbortSP);
+            defineProperty(AbortSP);
 
         if (HasTrackMode() && TrackModeS != nullptr)
             defineProperty(&TrackModeSP);
         if (CanControlTrack())
-            defineProperty(&TrackStateSP);
+            defineProperty(TrackStateSP);
         if (HasTrackRate())
-            defineProperty(&TrackRateNP);
+            defineProperty(TrackRateNP);
 
 
         if (CanGOTO())
         {
-            defineProperty(&MovementNSSP);
-            defineProperty(&MovementWESP);
+            defineProperty(MovementNSSP);
+            defineProperty(MovementWESP);
             if (nSlewRate >= 4)
                 defineProperty(&SlewRateSP);
-            defineProperty(&TargetNP);
+            defineProperty(TargetNP);
         }
 
         if (HasTime())
-            defineProperty(&TimeTP);
+            defineProperty(TimeTP);
         if (HasLocation())
-            defineProperty(&LocationNP);
+            defineProperty(LocationNP);
         if (CanPark())
         {
-            defineProperty(&ParkSP);
+            defineProperty(ParkSP);
             if (parkDataType != PARK_NONE)
             {
-                defineProperty(&ParkPositionNP);
-                defineProperty(&ParkOptionSP);
+                defineProperty(ParkPositionNP);
+                defineProperty(ParkOptionSP);
             }
         }
 
         if (HasPierSide())
-            defineProperty(&PierSideSP);
+            defineProperty(PierSideSP);
 
         if (HasPierSideSimulation())
         {
-            defineProperty(&SimulatePierSideSP);
+            defineProperty(SimulatePierSideSP);
             ISState value;
             if (IUGetConfigSwitch(getDefaultName(), "SIMULATE_PIER_SIDE", "SIMULATE_YES", &value) )
                 setSimulatePierSide(value == ISS_ON);
@@ -393,76 +393,76 @@ bool Telescope::updateProperties()
 
         if (CanTrackSatellite())
         {
-            defineProperty(&TLEtoTrackTP);
-            defineProperty(&SatPassWindowTP);
-            defineProperty(&TrackSatSP);
+            defineProperty(TLEtoTrackTP);
+            defineProperty(SatPassWindowTP);
+            defineProperty(TrackSatSP);
         }
 
         if (HasPECState())
-            defineProperty(&PECStateSP);
+            defineProperty(PECStateSP);
 
-        defineProperty(&ScopeConfigNameTP);
+        defineProperty(ScopeConfigNameTP);
         defineProperty(&ScopeConfigsSP);
     }
     else
     {
         if (CanGOTO() || CanSync())
-            deleteProperty(CoordSP.name);
-        deleteProperty(EqNP.name);
+            deleteProperty(CoordSP.getName());
+        deleteProperty(EqNP.getName());
         if (CanAbort())
-            deleteProperty(AbortSP.name);
+            deleteProperty(AbortSP.getName());
         if (HasTrackMode() && TrackModeS != nullptr)
             deleteProperty(TrackModeSP.name);
         if (HasTrackRate())
-            deleteProperty(TrackRateNP.name);
+            deleteProperty(TrackRateNP.getName());
         if (CanControlTrack())
-            deleteProperty(TrackStateSP.name);
+            deleteProperty(TrackStateSP.getName());
 
         if (CanGOTO())
         {
-            deleteProperty(MovementNSSP.name);
-            deleteProperty(MovementWESP.name);
+            deleteProperty(MovementNSSP.getName());
+            deleteProperty(MovementWESP.getName());
             if (nSlewRate >= 4)
                 deleteProperty(SlewRateSP.name);
-            deleteProperty(TargetNP.name);
+            deleteProperty(TargetNP.getName());
         }
 
         if (HasTime())
-            deleteProperty(TimeTP.name);
+            deleteProperty(TimeTP.getName());
         if (HasLocation())
-            deleteProperty(LocationNP.name);
+            deleteProperty(LocationNP.getName());
 
         if (CanPark())
         {
-            deleteProperty(ParkSP.name);
+            deleteProperty(ParkSP.getName());
             if (parkDataType != PARK_NONE)
             {
-                deleteProperty(ParkPositionNP.name);
-                deleteProperty(ParkOptionSP.name);
+                deleteProperty(ParkPositionNP.getName());
+                deleteProperty(ParkOptionSP.getName());
             }
         }
 
         if (HasPierSide())
-            deleteProperty(PierSideSP.name);
+            deleteProperty(PierSideSP.getName());
 
         if (HasPierSideSimulation())
         {
-            deleteProperty(SimulatePierSideSP.name);
+            deleteProperty(SimulatePierSideSP.getName());
             if (getSimulatePierSide() == true)
-                deleteProperty(PierSideSP.name);
+                deleteProperty(PierSideSP.getName());
         }
 
         if (CanTrackSatellite())
         {
-            deleteProperty(TLEtoTrackTP.name);
-            deleteProperty(SatPassWindowTP.name);
-            deleteProperty(TrackSatSP.name);
+            deleteProperty(TLEtoTrackTP.getName());
+            deleteProperty(SatPassWindowTP.getName());
+            deleteProperty(TrackSatSP.getName());
         }
 
         if (HasPECState())
-            deleteProperty(PECStateSP.name);
+            deleteProperty(PECStateSP.getName());
 
-        deleteProperty(ScopeConfigNameTP.name);
+        deleteProperty(ScopeConfigNameTP.getName());
         deleteProperty(ScopeConfigsSP.name);
     }
 
@@ -477,21 +477,21 @@ bool Telescope::updateProperties()
             {
                 if (useJoystick->sp[0].s == ISS_ON)
                 {
-                    defineProperty(&MotionControlModeTP);
+                    defineProperty(MotionControlModeTP);
                     loadConfig(true, "MOTION_CONTROL_MODE");
-                    defineProperty(&LockAxisSP);
+                    defineProperty(LockAxisSP);
                     loadConfig(true, "LOCK_AXIS");
                 }
                 else
                 {
-                    deleteProperty(MotionControlModeTP.name);
-                    deleteProperty(LockAxisSP.name);
+                    deleteProperty(MotionControlModeTP.getName());
+                    deleteProperty(LockAxisSP.getName());
                 }
             }
             else
             {
-                deleteProperty(MotionControlModeTP.name);
-                deleteProperty(LockAxisSP.name);
+                deleteProperty(MotionControlModeTP.getName());
+                deleteProperty(LockAxisSP.getName());
             }
         }
     }
@@ -587,7 +587,7 @@ bool Telescope::ISSnoopDevice(XMLEle *root)
                         else if (IsLocked && (!strcmp(elemName, "UNPARK")) && !strcmp(pcdataXMLEle(ep), "On"))
                             IsLocked = false;
                     }
-                    if (prevState != IsLocked && (DomePolicyS[DOME_LOCKS].s == ISS_ON))
+                    if (prevState != IsLocked && (DomePolicySP[DOME_LOCKS].getState() == ISS_ON))
                         LOGF_INFO("Dome status changed. Lock is set to: %s", IsLocked ? "locked" : "unlock");
                 }
             return true;
@@ -625,33 +625,33 @@ bool Telescope::saveConfigItems(FILE *fp)
 {
     DefaultDevice::saveConfigItems(fp);
 
-    IUSaveConfigText(fp, &ActiveDeviceTP);
-    IUSaveConfigSwitch(fp, &DomePolicySP);
+    ActiveDeviceTP.save(fp);
+    DomePolicySP.save(fp);
 
     // Ensure that we only save valid locations
-    if (HasLocation() && (LocationN[LOCATION_LONGITUDE].value != 0 || LocationN[LOCATION_LATITUDE].value != 0))
-        IUSaveConfigNumber(fp, &LocationNP);
+    if (HasLocation() && (LocationNP[LOCATION_LONGITUDE].value != 0 || LocationNP[LOCATION_LATITUDE].getValue() != 0))
+        LocationNP.save(fp);
 
     if (!HasDefaultScopeConfig())
     {
-        if (ScopeParametersNP.s == IPS_OK)
-            IUSaveConfigNumber(fp, &ScopeParametersNP);
-        if (ScopeConfigNameTP.s == IPS_OK)
-            IUSaveConfigText(fp, &ScopeConfigNameTP);
+        if (ScopeParametersNP.getState() == IPS_OK)
+            ScopeParametersNP.save(fp);
+        if (ScopeConfigNameTP.getState() == IPS_OK)
+            ScopeConfigNameTP.save(fp);
     }
     if (SlewRateS != nullptr)
         IUSaveConfigSwitch(fp, &SlewRateSP);
     if (HasPECState())
-        IUSaveConfigSwitch(fp, &PECStateSP);
+        PECStateSP.save(fp);
     if (HasTrackMode())
         IUSaveConfigSwitch(fp, &TrackModeSP);
     if (HasTrackRate())
-        IUSaveConfigNumber(fp, &TrackRateNP);
+        TrackRateNP.save(fp);
 
     controller->saveConfigItems(fp);
-    IUSaveConfigSwitch(fp, &MotionControlModeTP);
-    IUSaveConfigSwitch(fp, &LockAxisSP);
-    IUSaveConfigSwitch(fp, &SimulatePierSideSP);
+    MotionControlModeTP.save(fp);
+    LockAxisSP.save(fp);
+    SimulatePierSideSP.save(fp);
 
     return true;
 }
@@ -662,40 +662,40 @@ void Telescope::NewRaDec(double ra, double dec)
     {
         case SCOPE_PARKED:
         case SCOPE_IDLE:
-            EqNP.s = IPS_IDLE;
+            EqNP.setState(IPS_IDLE);
             break;
 
         case SCOPE_SLEWING:
         case SCOPE_PARKING:
-            EqNP.s = IPS_BUSY;
+            EqNP.setState(IPS_BUSY);
             break;
 
         case SCOPE_TRACKING:
-            EqNP.s = IPS_OK;
+            EqNP.setState(IPS_OK);
             break;
     }
 
-    if (TrackState != SCOPE_TRACKING && CanControlTrack() && TrackStateS[TRACK_ON].s == ISS_ON)
+    if (TrackState != SCOPE_TRACKING && CanControlTrack() && TrackStateSP[TRACK_ON].s == ISS_ON)
     {
-        TrackStateSP.s = IPS_IDLE;
-        TrackStateS[TRACK_ON].s = ISS_OFF;
-        TrackStateS[TRACK_OFF].s = ISS_ON;
-        IDSetSwitch(&TrackStateSP, nullptr);
+        TrackStateSP.setState(IPS_IDLE);
+        TrackStateSP[TRACK_ON].setState(ISS_OFF);
+        TrackStateSP[TRACK_OFF].setState(ISS_ON);
+        TrackStateSP.apply();
     }
-    else if (TrackState == SCOPE_TRACKING && CanControlTrack() && TrackStateS[TRACK_OFF].s == ISS_ON)
+    else if (TrackState == SCOPE_TRACKING && CanControlTrack() && TrackStateSP[TRACK_OFF].s == ISS_ON)
     {
-        TrackStateSP.s = IPS_BUSY;
-        TrackStateS[TRACK_ON].s = ISS_ON;
-        TrackStateS[TRACK_OFF].s = ISS_OFF;
-        IDSetSwitch(&TrackStateSP, nullptr);
+        TrackStateSP.setState(IPS_BUSY);
+        TrackStateSP[TRACK_ON].setState(ISS_ON);
+        TrackStateSP[TRACK_OFF].setState(ISS_OFF);
+        TrackStateSP.apply();
     }
 
-    if (EqN[AXIS_RA].value != ra || EqN[AXIS_DE].value != dec || EqNP.s != lastEqState)
+    if (EqNP[AXIS_RA].value != ra || EqNP[AXIS_DE].getValue() != dec || EqNP.getState() != lastEqState)
     {
-        EqN[AXIS_RA].value = ra;
-        EqN[AXIS_DE].value = dec;
-        lastEqState        = EqNP.s;
-        IDSetNumber(&EqNP, nullptr);
+        EqNP[AXIS_RA].setValue(ra);
+        EqNP[AXIS_DE].setValue(dec);
+        lastEqState        = EqNP.getState();
+        EqNP.apply();
     }
 }
 
@@ -713,9 +713,9 @@ bool Telescope::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
     INDI_UNUSED(dir);
     INDI_UNUSED(command);
     DEBUG(Logger::DBG_ERROR, "Telescope does not support North/South motion.");
-    IUResetSwitch(&MovementNSSP);
-    MovementNSSP.s = IPS_IDLE;
-    IDSetSwitch(&MovementNSSP, nullptr);
+    MovementNSSP.reset();
+    MovementNSSP.setState(IPS_IDLE);
+    MovementNSSP.apply();
     return false;
 }
 
@@ -724,9 +724,9 @@ bool Telescope::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
     INDI_UNUSED(dir);
     INDI_UNUSED(command);
     DEBUG(Logger::DBG_ERROR, "Telescope does not support West/East motion.");
-    IUResetSwitch(&MovementWESP);
-    MovementWESP.s = IPS_IDLE;
-    IDSetSwitch(&MovementWESP, nullptr);
+    MovementWESP.reset();
+    MovementWESP.setState(IPS_IDLE);
+    MovementWESP.apply();
     return false;
 }
 
@@ -738,7 +738,7 @@ bool Telescope::ISNewText(const char *dev, const char *name, char *texts[], char
     //  first check if it's for our device
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (!strcmp(name, TimeTP.name))
+        if (TimeTP.isNameMatch(name))
         {
             int utcindex    = IUFindIndex("UTC", names, n);
             int offsetindex = IUFindIndex("OFFSET", names, n);
@@ -746,26 +746,26 @@ bool Telescope::ISNewText(const char *dev, const char *name, char *texts[], char
             return processTimeInfo(texts[utcindex], texts[offsetindex]);
         }
 
-        if (!strcmp(name, ActiveDeviceTP.name))
+        if (ActiveDeviceTP.isNameMatch(name))
         {
-            ActiveDeviceTP.s = IPS_OK;
-            IUUpdateText(&ActiveDeviceTP, texts, names, n);
+            ActiveDeviceTP.setState(IPS_OK);
+            ActiveDeviceTP.update(texts, names, n);
             //  Update client display
-            IDSetText(&ActiveDeviceTP, nullptr);
+            ActiveDeviceTP.apply();
 
-            IDSnoopDevice(ActiveDeviceT[0].text, "GEOGRAPHIC_COORD");
-            IDSnoopDevice(ActiveDeviceT[0].text, "TIME_UTC");
+            IDSnoopDevice(ActiveDeviceTP[0].getText(), "GEOGRAPHIC_COORD");
+            IDSnoopDevice(ActiveDeviceTP[0].getText(), "TIME_UTC");
 
-            IDSnoopDevice(ActiveDeviceT[1].text, "DOME_PARK");
-            IDSnoopDevice(ActiveDeviceT[1].text, "DOME_SHUTTER");
+            IDSnoopDevice(ActiveDeviceTP[1].getText(), "DOME_PARK");
+            IDSnoopDevice(ActiveDeviceTP[1].getText(), "DOME_SHUTTER");
             return true;
         }
 
         if (name && std::string(name) == "SCOPE_CONFIG_NAME")
         {
-            ScopeConfigNameTP.s = IPS_OK;
-            IUUpdateText(&ScopeConfigNameTP, texts, names, n);
-            IDSetText(&ScopeConfigNameTP, nullptr);
+            ScopeConfigNameTP.setState(IPS_OK);
+            ScopeConfigNameTP.update(texts, names, n);
+            ScopeConfigNameTP.apply();
             UpdateScopeConfig();
             return true;
         }
@@ -796,12 +796,12 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
 
             for (int x = 0; x < n; x++)
             {
-                INumber *eqp = IUFindNumber(&EqNP, names[x]);
-                if (eqp == &EqN[AXIS_RA])
+                INumber *eqp = EqNP.findWidgetByName(names[x]);
+                if (eqp == &EqNP[AXIS_RA])
                 {
                     ra = values[x];
                 }
-                else if (eqp == &EqN[AXIS_DE])
+                else if (eqp == &EqNP[AXIS_DE])
                 {
                     dec = values[x];
                 }
@@ -815,8 +815,8 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
                     {
                         DEBUG(Logger::DBG_WARNING,
                               "Please unpark the mount before issuing any motion/sync commands.");
-                        EqNP.s = lastEqState = IPS_IDLE;
-                        IDSetNumber(&EqNP, nullptr);
+                        EqNP.setState(lastEqState = IPS_IDLE);
+                        EqNP.apply();
                         return false;
                     }
                 }
@@ -825,15 +825,15 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
                 if (CanSync())
                 {
                     ISwitch *sw;
-                    sw = IUFindSwitch(&CoordSP, "SYNC");
+                    sw = CoordSP.findWidgetByName("SYNC");
                     if ((sw != nullptr) && (sw->s == ISS_ON))
                     {
                         rc = Sync(ra, dec);
                         if (rc)
-                            EqNP.s = lastEqState = IPS_OK;
+                            EqNP.setState(lastEqState = IPS_OK);
                         else
-                            EqNP.s = lastEqState = IPS_ALERT;
-                        IDSetNumber(&EqNP, nullptr);
+                            EqNP.setState(lastEqState = IPS_ALERT);
+                        EqNP.apply();
                         return rc;
                     }
                 }
@@ -844,17 +844,17 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
                 rc = Goto(ra, dec);
                 if (rc)
                 {
-                    EqNP.s = lastEqState = IPS_BUSY;
+                    EqNP.setState(lastEqState = IPS_BUSY);
                     //  Now fill in target co-ords, so domes can start turning
-                    TargetN[AXIS_RA].value = ra;
-                    TargetN[AXIS_DE].value = dec;
-                    IDSetNumber(&TargetNP, nullptr);
+                    TargetNP[AXIS_RA].setValue(ra);
+                    TargetNP[AXIS_DE].setValue(dec);
+                    TargetNP.apply();
                 }
                 else
                 {
-                    EqNP.s = lastEqState = IPS_ALERT;
+                    EqNP.setState(lastEqState = IPS_ALERT);
                 }
-                IDSetNumber(&EqNP, nullptr);
+                EqNP.apply();
             }
             return rc;
         }
@@ -870,8 +870,8 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
 
             if (latindex == -1 || longindex == -1 || elevationindex == -1)
             {
-                LocationNP.s = IPS_ALERT;
-                IDSetNumber(&LocationNP, "Location data missing or corrupted.");
+                LocationNP.setState(IPS_ALERT);
+                LocationNP.apply("Location data missing or corrupted.");
             }
 
             double targetLat  = values[latindex];
@@ -886,10 +886,10 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
         ///////////////////////////////////
         if (strcmp(name, "TELESCOPE_INFO") == 0)
         {
-            ScopeParametersNP.s = IPS_OK;
+            ScopeParametersNP.setState(IPS_OK);
 
-            IUUpdateNumber(&ScopeParametersNP, values, names, n);
-            IDSetNumber(&ScopeParametersNP, nullptr);
+            ScopeParametersNP.update(values, names, n);
+            ScopeParametersNP.apply();
             UpdateScopeConfig();
             return true;
         }
@@ -897,17 +897,17 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
         ///////////////////////////////////
         // Park Position
         ///////////////////////////////////
-        if (strcmp(name, ParkPositionNP.name) == 0)
+        if (ParkPositionNP.isNameMatch(name))
         {
             double axis1 = std::numeric_limits<double>::quiet_NaN(), axis2 = std::numeric_limits<double>::quiet_NaN();
             for (int x = 0; x < n; x++)
             {
-                INumber *parkPosAxis = IUFindNumber(&ParkPositionNP, names[x]);
-                if (parkPosAxis == &ParkPositionN[AXIS_RA])
+                INumber *parkPosAxis = ParkPositionNP.findWidgetByName(names[x]);
+                if (parkPosAxis == &ParkPositionNP[AXIS_RA])
                 {
                     axis1 = values[x];
                 }
-                else if (parkPosAxis == &ParkPositionN[AXIS_DE])
+                else if (parkPosAxis == &ParkPositionNP[AXIS_DE])
                 {
                     axis2 = values[x];
                 }
@@ -921,32 +921,32 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
 
                 if (rc)
                 {
-                    IUUpdateNumber(&ParkPositionNP, values, names, n);
-                    Axis1ParkPosition = ParkPositionN[AXIS_RA].value;
-                    Axis2ParkPosition = ParkPositionN[AXIS_DE].value;
+                    ParkPositionNP.update(values, names, n);
+                    Axis1ParkPosition = ParkPositionNP[AXIS_RA].getValue();
+                    Axis2ParkPosition = ParkPositionNP[AXIS_DE].getValue();
                 }
 
-                ParkPositionNP.s = rc ? IPS_OK : IPS_ALERT;
+                ParkPositionNP.setState(rc ? IPS_OK : IPS_ALERT);
             }
             else
-                ParkPositionNP.s = IPS_ALERT;
+                ParkPositionNP.setState(IPS_ALERT);
 
-            IDSetNumber(&ParkPositionNP, nullptr);
+            ParkPositionNP.apply();
             return true;
         }
 
         ///////////////////////////////////
         // Track Rate
         ///////////////////////////////////
-        if (strcmp(name, TrackRateNP.name) == 0)
+        if (TrackRateNP.isNameMatch(name))
         {
-            double preAxis1 = TrackRateN[AXIS_RA].value, preAxis2 = TrackRateN[AXIS_DE].value;
-            bool rc = (IUUpdateNumber(&TrackRateNP, values, names, n) == 0);
+            double preAxis1 = TrackRateNP[AXIS_RA].getValue(), preAxis2 = TrackRateNP[AXIS_DE].getValue();
+            bool rc = (TrackRateNP.update(values, names, n) == 0);
 
             if (!rc)
             {
-                TrackRateNP.s = IPS_ALERT;
-                IDSetNumber(&TrackRateNP, nullptr);
+                TrackRateNP.setState(IPS_ALERT);
+                TrackRateNP.apply();
                 return false;
             }
 
@@ -955,19 +955,19 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
                 // Check that we do not abruplty change positive tracking rates to negative ones.
                 // tracking must be stopped first.
                 // Give warning is tracking sign would cause a reverse in direction
-                if ( (preAxis1 * TrackRateN[AXIS_RA].value < 0) || (preAxis2 * TrackRateN[AXIS_DE].value < 0) )
+                if ( (preAxis1 * TrackRateNP[AXIS_RA].getValue() < 0) || (preAxis2 * TrackRateNP[AXIS_DE].getValue() < 0) )
                 {
                     LOG_ERROR("Cannot reverse tracking while tracking is engaged. Disengage tracking then try again.");
                     return false;
                 }
 
                 // All is fine, ask mount to change tracking rate
-                rc = SetTrackRate(TrackRateN[AXIS_RA].value, TrackRateN[AXIS_DE].value);
+                rc = SetTrackRate(TrackRateNP[AXIS_RA].value, TrackRateNP[AXIS_DE].getValue());
 
                 if (!rc)
                 {
-                    TrackRateN[AXIS_RA].value = preAxis1;
-                    TrackRateN[AXIS_DE].value = preAxis2;
+                    TrackRateNP[AXIS_RA].setValue(preAxis1);
+                    TrackRateNP[AXIS_DE].setValue(preAxis2);
                 }
             }
 
@@ -980,8 +980,8 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
             }
 
             // If mount is NOT tracking, we simply accept whatever valid values for use when mount tracking is engaged.
-            TrackRateNP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetNumber(&TrackRateNP, nullptr);
+            TrackRateNP.setState(rc ? IPS_OK : IPS_ALERT);
+            TrackRateNP.apply();
             return true;
         }
     }
@@ -997,13 +997,13 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         //  This one is for us
-        if (!strcmp(name, CoordSP.name))
+        if (CoordSP.isNameMatch(name))
         {
             //  client is telling us what to do with co-ordinate requests
-            CoordSP.s = IPS_OK;
-            IUUpdateSwitch(&CoordSP, states, names, n);
+            CoordSP.setState(IPS_OK);
+            CoordSP.update(states, names, n);
             //  Update client display
-            IDSetSwitch(&CoordSP, nullptr);
+            CoordSP.apply();
             return true;
         }
 
@@ -1030,88 +1030,88 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         // Parking
         ///////////////////////////////////
-        if (!strcmp(name, ParkSP.name))
+        if (ParkSP.isNameMatch(name))
         {
             if (TrackState == SCOPE_PARKING)
             {
-                IUResetSwitch(&ParkSP);
-                ParkSP.s = IPS_ALERT;
+                ParkSP.reset();
+                ParkSP.setState(IPS_ALERT);
                 Abort();
                 LOG_INFO("Parking/Unparking aborted.");
-                IDSetSwitch(&ParkSP, nullptr);
+                ParkSP.apply();
                 return true;
             }
 
-            int preIndex = IUFindOnSwitchIndex(&ParkSP);
-            IUUpdateSwitch(&ParkSP, states, names, n);
+            int preIndex = ParkSP.findOnSwitchIndex();
+            ParkSP.update(states, names, n);
 
-            bool toPark = (ParkS[0].s == ISS_ON);
+            bool toPark = (ParkSP[0].getState() == ISS_ON);
 
             if (toPark == false && TrackState != SCOPE_PARKED)
             {
-                IUResetSwitch(&ParkSP);
-                ParkS[1].s = ISS_ON;
-                ParkSP.s   = IPS_IDLE;
+                ParkSP.reset();
+                ParkSP[1].setState(ISS_ON);
+                ParkSP.setState(IPS_IDLE);
                 LOG_INFO("Telescope already unparked.");
                 IsParked = false;
-                IDSetSwitch(&ParkSP, nullptr);
+                ParkSP.apply();
                 return true;
             }
 
             if (toPark == false && isLocked())
             {
-                IUResetSwitch(&ParkSP);
-                ParkS[0].s = ISS_ON;
-                ParkSP.s   = IPS_ALERT;
+                ParkSP.reset();
+                ParkSP[0].setState(ISS_ON);
+                ParkSP.setState(IPS_ALERT);
                 LOG_WARN("Cannot unpark mount when dome is locking. See: Dome Policy in options tab.");
                 IsParked = true;
-                IDSetSwitch(&ParkSP, nullptr);
+                ParkSP.apply();
                 return true;
             }
 
             if (toPark && TrackState == SCOPE_PARKED)
             {
-                IUResetSwitch(&ParkSP);
-                ParkS[0].s = ISS_ON;
-                ParkSP.s   = IPS_IDLE;
+                ParkSP.reset();
+                ParkSP[0].setState(ISS_ON);
+                ParkSP.setState(IPS_IDLE);
                 LOG_INFO("Telescope already parked.");
-                IDSetSwitch(&ParkSP, nullptr);
+                ParkSP.apply();
                 return true;
             }
 
             RememberTrackState = TrackState;
 
-            IUResetSwitch(&ParkSP);
+            ParkSP.reset();
             bool rc = toPark ? Park() : UnPark();
             if (rc)
             {
                 if (TrackState == SCOPE_PARKING)
                 {
-                    ParkS[0].s = toPark ? ISS_ON : ISS_OFF;
-                    ParkS[1].s = toPark ? ISS_OFF : ISS_ON;
-                    ParkSP.s   = IPS_BUSY;
+                    ParkSP[0].setState(toPark ? ISS_ON : ISS_OFF);
+                    ParkSP[1].setState(toPark ? ISS_OFF : ISS_ON);
+                    ParkSP.setState(IPS_BUSY);
                 }
                 else
                 {
-                    ParkS[0].s = toPark ? ISS_ON : ISS_OFF;
-                    ParkS[1].s = toPark ? ISS_OFF : ISS_ON;
-                    ParkSP.s   = IPS_OK;
+                    ParkSP[0].setState(toPark ? ISS_ON : ISS_OFF);
+                    ParkSP[1].setState(toPark ? ISS_OFF : ISS_ON);
+                    ParkSP.setState(IPS_OK);
                 }
             }
             else
             {
-                ParkS[preIndex].s = ISS_ON;
-                ParkSP.s          = IPS_ALERT;
+                ParkSP[preIndex].setState(ISS_ON);
+                ParkSP.setState(IPS_ALERT);
             }
 
-            IDSetSwitch(&ParkSP, nullptr);
+            ParkSP.apply();
             return true;
         }
 
         ///////////////////////////////////
         // NS Motion
         ///////////////////////////////////
-        if (!strcmp(name, MovementNSSP.name))
+        if (MovementNSSP.isNameMatch(name))
         {
             // Check if it is already parked.
             if (CanPark())
@@ -1120,18 +1120,18 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                 {
                     DEBUG(Logger::DBG_WARNING,
                           "Please unpark the mount before issuing any motion/sync commands.");
-                    MovementNSSP.s = IPS_IDLE;
-                    IDSetSwitch(&MovementNSSP, nullptr);
+                    MovementNSSP.setState(IPS_IDLE);
+                    MovementNSSP.apply();
                     return false;
                 }
             }
 
-            IUUpdateSwitch(&MovementNSSP, states, names, n);
+            MovementNSSP.update(states, names, n);
 
-            int current_motion = IUFindOnSwitchIndex(&MovementNSSP);
+            int current_motion = MovementNSSP.findOnSwitchIndex();
 
             // if same move requested, return
-            if (MovementNSSP.s == IPS_BUSY && current_motion == last_ns_motion)
+            if (MovementNSSP.getState() == IPS_BUSY && current_motion == last_ns_motion)
                 return true;
 
             // Time to stop motion
@@ -1139,16 +1139,16 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
             {
                 if (MoveNS(last_ns_motion == 0 ? DIRECTION_NORTH : DIRECTION_SOUTH, MOTION_STOP))
                 {
-                    IUResetSwitch(&MovementNSSP);
-                    MovementNSSP.s = IPS_IDLE;
+                    MovementNSSP.reset();
+                    MovementNSSP.setState(IPS_IDLE);
                     last_ns_motion = -1;
                     // Update Target when stopped so that domes can track
-                    TargetN[AXIS_RA].value = EqN[AXIS_RA].value;
-                    TargetN[AXIS_DE].value = EqN[AXIS_DE].value;
-                    IDSetNumber(&TargetNP, nullptr);
+                    TargetNP[AXIS_RA].setValue(EqNP[AXIS_RA].getValue());
+                    TargetNP[AXIS_DE].setValue(EqNP[AXIS_DE].getValue());
+                    TargetNP.apply();
                 }
                 else
-                    MovementNSSP.s = IPS_ALERT;
+                    MovementNSSP.setState(IPS_ALERT);
             }
             else
             {
@@ -1157,18 +1157,18 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
                 if (MoveNS(current_motion == 0 ? DIRECTION_NORTH : DIRECTION_SOUTH, MOTION_START))
                 {
-                    MovementNSSP.s = IPS_BUSY;
+                    MovementNSSP.setState(IPS_BUSY);
                     last_ns_motion = current_motion;
                 }
                 else
                 {
-                    IUResetSwitch(&MovementNSSP);
-                    MovementNSSP.s = IPS_ALERT;
+                    MovementNSSP.reset();
+                    MovementNSSP.setState(IPS_ALERT);
                     last_ns_motion = -1;
                 }
             }
 
-            IDSetSwitch(&MovementNSSP, nullptr);
+            MovementNSSP.apply();
 
             return true;
         }
@@ -1176,7 +1176,7 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         // WE Motion
         ///////////////////////////////////
-        if (!strcmp(name, MovementWESP.name))
+        if (MovementWESP.isNameMatch(name))
         {
             // Check if it is already parked.
             if (CanPark())
@@ -1185,18 +1185,18 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                 {
                     DEBUG(Logger::DBG_WARNING,
                           "Please unpark the mount before issuing any motion/sync commands.");
-                    MovementWESP.s = IPS_IDLE;
-                    IDSetSwitch(&MovementWESP, nullptr);
+                    MovementWESP.setState(IPS_IDLE);
+                    MovementWESP.apply();
                     return false;
                 }
             }
 
-            IUUpdateSwitch(&MovementWESP, states, names, n);
+            MovementWESP.update(states, names, n);
 
-            int current_motion = IUFindOnSwitchIndex(&MovementWESP);
+            int current_motion = MovementWESP.findOnSwitchIndex();
 
             // if same move requested, return
-            if (MovementWESP.s == IPS_BUSY && current_motion == last_we_motion)
+            if (MovementWESP.getState() == IPS_BUSY && current_motion == last_we_motion)
                 return true;
 
             // Time to stop motion
@@ -1204,16 +1204,16 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
             {
                 if (MoveWE(last_we_motion == 0 ? DIRECTION_WEST : DIRECTION_EAST, MOTION_STOP))
                 {
-                    IUResetSwitch(&MovementWESP);
-                    MovementWESP.s = IPS_IDLE;
+                    MovementWESP.reset();
+                    MovementWESP.setState(IPS_IDLE);
                     last_we_motion = -1;
                     // Update Target when stopped so that domes can track
-                    TargetN[AXIS_RA].value = EqN[AXIS_RA].value;
-                    TargetN[AXIS_DE].value = EqN[AXIS_DE].value;
-                    IDSetNumber(&TargetNP, nullptr);
+                    TargetNP[AXIS_RA].setValue(EqNP[AXIS_RA].getValue());
+                    TargetNP[AXIS_DE].setValue(EqNP[AXIS_DE].getValue());
+                    TargetNP.apply();
                 }
                 else
-                    MovementWESP.s = IPS_ALERT;
+                    MovementWESP.setState(IPS_ALERT);
             }
             else
             {
@@ -1222,18 +1222,18 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
                 if (MoveWE(current_motion == 0 ? DIRECTION_WEST : DIRECTION_EAST, MOTION_START))
                 {
-                    MovementWESP.s = IPS_BUSY;
+                    MovementWESP.setState(IPS_BUSY);
                     last_we_motion = current_motion;
                 }
                 else
                 {
-                    IUResetSwitch(&MovementWESP);
-                    MovementWESP.s = IPS_ALERT;
+                    MovementWESP.reset();
+                    MovementWESP.setState(IPS_ALERT);
                     last_we_motion = -1;
                 }
             }
 
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementWESP.apply();
 
             return true;
         }
@@ -1241,39 +1241,39 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         // Abort Motion
         ///////////////////////////////////
-        if (!strcmp(name, AbortSP.name))
+        if (AbortSP.isNameMatch(name))
         {
-            IUResetSwitch(&AbortSP);
+            AbortSP.reset();
 
             if (Abort())
             {
-                AbortSP.s = IPS_OK;
+                AbortSP.setState(IPS_OK);
 
-                if (ParkSP.s == IPS_BUSY)
+                if (ParkSP.getState() == IPS_BUSY)
                 {
-                    IUResetSwitch(&ParkSP);
-                    ParkSP.s = IPS_ALERT;
-                    IDSetSwitch(&ParkSP, nullptr);
+                    ParkSP.reset();
+                    ParkSP.setState(IPS_ALERT);
+                    ParkSP.apply();
 
                     LOG_INFO("Parking aborted.");
                 }
-                if (EqNP.s == IPS_BUSY)
+                if (EqNP.getState() == IPS_BUSY)
                 {
-                    EqNP.s = lastEqState = IPS_IDLE;
-                    IDSetNumber(&EqNP, nullptr);
+                    EqNP.setState(lastEqState = IPS_IDLE);
+                    EqNP.apply();
                     LOG_INFO("Slew/Track aborted.");
                 }
-                if (MovementWESP.s == IPS_BUSY)
+                if (MovementWESP.getState() == IPS_BUSY)
                 {
-                    IUResetSwitch(&MovementWESP);
-                    MovementWESP.s = IPS_IDLE;
-                    IDSetSwitch(&MovementWESP, nullptr);
+                    MovementWESP.reset();
+                    MovementWESP.setState(IPS_IDLE);
+                    MovementWESP.apply();
                 }
-                if (MovementNSSP.s == IPS_BUSY)
+                if (MovementNSSP.getState() == IPS_BUSY)
                 {
-                    IUResetSwitch(&MovementNSSP);
-                    MovementNSSP.s = IPS_IDLE;
-                    IDSetSwitch(&MovementNSSP, nullptr);
+                    MovementNSSP.reset();
+                    MovementNSSP.setState(IPS_IDLE);
+                    MovementNSSP.apply();
                 }
 
                 last_ns_motion = last_we_motion = -1;
@@ -1289,9 +1289,9 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                 }
             }
             else
-                AbortSP.s = IPS_ALERT;
+                AbortSP.setState(IPS_ALERT);
 
-            IDSetSwitch(&AbortSP, nullptr);
+            AbortSP.apply();
 
             return true;
         }
@@ -1334,15 +1334,15 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         // Track State
         ///////////////////////////////////
-        if (!strcmp(name, TrackStateSP.name))
+        if (TrackStateSP.isNameMatch(name))
         {
-            int previousState = IUFindOnSwitchIndex(&TrackStateSP);
-            IUUpdateSwitch(&TrackStateSP, states, names, n);
-            int targetState = IUFindOnSwitchIndex(&TrackStateSP);
+            int previousState = TrackStateSP.findOnSwitchIndex();
+            TrackStateSP.update(states, names, n);
+            int targetState = TrackStateSP.findOnSwitchIndex();
 
             if (previousState == targetState)
             {
-                IDSetSwitch(&TrackStateSP, nullptr);
+                TrackStateSP.apply();
                 return true;
             }
 
@@ -1358,42 +1358,42 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
             {
                 TrackState = (targetState == TRACK_ON) ? SCOPE_TRACKING : SCOPE_IDLE;
 
-                TrackStateSP.s = (targetState == TRACK_ON) ? IPS_BUSY : IPS_IDLE;
+                TrackStateSP.setState((targetState == TRACK_ON) ? IPS_BUSY : IPS_IDLE);
 
-                TrackStateS[TRACK_ON].s = (targetState == TRACK_ON) ? ISS_ON : ISS_OFF;
-                TrackStateS[TRACK_OFF].s = (targetState == TRACK_ON) ? ISS_OFF : ISS_ON;
+                TrackStateSP[TRACK_ON].setState((targetState == TRACK_ON) ? ISS_ON : ISS_OFF);
+                TrackStateSP[TRACK_OFF].setState((targetState == TRACK_ON) ? ISS_OFF : ISS_ON);
             }
             else
             {
-                TrackStateSP.s = IPS_ALERT;
-                IUResetSwitch(&TrackStateSP);
-                TrackStateS[previousState].s = ISS_ON;
+                TrackStateSP.setState(IPS_ALERT);
+                TrackStateSP.reset();
+                TrackStateSP[previousState].setState(ISS_ON);
             }
 
-            IDSetSwitch(&TrackStateSP, nullptr);
+            TrackStateSP.apply();
             return true;
         }
 
         ///////////////////////////////////
         // Park Options
         ///////////////////////////////////
-        if (!strcmp(name, ParkOptionSP.name))
+        if (ParkOptionSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&ParkOptionSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&ParkOptionSP);
+            ParkOptionSP.update(states, names, n);
+            int index = ParkOptionSP.findOnSwitchIndex();
             if (index == -1)
                 return false;
 
-            IUResetSwitch(&ParkOptionSP);
+            ParkOptionSP.reset();
 
             bool rc = false;
 
-            if ((TrackState != SCOPE_IDLE && TrackState != SCOPE_TRACKING) || MovementNSSP.s == IPS_BUSY ||
-                    MovementWESP.s == IPS_BUSY)
+            if ((TrackState != SCOPE_IDLE && TrackState != SCOPE_TRACKING) || MovementNSSP.getState() == IPS_BUSY ||
+                    MovementWESP.getState() == IPS_BUSY)
             {
                 LOG_INFO("Can not change park position while slewing or already parked...");
-                ParkOptionSP.s = IPS_ALERT;
-                IDSetSwitch(&ParkOptionSP, nullptr);
+                ParkOptionSP.setState(IPS_ALERT);
+                ParkOptionSP.apply();
                 return false;
             }
 
@@ -1421,8 +1421,8 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                     break;
             }
 
-            ParkOptionSP.s = rc ? IPS_OK : IPS_ALERT;
-            IDSetSwitch(&ParkOptionSP, nullptr);
+            ParkOptionSP.setState(rc ? IPS_OK : IPS_ALERT);
+            ParkOptionSP.apply();
 
             return true;
         }
@@ -1430,10 +1430,10 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         // Parking Dome Policy
         ///////////////////////////////////
-        if (!strcmp(name, DomePolicySP.name))
+        if (DomePolicySP.isNameMatch(name))
         {
-            IUUpdateSwitch(&DomePolicySP, states, names, n);
-            if (DomePolicyS[DOME_IGNORED].s == ISS_ON)
+            DomePolicySP.update(states, names, n);
+            if (DomePolicySP[DOME_IGNORED].getState() == ISS_ON)
                 LOG_INFO("Dome Policy set to: Dome ignored. Mount can park or unpark regardless of dome parking state.");
             else
                 LOG_WARN("Dome Policy set to: Dome locks. This prevents the mount from unparking when dome is parked.");
@@ -1448,9 +1448,9 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                          "park if dome is parking. This will disable the locking for dome "
                          "parking, EVEN IF MOUNT PARKING FAILS.");
 #endif
-            DomePolicySP.s = IPS_OK;
-            IDSetSwitch(&DomePolicySP, nullptr);
-            triggerSnoop(ActiveDeviceT[1].text, "DOME_PARK");
+            DomePolicySP.setState(IPS_OK);
+            DomePolicySP.apply();
+            triggerSnoop(ActiveDeviceTP[1].getText(), "DOME_PARK");
             return true;
         }
 
@@ -1458,15 +1458,15 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         // Simulate Pier Side
         // This ia a major change to the design of the simulated scope, it might not handle changes on the fly
         ///////////////////////////////////
-        if (!strcmp(name, SimulatePierSideSP.name))
+        if (SimulatePierSideSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&SimulatePierSideSP, states, names, n);
-            int index = IUFindOnSwitchIndex(&SimulatePierSideSP);
+            SimulatePierSideSP.update(states, names, n);
+            int index = SimulatePierSideSP.findOnSwitchIndex();
             if (index == -1)
             {
-                SimulatePierSideSP.s = IPS_ALERT;
+                SimulatePierSideSP.setState(IPS_ALERT);
                 LOG_INFO("Cannot determine whether pier side simulation should be switched on or off.");
-                IDSetSwitch(&SimulatePierSideSP, nullptr);
+                SimulatePierSideSP.apply();
                 return false;
             }
 
@@ -1479,7 +1479,7 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
             {
                 // set the pier side from the current Ra
                 // assumes we haven't tracked across the meridian
-                setPierSide(expectedPierSide(EqN[AXIS_RA].value));
+                setPierSide(expectedPierSide(EqNP[AXIS_RA].value));
             }
             return true;
         }
@@ -1487,14 +1487,14 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         // Joystick Motion Control Mode
         ///////////////////////////////////
-        if (!strcmp(name, MotionControlModeTP.name))
+        if (MotionControlModeTP.isNameMatch(name))
         {
-            IUUpdateSwitch(&MotionControlModeTP, states, names, n);
-            MotionControlModeTP.s = IPS_OK;
-            IDSetSwitch(&MotionControlModeTP, nullptr);
-            if (MotionControlModeT[MOTION_CONTROL_JOYSTICK].s == ISS_ON)
+            MotionControlModeTP.update(states, names, n);
+            MotionControlModeTP.setState(IPS_OK);
+            MotionControlModeTP.apply();
+            if (MotionControlModeTP[MOTION_CONTROL_JOYSTICK].getState() == ISS_ON)
                 LOG_INFO("Motion control is set to 4-way joystick.");
-            else if (MotionControlModeT[MOTION_CONTROL_AXES].s == ISS_ON)
+            else if (MotionControlModeTP[MOTION_CONTROL_AXES].getState() == ISS_ON)
                 LOG_INFO("Motion control is set to 2 separate axes.");
             else
                 DEBUGF(Logger::DBG_WARNING, "Motion control is set to unknown value %d!", n);
@@ -1504,14 +1504,14 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         // Joystick Lock Axis
         ///////////////////////////////////
-        if (!strcmp(name, LockAxisSP.name))
+        if (LockAxisSP.isNameMatch(name))
         {
-            IUUpdateSwitch(&LockAxisSP, states, names, n);
-            LockAxisSP.s = IPS_OK;
-            IDSetSwitch(&LockAxisSP, nullptr);
-            if (LockAxisS[AXIS_RA].s == ISS_ON)
+            LockAxisSP.update(states, names, n);
+            LockAxisSP.setState(IPS_OK);
+            LockAxisSP.apply();
+            if (LockAxisSP[AXIS_RA].getState() == ISS_ON)
                 LOG_INFO("Joystick motion is locked to West/East axis only.");
-            else if (LockAxisS[AXIS_DE].s == ISS_ON)
+            else if (LockAxisSP[AXIS_DE].getState() == ISS_ON)
                 LOG_INFO("Joystick motion is locked to North/South axis only.");
             else
                 LOG_INFO("Joystick motion is unlocked.");
@@ -1537,13 +1537,13 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ISwitchVectorProperty *useJoystick = getSwitch("USEJOYSTICK");
         if (useJoystick && useJoystick->sp[0].s == ISS_ON)
         {
-            defineProperty(&MotionControlModeTP);
-            defineProperty(&LockAxisSP);
+            defineProperty(MotionControlModeTP);
+            defineProperty(LockAxisSP);
         }
         else
         {
-            deleteProperty(MotionControlModeTP.name);
-            deleteProperty(LockAxisSP.name);
+            deleteProperty(MotionControlModeTP.getName());
+            deleteProperty(LockAxisSP.getName());
         }
 
     }
@@ -1582,8 +1582,8 @@ void Telescope::TimerHit()
         if (!rc)
         {
             //  read was not good
-            EqNP.s = lastEqState = IPS_ALERT;
-            IDSetNumber(&EqNP, nullptr);
+            EqNP.setState(lastEqState = IPS_ALERT);
+            EqNP.apply();
         }
 
         SetTimer(getCurrentPollingPeriod());
@@ -1671,8 +1671,8 @@ bool Telescope::processTimeInfo(const char *utc, const char *offset)
 
     if (extractISOTime(utc, &utc_date) == -1)
     {
-        TimeTP.s = IPS_ALERT;
-        IDSetText(&TimeTP, "Date/Time is invalid: %s.", utc);
+        TimeTP.setState(IPS_ALERT);
+        TimeTP.apply("Date/Time is invalid: %s.", utc);
         return false;
     }
 
@@ -1680,16 +1680,16 @@ bool Telescope::processTimeInfo(const char *utc, const char *offset)
 
     if (updateTime(&utc_date, utc_offset))
     {
-        IUSaveText(&TimeT[0], utc);
-        IUSaveText(&TimeT[1], offset);
-        TimeTP.s = IPS_OK;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP[0].setText(utc);
+        TimeTP[1].setText(offset);
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
         return true;
     }
     else
     {
-        TimeTP.s = IPS_ALERT;
-        IDSetText(&TimeTP, nullptr);
+        TimeTP.setState(IPS_ALERT);
+        TimeTP.apply();
         return false;
     }
 }
@@ -1697,29 +1697,29 @@ bool Telescope::processTimeInfo(const char *utc, const char *offset)
 bool Telescope::processLocationInfo(double latitude, double longitude, double elevation)
 {
     // Do not update if not necessary
-    if (latitude == LocationN[LOCATION_LATITUDE].value && longitude == LocationN[LOCATION_LONGITUDE].value &&
-            elevation == LocationN[LOCATION_ELEVATION].value)
+    if (latitude == LocationNP[LOCATION_LATITUDE].value && longitude == LocationNP[LOCATION_LONGITUDE].value &&
+            elevation == LocationNP[LOCATION_ELEVATION].getValue())
     {
-        LocationNP.s = IPS_OK;
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.setState(IPS_OK);
+        LocationNP.apply();
         return true;
     }
     else if (latitude == 0 && longitude == 0)
     {
         LOG_DEBUG("Silently ignoring invalid latitude and longitude.");
-        LocationNP.s = IPS_IDLE;
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.setState(IPS_IDLE);
+        LocationNP.apply();
         return false;
     }
 
     if (updateLocation(latitude, longitude, elevation))
     {
-        LocationNP.s                        = IPS_OK;
-        LocationN[LOCATION_LATITUDE].value  = latitude;
-        LocationN[LOCATION_LONGITUDE].value = longitude;
-        LocationN[LOCATION_ELEVATION].value = elevation;
+        LocationNP.setState(IPS_OK);
+        LocationNP[LOCATION_LATITUDE].setValue(latitude);
+        LocationNP[LOCATION_LONGITUDE].setValue(longitude);
+        LocationNP[LOCATION_ELEVATION].setValue(elevation);
         //  Update client display
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
 
         // Always save geographic coord config immediately.
         saveConfig(true, "GEOGRAPHIC_COORD");
@@ -1730,9 +1730,9 @@ bool Telescope::processLocationInfo(double latitude, double longitude, double el
     }
     else
     {
-        LocationNP.s = IPS_ALERT;
+        LocationNP.setState(IPS_ALERT);
         //  Update client display
-        IDSetNumber(&LocationNP, nullptr);
+        LocationNP.apply();
 
         return false;
     }
@@ -1784,17 +1784,17 @@ void Telescope::SetTelescopeCapability(uint32_t cap, uint8_t slewRateCount)
 
     // If both GOTO and SYNC are supported
     if (CanGOTO() && CanSync())
-        IUFillSwitchVector(&CoordSP, CoordS, 3, getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
+        CoordSP.fill(getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
                            ISR_1OFMANY, 60, IPS_IDLE);
     // If ONLY GOTO is supported
     else if (CanGOTO())
-        IUFillSwitchVector(&CoordSP, CoordS, 2, getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
+        CoordSP.fill(getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
                            ISR_1OFMANY, 60, IPS_IDLE);
     // If ONLY SYNC is supported
     else if (CanSync())
     {
-        IUFillSwitch(&CoordS[0], "SYNC", "Sync", ISS_ON);
-        IUFillSwitchVector(&CoordSP, CoordS, 1, getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
+        CoordSP[0].fill("SYNC", "Sync", ISS_ON);
+        CoordSP.fill(getDeviceName(), "ON_COORD_SET", "On Set", MAIN_CONTROL_TAB, IP_RW,
                            ISR_1OFMANY, 60, IPS_IDLE);
     }
 
@@ -1841,35 +1841,35 @@ void Telescope::SetParkDataType(TelescopeParkData type)
         switch (parkDataType)
         {
             case PARK_RA_DEC:
-                IUFillNumber(&ParkPositionN[AXIS_RA], "PARK_RA", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-                IUFillNumber(&ParkPositionN[AXIS_DE], "PARK_DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+                ParkPositionNP[AXIS_RA].fill("PARK_RA", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+                ParkPositionNP[AXIS_DE].fill("PARK_DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
                 break;
 
             case PARK_HA_DEC:
-                IUFillNumber(&ParkPositionN[AXIS_RA], "PARK_HA", "HA (hh:mm:ss)", "%010.6m", -12, 12, 0, 0);
-                IUFillNumber(&ParkPositionN[AXIS_DE], "PARK_DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+                ParkPositionNP[AXIS_RA].fill("PARK_HA", "HA (hh:mm:ss)", "%010.6m", -12, 12, 0, 0);
+                ParkPositionNP[AXIS_DE].fill("PARK_DEC", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
                 break;
 
             case PARK_AZ_ALT:
-                IUFillNumber(&ParkPositionN[AXIS_AZ], "PARK_AZ", "AZ D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
-                IUFillNumber(&ParkPositionN[AXIS_ALT], "PARK_ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
+                ParkPositionNP[AXIS_AZ].fill("PARK_AZ", "AZ D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
+                ParkPositionNP[AXIS_ALT].fill("PARK_ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
                 break;
 
             case PARK_RA_DEC_ENCODER:
-                IUFillNumber(&ParkPositionN[AXIS_RA], "PARK_RA", "RA Encoder", "%.0f", 0, 16777215, 1, 0);
-                IUFillNumber(&ParkPositionN[AXIS_DE], "PARK_DEC", "DEC Encoder", "%.0f", 0, 16777215, 1, 0);
+                ParkPositionNP[AXIS_RA].fill("PARK_RA", "RA Encoder", "%.0f", 0, 16777215, 1, 0);
+                ParkPositionNP[AXIS_DE].fill("PARK_DEC", "DEC Encoder", "%.0f", 0, 16777215, 1, 0);
                 break;
 
             case PARK_AZ_ALT_ENCODER:
-                IUFillNumber(&ParkPositionN[AXIS_RA], "PARK_AZ", "AZ Encoder", "%.0f", 0, 16777215, 1, 0);
-                IUFillNumber(&ParkPositionN[AXIS_DE], "PARK_ALT", "ALT Encoder", "%.0f", 0, 16777215, 1, 0);
+                ParkPositionNP[AXIS_RA].fill("PARK_AZ", "AZ Encoder", "%.0f", 0, 16777215, 1, 0);
+                ParkPositionNP[AXIS_DE].fill("PARK_ALT", "ALT Encoder", "%.0f", 0, 16777215, 1, 0);
                 break;
 
             default:
                 break;
         }
 
-        IUFillNumberVector(&ParkPositionNP, ParkPositionN, 2, getDeviceName(), "TELESCOPE_PARK_POSITION",
+        ParkPositionNP.fill(getDeviceName(), "TELESCOPE_PARK_POSITION",
                            "Park Position", SITE_TAB, IP_RW, 60, IPS_IDLE);
     }
 }
@@ -1877,23 +1877,23 @@ void Telescope::SetParkDataType(TelescopeParkData type)
 void Telescope::SyncParkStatus(bool isparked)
 {
     IsParked = isparked;
-    IUResetSwitch(&ParkSP);
-    ParkSP.s = IPS_OK;
+    ParkSP.reset();
+    ParkSP.setState(IPS_OK);
 
     if (IsParked)
     {
-        ParkS[0].s = ISS_ON;
+        ParkSP[0].setState(ISS_ON);
         TrackState = SCOPE_PARKED;
         LOG_INFO("Mount is parked.");
     }
     else
     {
-        ParkS[1].s = ISS_ON;
+        ParkSP[1].setState(ISS_ON);
         TrackState = SCOPE_IDLE;
         LOG_INFO("Mount is unparked.");
     }
 
-    IDSetSwitch(&ParkSP, nullptr);
+    ParkSP.apply();
 }
 
 void Telescope::SetParked(bool isparked)
@@ -1922,9 +1922,9 @@ bool Telescope::InitPark()
     SyncParkStatus(isParked());
 
     LOGF_DEBUG("InitPark Axis1 %.2f Axis2 %.2f", Axis1ParkPosition, Axis2ParkPosition);
-    ParkPositionN[AXIS_RA].value = Axis1ParkPosition;
-    ParkPositionN[AXIS_DE].value = Axis2ParkPosition;
-    IDSetNumber(&ParkPositionNP, nullptr);
+    ParkPositionNP[AXIS_RA].setValue(Axis1ParkPosition);
+    ParkPositionNP[AXIS_DE].setValue(Axis2ParkPosition);
+    ParkPositionNP.apply();
 
     return true;
 }
@@ -2232,8 +2232,8 @@ void Telescope::SetAxis1Park(double value)
 {
     LOGF_DEBUG("Setting Park Axis1 to %.2f", value);
     Axis1ParkPosition            = value;
-    ParkPositionN[AXIS_RA].value = value;
-    IDSetNumber(&ParkPositionNP, nullptr);
+    ParkPositionNP[AXIS_RA].setValue(value);
+    ParkPositionNP.apply();
 }
 
 void Telescope::SetAxis1ParkDefault(double value)
@@ -2246,8 +2246,8 @@ void Telescope::SetAxis2Park(double value)
 {
     LOGF_DEBUG("Setting Park Axis2 to %.2f", value);
     Axis2ParkPosition            = value;
-    ParkPositionN[AXIS_DE].value = value;
-    IDSetNumber(&ParkPositionNP, nullptr);
+    ParkPositionNP[AXIS_DE].setValue(value);
+    ParkPositionNP.apply();
 }
 
 void Telescope::SetAxis2ParkDefault(double value)
@@ -2258,7 +2258,7 @@ void Telescope::SetAxis2ParkDefault(double value)
 
 bool Telescope::isLocked() const
 {
-    return DomePolicyS[DOME_LOCKS].s == ISS_ON && IsLocked;
+    return DomePolicySP[DOME_LOCKS].getState() == ISS_ON && IsLocked;
 }
 
 bool Telescope::SetSlewRate(int index)
@@ -2277,26 +2277,26 @@ void Telescope::processButton(const char *button_n, ISState state)
     {
         ISwitchVectorProperty *trackSW = getSwitch("TELESCOPE_TRACK_MODE");
         // Only abort if we have some sort of motion going on
-        if (ParkSP.s == IPS_BUSY || MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY || EqNP.s == IPS_BUSY ||
+        if (ParkSP.getState() == IPS_BUSY || MovementNSSP.getState() == IPS_BUSY || MovementWESP.getState() == IPS_BUSY || EqNP.getState() == IPS_BUSY ||
                 (trackSW && trackSW->s == IPS_BUSY))
         {
             // Invoke parent processing so that Telescope takes care of abort cross-check
             ISState states[1] = { ISS_ON };
-            const char *names[1]    = { AbortS[0].name };
-            ISNewSwitch(getDeviceName(), AbortSP.name, states, const_cast<char **>(names), 1);
+            const char *names[1]    = { AbortSP[0].getName() };
+            ISNewSwitch(getDeviceName(), AbortSP.getName(), states, const_cast<char **>(names), 1);
         }
     }
     else if (!strcmp(button_n, "PARKBUTTON"))
     {
         ISState states[2] = { ISS_ON, ISS_OFF };
-        const char *names[2]    = { ParkS[0].name, ParkS[1].name };
-        ISNewSwitch(getDeviceName(), ParkSP.name, states, const_cast<char **>(names), 2);
+        const char *names[2]    = { ParkSP[0].getName(), ParkSP[1].getName() };
+        ISNewSwitch(getDeviceName(), ParkSP.getName(), states, const_cast<char **>(names), 2);
     }
     else if (!strcmp(button_n, "UNPARKBUTTON"))
     {
         ISState states[2] = { ISS_OFF, ISS_ON };
-        const char *names[2]    = { ParkS[0].name, ParkS[1].name };
-        ISNewSwitch(getDeviceName(), ParkSP.name, states, const_cast<char **>(names), 2);
+        const char *names[2]    = { ParkSP[0].getName(), ParkSP[1].getName() };
+        ISNewSwitch(getDeviceName(), ParkSP.getName(), states, const_cast<char **>(names), 2);
     }
     else if (!strcmp(button_n, "SLEWPRESETUP"))
     {
@@ -2310,7 +2310,7 @@ void Telescope::processButton(const char *button_n, ISState state)
 
 void Telescope::processJoystick(const char *joystick_n, double mag, double angle)
 {
-    if (MotionControlModeTP.sp[MOTION_CONTROL_JOYSTICK].s == ISS_ON && !strcmp(joystick_n, "MOTIONDIR"))
+    if (MotionControlModeTP[MOTION_CONTROL_JOYSTICK].s == ISS_ON && !strcmp(joystick_n, "MOTIONDIR"))
     {
         if ((TrackState == SCOPE_PARKING) || (TrackState == SCOPE_PARKED))
         {
@@ -2326,7 +2326,7 @@ void Telescope::processJoystick(const char *joystick_n, double mag, double angle
 
 void Telescope::processAxis(const char *axis_n, double value)
 {
-    if (MotionControlModeTP.sp[MOTION_CONTROL_AXES].s == ISS_ON)
+    if (MotionControlModeTP[MOTION_CONTROL_AXES].s == ISS_ON)
     {
         if (!strcmp(axis_n, "MOTIONDIRNS") || !strcmp(axis_n, "MOTIONDIRWE"))
         {
@@ -2394,33 +2394,33 @@ void Telescope::processNSWE(double mag, double angle)
     if (mag < 0.5)
     {
         // Moving in the same direction will make it stop
-        if (MovementNSSP.s == IPS_BUSY)
+        if (MovementNSSP.getState() == IPS_BUSY)
         {
-            if (MoveNS(MovementNSSP.sp[0].s == ISS_ON ? DIRECTION_NORTH : DIRECTION_SOUTH, MOTION_STOP))
+            if (MoveNS(MovementNSSP[0].s == ISS_ON ? DIRECTION_NORTH : DIRECTION_SOUTH, MOTION_STOP))
             {
-                IUResetSwitch(&MovementNSSP);
-                MovementNSSP.s = IPS_IDLE;
-                IDSetSwitch(&MovementNSSP, nullptr);
+                MovementNSSP.reset();
+                MovementNSSP.setState(IPS_IDLE);
+                MovementNSSP.apply();
             }
             else
             {
-                MovementNSSP.s = IPS_ALERT;
-                IDSetSwitch(&MovementNSSP, nullptr);
+                MovementNSSP.setState(IPS_ALERT);
+                MovementNSSP.apply();
             }
         }
 
-        if (MovementWESP.s == IPS_BUSY)
+        if (MovementWESP.getState() == IPS_BUSY)
         {
-            if (MoveWE(MovementWESP.sp[0].s == ISS_ON ? DIRECTION_WEST : DIRECTION_EAST, MOTION_STOP))
+            if (MoveWE(MovementWESP[0].s == ISS_ON ? DIRECTION_WEST : DIRECTION_EAST, MOTION_STOP))
             {
-                IUResetSwitch(&MovementWESP);
-                MovementWESP.s = IPS_IDLE;
-                IDSetSwitch(&MovementWESP, nullptr);
+                MovementWESP.reset();
+                MovementWESP.setState(IPS_IDLE);
+                MovementWESP.apply();
             }
             else
             {
-                MovementWESP.s = IPS_ALERT;
-                IDSetSwitch(&MovementWESP, nullptr);
+                MovementWESP.setState(IPS_ALERT);
+                MovementWESP.apply();
             }
         }
     }
@@ -2428,7 +2428,7 @@ void Telescope::processNSWE(double mag, double angle)
     else if (mag > 0.9)
     {
         // Only one axis can move at a time
-        if (LockAxisS[AXIS_RA].s == ISS_ON)
+        if (LockAxisSP[AXIS_RA].getState() == ISS_ON)
         {
             // West
             if (angle >= 90 && angle <= 270)
@@ -2437,7 +2437,7 @@ void Telescope::processNSWE(double mag, double angle)
             else
                 angle = 0;
         }
-        else if (LockAxisS[AXIS_DE].s == ISS_ON)
+        else if (LockAxisSP[AXIS_DE].getState() == ISS_ON)
         {
             // North
             if (angle >= 0 && angle <= 180)
@@ -2469,50 +2469,50 @@ void Telescope::processNSWE(double mag, double angle)
         if (angle > 0 && angle < 180)
         {
             // Don't try to move if you're busy and moving in the same direction
-            if (MovementNSSP.s != IPS_BUSY || MovementNSS[0].s != ISS_ON)
+            if (MovementNSSP.getState() != IPS_BUSY || MovementNSSP[0].getState() != ISS_ON)
                 MoveNS(DIRECTION_NORTH, MOTION_START);
 
-            MovementNSSP.s                     = IPS_BUSY;
-            MovementNSSP.sp[DIRECTION_NORTH].s = ISS_ON;
-            MovementNSSP.sp[DIRECTION_SOUTH].s = ISS_OFF;
-            IDSetSwitch(&MovementNSSP, nullptr);
+            MovementNSSP.setState(IPS_BUSY);
+            MovementNSSP[DIRECTION_NORTH].setState(ISS_ON);
+            MovementNSSP[DIRECTION_SOUTH].setState(ISS_OFF);
+            MovementNSSP.apply();
         }
         // South
         if (angle > 180 && angle < 360)
         {
             // Don't try to move if you're busy and moving in the same direction
-            if (MovementNSSP.s != IPS_BUSY || MovementNSS[1].s != ISS_ON)
+            if (MovementNSSP.getState() != IPS_BUSY || MovementNSSP[1].getState() != ISS_ON)
                 MoveNS(DIRECTION_SOUTH, MOTION_START);
 
-            MovementNSSP.s                     = IPS_BUSY;
-            MovementNSSP.sp[DIRECTION_NORTH].s = ISS_OFF;
-            MovementNSSP.sp[DIRECTION_SOUTH].s = ISS_ON;
-            IDSetSwitch(&MovementNSSP, nullptr);
+            MovementNSSP.setState(IPS_BUSY);
+            MovementNSSP[DIRECTION_NORTH].setState(ISS_OFF);
+            MovementNSSP[DIRECTION_SOUTH].setState(ISS_ON);
+            MovementNSSP.apply();
         }
         // East
         if (angle < 90 || angle > 270)
         {
             // Don't try to move if you're busy and moving in the same direction
-            if (MovementWESP.s != IPS_BUSY || MovementWES[1].s != ISS_ON)
+            if (MovementWESP.getState() != IPS_BUSY || MovementWESP[1].getState() != ISS_ON)
                 MoveWE(DIRECTION_EAST, MOTION_START);
 
-            MovementWESP.s                    = IPS_BUSY;
-            MovementWESP.sp[DIRECTION_WEST].s = ISS_OFF;
-            MovementWESP.sp[DIRECTION_EAST].s = ISS_ON;
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementWESP.setState(IPS_BUSY);
+            MovementWESP[DIRECTION_WEST].setState(ISS_OFF);
+            MovementWESP[DIRECTION_EAST].setState(ISS_ON);
+            MovementWESP.apply();
         }
 
         // West
         if (angle > 90 && angle < 270)
         {
             // Don't try to move if you're busy and moving in the same direction
-            if (MovementWESP.s != IPS_BUSY || MovementWES[0].s != ISS_ON)
+            if (MovementWESP.getState() != IPS_BUSY || MovementWESP[0].getState() != ISS_ON)
                 MoveWE(DIRECTION_WEST, MOTION_START);
 
-            MovementWESP.s                    = IPS_BUSY;
-            MovementWESP.sp[DIRECTION_WEST].s = ISS_ON;
-            MovementWESP.sp[DIRECTION_EAST].s = ISS_OFF;
-            IDSetSwitch(&MovementWESP, nullptr);
+            MovementWESP.setState(IPS_BUSY);
+            MovementWESP[DIRECTION_WEST].setState(ISS_ON);
+            MovementWESP[DIRECTION_EAST].setState(ISS_OFF);
+            MovementWESP.apply();
         }
     }
 }
@@ -2574,10 +2574,10 @@ void Telescope::setPierSide(TelescopePierSide side)
 
     if (currentPierSide != lastPierSide)
     {
-        PierSideS[PIER_WEST].s = (side == PIER_WEST) ? ISS_ON : ISS_OFF;
-        PierSideS[PIER_EAST].s = (side == PIER_EAST) ? ISS_ON : ISS_OFF;
-        PierSideSP.s           = IPS_OK;
-        IDSetSwitch(&PierSideSP, nullptr);
+        PierSideSP[PIER_WEST].setState((side == PIER_WEST) ? ISS_ON : ISS_OFF);
+        PierSideSP[PIER_EAST].setState((side == PIER_EAST) ? ISS_ON : ISS_OFF);
+        PierSideSP.setState(IPS_OK);
+        PierSideSP.apply();
 
         lastPierSide = currentPierSide;
     }
@@ -2609,10 +2609,10 @@ void Telescope::setPECState(TelescopePECState state)
     if (currentPECState != lastPECState)
     {
 
-        PECStateS[PEC_OFF].s = (state == PEC_ON) ? ISS_OFF : ISS_ON;
-        PECStateS[PEC_ON].s  = (state == PEC_ON) ? ISS_ON  : ISS_OFF;
-        PECStateSP.s         = IPS_OK;
-        IDSetSwitch(&PECStateSP, nullptr);
+        PECStateSP[PEC_OFF].setState((state == PEC_ON) ? ISS_OFF : ISS_ON);
+        PECStateSP[PEC_ON].setState((state == PEC_ON) ? ISS_ON  : ISS_OFF);
+        PECStateSP.setState(IPS_OK);
+        PECStateSP.apply();
 
         lastPECState = currentPECState;
     }
@@ -2731,30 +2731,30 @@ bool Telescope::LoadScopeConfig()
     }
     ConfigName = pcdataXMLEle(XmlNode);
     // Store the loaded values
-    if (IUFindNumber(&ScopeParametersNP, "TELESCOPE_FOCAL_LENGTH"))
+    if (ScopeParametersNP.findWidgetByName("TELESCOPE_FOCAL_LENGTH"))
     {
-        IUFindNumber(&ScopeParametersNP, "TELESCOPE_FOCAL_LENGTH")->value = ScopeFoc;
+        ScopeParametersNP.findWidgetByName("TELESCOPE_FOCAL_LENGTH")->value = ScopeFoc;
     }
-    if (IUFindNumber(&ScopeParametersNP, "TELESCOPE_APERTURE"))
+    if (ScopeParametersNP.findWidgetByName("TELESCOPE_APERTURE"))
     {
-        IUFindNumber(&ScopeParametersNP, "TELESCOPE_APERTURE")->value = ScopeAp;
+        ScopeParametersNP.findWidgetByName("TELESCOPE_APERTURE")->value = ScopeAp;
     }
-    if (IUFindNumber(&ScopeParametersNP, "GUIDER_FOCAL_LENGTH"))
+    if (ScopeParametersNP.findWidgetByName("GUIDER_FOCAL_LENGTH"))
     {
-        IUFindNumber(&ScopeParametersNP, "GUIDER_FOCAL_LENGTH")->value = GScopeFoc;
+        ScopeParametersNP.findWidgetByName("GUIDER_FOCAL_LENGTH")->value = GScopeFoc;
     }
-    if (IUFindNumber(&ScopeParametersNP, "GUIDER_APERTURE"))
+    if (ScopeParametersNP.findWidgetByName("GUIDER_APERTURE"))
     {
-        IUFindNumber(&ScopeParametersNP, "GUIDER_APERTURE")->value = GScopeAp;
+        ScopeParametersNP.findWidgetByName("GUIDER_APERTURE")->value = GScopeAp;
     }
-    if (IUFindText(&ScopeConfigNameTP, "SCOPE_CONFIG_NAME"))
+    if (ScopeConfigNameTP.findWidgetByName("SCOPE_CONFIG_NAME"))
     {
-        IUSaveText(IUFindText(&ScopeConfigNameTP, "SCOPE_CONFIG_NAME"), ConfigName.c_str());
+        IUSaveText(ScopeConfigNameTP.findWidgetByName("SCOPE_CONFIG_NAME"), ConfigName.c_str());
     }
-    ScopeParametersNP.s = IPS_OK;
-    IDSetNumber(&ScopeParametersNP, nullptr);
-    ScopeConfigNameTP.s = IPS_OK;
-    IDSetText(&ScopeConfigNameTP, nullptr);
+    ScopeParametersNP.setState(IPS_OK);
+    ScopeParametersNP.apply();
+    ScopeConfigNameTP.setState(IPS_OK);
+    ScopeConfigNameTP.apply();
     delXMLEle(RootXmlNode);
     return true;
 }
@@ -2826,26 +2826,26 @@ bool Telescope::UpdateScopeConfig()
     double GScopeFoc = 0, GScopeAp = 0;
     std::string ConfigName;
 
-    if (IUFindNumber(&ScopeParametersNP, "TELESCOPE_FOCAL_LENGTH"))
+    if (ScopeParametersNP.findWidgetByName("TELESCOPE_FOCAL_LENGTH"))
     {
-        ScopeFoc = IUFindNumber(&ScopeParametersNP, "TELESCOPE_FOCAL_LENGTH")->value;
+        ScopeFoc = ScopeParametersNP.findWidgetByName("TELESCOPE_FOCAL_LENGTH")->value;
     }
-    if (IUFindNumber(&ScopeParametersNP, "TELESCOPE_APERTURE"))
+    if (ScopeParametersNP.findWidgetByName("TELESCOPE_APERTURE"))
     {
-        ScopeAp = IUFindNumber(&ScopeParametersNP, "TELESCOPE_APERTURE")->value;
+        ScopeAp = ScopeParametersNP.findWidgetByName("TELESCOPE_APERTURE")->value;
     }
-    if (IUFindNumber(&ScopeParametersNP, "GUIDER_FOCAL_LENGTH"))
+    if (ScopeParametersNP.findWidgetByName("GUIDER_FOCAL_LENGTH"))
     {
-        GScopeFoc = IUFindNumber(&ScopeParametersNP, "GUIDER_FOCAL_LENGTH")->value;
+        GScopeFoc = ScopeParametersNP.findWidgetByName("GUIDER_FOCAL_LENGTH")->value;
     }
-    if (IUFindNumber(&ScopeParametersNP, "GUIDER_APERTURE"))
+    if (ScopeParametersNP.findWidgetByName("GUIDER_APERTURE"))
     {
-        GScopeAp = IUFindNumber(&ScopeParametersNP, "GUIDER_APERTURE")->value;
+        GScopeAp = ScopeParametersNP.findWidgetByName("GUIDER_APERTURE")->value;
     }
-    if (IUFindText(&ScopeConfigNameTP, "SCOPE_CONFIG_NAME") &&
-            IUFindText(&ScopeConfigNameTP, "SCOPE_CONFIG_NAME")->text)
+    if (ScopeConfigNameTP.findWidgetByName("SCOPE_CONFIG_NAME") &&
+            ScopeConfigNameTP.findWidgetByName("SCOPE_CONFIG_NAME")->text)
     {
-        ConfigName = IUFindText(&ScopeConfigNameTP, "SCOPE_CONFIG_NAME")->text;
+        ConfigName = ScopeConfigNameTP.findWidgetByName("SCOPE_CONFIG_NAME")->text;
     }
     // Save the values to the actual XML file
     if (!CheckFile(ScopeConfigFileName, true))
@@ -3010,15 +3010,15 @@ void Telescope::sendTimeFromSystem()
     struct std::tm *utctimeinfo = std::gmtime(&t);
 
     strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", utctimeinfo);
-    IUSaveText(&TimeT[0], ts);
+    TimeTP[0].setText(ts);
 
     struct std::tm *localtimeinfo = std::localtime(&t);
     snprintf(ts, sizeof(ts), "%4.2f", (localtimeinfo->tm_gmtoff / 3600.0));
-    IUSaveText(&TimeT[1], ts);
+    TimeTP[1].setText(ts);
 
-    TimeTP.s = IPS_OK;
+    TimeTP.setState(IPS_OK);
 
-    IDSetText(&TimeTP, nullptr);
+    TimeTP.apply();
 }
 
 bool Telescope::getSimulatePierSide() const
@@ -3041,21 +3041,21 @@ const char * Telescope::getPierSideStr(TelescopePierSide ps)
 
 void Telescope::setSimulatePierSide(bool simulate)
 {
-    IUResetSwitch(&SimulatePierSideSP);
-    SimulatePierSideS[0].s = simulate ? ISS_ON : ISS_OFF;
-    SimulatePierSideS[1].s = simulate ? ISS_OFF : ISS_ON;
-    SimulatePierSideSP.s = IPS_OK;
-    IDSetSwitch(&SimulatePierSideSP, nullptr);
+    SimulatePierSideSP.reset();
+    SimulatePierSideSP[0].setState(simulate ? ISS_ON : ISS_OFF);
+    SimulatePierSideSP[1].setState(simulate ? ISS_OFF : ISS_ON);
+    SimulatePierSideSP.setState(IPS_OK);
+    SimulatePierSideSP.apply();
 
     if (simulate)
     {
         capability |= TELESCOPE_HAS_PIER_SIDE;
-        defineProperty(&PierSideSP);
+        defineProperty(PierSideSP);
     }
     else
     {
         capability &= static_cast<uint32_t>(~TELESCOPE_HAS_PIER_SIDE);
-        deleteProperty(PierSideSP.name);
+        deleteProperty(PierSideSP.getName());
     }
 
     m_simulatePierSide = simulate;

--- a/libs/indibase/inditelescope.h
+++ b/libs/indibase/inditelescope.h
@@ -24,6 +24,11 @@
 
 #include <string>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 /**
  * \class Telescope
  * \brief Class to provide general functionality of a telescope device.
@@ -693,37 +698,29 @@ class Telescope : public DefaultDevice
         TelescopeStatus RememberTrackState {SCOPE_IDLE};
 
         // All telescopes should produce equatorial co-ordinates
-        INumberVectorProperty EqNP;
-        INumber EqN[2];
+        INDI::PropertyNumber EqNP {2};
 
         // When a goto is issued, domes will snoop the target property
         // to start moving the dome when a telescope moves
-        INumberVectorProperty TargetNP;
-        INumber TargetN[2];
+        INDI::PropertyNumber TargetNP {2};
 
         // Abort motion
-        ISwitchVectorProperty AbortSP;
-        ISwitch AbortS[1];
+        INDI::PropertySwitch AbortSP {1};
 
         // On a coord_set message, sync, or slew
-        ISwitchVectorProperty CoordSP;
-        ISwitch CoordS[3];
+        INDI::PropertySwitch CoordSP {3};
 
         // A number vector that stores lattitude and longitude
-        INumberVectorProperty LocationNP;
-        INumber LocationN[3];
+        INDI::PropertyNumber LocationNP {3};
 
         // A Switch in the client interface to park the scope
-        ISwitchVectorProperty ParkSP;
-        ISwitch ParkS[2];
+        INDI::PropertySwitch ParkSP {2};
 
         // Custom parking position
-        INumber ParkPositionN[2];
-        INumberVectorProperty ParkPositionNP;
+        INDI::PropertyNumber ParkPositionNP {2};
 
         // Custom parking options
-        ISwitch ParkOptionS[4];
-        ISwitchVectorProperty ParkOptionSP;
+        INDI::PropertySwitch ParkOptionSP {4};
         enum
         {
             PARK_CURRENT,
@@ -733,37 +730,30 @@ class Telescope : public DefaultDevice
         };
 
         // A switch for North/South motion
-        ISwitch MovementNSS[2];
-        ISwitchVectorProperty MovementNSSP;
+        INDI::PropertySwitch MovementNSSP {2};
 
         // A switch for West/East motion
-        ISwitch MovementWES[2];
-        ISwitchVectorProperty MovementWESP;
+        INDI::PropertySwitch MovementWESP {2};
 
         // Slew Rate
         ISwitchVectorProperty SlewRateSP;
         ISwitch *SlewRateS {nullptr};
 
         // Telescope & guider aperture and focal length
-        INumber ScopeParametersN[4];
-        INumberVectorProperty ScopeParametersNP;
+        INDI::PropertyNumber ScopeParametersNP {4};
 
         // UTC and UTC Offset
-        IText TimeT[2] {};
-        ITextVectorProperty TimeTP;
+        INDI::PropertyText TimeTP {2};
         void sendTimeFromSystem();
 
         // Active GPS/Dome device to snoop
-        ITextVectorProperty ActiveDeviceTP;
-        IText ActiveDeviceT[2] {};
+        INDI::PropertyText ActiveDeviceTP {2};
 
         // Switch to lock if dome is closed.
-        ISwitchVectorProperty DomePolicySP;
-        ISwitch DomePolicyS[2];
+        INDI::PropertySwitch DomePolicySP {2};
 
         // Switch for choosing between motion control by 4-way joystick or two seperate axes
-        ISwitchVectorProperty MotionControlModeTP;
-        ISwitch MotionControlModeT[2];
+        INDI::PropertySwitch MotionControlModeTP {2};
         enum
         {
             MOTION_CONTROL_JOYSTICK,
@@ -771,16 +761,13 @@ class Telescope : public DefaultDevice
         };
 
         // Lock Joystick Axis to one direciton only
-        ISwitch LockAxisS[2];
-        ISwitchVectorProperty LockAxisSP;
+        INDI::PropertySwitch LockAxisSP {2};
 
         // Pier Side
-        ISwitch PierSideS[2];
-        ISwitchVectorProperty PierSideSP;
+        INDI::PropertySwitch PierSideSP {2};
 
         // Pier Side Simulation
-        ISwitchVectorProperty SimulatePierSideSP;
-        ISwitch SimulatePierSideS[2];
+        INDI::PropertySwitch SimulatePierSideSP {2};
         bool getSimulatePierSide() const;
         void setSimulatePierSide(bool value);
 
@@ -794,8 +781,7 @@ class Telescope : public DefaultDevice
          * \brief Text Vector property defining the orbital elements of an artificial satellite (TLE).
          * \ref drivers/telescope/lx200_10micron.cpp "Example implementation"
          */
-        ITextVectorProperty TLEtoTrackTP;
-        IText TLEtoTrackT[1] {};
+        INDI::PropertyText TLEtoTrackTP {1};
         /**
          * \struct SatelliteWindow
          * \brief Satellite pass: window start and end.
@@ -810,8 +796,7 @@ class Telescope : public DefaultDevice
          * \brief Text Vector property defining the start and end of a satellite pass (window contains pass).
          * \ref drivers/telescope/lx200_10micron.cpp "Example implementation"
          */
-        ITextVectorProperty SatPassWindowTP;
-        IText SatPassWindowT[SAT_PASS_WINDOW_COUNT] {};
+        INDI::PropertyText SatPassWindowTP {SAT_PASS_WINDOW_COUNT};
         /**
          * \struct SatelliteTracking
          * \brief Possible states for the satellite tracking.
@@ -826,24 +811,20 @@ class Telescope : public DefaultDevice
          * \brief Switch Vector property defining the state of the satellite tracking of the mount.
          * \ref drivers/telescope/lx200_10micron.cpp "Example implementation"
          */
-        ISwitchVectorProperty TrackSatSP;
-        ISwitch TrackSatS[SAT_TRACK_COUNT];
+        INDI::PropertySwitch TrackSatSP {SAT_TRACK_COUNT};
         
         // PEC State
-        ISwitch PECStateS[2];
-        ISwitchVectorProperty PECStateSP;
+        INDI::PropertySwitch PECStateSP {2};
 
         // Track Mode
         ISwitchVectorProperty TrackModeSP;
         ISwitch *TrackModeS { nullptr };
 
         // Track State
-        ISwitchVectorProperty TrackStateSP;
-        ISwitch TrackStateS[2];
+        INDI::PropertySwitch TrackStateSP {2};
 
         // Track Rate
-        INumberVectorProperty TrackRateNP;
-        INumber TrackRateN[2];
+        INDI::PropertyNumber TrackRateNP {2};
 
         // PEC State
         TelescopePECState lastPECState {PEC_UNKNOWN}, currentPECState {PEC_UNKNOWN};
@@ -884,8 +865,7 @@ class Telescope : public DefaultDevice
         ISwitchVectorProperty ScopeConfigsSP;
 
         // Scope config name
-        ITextVectorProperty ScopeConfigNameTP;
-        IText ScopeConfigNameT[1] {};
+        INDI::PropertyText ScopeConfigNameTP {1};
 
         /// The telescope/guide scope configuration file name
         const std::string ScopeConfigFileName;

--- a/libs/indibase/indiweather.h
+++ b/libs/indibase/indiweather.h
@@ -29,6 +29,11 @@
 
 #include <list>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 namespace Connection
 {
 class Serial;
@@ -129,24 +134,19 @@ class Weather : public DefaultDevice, public WeatherInterface
         virtual bool Handshake();
 
         // A number vector that stores lattitude and longitude
-        INumberVectorProperty LocationNP;
-        INumber LocationN[3];
+        INDI::PropertyNumber LocationNP {3};
 
         // Active devices to snoop
-        ITextVectorProperty ActiveDeviceTP;
-        IText ActiveDeviceT[1] {};
+        INDI::PropertyText ActiveDeviceTP {1};
 
         // Update Period
-        INumber UpdatePeriodN[1];
-        INumberVectorProperty UpdatePeriodNP;
+        INDI::PropertyNumber UpdatePeriodNP {1};
 
         // Refresh data
-        ISwitch RefreshS[1];
-        ISwitchVectorProperty RefreshSP;
+        INDI::PropertySwitch RefreshSP {1};
 
         // Override
-        ISwitch OverrideS[1];
-        ISwitchVectorProperty OverrideSP;
+        INDI::PropertySwitch OverrideSP {1};
 
         Connection::Serial *serialConnection {nullptr};
         Connection::TCP *tcpConnection       {nullptr};

--- a/libs/lx/Lx.cpp
+++ b/libs/lx/Lx.cpp
@@ -20,7 +20,7 @@ void Lx::setCamerafd(int fd)
 
 bool Lx::isEnabled()
 {
-    return (LxEnableS[1].s == ISS_ON);
+    return (LxEnableSP[1].getState() == ISS_ON);
 }
 
 bool Lx::initProperties(INDI::DefaultDevice *device)
@@ -28,74 +28,74 @@ bool Lx::initProperties(INDI::DefaultDevice *device)
     //IDLog("Initializing Long Exposure Properties\n");
     dev         = device;
     device_name = dev->getDeviceName();
-    IUFillSwitch(&LxEnableS[0], "Disable", "", ISS_ON);
-    IUFillSwitch(&LxEnableS[1], "Enable", "", ISS_OFF);
-    IUFillSwitchVector(&LxEnableSP, LxEnableS, NARRAY(LxEnableS), device_name, "Activate", "", LX_TAB, IP_RW,
+    LxEnableSP[0].fill("Disable", "", ISS_ON);
+    LxEnableSP[1].fill("Enable", "", ISS_OFF);
+    LxEnableSP.fill(device_name, "Activate", "", LX_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LxModeS[LXSERIAL], "Serial", "", ISS_ON);
-    //IUFillSwitch(&LxModeS[LXPARALLEL], "Parallel", "", ISS_OFF);
-    IUFillSwitch(&LxModeS[LXLED], "SPC900 LED", "", ISS_OFF);
-    //IUFillSwitch(&LxModeS[LXGPIO], "GPIO (Arm/RPI)", "", ISS_OFF);
-    //  IUFillSwitch(&LxModeS[4], "IndiDuino Switcher", "", ISS_OFF); // Snooping is not enough
-    IUFillSwitchVector(&LxModeSP, LxModeS, NARRAY(LxModeS), device_name, "LX Mode", "", LX_TAB, IP_RW, ISR_1OFMANY, 0,
+    LxModeSP[LXSERIAL].fill("Serial", "", ISS_ON);
+    //LxModeSP[LXPARALLEL].fill("Parallel", "", ISS_OFF);
+    LxModeSP[LXLED].fill("SPC900 LED", "", ISS_OFF);
+    //LxModeSP[LXGPIO].fill("GPIO (Arm/RPI)", "", ISS_OFF);
+    //  LxModeSP[4].fill("IndiDuino Switcher", "", ISS_OFF); // Snooping is not enough
+    LxModeSP.fill(device_name, "LX Mode", "", LX_TAB, IP_RW, ISR_1OFMANY, 0,
                        IPS_IDLE);
-    IUFillText(&LxPortT[0], "Port", "", "/dev/ttyUSB0");
-    IUFillTextVector(&LxPortTP, LxPortT, NARRAY(LxPortT), device_name, "Lx port", "", LX_TAB, IP_RW, 0, IPS_IDLE);
-    IUFillSwitch(&LxSerialOptionS[0], "Use DTR (pin 4)", "", ISS_OFF);
-    IUFillSwitch(&LxSerialOptionS[1], "Use RTS (pin 7)", "", ISS_ON);
-    IUFillSwitch(&LxSerialOptionS[2], "Use Serial command", "", ISS_OFF);
-    IUFillSwitchVector(&LxSerialOptionSP, LxSerialOptionS, NARRAY(LxSerialOptionS), device_name, "Serial Options", "",
+    LxPortTP[0].fill("Port", "", "/dev/ttyUSB0");
+    LxPortTP.fill(device_name, "Lx port", "", LX_TAB, IP_RW, 0, IPS_IDLE);
+    LxSerialOptionSP[0].fill("Use DTR (pin 4)", "", ISS_OFF);
+    LxSerialOptionSP[1].fill("Use RTS (pin 7)", "", ISS_ON);
+    LxSerialOptionSP[2].fill("Use Serial command", "", ISS_OFF);
+    LxSerialOptionSP.fill(device_name, "Serial Options", "",
                        LX_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LxParallelOptionS[0], "Use Data 0 (pin 2)", "", ISS_OFF);
-    IUFillSwitch(&LxParallelOptionS[1], "Use Data 1 (pin 3)", "", ISS_ON); // Steve's Chambers Schematics
-    IUFillSwitch(&LxParallelOptionS[2], "Use Data 2 (pin 4)", "", ISS_OFF);
-    IUFillSwitch(&LxParallelOptionS[3], "Use Data 3 (pin 5)", "", ISS_OFF);
-    IUFillSwitch(&LxParallelOptionS[4], "Use Data 4 (pin 6)", "", ISS_OFF);
-    IUFillSwitch(&LxParallelOptionS[5], "Use Data 5 (pin 7)", "", ISS_OFF);
-    IUFillSwitch(&LxParallelOptionS[6], "Use Data 6 (pin 8)", "", ISS_OFF);
-    IUFillSwitch(&LxParallelOptionS[7], "Use Data 7 (pin 9)", "", ISS_OFF);
-    IUFillSwitch(&LxParallelOptionS[8], "Use Parallel command", "", ISS_OFF);
-    IUFillSwitchVector(&LxParallelOptionSP, LxParallelOptionS, NARRAY(LxParallelOptionS), device_name,
+    LxParallelOptionSP[0].fill("Use Data 0 (pin 2)", "", ISS_OFF);
+    LxParallelOptionSP[1].fill("Use Data 1 (pin 3)", "", ISS_ON); // Steve's Chambers Schematics
+    LxParallelOptionSP[2].fill("Use Data 2 (pin 4)", "", ISS_OFF);
+    LxParallelOptionSP[3].fill("Use Data 3 (pin 5)", "", ISS_OFF);
+    LxParallelOptionSP[4].fill("Use Data 4 (pin 6)", "", ISS_OFF);
+    LxParallelOptionSP[5].fill("Use Data 5 (pin 7)", "", ISS_OFF);
+    LxParallelOptionSP[6].fill("Use Data 6 (pin 8)", "", ISS_OFF);
+    LxParallelOptionSP[7].fill("Use Data 7 (pin 9)", "", ISS_OFF);
+    LxParallelOptionSP[8].fill("Use Parallel command", "", ISS_OFF);
+    LxParallelOptionSP.fill(device_name,
                        "Parallel Options", "", LX_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillText(&LxStartStopCmdT[0], "Start command", "", ":O1");
-    IUFillText(&LxStartStopCmdT[1], "Stop command", "", ":O0");
-    IUFillTextVector(&LxStartStopCmdTP, LxStartStopCmdT, NARRAY(LxStartStopCmdT), device_name, "Start/Stop commands",
+    LxStartStopCmdTP[0].fill("Start command", "", ":O1");
+    LxStartStopCmdTP[1].fill("Stop command", "", ":O0");
+    LxStartStopCmdTP.fill(device_name, "Start/Stop commands",
                      "", LX_TAB, IP_RW, 0, IPS_IDLE);
-    IUFillSwitch(&LxLogicalLevelS[0], "Low to High", "", ISS_ON);
-    IUFillSwitch(&LxLogicalLevelS[1], "High to Low", "", ISS_OFF);
-    IUFillSwitchVector(&LxLogicalLevelSP, LxLogicalLevelS, NARRAY(LxLogicalLevelS), device_name, "Start Transition", "",
+    LxLogicalLevelSP[0].fill("Low to High", "", ISS_ON);
+    LxLogicalLevelSP[1].fill("High to Low", "", ISS_OFF);
+    LxLogicalLevelSP.fill(device_name, "Start Transition", "",
                        LX_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LxSerialSpeedS[0], "1200", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSpeedS[1], "2400", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSpeedS[2], "4800", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSpeedS[3], "9600", "", ISS_ON);
-    IUFillSwitch(&LxSerialSpeedS[4], "19200", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSpeedS[5], "38400", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSpeedS[6], "57600", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSpeedS[7], "115200", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSpeedS[8], "230400", "", ISS_OFF);
-    IUFillSwitchVector(&LxSerialSpeedSP, LxSerialSpeedS, NARRAY(LxSerialSpeedS), device_name, "Serial speed", "",
+    LxSerialSpeedSP[0].fill("1200", "", ISS_OFF);
+    LxSerialSpeedSP[1].fill("2400", "", ISS_OFF);
+    LxSerialSpeedSP[2].fill("4800", "", ISS_OFF);
+    LxSerialSpeedSP[3].fill("9600", "", ISS_ON);
+    LxSerialSpeedSP[4].fill("19200", "", ISS_OFF);
+    LxSerialSpeedSP[5].fill("38400", "", ISS_OFF);
+    LxSerialSpeedSP[6].fill("57600", "", ISS_OFF);
+    LxSerialSpeedSP[7].fill("115200", "", ISS_OFF);
+    LxSerialSpeedSP[8].fill("230400", "", ISS_OFF);
+    LxSerialSpeedSP.fill(device_name, "Serial speed", "",
                        LX_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LxSerialSizeS[0], "5", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSizeS[1], "6", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSizeS[2], "7", "", ISS_OFF);
-    IUFillSwitch(&LxSerialSizeS[3], "8", "", ISS_ON);
-    IUFillSwitchVector(&LxSerialSizeSP, LxSerialSizeS, NARRAY(LxSerialSizeS), device_name, "Serial size", "", LX_TAB,
+    LxSerialSizeSP[0].fill("5", "", ISS_OFF);
+    LxSerialSizeSP[1].fill("6", "", ISS_OFF);
+    LxSerialSizeSP[2].fill("7", "", ISS_OFF);
+    LxSerialSizeSP[3].fill("8", "", ISS_ON);
+    LxSerialSizeSP.fill(device_name, "Serial size", "", LX_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LxSerialParityS[0], "None", "", ISS_ON);
-    IUFillSwitch(&LxSerialParityS[1], "Even", "", ISS_OFF);
-    IUFillSwitch(&LxSerialParityS[2], "Odd", "", ISS_OFF);
-    IUFillSwitchVector(&LxSerialParitySP, LxSerialParityS, NARRAY(LxSerialParityS), device_name, "Serial parity", "",
+    LxSerialParitySP[0].fill("None", "", ISS_ON);
+    LxSerialParitySP[1].fill("Even", "", ISS_OFF);
+    LxSerialParitySP[2].fill("Odd", "", ISS_OFF);
+    LxSerialParitySP.fill(device_name, "Serial parity", "",
                        LX_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LxSerialStopS[0], "1", "", ISS_ON);
-    IUFillSwitch(&LxSerialStopS[1], "2", "", ISS_OFF);
-    IUFillSwitchVector(&LxSerialStopSP, LxSerialStopS, NARRAY(LxSerialStopS), device_name, "Serial stop", "", LX_TAB,
+    LxSerialStopSP[0].fill("1", "", ISS_ON);
+    LxSerialStopSP[1].fill("2", "", ISS_OFF);
+    LxSerialStopSP.fill(device_name, "Serial stop", "", LX_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillSwitch(&LxSerialAddeolS[0], "None", "", ISS_OFF);
-    IUFillSwitch(&LxSerialAddeolS[1], "CR (OxD, \\r)", "", ISS_ON);
-    IUFillSwitch(&LxSerialAddeolS[2], "LF (0xA, \\n)", "", ISS_OFF);
-    IUFillSwitch(&LxSerialAddeolS[3], "CR+LF", "", ISS_OFF);
-    IUFillSwitchVector(&LxSerialAddeolSP, LxSerialAddeolS, NARRAY(LxSerialAddeolS), device_name, "Add EOL", "", LX_TAB,
+    LxSerialAddeolSP[0].fill("None", "", ISS_OFF);
+    LxSerialAddeolSP[1].fill("CR (OxD, \\r)", "", ISS_ON);
+    LxSerialAddeolSP[2].fill("LF (0xA, \\n)", "", ISS_OFF);
+    LxSerialAddeolSP[3].fill("CR+LF", "", ISS_OFF);
+    LxSerialAddeolSP.fill(device_name, "Add EOL", "", LX_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
     FlashStrobeSP     = nullptr;
     FlashStrobeStopSP = nullptr;
@@ -108,18 +108,18 @@ bool Lx::updateProperties()
     if (dev->isConnected())
     {
         INDI::Property *pfound;
-        dev->defineProperty(&LxEnableSP);
-        dev->defineProperty(&LxModeSP);
-        dev->defineProperty(&LxPortTP);
-        dev->defineProperty(&LxSerialOptionSP);
-        //dev->defineProperty(&LxParallelOptionSP);
-        dev->defineProperty(&LxStartStopCmdTP);
-        dev->defineProperty(&LxLogicalLevelSP);
-        dev->defineProperty(&LxSerialSpeedSP);
-        dev->defineProperty(&LxSerialSizeSP);
-        dev->defineProperty(&LxSerialParitySP);
-        dev->defineProperty(&LxSerialStopSP);
-        dev->defineProperty(&LxSerialAddeolSP);
+        dev->defineProperty(LxEnableSP);
+        dev->defineProperty(LxModeSP);
+        dev->defineProperty(LxPortTP);
+        dev->defineProperty(LxSerialOptionSP);
+        //dev->defineProperty(LxParallelOptionSP);
+        dev->defineProperty(LxStartStopCmdTP);
+        dev->defineProperty(LxLogicalLevelSP);
+        dev->defineProperty(LxSerialSpeedSP);
+        dev->defineProperty(LxSerialSizeSP);
+        dev->defineProperty(LxSerialParitySP);
+        dev->defineProperty(LxSerialStopSP);
+        dev->defineProperty(LxSerialAddeolSP);
         pfound = findbyLabel(dev, (char *)"Strobe");
         if (pfound)
         {
@@ -130,18 +130,18 @@ bool Lx::updateProperties()
     }
     else
     {
-        dev->deleteProperty(LxEnableSP.name);
-        dev->deleteProperty(LxModeSP.name);
-        dev->deleteProperty(LxPortTP.name);
-        dev->deleteProperty(LxSerialOptionSP.name);
-        //dev->deleteProperty(LxParallelOptionSP.name);
-        dev->deleteProperty(LxStartStopCmdTP.name);
-        dev->deleteProperty(LxLogicalLevelSP.name);
-        dev->deleteProperty(LxSerialSpeedSP.name);
-        dev->deleteProperty(LxSerialSizeSP.name);
-        dev->deleteProperty(LxSerialParitySP.name);
-        dev->deleteProperty(LxSerialStopSP.name);
-        dev->deleteProperty(LxSerialAddeolSP.name);
+        dev->deleteProperty(LxEnableSP.getName());
+        dev->deleteProperty(LxModeSP.getName());
+        dev->deleteProperty(LxPortTP.getName());
+        dev->deleteProperty(LxSerialOptionSP.getName());
+        //dev->deleteProperty(LxParallelOptionSP.getName());
+        dev->deleteProperty(LxStartStopCmdTP.getName());
+        dev->deleteProperty(LxLogicalLevelSP.getName());
+        dev->deleteProperty(LxSerialSpeedSP.getName());
+        dev->deleteProperty(LxSerialSizeSP.getName());
+        dev->deleteProperty(LxSerialParitySP.getName());
+        dev->deleteProperty(LxSerialStopSP.getName());
+        dev->deleteProperty(LxSerialAddeolSP.getName());
         FlashStrobeSP     = nullptr;
         FlashStrobeStopSP = nullptr;
     }
@@ -154,124 +154,124 @@ bool Lx::ISNewSwitch(const char *devname, const char *name, ISState *states, cha
     if (devname && strcmp(device_name, devname))
         return true;
 
-    if (!strcmp(name, LxEnableSP.name))
+    if (LxEnableSP.isNameMatch(name))
     {
-        IUResetSwitch(&LxEnableSP);
-        IUUpdateSwitch(&LxEnableSP, states, names, n);
-        LxEnableSP.s = IPS_OK;
+        LxEnableSP.reset();
+        LxEnableSP.update(states, names, n);
+        LxEnableSP.setState(IPS_OK);
 
-        IDSetSwitch(&LxEnableSP, "%s long exposure on device %s", (LxEnableS[0].s == ISS_ON ? "Disabling" : "Enabling"),
+        LxEnableSP.apply("%s long exposure on device %s", (LxEnableSP[0].getState() == ISS_ON ? "Disabling" : "Enabling"),
                     device_name);
         return true;
     }
 
-    if (!strcmp(name, LxModeSP.name))
+    if (LxModeSP.isNameMatch(name))
     {
         unsigned int index, oldindex;
-        oldindex = IUFindOnSwitchIndex(&LxModeSP);
-        IUResetSwitch(&LxModeSP);
-        IUUpdateSwitch(&LxModeSP, states, names, n);
-        LxModeSP.s = IPS_OK;
-        index      = IUFindOnSwitchIndex(&LxModeSP);
+        oldindex = LxModeSP.findOnSwitchIndex();
+        LxModeSP.reset();
+        LxModeSP.update(states, names, n);
+        LxModeSP.setState(IPS_OK);
+        index      = LxModeSP.findOnSwitchIndex();
         if (index == LXLED)
             if (!checkPWC())
             {
-                IUResetSwitch(&LxModeSP);
-                LxModeSP.s          = IPS_ALERT;
-                LxModeS[oldindex].s = ISS_ON;
-                IDSetSwitch(&LxModeSP, "Can not set Lx Mode to %s", LxModeS[index].name);
+                LxModeSP.reset();
+                LxModeSP.setState(IPS_ALERT);
+                LxModeSP[oldindex].setState(ISS_ON);
+                LxModeSP.apply("Can not set Lx Mode to %s", LxModeSP[index].getName());
                 return false;
             }
-        IDSetSwitch(&LxModeSP, "Setting Lx Mode to %s", LxModeS[index].name);
+        LxModeSP.apply("Setting Lx Mode to %s", LxModeSP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxSerialOptionSP.name))
+    if (LxSerialOptionSP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxSerialOptionSP);
-        IUUpdateSwitch(&LxSerialOptionSP, states, names, n);
-        LxSerialOptionSP.s = IPS_OK;
-        index              = IUFindOnSwitchIndex(&LxSerialOptionSP);
-        IDSetSwitch(&LxSerialOptionSP, "Setting Lx Serial option: %s", LxSerialOptionS[index].name);
+        LxSerialOptionSP.reset();
+        LxSerialOptionSP.update(states, names, n);
+        LxSerialOptionSP.setState(IPS_OK);
+        index              = LxSerialOptionSP.findOnSwitchIndex();
+        LxSerialOptionSP.apply("Setting Lx Serial option: %s", LxSerialOptionSP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxParallelOptionSP.name))
+    if (LxParallelOptionSP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxParallelOptionSP);
-        IUUpdateSwitch(&LxParallelOptionSP, states, names, n);
-        LxParallelOptionSP.s = IPS_OK;
-        index                = IUFindOnSwitchIndex(&LxParallelOptionSP);
-        IDSetSwitch(&LxParallelOptionSP, "Setting Lx Parallel option: %s", LxParallelOptionS[index].name);
+        LxParallelOptionSP.reset();
+        LxParallelOptionSP.update(states, names, n);
+        LxParallelOptionSP.setState(IPS_OK);
+        index                = LxParallelOptionSP.findOnSwitchIndex();
+        LxParallelOptionSP.apply("Setting Lx Parallel option: %s", LxParallelOptionSP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxLogicalLevelSP.name))
+    if (LxLogicalLevelSP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxLogicalLevelSP);
-        IUUpdateSwitch(&LxLogicalLevelSP, states, names, n);
-        LxLogicalLevelSP.s = IPS_OK;
-        index              = IUFindOnSwitchIndex(&LxLogicalLevelSP);
-        IDSetSwitch(&LxLogicalLevelSP, "Setting Lx logical levels for start transition: %s",
-                    LxLogicalLevelS[index].name);
+        LxLogicalLevelSP.reset();
+        LxLogicalLevelSP.update(states, names, n);
+        LxLogicalLevelSP.setState(IPS_OK);
+        index              = LxLogicalLevelSP.findOnSwitchIndex();
+        LxLogicalLevelSP.apply("Setting Lx logical levels for start transition: %s",
+                    LxLogicalLevelSP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxSerialSpeedSP.name))
+    if (LxSerialSpeedSP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxSerialSpeedSP);
-        IUUpdateSwitch(&LxSerialSpeedSP, states, names, n);
-        LxSerialSpeedSP.s = IPS_OK;
-        index             = IUFindOnSwitchIndex(&LxSerialSpeedSP);
-        IDSetSwitch(&LxSerialSpeedSP, "Setting Lx serial speed: %s", LxSerialSpeedS[index].name);
+        LxSerialSpeedSP.reset();
+        LxSerialSpeedSP.update(states, names, n);
+        LxSerialSpeedSP.setState(IPS_OK);
+        index             = LxSerialSpeedSP.findOnSwitchIndex();
+        LxSerialSpeedSP.apply("Setting Lx serial speed: %s", LxSerialSpeedSP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxSerialSizeSP.name))
+    if (LxSerialSizeSP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxSerialSizeSP);
-        IUUpdateSwitch(&LxSerialSizeSP, states, names, n);
-        LxSerialSizeSP.s = IPS_OK;
-        index            = IUFindOnSwitchIndex(&LxSerialSizeSP);
-        IDSetSwitch(&LxSerialSizeSP, "Setting Lx serial word size: %s", LxSerialSizeS[index].name);
+        LxSerialSizeSP.reset();
+        LxSerialSizeSP.update(states, names, n);
+        LxSerialSizeSP.setState(IPS_OK);
+        index            = LxSerialSizeSP.findOnSwitchIndex();
+        LxSerialSizeSP.apply("Setting Lx serial word size: %s", LxSerialSizeSP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxSerialParitySP.name))
+    if (LxSerialParitySP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxSerialParitySP);
-        IUUpdateSwitch(&LxSerialParitySP, states, names, n);
-        LxSerialParitySP.s = IPS_OK;
-        index              = IUFindOnSwitchIndex(&LxSerialParitySP);
-        IDSetSwitch(&LxSerialParitySP, "Setting Lx serial parity: %s", LxSerialParityS[index].name);
+        LxSerialParitySP.reset();
+        LxSerialParitySP.update(states, names, n);
+        LxSerialParitySP.setState(IPS_OK);
+        index              = LxSerialParitySP.findOnSwitchIndex();
+        LxSerialParitySP.apply("Setting Lx serial parity: %s", LxSerialParitySP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxSerialStopSP.name))
+    if (LxSerialStopSP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxSerialStopSP);
-        IUUpdateSwitch(&LxSerialStopSP, states, names, n);
-        LxSerialStopSP.s = IPS_OK;
-        index            = IUFindOnSwitchIndex(&LxSerialStopSP);
-        IDSetSwitch(&LxSerialStopSP, "Setting Lx serial stop bits: %s", LxSerialStopS[index].name);
+        LxSerialStopSP.reset();
+        LxSerialStopSP.update(states, names, n);
+        LxSerialStopSP.setState(IPS_OK);
+        index            = LxSerialStopSP.findOnSwitchIndex();
+        LxSerialStopSP.apply("Setting Lx serial stop bits: %s", LxSerialStopSP[index].getName());
         return true;
     }
 
-    if (!strcmp(name, LxSerialAddeolSP.name))
+    if (LxSerialAddeolSP.isNameMatch(name))
     {
         unsigned int index;
-        IUResetSwitch(&LxSerialAddeolSP);
-        IUUpdateSwitch(&LxSerialAddeolSP, states, names, n);
-        LxSerialAddeolSP.s = IPS_OK;
-        index              = IUFindOnSwitchIndex(&LxSerialAddeolSP);
-        IDSetSwitch(&LxSerialAddeolSP, "Setting Lx End of Line: %s", LxSerialAddeolS[index].name);
+        LxSerialAddeolSP.reset();
+        LxSerialAddeolSP.update(states, names, n);
+        LxSerialAddeolSP.setState(IPS_OK);
+        index              = LxSerialAddeolSP.findOnSwitchIndex();
+        LxSerialAddeolSP.apply("Setting Lx End of Line: %s", LxSerialAddeolSP[index].getName());
         return true;
     }
 
@@ -285,29 +285,29 @@ bool Lx::ISNewText(const char *devname, const char *name, char *texts[], char *n
     if (devname && strcmp(device_name, devname))
         return true;
 
-    if (!strcmp(name, LxPortTP.name))
+    if (LxPortTP.isNameMatch(name))
     {
-        LxPortTP.s = IPS_OK;
-        tp         = IUFindText(&LxPortTP, names[0]);
+        LxPortTP.setState(IPS_OK);
+        tp         = LxPortTP.findWidgetByName(names[0]);
         if (!tp)
             return false;
 
         IUSaveText(tp, texts[0]);
-        IDSetText(&LxPortTP, "Setting Lx port to %s", tp->text);
+        LxPortTP.apply("Setting Lx port to %s", tp->text);
         return true;
     }
 
-    if (!strcmp(name, LxStartStopCmdTP.name))
+    if (LxStartStopCmdTP.isNameMatch(name))
     {
-        LxStartStopCmdTP.s = IPS_OK;
+        LxStartStopCmdTP.setState(IPS_OK);
         for (int i = 0; i < n; i++)
         {
-            tp = IUFindText(&LxStartStopCmdTP, names[i]);
+            tp = LxStartStopCmdTP.findWidgetByName(names[i]);
             if (!tp)
                 return false;
             IUSaveText(tp, texts[i]);
         }
-        IDSetText(&LxStartStopCmdTP, "Setting Lx Start/stop commands");
+        LxStartStopCmdTP.apply("Setting Lx Start/stop commands");
         return true;
     }
 
@@ -316,14 +316,14 @@ bool Lx::ISNewText(const char *devname, const char *name, char *texts[], char *n
 
 unsigned int Lx::getLxmode()
 {
-    return IUFindOnSwitchIndex(&LxModeSP);
+    return LxModeSP.findOnSwitchIndex();
 }
 
 bool Lx::startLx()
 {
     unsigned int index;
     IDMessage(device_name, "Starting Long Exposure");
-    index = IUFindOnSwitchIndex(&LxModeSP);
+    index = LxModeSP.findOnSwitchIndex();
     switch (index)
     {
         case LXSERIAL:
@@ -341,7 +341,7 @@ int Lx::stopLx()
     unsigned int index = 0;
 
     IDMessage(device_name, "Stopping Long Exposure");
-    index = IUFindOnSwitchIndex(&LxModeSP);
+    index = LxModeSP.findOnSwitchIndex();
     switch (index)
     {
         case LXSERIAL:
@@ -461,20 +461,20 @@ void Lx::getSerialOptions(unsigned int *speed, unsigned int *wordsize, unsigned 
     unsigned int sizeopts[]   = { 5, 6, 7, 8 };
     unsigned int parityopts[] = { PARITY_NONE, PARITY_EVEN, PARITY_ODD };
     unsigned int stopopts[]   = { 1, 2 };
-    index                     = IUFindOnSwitchIndex(&LxSerialSpeedSP);
+    index                     = LxSerialSpeedSP.findOnSwitchIndex();
     *speed                    = speedopts[index];
-    index                     = IUFindOnSwitchIndex(&LxSerialSizeSP);
+    index                     = LxSerialSizeSP.findOnSwitchIndex();
     *wordsize                 = sizeopts[index];
-    index                     = IUFindOnSwitchIndex(&LxSerialParitySP);
+    index                     = LxSerialParitySP.findOnSwitchIndex();
     *parity                   = parityopts[index];
-    index                     = IUFindOnSwitchIndex(&LxSerialStopSP);
+    index                     = LxSerialStopSP.findOnSwitchIndex();
     *stops                    = stopopts[index];
 }
 
 const char *Lx::getSerialEOL()
 {
     unsigned int index;
-    index = IUFindOnSwitchIndex(&LxSerialAddeolSP);
+    index = LxSerialAddeolSP.findOnSwitchIndex();
     switch (index)
     {
         case 0:
@@ -493,25 +493,25 @@ bool Lx::startLxSerial()
 {
     unsigned int speed = 0, wordsize = 0, parity = 0, stops = 0;
     const char *eol = nullptr;
-    unsigned int index = IUFindOnSwitchIndex(&LxSerialOptionSP);
+    unsigned int index = LxSerialOptionSP.findOnSwitchIndex();
     int ret = 0;
 
     switch (index)
     {
         case 0:
-            serialfd = openserial(LxPortT[0].text);
+            serialfd = openserial(LxPortTP[0].getText());
             if (serialfd < 0)
                 return false;
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 setDTR(serialfd, 1);
             else
                 setDTR(serialfd, 0);
             break;
         case 1:
-            serialfd = openserial(LxPortT[0].text);
+            serialfd = openserial(LxPortTP[0].getText());
             if (serialfd < 0)
                 return false;
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 setRTS(serialfd, 1);
             else
                 setRTS(serialfd, 0);
@@ -519,11 +519,11 @@ bool Lx::startLxSerial()
         case 2:
             getSerialOptions(&speed, &wordsize, &parity, &stops);
             eol = getSerialEOL();
-            tty_connect(LxPortT[0].text, speed, wordsize, parity, stops, &serialfd);
+            tty_connect(LxPortTP[0].getText(), speed, wordsize, parity, stops, &serialfd);
             if (serialfd < 0)
                 return false;
 
-            ret = write(serialfd, LxStartStopCmdT[0].text, strlen(LxStartStopCmdT[0].text));
+            ret = write(serialfd, LxStartStopCmdTP[0].getText(), strlen(LxStartStopCmdTP[0].getText()));
             ret = write(serialfd, eol, strlen(eol));
             break;
     }
@@ -534,24 +534,24 @@ int Lx::stopLxSerial()
 {
     int ret = 0;
     const char *eol = nullptr;
-    unsigned int index = IUFindOnSwitchIndex(&LxSerialOptionSP);
+    unsigned int index = LxSerialOptionSP.findOnSwitchIndex();
 
     switch (index)
     {
         case 0:
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 setDTR(serialfd, 0);
             else
                 setDTR(serialfd, 1);
             break;
         case 1:
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 setRTS(serialfd, 0);
             else
                 setRTS(serialfd, 1);
             break;
         case 2:
-            ret = write(serialfd, LxStartStopCmdT[1].text, strlen(LxStartStopCmdT[1].text));
+            ret = write(serialfd, LxStartStopCmdTP[1].getText(), strlen(LxStartStopCmdTP[1].getText()));
             eol = getSerialEOL();
             ret = write(serialfd, eol, strlen(eol));
             break;
@@ -631,13 +631,13 @@ bool Lx::startLxPWC()
     switch (ledmethod)
     {
         case PWCIOCTL:
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 pwcsetLed(25500, 0);
             else
                 pwcsetLed(0, 25500);
             return true;
         case FLASHLED:
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 pwcsetflashon();
             else
                 pwcsetflashoff();
@@ -652,13 +652,13 @@ int Lx::stopLxPWC()
     switch (ledmethod)
     {
         case PWCIOCTL:
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 pwcsetLed(0, 25500);
             else
                 pwcsetLed(25500, 0);
             return 0;
         case FLASHLED:
-            if (LxLogicalLevelS[0].s == ISS_ON)
+            if (LxLogicalLevelSP[0].getState() == ISS_ON)
                 pwcsetflashoff();
             else
                 pwcsetflashon();

--- a/libs/lx/Lx.h
+++ b/libs/lx/Lx.h
@@ -9,6 +9,10 @@
 //For serial control
 #include <termios.h>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+
 #define LX_TAB "Long Exposure"
 // LX Modes
 #define LXSERIAL   0
@@ -21,30 +25,18 @@
 class Lx
 {
   public:
-    ISwitch LxEnableS[2];
-    ISwitchVectorProperty LxEnableSP;
-    ISwitch LxModeS[LXMODENUM];
-    ISwitchVectorProperty LxModeSP;
-    IText LxPortT[1];
-    ITextVectorProperty LxPortTP;
-    ISwitch LxSerialOptionS[3];
-    ISwitchVectorProperty LxSerialOptionSP;
-    ISwitch LxParallelOptionS[9];
-    ISwitchVectorProperty LxParallelOptionSP;
-    IText LxStartStopCmdT[2];
-    ITextVectorProperty LxStartStopCmdTP;
-    ISwitch LxLogicalLevelS[2];
-    ISwitchVectorProperty LxLogicalLevelSP;
-    ISwitch LxSerialSpeedS[9];
-    ISwitchVectorProperty LxSerialSpeedSP;
-    ISwitch LxSerialSizeS[4];
-    ISwitchVectorProperty LxSerialSizeSP;
-    ISwitch LxSerialParityS[3];
-    ISwitchVectorProperty LxSerialParitySP;
-    ISwitch LxSerialStopS[2];
-    ISwitchVectorProperty LxSerialStopSP;
-    ISwitch LxSerialAddeolS[4];
-    ISwitchVectorProperty LxSerialAddeolSP;
+    INDI::PropertySwitch LxEnableSP {2};
+    INDI::PropertySwitch LxModeSP {LXMODENUM};
+    INDI::PropertyText LxPortTP {1};
+    INDI::PropertySwitch LxSerialOptionSP {3};
+    INDI::PropertySwitch LxParallelOptionSP {9};
+    INDI::PropertyText LxStartStopCmdTP {2};
+    INDI::PropertySwitch LxLogicalLevelSP {2};
+    INDI::PropertySwitch LxSerialSpeedSP {9};
+    INDI::PropertySwitch LxSerialSizeSP {4};
+    INDI::PropertySwitch LxSerialParitySP {3};
+    INDI::PropertySwitch LxSerialStopSP {2};
+    INDI::PropertySwitch LxSerialAddeolSP {4};
 
     bool isEnabled();
     void setCamerafd(int fd);

--- a/libs/stream/streammanager.cpp
+++ b/libs/stream/streammanager.cpp
@@ -88,85 +88,85 @@ const char * StreamManager::getDeviceName()
 bool StreamManager::initProperties()
 {
     /* Video Stream */
-    IUFillSwitch(&StreamS[0], "STREAM_ON", "Stream On", ISS_OFF);
-    IUFillSwitch(&StreamS[1], "STREAM_OFF", "Stream Off", ISS_ON);
+    StreamSP[0].fill("STREAM_ON", "Stream On", ISS_OFF);
+    StreamSP[1].fill("STREAM_OFF", "Stream Off", ISS_ON);
     if(currentDevice->getDriverInterface() & INDI::DefaultDevice::SENSOR_INTERFACE)
-        IUFillSwitchVector(&StreamSP, StreamS, NARRAY(StreamS), getDeviceName(), "SENSOR_DATA_STREAM", "Video Stream",
+        StreamSP.fill(getDeviceName(), "SENSOR_DATA_STREAM", "Video Stream",
                            STREAM_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
     else
-        IUFillSwitchVector(&StreamSP, StreamS, NARRAY(StreamS), getDeviceName(), "CCD_VIDEO_STREAM", "Video Stream",
+        StreamSP.fill(getDeviceName(), "CCD_VIDEO_STREAM", "Video Stream",
                            STREAM_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    IUFillNumber(&StreamExposureN[STREAM_EXPOSURE], "STREAMING_EXPOSURE_VALUE", "Duration (s)", "%.6f", 0.000001, 60, 0.1, 0.1);
-    IUFillNumber(&StreamExposureN[STREAM_DIVISOR], "STREAMING_DIVISOR_VALUE", "Divisor", "%.f", 1, 15, 1, 1);
-    IUFillNumberVector(&StreamExposureNP, StreamExposureN, NARRAY(StreamExposureN), getDeviceName(), "STREAMING_EXPOSURE",
+    StreamExposureNP[STREAM_EXPOSURE].fill("STREAMING_EXPOSURE_VALUE", "Duration (s)", "%.6f", 0.000001, 60, 0.1, 0.1);
+    StreamExposureNP[STREAM_DIVISOR].fill("STREAMING_DIVISOR_VALUE", "Divisor", "%.f", 1, 15, 1, 1);
+    StreamExposureNP.fill(getDeviceName(), "STREAMING_EXPOSURE",
                        "Expose", STREAM_TAB, IP_RW, 60, IPS_IDLE);
 
     /* Measured FPS */
-    IUFillNumber(&FpsN[FPS_INSTANT], "EST_FPS", "Instant.", "%.2f", 0.0, 999.0, 0.0, 30);
-    IUFillNumber(&FpsN[FPS_AVERAGE], "AVG_FPS", "Average (1 sec.)", "%.2f", 0.0, 999.0, 0.0, 30);
-    IUFillNumberVector(&FpsNP, FpsN, NARRAY(FpsN), getDeviceName(), "FPS", "FPS", STREAM_TAB, IP_RO, 60, IPS_IDLE);
+    FpsNP[FPS_INSTANT].fill("EST_FPS", "Instant.", "%.2f", 0.0, 999.0, 0.0, 30);
+    FpsNP[FPS_AVERAGE].fill("AVG_FPS", "Average (1 sec.)", "%.2f", 0.0, 999.0, 0.0, 30);
+    FpsNP.fill(getDeviceName(), "FPS", "FPS", STREAM_TAB, IP_RO, 60, IPS_IDLE);
 
     /* Record Frames */
     /* File */
     std::string defaultDirectory = std::string(getenv("HOME")) + std::string("/indi__D_");
-    IUFillText(&RecordFileT[0], "RECORD_FILE_DIR", "Dir.", defaultDirectory.data());
-    IUFillText(&RecordFileT[1], "RECORD_FILE_NAME", "Name", "indi_record__T_");
-    IUFillTextVector(&RecordFileTP, RecordFileT, NARRAY(RecordFileT), getDeviceName(), "RECORD_FILE", "Record File",
+    RecordFileTP[0].fill("RECORD_FILE_DIR", "Dir.", defaultDirectory.data());
+    RecordFileTP[1].fill("RECORD_FILE_NAME", "Name", "indi_record__T_");
+    RecordFileTP.fill(getDeviceName(), "RECORD_FILE", "Record File",
                      STREAM_TAB, IP_RW, 0, IPS_IDLE);
 
     /* Record Options */
-    IUFillNumber(&RecordOptionsN[0], "RECORD_DURATION", "Duration (sec)", "%.3f", 0.001, 999999.0, 0.0, 1);
-    IUFillNumber(&RecordOptionsN[1], "RECORD_FRAME_TOTAL", "Frames", "%.f", 1.0, 999999999.0, 1.0, 30.0);
-    IUFillNumberVector(&RecordOptionsNP, RecordOptionsN, NARRAY(RecordOptionsN), getDeviceName(), "RECORD_OPTIONS",
+    RecordOptionsNP[0].fill("RECORD_DURATION", "Duration (sec)", "%.3f", 0.001, 999999.0, 0.0, 1);
+    RecordOptionsNP[1].fill("RECORD_FRAME_TOTAL", "Frames", "%.f", 1.0, 999999999.0, 1.0, 30.0);
+    RecordOptionsNP.fill(getDeviceName(), "RECORD_OPTIONS",
                        "Record Options", STREAM_TAB, IP_RW, 60, IPS_IDLE);
 
     /* Record Switch */
-    IUFillSwitch(&RecordStreamS[RECORD_ON], "RECORD_ON", "Record On", ISS_OFF);
-    IUFillSwitch(&RecordStreamS[RECORD_TIME], "RECORD_DURATION_ON", "Record (Duration)", ISS_OFF);
-    IUFillSwitch(&RecordStreamS[RECORD_FRAME], "RECORD_FRAME_ON", "Record (Frames)", ISS_OFF);
-    IUFillSwitch(&RecordStreamS[RECORD_OFF], "RECORD_OFF", "Record Off", ISS_ON);
-    IUFillSwitchVector(&RecordStreamSP, RecordStreamS, NARRAY(RecordStreamS), getDeviceName(), "RECORD_STREAM",
+    RecordStreamSP[RECORD_ON].fill("RECORD_ON", "Record On", ISS_OFF);
+    RecordStreamSP[RECORD_TIME].fill("RECORD_DURATION_ON", "Record (Duration)", ISS_OFF);
+    RecordStreamSP[RECORD_FRAME].fill("RECORD_FRAME_ON", "Record (Frames)", ISS_OFF);
+    RecordStreamSP[RECORD_OFF].fill("RECORD_OFF", "Record Off", ISS_ON);
+    RecordStreamSP.fill(getDeviceName(), "RECORD_STREAM",
                        "Video Record", STREAM_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     if(currentDevice->getDriverInterface() & INDI::DefaultDevice::CCD_INTERFACE)
     {
         // CCD Streaming Frame
-        IUFillNumber(&StreamFrameN[0], "X", "Left ", "%.f", 0, 0.0, 0, 0);
-        IUFillNumber(&StreamFrameN[1], "Y", "Top", "%.f", 0, 0, 0, 0);
-        IUFillNumber(&StreamFrameN[2], "WIDTH", "Width", "%.f", 0, 0.0, 0, 0.0);
-        IUFillNumber(&StreamFrameN[3], "HEIGHT", "Height", "%.f", 0, 0, 0, 0.0);
-        IUFillNumberVector(&StreamFrameNP, StreamFrameN, 4, getDeviceName(), "CCD_STREAM_FRAME", "Frame", STREAM_TAB, IP_RW,
+        StreamFrameNP[0].fill("X", "Left ", "%.f", 0, 0.0, 0, 0);
+        StreamFrameNP[1].fill("Y", "Top", "%.f", 0, 0, 0, 0);
+        StreamFrameNP[2].fill("WIDTH", "Width", "%.f", 0, 0.0, 0, 0.0);
+        StreamFrameNP[3].fill("HEIGHT", "Height", "%.f", 0, 0, 0, 0.0);
+        StreamFrameNP.fill(getDeviceName(), "CCD_STREAM_FRAME", "Frame", STREAM_TAB, IP_RW,
                            60, IPS_IDLE);
     }
 
     // Encoder Selection
-    IUFillSwitch(&EncoderS[ENCODER_RAW], "RAW", "RAW", ISS_ON);
-    IUFillSwitch(&EncoderS[ENCODER_MJPEG], "MJPEG", "MJPEG", ISS_OFF);
+    EncoderSP[ENCODER_RAW].fill("RAW", "RAW", ISS_ON);
+    EncoderSP[ENCODER_MJPEG].fill("MJPEG", "MJPEG", ISS_OFF);
     if(currentDevice->getDriverInterface() & INDI::DefaultDevice::SENSOR_INTERFACE)
-        IUFillSwitchVector(&EncoderSP, EncoderS, NARRAY(EncoderS), getDeviceName(), "SENSOR_STREAM_ENCODER", "Encoder", STREAM_TAB,
+        EncoderSP.fill(getDeviceName(), "SENSOR_STREAM_ENCODER", "Encoder", STREAM_TAB,
                            IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
     else
-        IUFillSwitchVector(&EncoderSP, EncoderS, NARRAY(EncoderS), getDeviceName(), "CCD_STREAM_ENCODER", "Encoder", STREAM_TAB,
+        EncoderSP.fill(getDeviceName(), "CCD_STREAM_ENCODER", "Encoder", STREAM_TAB,
                            IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Recorder Selector
-    IUFillSwitch(&RecorderS[RECORDER_RAW], "SER", "SER", ISS_ON);
-    IUFillSwitch(&RecorderS[RECORDER_OGV], "OGV", "OGV", ISS_OFF);
+    RecorderSP[RECORDER_RAW].fill("SER", "SER", ISS_ON);
+    RecorderSP[RECORDER_OGV].fill("OGV", "OGV", ISS_OFF);
     if(currentDevice->getDriverInterface() & INDI::DefaultDevice::SENSOR_INTERFACE)
-        IUFillSwitchVector(&RecorderSP, RecorderS, NARRAY(RecorderS), getDeviceName(), "SENSOR_STREAM_RECORDER", "Recorder",
+        RecorderSP.fill(getDeviceName(), "SENSOR_STREAM_RECORDER", "Recorder",
                            STREAM_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
     else
-        IUFillSwitchVector(&RecorderSP, RecorderS, NARRAY(RecorderS), getDeviceName(), "CCD_STREAM_RECORDER", "Recorder",
+        RecorderSP.fill(getDeviceName(), "CCD_STREAM_RECORDER", "Recorder",
                            STREAM_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
     // If we do not have theora installed, let's just define SER default recorder
 #ifndef HAVE_THEORA
-    RecorderSP.nsp = 1;
+    RecorderSP.resize(1);
 #endif
 
     // Limits
-    IUFillNumber(&LimitsN[LIMITS_BUFFER_MAX], "LIMITS_BUFFER_MAX", "Maximum Buffer Size (MB)", "%.0f", 1, 1024*64, 1, 512);
-    IUFillNumber(&LimitsN[LIMITS_PREVIEW_FPS], "LIMITS_PREVIEW_FPS", "Maximum Preview FPS", "%.0f", 1, 120, 1, 10);
-    IUFillNumberVector(&LimitsNP, LimitsN, NARRAY(LimitsN), getDeviceName(), "LIMITS",
+    LimitsNP[LIMITS_BUFFER_MAX].fill("LIMITS_BUFFER_MAX", "Maximum Buffer Size (MB)", "%.0f", 1, 1024*64, 1, 512);
+    LimitsNP[LIMITS_PREVIEW_FPS].fill("LIMITS_PREVIEW_FPS", "Maximum Preview FPS", "%.0f", 1, 120, 1, 10);
+    LimitsNP.fill(getDeviceName(), "LIMITS",
                        "Limits", STREAM_TAB, IP_RW, 0, IPS_IDLE);
     return true;
 }
@@ -179,17 +179,17 @@ void StreamManager::ISGetProperties(const char * dev)
 
     if (currentDevice->isConnected())
     {
-        currentDevice->defineProperty(&StreamSP);
+        currentDevice->defineProperty(StreamSP);
         if (m_hasStreamingExposure)
-            currentDevice->defineProperty(&StreamExposureNP);
-        currentDevice->defineProperty(&FpsNP);
-        currentDevice->defineProperty(&RecordStreamSP);
-        currentDevice->defineProperty(&RecordFileTP);
-        currentDevice->defineProperty(&RecordOptionsNP);
-        currentDevice->defineProperty(&StreamFrameNP);
-        currentDevice->defineProperty(&EncoderSP);
-        currentDevice->defineProperty(&RecorderSP);
-        currentDevice->defineProperty(&LimitsNP);
+            currentDevice->defineProperty(StreamExposureNP);
+        currentDevice->defineProperty(FpsNP);
+        currentDevice->defineProperty(RecordStreamSP);
+        currentDevice->defineProperty(RecordFileTP);
+        currentDevice->defineProperty(RecordOptionsNP);
+        currentDevice->defineProperty(StreamFrameNP);
+        currentDevice->defineProperty(EncoderSP);
+        currentDevice->defineProperty(RecorderSP);
+        currentDevice->defineProperty(LimitsNP);
     }
 }
 
@@ -207,31 +207,31 @@ bool StreamManager::updateProperties()
         }
         imageB  = imageBP->bp;
 
-        currentDevice->defineProperty(&StreamSP);
+        currentDevice->defineProperty(StreamSP);
         if (m_hasStreamingExposure)
-            currentDevice->defineProperty(&StreamExposureNP);
-        currentDevice->defineProperty(&FpsNP);
-        currentDevice->defineProperty(&RecordStreamSP);
-        currentDevice->defineProperty(&RecordFileTP);
-        currentDevice->defineProperty(&RecordOptionsNP);
-        currentDevice->defineProperty(&StreamFrameNP);
-        currentDevice->defineProperty(&EncoderSP);
-        currentDevice->defineProperty(&RecorderSP);
-        currentDevice->defineProperty(&LimitsNP);
+            currentDevice->defineProperty(StreamExposureNP);
+        currentDevice->defineProperty(FpsNP);
+        currentDevice->defineProperty(RecordStreamSP);
+        currentDevice->defineProperty(RecordFileTP);
+        currentDevice->defineProperty(RecordOptionsNP);
+        currentDevice->defineProperty(StreamFrameNP);
+        currentDevice->defineProperty(EncoderSP);
+        currentDevice->defineProperty(RecorderSP);
+        currentDevice->defineProperty(LimitsNP);
     }
     else
     {
-        currentDevice->deleteProperty(StreamSP.name);
+        currentDevice->deleteProperty(StreamSP.getName());
         if (m_hasStreamingExposure)
-            currentDevice->deleteProperty(StreamExposureNP.name);
-        currentDevice->deleteProperty(FpsNP.name);
-        currentDevice->deleteProperty(RecordFileTP.name);
-        currentDevice->deleteProperty(RecordStreamSP.name);
-        currentDevice->deleteProperty(RecordOptionsNP.name);
-        currentDevice->deleteProperty(StreamFrameNP.name);
-        currentDevice->deleteProperty(EncoderSP.name);
-        currentDevice->deleteProperty(RecorderSP.name);
-        currentDevice->deleteProperty(LimitsNP.name);
+            currentDevice->deleteProperty(StreamExposureNP.getName());
+        currentDevice->deleteProperty(FpsNP.getName());
+        currentDevice->deleteProperty(RecordFileTP.getName());
+        currentDevice->deleteProperty(RecordStreamSP.getName());
+        currentDevice->deleteProperty(RecordOptionsNP.getName());
+        currentDevice->deleteProperty(StreamFrameNP.getName());
+        currentDevice->deleteProperty(EncoderSP.getName());
+        currentDevice->deleteProperty(RecorderSP.getName());
+        currentDevice->deleteProperty(LimitsNP.getName());
     }
 
     return true;
@@ -254,11 +254,11 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
 
     // Discard every N frame.
     // do not count it to fps statistics
-    // N is StreamExposureN[STREAM_DIVISOR].value
+    // N is StreamExposureNP[STREAM_DIVISOR].getValue()
     ++m_frameCountDivider;
     if (
-        (StreamExposureN[STREAM_DIVISOR].value > 1) &&
-        (m_frameCountDivider % static_cast<int>(StreamExposureN[STREAM_DIVISOR].value)) == 0
+        (StreamExposureNP[STREAM_DIVISOR].value > 1) &&
+        (m_frameCountDivider % static_cast<int>(StreamExposureNP[STREAM_DIVISOR].value)) == 0
     )
     {
         return;
@@ -266,20 +266,20 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
 
     if (m_FPSAverage.newFrame())
     {
-        FpsN[1].value = m_FPSAverage.framesPerSecond();
+        FpsNP[1].setValue(m_FPSAverage.framesPerSecond());
     }
 
     if (m_FPSFast.newFrame())
     {
-        FpsN[0].value = m_FPSFast.framesPerSecond();
+        FpsNP[0].setValue(m_FPSFast.framesPerSecond());
         if (m_fastFPSUpdate.try_lock()) // don't block stream thread / record thread
-            std::thread([&](){ IDSetNumber(&FpsNP, nullptr); m_fastFPSUpdate.unlock(); }).detach();
+            std::thread([&](){ FpsNP.apply(); m_fastFPSUpdate.unlock(); }).detach();
     }
 
     if (isStreaming() || isRecording())
     {
         size_t allocatedSize = nbytes * m_framesIncoming.size() / 1024 / 1024; // allocated size in MB
-        if (allocatedSize > LimitsN[LIMITS_BUFFER_MAX].value)
+        if (allocatedSize > LimitsNP[LIMITS_BUFFER_MAX].getValue())
         {
             LOG_WARN("Frame buffer is full, skipping frame...");
             return;
@@ -296,8 +296,8 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
 
         // captured all frames, stream should be close
         if (
-            (RecordStreamSP.sp[RECORD_FRAME].s == ISS_ON && m_FPSRecorder.totalFrames() >= (RecordOptionsNP.np[1].value)) ||
-            (RecordStreamSP.sp[RECORD_TIME].s  == ISS_ON && m_FPSRecorder.totalTime()   >= (RecordOptionsNP.np[0].value * 1000.0))
+            (RecordStreamSP[RECORD_FRAME].s == ISS_ON && m_FPSRecorder.totalFrames() >= (RecordOptionsNP[1].value)) ||
+            (RecordStreamSP[RECORD_TIME].s  == ISS_ON && m_FPSRecorder.totalTime()   >= (RecordOptionsNP[0].value * 1000.0))
         )
         {
             LOG_INFO("Waiting for all buffered frames to be recorded");
@@ -310,11 +310,11 @@ void StreamManager::newFrame(const uint8_t * buffer, uint32_t nbytes)
                 m_FPSRecorder.totalFrames()
             );
 #endif
-            RecordStreamSP.sp[RECORD_TIME].s  = ISS_OFF;
-            RecordStreamSP.sp[RECORD_FRAME].s = ISS_OFF;
-            RecordStreamSP.sp[RECORD_OFF].s   = ISS_ON;
-            RecordStreamSP.s = IPS_IDLE;
-            IDSetSwitch(&RecordStreamSP, nullptr);
+            RecordStreamSP[RECORD_TIME].setState(ISS_OFF);
+            RecordStreamSP[RECORD_FRAME].setState(ISS_OFF);
+            RecordStreamSP[RECORD_OFF].setState(ISS_ON);
+            RecordStreamSP.setState(IPS_IDLE);
+            RecordStreamSP.apply();
 
             stopRecording();
         }
@@ -329,10 +329,10 @@ void StreamManager::asyncStreamThread()
     std::vector<uint8_t> subframeBuffer;  // Subframe buffer for recording/streaming
     std::vector<uint8_t> downscaleBuffer; // Downscale buffer for streaming
 
-    double frameW = StreamFrameN[CCDChip::FRAME_W].value;
-    double frameH = StreamFrameN[CCDChip::FRAME_H].value;
-    double frameX = StreamFrameN[CCDChip::FRAME_X].value;
-    double frameY = StreamFrameN[CCDChip::FRAME_Y].value;
+    double frameW = StreamFrameNP[CCDChip::FRAME_W].getValue();
+    double frameH = StreamFrameNP[CCDChip::FRAME_H].getValue();
+    double frameX = StreamFrameNP[CCDChip::FRAME_X].getValue();
+    double frameY = StreamFrameNP[CCDChip::FRAME_Y].getValue();
 
     while(!m_framesThreadTerminate)
     {
@@ -377,12 +377,12 @@ void StreamManager::asyncStreamThread()
             frameY = subY;
             frameW = subW;
             frameH = subH;
-            StreamFrameN[CCDChip::FRAME_W].value = frameW;
-            StreamFrameN[CCDChip::FRAME_H].value = frameH;
-            StreamFrameN[CCDChip::FRAME_X].value = frameX;
-            StreamFrameN[CCDChip::FRAME_Y].value = frameY;
-            StreamFrameNP.s = IPS_IDLE;
-            IDSetNumber(&StreamFrameNP, nullptr);
+            StreamFrameNP[CCDChip::FRAME_W].setValue(frameW);
+            StreamFrameNP[CCDChip::FRAME_H].setValue(frameH);
+            StreamFrameNP[CCDChip::FRAME_X].setValue(frameX);
+            StreamFrameNP[CCDChip::FRAME_Y].setValue(frameY);
+            StreamFrameNP.setState(IPS_IDLE);
+            StreamFrameNP.apply();
         }
 #endif
 
@@ -448,24 +448,24 @@ void StreamManager::asyncStreamThread()
 
 void StreamManager::setSize(uint16_t width, uint16_t height)
 {
-    if (width != StreamFrameN[CCDChip::FRAME_W].value || height != StreamFrameN[CCDChip::FRAME_H].value)
+    if (width != StreamFrameNP[CCDChip::FRAME_W].value || height != StreamFrameNP[CCDChip::FRAME_H].getValue())
     {
         if (m_PixelFormat == INDI_JPG)
             LOG_WARN("Cannot subframe JPEG streams.");
 
-        StreamFrameN[CCDChip::FRAME_X].value = 0;
-        StreamFrameN[CCDChip::FRAME_X].max   = width - 1;
-        StreamFrameN[CCDChip::FRAME_Y].value = 0;
-        StreamFrameN[CCDChip::FRAME_Y].max   = height - 1;
-        StreamFrameN[CCDChip::FRAME_W].value = width;
-        StreamFrameN[CCDChip::FRAME_W].min   = 10;
-        StreamFrameN[CCDChip::FRAME_W].max   = width;
-        StreamFrameN[CCDChip::FRAME_H].value = height;
-        StreamFrameN[CCDChip::FRAME_H].min   = 10;
-        StreamFrameN[CCDChip::FRAME_H].max   = height;
+        StreamFrameNP[CCDChip::FRAME_X].setValue(0);
+        StreamFrameNP[CCDChip::FRAME_X].setMax(width - 1);
+        StreamFrameNP[CCDChip::FRAME_Y].setValue(0);
+        StreamFrameNP[CCDChip::FRAME_Y].setMax(height - 1);
+        StreamFrameNP[CCDChip::FRAME_W].setValue(width);
+        StreamFrameNP[CCDChip::FRAME_W].setMin(10);
+        StreamFrameNP[CCDChip::FRAME_W].setMax(width);
+        StreamFrameNP[CCDChip::FRAME_H].setValue(height);
+        StreamFrameNP[CCDChip::FRAME_H].setMin(10);
+        StreamFrameNP[CCDChip::FRAME_H].setMax(height);
 
-        StreamFrameNP.s = IPS_OK;
-        IUUpdateMinMax(&StreamFrameNP);
+        StreamFrameNP.setState(IPS_OK);
+        StreamFrameNP.updateMinMax();
     }
 
     // Width & Height are BINNED dimensions.
@@ -569,14 +569,14 @@ bool StreamManager::startRecording()
         }
     }
 
-    recorder->setFPS(FpsN[FPS_AVERAGE].value);
+    recorder->setFPS(FpsNP[FPS_AVERAGE].value);
 
     /* pattern substitution */
-    recordfiledir.assign(RecordFileTP.tp[0].text);
+    recordfiledir.assign(RecordFileTP[0].text);
     expfiledir = expand(recordfiledir, patterns);
     if (expfiledir.at(expfiledir.size() - 1) != '/')
         expfiledir += '/';
-    recordfilename.assign(RecordFileTP.tp[1].text);
+    recordfilename.assign(RecordFileTP[1].text);
     expfilename = expand(recordfilename, patterns);
     if (expfilename.size() < 4 || expfilename.substr(expfilename.size() - 4, 4) != recorder->getExtension())
         expfilename += recorder->getExtension();
@@ -594,8 +594,8 @@ bool StreamManager::startRecording()
     }
     if (!recorder->open(filename.c_str(), errmsg))
     {
-        RecordStreamSP.s = IPS_ALERT;
-        IDSetSwitch(&RecordStreamSP, nullptr);
+        RecordStreamSP.setState(IPS_ALERT);
+        RecordStreamSP.apply();
         LOGF_WARN("Can not open record file: %s", errmsg);
         return false;
     }
@@ -611,7 +611,7 @@ bool StreamManager::startRecording()
     }
     else
     {
-        //if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        //if (ImageColorSP[IMAGE_GRAYSCALE].getState() == ISS_ON)
         if (dynamic_cast<INDI::CCD*>(currentDevice)->PrimaryCCD.getNAxis() == 2)
             recorder->setDefaultMono();
         else
@@ -632,10 +632,10 @@ bool StreamManager::startRecording()
         if (m_isStreaming == false && dynamic_cast<INDI::CCD*>(currentDevice)->StartStreaming() == false)
         {
             LOG_ERROR("Failed to start recording.");
-            RecordStreamSP.s = IPS_ALERT;
-            IUResetSwitch(&RecordStreamSP);
-            RecordStreamS[RECORD_OFF].s = ISS_ON;
-            IDSetSwitch(&RecordStreamSP, nullptr);
+            RecordStreamSP.setState(IPS_ALERT);
+            RecordStreamSP.reset();
+            RecordStreamSP[RECORD_OFF].setState(ISS_ON);
+            RecordStreamSP.apply();
         }
     }
     else if(currentDevice->getDriverInterface() & INDI::DefaultDevice::SENSOR_INTERFACE)
@@ -643,10 +643,10 @@ bool StreamManager::startRecording()
         if (m_isStreaming == false && dynamic_cast<INDI::SensorInterface*>(currentDevice)->StartStreaming() == false)
         {
             LOG_ERROR("Failed to start recording.");
-            RecordStreamSP.s = IPS_ALERT;
-            IUResetSwitch(&RecordStreamSP);
-            RecordStreamS[RECORD_OFF].s = ISS_ON;
-            IDSetSwitch(&RecordStreamSP, nullptr);
+            RecordStreamSP.setState(IPS_ALERT);
+            RecordStreamSP.reset();
+            RecordStreamSP[RECORD_OFF].setState(ISS_ON);
+            RecordStreamSP.apply();
         }
     }
     m_isRecording = true;
@@ -696,7 +696,7 @@ bool StreamManager::ISNewSwitch(const char * dev, const char * name, ISState * s
         return false;
 
     /* Video Stream */
-    if (!strcmp(name, StreamSP.name))
+    if (StreamSP.isNameMatch(name))
     {
         for (int i = 0; i < n; i++)
         {
@@ -715,47 +715,47 @@ bool StreamManager::ISNewSwitch(const char * dev, const char * name, ISState * s
     }
 
     // Record Stream
-    if (!strcmp(name, RecordStreamSP.name))
+    if (RecordStreamSP.isNameMatch(name))
     {
-        int prevSwitch = IUFindOnSwitchIndex(&RecordStreamSP);
-        IUUpdateSwitch(&RecordStreamSP, states, names, n);
+        int prevSwitch = RecordStreamSP.findOnSwitchIndex();
+        RecordStreamSP.update(states, names, n);
 
-        if (m_isRecording && RecordStreamSP.sp[RECORD_OFF].s != ISS_ON)
+        if (m_isRecording && RecordStreamSP[RECORD_OFF].s != ISS_ON)
         {
-            IUResetSwitch(&RecordStreamSP);
-            RecordStreamS[prevSwitch].s = ISS_ON;
-            IDSetSwitch(&RecordStreamSP, nullptr);
+            RecordStreamSP.reset();
+            RecordStreamSP[prevSwitch].setState(ISS_ON);
+            RecordStreamSP.apply();
             LOG_WARN("Recording device is busy.");
             return true;
         }
 
-        if ((RecordStreamSP.sp[RECORD_ON].s == ISS_ON) ||
-                (RecordStreamSP.sp[RECORD_TIME].s == ISS_ON) ||
-                (RecordStreamSP.sp[RECORD_FRAME].s == ISS_ON))
+        if ((RecordStreamSP[RECORD_ON].s == ISS_ON) ||
+                (RecordStreamSP[RECORD_TIME].s == ISS_ON) ||
+                (RecordStreamSP[RECORD_FRAME].s == ISS_ON))
         {
             if (!m_isRecording)
             {
-                RecordStreamSP.s = IPS_BUSY;
-                if (RecordStreamSP.sp[RECORD_TIME].s == ISS_ON)
-                    LOGF_INFO("Starting video record (Duration): %g secs.", RecordOptionsNP.np[0].value);
-                else if (RecordStreamSP.sp[RECORD_FRAME].s == ISS_ON)
-                    LOGF_INFO("Starting video record (Frame count): %d.", static_cast<int>(RecordOptionsNP.np[1].value));
+                RecordStreamSP.setState(IPS_BUSY);
+                if (RecordStreamSP[RECORD_TIME].s == ISS_ON)
+                    LOGF_INFO("Starting video record (Duration): %g secs.", RecordOptionsNP[0].getValue());
+                else if (RecordStreamSP[RECORD_FRAME].s == ISS_ON)
+                    LOGF_INFO("Starting video record (Frame count): %d.", static_cast<int>(RecordOptionsNP[1].value));
                 else
                     LOG_INFO("Starting video record.");
 
                 if (!startRecording())
                 {
-                    IUResetSwitch(&RecordStreamSP);
-                    RecordStreamSP.sp[RECORD_OFF].s = ISS_ON;
-                    RecordStreamSP.s = IPS_ALERT;
+                    RecordStreamSP.reset();
+                    RecordStreamSP[RECORD_OFF].setState(ISS_ON);
+                    RecordStreamSP.setState(IPS_ALERT);
                 }
             }
         }
         else
         {
-            RecordStreamSP.s = IPS_IDLE;
+            RecordStreamSP.setState(IPS_IDLE);
             m_Format.clear();
-            FpsN[FPS_INSTANT].value = FpsN[FPS_AVERAGE].value = 0;
+            FpsNP[FPS_INSTANT].setValue(FpsNP[FPS_AVERAGE].value = 0);
             if (m_isRecording)
             {
                 LOG_INFO("Recording stream has been disabled. Closing the stream...");
@@ -763,17 +763,17 @@ bool StreamManager::ISNewSwitch(const char * dev, const char * name, ISState * s
             }
         }
 
-        IDSetSwitch(&RecordStreamSP, nullptr);
+        RecordStreamSP.apply();
         return true;
     }
 
     // Encoder Selection
-    if (!strcmp(name, EncoderSP.name))
+    if (EncoderSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&EncoderSP, states, names, n);
-        EncoderSP.s = IPS_ALERT;
+        EncoderSP.update(states, names, n);
+        EncoderSP.setState(IPS_ALERT);
 
-        const char * selectedEncoder = IUFindOnSwitch(&EncoderSP)->name;
+        const char * selectedEncoder = EncoderSP.findOnSwitch()->name;
 
         for (EncoderInterface * oneEncoder : encoderManager->getEncoderList())
         {
@@ -785,20 +785,20 @@ bool StreamManager::ISNewSwitch(const char * dev, const char * name, ISState * s
 
                 encoder = oneEncoder;
 
-                EncoderSP.s = IPS_OK;
+                EncoderSP.setState(IPS_OK);
             }
         }
-        IDSetSwitch(&EncoderSP, nullptr);
+        EncoderSP.apply();
         return true;
     }
 
     // Recorder Selection
-    if (!strcmp(name, RecorderSP.name))
+    if (RecorderSP.isNameMatch(name))
     {
-        IUUpdateSwitch(&RecorderSP, states, names, n);
-        RecorderSP.s = IPS_ALERT;
+        RecorderSP.update(states, names, n);
+        RecorderSP.setState(IPS_ALERT);
 
-        const char * selectedRecorder = IUFindOnSwitch(&RecorderSP)->name;
+        const char * selectedRecorder = RecorderSP.findOnSwitch()->name;
 
         for (RecorderInterface * oneRecorder : recorderManager->getRecorderList())
         {
@@ -810,10 +810,10 @@ bool StreamManager::ISNewSwitch(const char * dev, const char * name, ISState * s
 
                 recorder = oneRecorder;
 
-                RecorderSP.s = IPS_OK;
+                RecorderSP.setState(IPS_OK);
             }
         }
-        IDSetSwitch(&RecorderSP, nullptr);
+        RecorderSP.apply();
         return true;
     }
 
@@ -827,17 +827,17 @@ bool StreamManager::ISNewText(const char * dev, const char * name, char * texts[
     if (dev != nullptr && strcmp(getDeviceName(), dev))
         return false;
 
-    if (!strcmp(name, RecordFileTP.name))
+    if (RecordFileTP.isNameMatch(name))
     {
-        IText * tp = IUFindText(&RecordFileTP, "RECORD_FILE_NAME");
+        IText * tp = RecordFileTP.findWidgetByName("RECORD_FILE_NAME");
         if (strchr(tp->text, '/'))
         {
             LOG_WARN("Dir. separator (/) not allowed in filename.");
             return true;
         }
 
-        IUUpdateText(&RecordFileTP, texts, names, n);
-        IDSetText(&RecordFileTP, nullptr);
+        RecordFileTP.update(texts, names, n);
+        RecordFileTP.apply();
         return true;
     }
 
@@ -851,29 +851,29 @@ bool StreamManager::ISNewNumber(const char * dev, const char * name, double valu
     if (dev != nullptr && strcmp(getDeviceName(), dev))
         return false;
 
-    if (!strcmp(StreamExposureNP.name, name))
+    if (StreamExposureNP.isNameMatch(name))
     {
-        IUUpdateNumber(&StreamExposureNP, values, names, n);
-        StreamExposureNP.s = IPS_OK;
-        IDSetNumber(&StreamExposureNP, nullptr);
+        StreamExposureNP.update(values, names, n);
+        StreamExposureNP.setState(IPS_OK);
+        StreamExposureNP.apply();
         return true;
     }
 
     /* Limits */
-    if (!strcmp(LimitsNP.name, name))
+    if (LimitsNP.isNameMatch(name))
     {
-        IUUpdateNumber(&LimitsNP, values, names, n);
+        LimitsNP.update(values, names, n);
 
-        m_FPSPreview.setTimeWindow(1000.0 / LimitsN[LIMITS_PREVIEW_FPS].value);
+        m_FPSPreview.setTimeWindow(1000.0 / LimitsNP[LIMITS_PREVIEW_FPS].getValue());
         m_FPSPreview.reset();
 
-        LimitsNP.s = IPS_OK;
-        IDSetNumber(&LimitsNP, nullptr);
+        LimitsNP.setState(IPS_OK);
+        LimitsNP.apply();
         return true;
     }
 
     /* Record Options */
-    if (!strcmp(RecordOptionsNP.name, name))
+    if (RecordOptionsNP.isNameMatch(name))
     {
         if (m_isRecording)
         {
@@ -881,14 +881,14 @@ bool StreamManager::ISNewNumber(const char * dev, const char * name, double valu
             return true;
         }
 
-        IUUpdateNumber(&RecordOptionsNP, values, names, n);
-        RecordOptionsNP.s = IPS_OK;
-        IDSetNumber(&RecordOptionsNP, nullptr);
+        RecordOptionsNP.update(values, names, n);
+        RecordOptionsNP.setState(IPS_OK);
+        RecordOptionsNP.apply();
         return true;
     }
 
     /* Stream Frame */
-    if (!strcmp(StreamFrameNP.name, name))
+    if (StreamFrameNP.isNameMatch(name))
     {
         if (m_isRecording)
         {
@@ -913,17 +913,17 @@ bool StreamManager::ISNewNumber(const char * dev, const char * name, double valu
             subH = 1;
         }
 
-        IUUpdateNumber(&StreamFrameNP, values, names, n);
-        StreamFrameNP.s = IPS_OK;
-        if (StreamFrameN[CCDChip::FRAME_X].value + StreamFrameN[CCDChip::FRAME_W].value > subW)
-            StreamFrameN[CCDChip::FRAME_W].value = subW - StreamFrameN[CCDChip::FRAME_X].value;
+        StreamFrameNP.update(values, names, n);
+        StreamFrameNP.setState(IPS_OK);
+        if (StreamFrameNP[CCDChip::FRAME_X].value + StreamFrameNP[CCDChip::FRAME_W].getValue() > subW)
+            StreamFrameNP[CCDChip::FRAME_W].setValue(subW - StreamFrameNP[CCDChip::FRAME_X].getValue());
 
-        if (StreamFrameN[CCDChip::FRAME_Y].value + StreamFrameN[CCDChip::FRAME_H].value > subH)
-            StreamFrameN[CCDChip::FRAME_H].value = subH - StreamFrameN[CCDChip::FRAME_Y].value;
+        if (StreamFrameNP[CCDChip::FRAME_Y].value + StreamFrameNP[CCDChip::FRAME_H].getValue() > subH)
+            StreamFrameNP[CCDChip::FRAME_H].setValue(subH - StreamFrameNP[CCDChip::FRAME_Y].getValue());
 
-        setSize(StreamFrameN[CCDChip::FRAME_W].value, StreamFrameN[CCDChip::FRAME_H].value);
+        setSize(StreamFrameNP[CCDChip::FRAME_W].value, StreamFrameNP[CCDChip::FRAME_H].getValue());
 
-        IDSetNumber(&StreamFrameNP, nullptr);
+        StreamFrameNP.apply();
         return true;
     }
 
@@ -937,7 +937,7 @@ bool StreamManager::setStream(bool enable)
     {
         if (!m_isStreaming)
         {
-            StreamSP.s       = IPS_BUSY;
+            StreamSP.setState(IPS_BUSY);
 #if 0
             if (StreamOptionsN[OPTION_RATE_DIVISOR].value > 0)
                 DEBUGF(INDI::Logger::DBG_SESSION,
@@ -946,24 +946,24 @@ bool StreamManager::setStream(bool enable)
             else
                 LOGF_INFO("Starting the video stream with target FPS %.f", StreamOptionsN[OPTION_TARGET_FPS].value);
 #endif
-            LOGF_INFO("Starting the video stream with target exposure %.6f s (Max theoritical FPS %.f)", StreamExposureN[0].value,
-                      1 / StreamExposureN[0].value);
+            LOGF_INFO("Starting the video stream with target exposure %.6f s (Max theoritical FPS %.f)", StreamExposureNP[0].getValue(),
+                      1 / StreamExposureNP[0].getValue());
 
             m_FPSAverage.reset();
             m_FPSFast.reset();
             m_FPSPreview.reset();
-            m_FPSPreview.setTimeWindow(1000.0 / LimitsN[LIMITS_PREVIEW_FPS].value);
+            m_FPSPreview.setTimeWindow(1000.0 / LimitsNP[LIMITS_PREVIEW_FPS].getValue());
             m_frameCountDivider = 0;
             
             if(currentDevice->getDriverInterface() & INDI::DefaultDevice::CCD_INTERFACE)
             {
                 if (dynamic_cast<INDI::CCD*>(currentDevice)->StartStreaming() == false)
                 {
-                    IUResetSwitch(&StreamSP);
-                    StreamS[1].s = ISS_ON;
-                    StreamSP.s   = IPS_ALERT;
+                    StreamSP.reset();
+                    StreamSP[1].setState(ISS_ON);
+                    StreamSP.setState(IPS_ALERT);
                     LOG_ERROR("Failed to start streaming.");
-                    IDSetSwitch(&StreamSP, nullptr);
+                    StreamSP.apply();
                     return false;
                 }
             }
@@ -971,27 +971,27 @@ bool StreamManager::setStream(bool enable)
             {
                 if (dynamic_cast<INDI::SensorInterface*>(currentDevice)->StartStreaming() == false)
                 {
-                    IUResetSwitch(&StreamSP);
-                    StreamS[1].s = ISS_ON;
-                    StreamSP.s   = IPS_ALERT;
+                    StreamSP.reset();
+                    StreamSP[1].setState(ISS_ON);
+                    StreamSP.setState(IPS_ALERT);
                     LOG_ERROR("Failed to start streaming.");
-                    IDSetSwitch(&StreamSP, nullptr);
+                    StreamSP.apply();
                     return false;
                 }
             }
             m_isStreaming = true;
             m_Format.clear();
-            FpsN[FPS_INSTANT].value = FpsN[FPS_AVERAGE].value = 0;
-            IUResetSwitch(&StreamSP);
-            StreamS[0].s = ISS_ON;
+            FpsNP[FPS_INSTANT].setValue(FpsNP[FPS_AVERAGE].value = 0);
+            StreamSP.reset();
+            StreamSP[0].setState(ISS_ON);
             recorder->setStreamEnabled(true);
         }
     }
     else
     {
-        StreamSP.s = IPS_IDLE;
+        StreamSP.setState(IPS_IDLE);
         m_Format.clear();
-        FpsN[FPS_INSTANT].value = FpsN[FPS_AVERAGE].value = 0;
+        FpsNP[FPS_INSTANT].setValue(FpsNP[FPS_AVERAGE].value = 0);
         if (m_isStreaming)
         {
             if (!m_isRecording)
@@ -1000,9 +1000,9 @@ bool StreamManager::setStream(bool enable)
                 {
                     if (dynamic_cast<INDI::CCD*>(currentDevice)->StopStreaming() == false)
                     {
-                        StreamSP.s = IPS_ALERT;
+                        StreamSP.setState(IPS_ALERT);
                         LOG_ERROR("Failed to stop streaming.");
-                        IDSetSwitch(&StreamSP, nullptr);
+                        StreamSP.apply();
                         return false;
                     }
                 }
@@ -1010,43 +1010,43 @@ bool StreamManager::setStream(bool enable)
                 {
                     if (dynamic_cast<INDI::SensorInterface*>(currentDevice)->StopStreaming() == false)
                     {
-                        StreamSP.s = IPS_ALERT;
+                        StreamSP.setState(IPS_ALERT);
                         LOG_ERROR("Failed to stop streaming.");
-                        IDSetSwitch(&StreamSP, nullptr);
+                        StreamSP.apply();
                         return false;
                     }
                 }
             }
 
-            IUResetSwitch(&StreamSP);
-            StreamS[1].s = ISS_ON;
+            StreamSP.reset();
+            StreamSP[1].setState(ISS_ON);
             m_isStreaming = false;
             m_Format.clear();
-            FpsN[FPS_INSTANT].value = FpsN[FPS_AVERAGE].value = 0;
+            FpsNP[FPS_INSTANT].setValue(FpsNP[FPS_AVERAGE].value = 0);
 
             recorder->setStreamEnabled(false);
         }
     }
 
-    IDSetSwitch(&StreamSP, nullptr);
+    StreamSP.apply();
     return true;
 }
 
 bool StreamManager::saveConfigItems(FILE * fp)
 {
-    IUSaveConfigSwitch(fp, &EncoderSP);
-    IUSaveConfigText(fp, &RecordFileTP);
-    IUSaveConfigNumber(fp, &RecordOptionsNP);
-    IUSaveConfigSwitch(fp, &RecorderSP);
+    EncoderSP.save(fp);
+    RecordFileTP.save(fp);
+    RecordOptionsNP.save(fp);
+    RecorderSP.save(fp);
     return true;
 }
 
 void StreamManager::getStreamFrame(uint16_t * x, uint16_t * y, uint16_t * w, uint16_t * h)
 {
-    *x = StreamFrameN[CCDChip::FRAME_X].value;
-    *y = StreamFrameN[CCDChip::FRAME_Y].value;
-    *w = StreamFrameN[CCDChip::FRAME_W].value;
-    *h = StreamFrameN[CCDChip::FRAME_H].value;
+    *x = StreamFrameNP[CCDChip::FRAME_X].getValue();
+    *y = StreamFrameNP[CCDChip::FRAME_Y].getValue();
+    *w = StreamFrameNP[CCDChip::FRAME_W].getValue();
+    *h = StreamFrameNP[CCDChip::FRAME_H].getValue();
 }
 
 bool StreamManager::uploadStream(const uint8_t * buffer, uint32_t nbytes)
@@ -1057,7 +1057,7 @@ bool StreamManager::uploadStream(const uint8_t * buffer, uint32_t nbytes)
         // Upload to client now
 #ifdef HAVE_WEBSOCKET
         if (dynamic_cast<INDI::CCD*>(currentDevice)->HasWebSocket()
-                && dynamic_cast<INDI::CCD*>(currentDevice)->WebSocketS[CCD::WEBSOCKET_ENABLED].s == ISS_ON)
+                && dynamic_cast<INDI::CCD*>(currentDevice)->WebSocketSP[CCD::WEBSOCKET_ENABLED].getState() == ISS_ON)
         {
             if (m_Format != ".stream_jpg")
             {
@@ -1094,7 +1094,7 @@ bool StreamManager::uploadStream(const uint8_t * buffer, uint32_t nbytes)
         {
 #ifdef HAVE_WEBSOCKET
             if (dynamic_cast<INDI::CCD*>(currentDevice)->HasWebSocket()
-                    && dynamic_cast<INDI::CCD*>(currentDevice)->WebSocketS[CCD::WEBSOCKET_ENABLED].s == ISS_ON)
+                    && dynamic_cast<INDI::CCD*>(currentDevice)->WebSocketSP[CCD::WEBSOCKET_ENABLED].getState() == ISS_ON)
             {
                 if (m_Format != ".stream")
                 {

--- a/libs/stream/streammanager.h
+++ b/libs/stream/streammanager.h
@@ -99,6 +99,11 @@
 
 #include <mutex>
 
+/* Smart Widget-Property */
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+
 namespace INDI
 {
 
@@ -206,19 +211,15 @@ private: // Utility for record file
     bool recordStream(const uint8_t *buffer, uint32_t nbytes, double deltams);
 
     /* Stream switch */
-    ISwitch StreamS[2];
-    ISwitchVectorProperty StreamSP;
+    INDI::PropertySwitch StreamSP {2};
 
     /* Record switch */
-    ISwitch RecordStreamS[4];
-    ISwitchVectorProperty RecordStreamSP;
+    INDI::PropertySwitch RecordStreamSP {4};
 
     /* Record File Info */
-    IText RecordFileT[2] {};
-    ITextVectorProperty RecordFileTP;
+    INDI::PropertyText RecordFileTP {2};
 
-    INumber StreamExposureN[2];
-    INumberVectorProperty StreamExposureNP;
+    INDI::PropertyNumber StreamExposureNP {2};
     enum
     {
         STREAM_EXPOSURE,
@@ -226,35 +227,29 @@ private: // Utility for record file
     };
 
     /* Measured FPS */
-    INumber FpsN[2];
-    INumberVectorProperty FpsNP;
+    INDI::PropertyNumber FpsNP {2};
     enum { FPS_INSTANT, FPS_AVERAGE };
 
     /* Record Options */
-    INumber RecordOptionsN[2];
-    INumberVectorProperty RecordOptionsNP;
+    INDI::PropertyNumber RecordOptionsNP {2};
 
     // Stream Frame
-    INumberVectorProperty StreamFrameNP;
-    INumber StreamFrameN[4];
+    INDI::PropertyNumber StreamFrameNP {4};
 
     /* BLOBs */
     IBLOBVectorProperty *imageBP = nullptr;
     IBLOB *imageB = nullptr;
 
     // Encoder Selector. It's static now but should this implemented as plugin interface?
-    ISwitch EncoderS[2];
-    ISwitchVectorProperty EncoderSP;
+    INDI::PropertySwitch EncoderSP {2};
     enum { ENCODER_RAW, ENCODER_MJPEG };
 
     // Recorder Selector. Static but should be implmeneted as a dynamic plugin interface
-    ISwitch RecorderS[2];
-    ISwitchVectorProperty RecorderSP;
+    INDI::PropertySwitch RecorderSP {2};
     enum { RECORDER_RAW, RECORDER_OGV };
 
     // Limits. Maximum queue size for incoming frames. FPS Limit for preview
-    INumber LimitsN[2];
-    INumberVectorProperty LimitsNP;
+    INDI::PropertyNumber LimitsNP {2};
     enum { LIMITS_BUFFER_MAX, LIMITS_PREVIEW_FPS };
 
     std::atomic<bool> m_isStreaming { false };
@@ -329,11 +324,11 @@ inline bool StreamManager::isBusy()
 
 inline double StreamManager::getTargetFPS()
 {
-    return 1.0 / StreamExposureN[0].value;
+    return 1.0 / StreamExposureNP[0].getValue();
 }
 inline double StreamManager::getTargetExposure()
 {
-    return StreamExposureN[0].value;
+    return StreamExposureNP[0].getValue();
 }
 
 inline void StreamManager::setStreamingExposureEnabled(bool enable)


### PR DESCRIPTION
Hi!

**DO NOT MERGE.**

Replacement IXXX/IXXXVectorProperty to INDI::PropertyXXX.
Pull request contains most of the source modifications (not all)

**Advantages:**
- Declaration of one class instead of two.
- Dynamic number of elements.
- Safe getters and setters instead of accessing a low-level structure.
- Safe functions for checking - Don't use strcmp/strncmp, use e.g. isNameMatch("SOME_NAME")
- Currently, only items are backward compatible. The INDI::WidgetView<IXXX> template is used, inheriting from IXXX.

**Potential issue:**
Public declarations 'IXXX/IXXXVectorProperty' can be used by other 3rd party classes.
Refactoring is removing the redundant array of "widgets" - and this can cause problems referencing a non-existent variable.

Before:
```cpp
#include "indiapi.h"

/* ... */
public:
    /* ... */
    ITextVectorProperty StatusTP;
    IText StatusT[3] {};
    /* ... */
```
After:
```cpp
#include "indipropertytext.h"

/* ... */
public:
    /* ... */
    INDI::PropertyText StatusTP {3};
    /* ... */
```

I suspect the indi-3rdparty build will fail - but it was successful nevertheless. I need help assessing how big the problems are causing these changes.

Please, test the library with other projects - mainly I mean the compilation process.

Regards,
Paweł Soja