### PR TITLE
Implement real periodic timer.

### DIFF
--- a/eventloop.c
+++ b/eventloop.c
@@ -314,6 +314,15 @@ int remainingTimer(int timer_id)
     return it == NULL ? -1 : remainingTimerNode(it);
 }
 
+/* Returns the timer's remaining value in nanoseconds left until the timeout.
+ * If the timer not exists, the returned value will be -1.
+ */
+int64_t nsecsRemainingTimer(int timer_id)
+{
+    TF *it = findTimer(timer_id);
+    return it == NULL ? -1 : remainingTimerNode(it) * 1000000;
+}
+
 /* add a new work procedure, fp, to be called with ud when nothing else to do.
  * return unique id for use with rmWorkProc().
  */
@@ -526,6 +535,11 @@ int IEAddPeriodicTimer(int millisecs, IE_TCF *fp, void *p)
 int IERemainingTimer(int timerid)
 {
     return (remainingTimer(timerid));
+}
+
+int64_t IENSecsRemainingTimer(int timerid)
+{
+    return (nsecsRemainingTimer(timerid));
 }
 
 void IERmTimer(int timerid)

--- a/eventloop.c
+++ b/eventloop.c
@@ -523,6 +523,11 @@ int IEAddPeriodicTimer(int millisecs, IE_TCF *fp, void *p)
     return (addPeriodicTimer(millisecs, (TCF *)fp, p));
 }
 
+int IERemainingTimer(int timerid)
+{
+    return (remainingTimer(timerid));
+}
+
 void IERmTimer(int timerid)
 {
     rmTimer(timerid);

--- a/eventloop.h
+++ b/eventloop.h
@@ -109,6 +109,13 @@ extern int addPeriodicTimer(int ms, TCF *fp, void *ud);
  */
 extern int remainingTimer(int tid);
 
+/** Returns the timer's remaining value in nanoseconds left until the timeout.
+ *
+ * \param tid the timer callback ID returned from addTimer() or addPeriodicTimer()
+ * \return  If the timer not exists, the returned value will be -1.
+ */
+extern int nsecRemainingTimer(int tid);
+
 /** Remove the timer with the given \e id, as returned from addTimer() or addPeriodicTimer().
 *
 * \param tid the timer callback ID returned from addTimer() or addPeriodicTimer().

--- a/eventloop.h
+++ b/eventloop.h
@@ -84,7 +84,7 @@ extern int addWorkProc(WPF *fp, void *ud);
 */
 extern void rmWorkProc(int wid);
 
-/** Register a new timer function, \e fp, to be called with \e ud as argument after \e ms. Add to list in order of decreasing time from epoch, ie, last entry runs soonest. The timer will only invoke the callback function \b once. You need to call addTimer again if you want to repeat the process.
+/** Register a new single-shot timer function, \e fp, to be called with \e ud as argument after \e ms.
 *
 * \param ms timer period in milliseconds.
 * \param fp a pointer to the callback function.
@@ -93,9 +93,18 @@ extern void rmWorkProc(int wid);
 */
 extern int addTimer(int ms, TCF *fp, void *ud);
 
-/** Remove the timer with the given \e id, as returned from addTimer().
+/** Register a new periodic timer function, \e fp, to be called with \e ud as argument after \e ms.
 *
-* \param tid the timer callback ID returned from addTimer().
+* \param ms timer period in milliseconds.
+* \param fp a pointer to the callback function.
+* \param ud a pointer to be passed to the callback function when called.
+* \return a unique id for use with rmTimer().
+*/
+extern int addPeriodicTimer(int ms, TCF *fp, void *ud);
+
+/** Remove the timer with the given \e id, as returned from addTimer() or addPeriodicTimer().
+*
+* \param tid the timer callback ID returned from addTimer() or addPeriodicTimer().
 */
 extern void rmTimer(int tid);
 

--- a/eventloop.h
+++ b/eventloop.h
@@ -102,6 +102,13 @@ extern int addTimer(int ms, TCF *fp, void *ud);
 */
 extern int addPeriodicTimer(int ms, TCF *fp, void *ud);
 
+/** Returns the timer's remaining value in milliseconds left until the timeout.
+ *
+ * \param tid the timer callback ID returned from addTimer() or addPeriodicTimer()
+ * \return  If the timer not exists, the returned value will be -1.
+ */
+extern int remainingTimer(int tid);
+
 /** Remove the timer with the given \e id, as returned from addTimer() or addPeriodicTimer().
 *
 * \param tid the timer callback ID returned from addTimer() or addPeriodicTimer().

--- a/indidevapi.h
+++ b/indidevapi.h
@@ -325,9 +325,7 @@ extern int IEAddCallback(int readfiledes, IE_CBF *fp, void *userpointer);
 */
 extern void IERmCallback(int callbackid);
 
-/** \brief Register a new timer function, \e fp, to be called with \e ud as argument after \e ms.
-
- Add to list in order of decreasing time from epoch, ie, last entry runs soonest. The timer will only invoke the callback function \b once. You need to call addTimer again if you want to repeat the process.
+/** \brief Register a new single-shot timer function, \e fp, to be called with \e ud as argument after \e ms.
 *
 * \param millisecs timer period in milliseconds.
 * \param fp a pointer to the callback function.
@@ -336,9 +334,18 @@ extern void IERmCallback(int callbackid);
 */
 extern int IEAddTimer(int millisecs, IE_TCF *fp, void *userpointer);
 
-/** \brief Remove the timer with the given \e timerid, as returned from IEAddTimer.
+/** \brief Register a new periodic timer function, \e fp, to be called with \e ud as argument after \e ms.
 *
-* \param timerid the timer callback ID returned from IEAddTimer().
+* \param millisecs timer period in milliseconds.
+* \param fp a pointer to the callback function.
+* \param userpointer a pointer to be passed to the callback function when called.
+* \return a unique id for use with IERmTimer().
+*/
+extern int IEAddPeriodicTimer(int millisecs, IE_TCF *fp, void *userpointer);
+
+/** \brief Remove the timer with the given \e timerid, as returned from IEAddTimer() or IEAddPeriodicTimer().
+*
+* \param timerid the timer callback ID returned from IEAddTimer() or IEAddPeriodicTimer().
 */
 extern void IERmTimer(int timerid);
 

--- a/indidevapi.h
+++ b/indidevapi.h
@@ -343,6 +343,13 @@ extern int IEAddTimer(int millisecs, IE_TCF *fp, void *userpointer);
 */
 extern int IEAddPeriodicTimer(int millisecs, IE_TCF *fp, void *userpointer);
 
+/** \brief Returns the timer's remaining value in milliseconds left until the timeout.
+ *
+ * \param timerid the timer callback ID returned from IEAddTimer() or IEAddPeriodicTimer()
+ * \return  If the timer not exists, the returned value will be -1.
+ */
+extern int IERemainingTimer(int timerid);
+
 /** \brief Remove the timer with the given \e timerid, as returned from IEAddTimer() or IEAddPeriodicTimer().
 *
 * \param timerid the timer callback ID returned from IEAddTimer() or IEAddPeriodicTimer().

--- a/indidevapi.h
+++ b/indidevapi.h
@@ -350,6 +350,13 @@ extern int IEAddPeriodicTimer(int millisecs, IE_TCF *fp, void *userpointer);
  */
 extern int IERemainingTimer(int timerid);
 
+/** Returns the timer's remaining value in nanoseconds left until the timeout.
+ *
+ * \param tid the timer callback ID returned from addTimer() or addPeriodicTimer()
+ * \return  If the timer not exists, the returned value will be -1.
+ */
+extern int IENSecRemainingTimer(int tid);
+
 /** \brief Remove the timer with the given \e timerid, as returned from IEAddTimer() or IEAddPeriodicTimer().
 *
 * \param timerid the timer callback ID returned from IEAddTimer() or IEAddPeriodicTimer().

--- a/libs/indibase/timer/indielapsedtimer.cpp
+++ b/libs/indibase/timer/indielapsedtimer.cpp
@@ -26,6 +26,10 @@ ElapsedTimer::ElapsedTimer()
     : d_ptr(new ElapsedTimerPrivate)
 { start(); }
 
+ElapsedTimer::ElapsedTimer(ElapsedTimerPrivate &dd)
+    : d_ptr(&dd)
+{ start(); }
+
 ElapsedTimer::~ElapsedTimer()
 { }
 

--- a/libs/indibase/timer/indielapsedtimer.cpp
+++ b/libs/indibase/timer/indielapsedtimer.cpp
@@ -48,8 +48,14 @@ int64_t ElapsedTimer::elapsed() const
 {
     D_PTR(const ElapsedTimer);
     std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
-
     return std::chrono::duration_cast<std::chrono::milliseconds>(now - d->start).count();
+}
+
+int64_t ElapsedTimer::nsecsElapsed() const
+{
+    D_PTR(const ElapsedTimer);
+    std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(now - d->start).count();
 }
 
 bool ElapsedTimer::hasExpired(int64_t timeout) const

--- a/libs/indibase/timer/indielapsedtimer.cpp
+++ b/libs/indibase/timer/indielapsedtimer.cpp
@@ -67,4 +67,10 @@ bool ElapsedTimer::hasExpired(int64_t timeout) const
     return elapsed() > timeout;
 }
 
+void ElapsedTimer::nsecsRewind(int64_t nsecs)
+{
+    D_PTR(ElapsedTimer);
+    d->start += std::chrono::nanoseconds(nsecs);
+}
+
 }

--- a/libs/indibase/timer/indielapsedtimer.h
+++ b/libs/indibase/timer/indielapsedtimer.h
@@ -35,13 +35,11 @@ class ElapsedTimerPrivate;
 class ElapsedTimer
 {
     DECLARE_PRIVATE(ElapsedTimer)
-
 public:
     ElapsedTimer();
     virtual ~ElapsedTimer();
 
 public:
-
     /** @brief Starts this timer. Once started, a timer value can be checked with elapsed(). */
     void start();
 
@@ -49,9 +47,11 @@ public:
     int64_t restart();
 
 public:
-
     /** @brief Returns the number of milliseconds since this ElapsedTimer was last started. */
     int64_t elapsed() const;
+
+    /** @brief Returns the number of nanoseconds since this ElapsedTimer was last started. */
+    int64_t nsecsElapsed() const;
 
     /** @brief Returns true if this ElapsedTimer has already expired by timeout milliseconds. */
     bool hasExpired(int64_t timeout) const;

--- a/libs/indibase/timer/indielapsedtimer.h
+++ b/libs/indibase/timer/indielapsedtimer.h
@@ -56,6 +56,10 @@ public:
     /** @brief Returns true if this ElapsedTimer has already expired by timeout milliseconds. */
     bool hasExpired(int64_t timeout) const;
 
+public:
+    /** @brief Rewind elapsed time of nsec nanoseconds */
+    void nsecsRewind(int64_t nsecs);
+
 protected:
     std::unique_ptr<ElapsedTimerPrivate> d_ptr;
     ElapsedTimer(ElapsedTimerPrivate &dd);

--- a/libs/indibase/timer/indielapsedtimer.h
+++ b/libs/indibase/timer/indielapsedtimer.h
@@ -58,6 +58,7 @@ public:
 
 protected:
     std::unique_ptr<ElapsedTimerPrivate> d_ptr;
+    ElapsedTimer(ElapsedTimerPrivate &dd);
 };
 
 }

--- a/libs/indibase/timer/inditimer.cpp
+++ b/libs/indibase/timer/inditimer.cpp
@@ -119,8 +119,8 @@ bool Timer::isSingleShot() const
 
 int Timer::remainingTime() const
 {
-    //D_PTR(const Timer);
-    return 0;
+    D_PTR(const Timer);
+    return d->timerId != -1 ? std::max(remainingTimer(d->timerId), 0) : 0;
 }
 
 int Timer::interval() const

--- a/libs/indibase/timer/inditimer.cpp
+++ b/libs/indibase/timer/inditimer.cpp
@@ -33,14 +33,19 @@ TimerPrivate::~TimerPrivate()
 
 void TimerPrivate::start()
 {
-    timerId = addTimer(interval, [](void *arg){
-        TimerPrivate *d = static_cast<TimerPrivate*>(arg);
-        d->p->timeout();
-        if (d->singleShot)
+    if (singleShot)
+    {
+        timerId = addTimer(interval, [](void *arg){
+            TimerPrivate *d = static_cast<TimerPrivate*>(arg);
+            d->p->timeout();
             d->timerId = -1;
-        else
-            d->start();
-    }, this);
+        }, this);
+    } else {
+        timerId = addPeriodicTimer(interval, [](void *arg){
+            TimerPrivate *d = static_cast<TimerPrivate*>(arg);
+            d->p->timeout();
+        }, this);
+    }
 }
 
 void TimerPrivate::stop()

--- a/libs/indibase/timer/inditimer.cpp
+++ b/libs/indibase/timer/inditimer.cpp
@@ -29,7 +29,9 @@ TimerPrivate::TimerPrivate(Timer *p)
 { }
 
 TimerPrivate::~TimerPrivate()
-{ }
+{
+    stop();
+}
 
 void TimerPrivate::start()
 {

--- a/libs/indibase/timer/inditimer.cpp
+++ b/libs/indibase/timer/inditimer.cpp
@@ -54,6 +54,10 @@ Timer::Timer()
     : d_ptr(new TimerPrivate(this))
 { }
 
+Timer::Timer(TimerPrivate &dd)
+    : d_ptr(&dd)
+{ }
+
 Timer::~Timer()
 { }
 

--- a/libs/indibase/timer/inditimer.cpp
+++ b/libs/indibase/timer/inditimer.cpp
@@ -37,8 +37,8 @@ void TimerPrivate::start()
     {
         timerId = addTimer(interval, [](void *arg){
             TimerPrivate *d = static_cast<TimerPrivate*>(arg);
-            d->p->timeout();
             d->timerId = -1;
+            d->p->timeout();
         }, this);
     } else {
         timerId = addPeriodicTimer(interval, [](void *arg){

--- a/libs/indibase/timer/inditimer.h
+++ b/libs/indibase/timer/inditimer.h
@@ -88,6 +88,7 @@ protected:
 
 protected:
     std::unique_ptr<TimerPrivate> d_ptr;
+    Timer(TimerPrivate &dd);
 };
 
 }

--- a/libs/indibase/timer/inditimer.h
+++ b/libs/indibase/timer/inditimer.h
@@ -72,7 +72,9 @@ public:
     /** @brief Returns whether the timer is a single-shot timer. */
     bool isSingleShot() const;
 
-    /** @brief This function doesn't work - yet. */
+    /** @brief Returns the timer's remaining value in milliseconds left until the timeout.
+     * If the timer not exists, the returned value will be -1.
+     */
     int remainingTime() const;
 
     /** @brief Returns the timeout interval in milliseconds. */

--- a/libs/indibase/timer/inditimer.h
+++ b/libs/indibase/timer/inditimer.h
@@ -82,7 +82,7 @@ public:
     /** @brief This static function calls a the given function after a given time interval. */
     static void singleShot(int msec, const std::function<void()> &callback);
 
-protected:
+public:
     /** @brief This function is called when the timer times out. */
     virtual void timeout();
 


### PR DESCRIPTION
Hi!

A lot of drivers uses periodic timers. Currently, "addTimer" must be called again.
This causes an imprecise frequency of callback calls.

```
2021-03-17T12:44:25: Driver timer_old_way: 1000.049 ms
2021-03-17T12:44:26: Driver timer_old_way: 2001.132 ms
2021-03-17T12:44:27: Driver timer_old_way: 3002.262 ms
2021-03-17T12:44:28: Driver timer_old_way: 4002.311 ms
2021-03-17T12:44:29: Driver timer_old_way: 5003.407 ms
2021-03-17T12:44:30: Driver timer_old_way: 6004.504 ms
2021-03-17T12:44:31: Driver timer_old_way: 7005.568 ms
```
I implemented the 'addPeriodicTimer' function.
```c
/** Register a new periodic timer function, \e fp, to be called with \e ud as argument after \e ms.
*
* \param ms timer period in milliseconds.
* \param fp a pointer to the callback function.
* \param ud a pointer to be passed to the callback function when called.
* \return a unique id for use with rmTimer().
*/
extern int addPeriodicTimer(int ms, TCF *fp, void *ud);
```
The added Timer stores the 'Interval' value and is not removed from the list after calling callback.
```c
static void checkTimer()
{
    TF *node = timefunc->next;

    if (node == NULL || remainingTimerNode(node) > 0)
        return;

    (*node->fp)(node->ud);

    node = dettachTimer(node);

    if (node == NULL)
        return;

    if (node->interval > 0)
    {
        node->tgo += node->interval;
        insertTimer(node);
    } else {
        free(node);
    }
}
```
Now, Callback is called predetermined times.
```
2021-03-17T12:45:36: Driver timer_new_way: 1000.057 ms
2021-03-17T12:45:37: Driver timer_new_way: 2000.061 ms
2021-03-17T12:45:38: Driver timer_new_way: 3000.077 ms
2021-03-17T12:45:39: Driver timer_new_way: 4000.081 ms
2021-03-17T12:45:40: Driver timer_new_way: 5000.075 ms
2021-03-17T12:45:41: Driver timer_new_way: 6000.084 ms
2021-03-17T12:45:42: Driver timer_new_way: 7000.083 ms
```

Source of example:
```cpp
#include "inditimer.h"
#include "indielapsedtimer.h"

static class Main
{
    INDI::Timer timer;
    INDI::ElapsedTimer elapsedTimer;

public:
    Main()
    {
        timer.callOnTimeout([&](){
            fprintf(stderr, "%.3f ms\n", elapsedTimer.nsecsElapsed() / 1000000.0);
        });
        
        timer.start(1000);
        elapsedTimer.start();
    }
} main_example;
```

I also added auxiliary features to check the remaining time to call callback.
```c

/** Returns the timer's remaining value in milliseconds left until the timeout.
 *
 * \param tid the timer callback ID returned from addTimer() or addPeriodicTimer()
 * \return  If the timer not exists, the returned value will be -1.
 */
extern int remainingTimer(int tid);

/** Returns the timer's remaining value in nanoseconds left until the timeout.
 *
 * \param tid the timer callback ID returned from addTimer() or addPeriodicTimer()
 * \return  If the timer not exists, the returned value will be -1.
 */
extern int nsecRemainingTimer(int tid);
```


High-Level Timers have also been updated and use new changes in eventloop.c.
```cpp
void TimerPrivate::start()
{
    if (singleShot)
    {
        timerId = addTimer(interval, [](void *arg){
            TimerPrivate *d = static_cast<TimerPrivate*>(arg);
            d->p->timeout();
            d->timerId = -1;
        }, this);
    } else {
        timerId = addPeriodicTimer(interval, [](void *arg){
            TimerPrivate *d = static_cast<TimerPrivate*>(arg);
            d->p->timeout();
        }, this);
    }
}
```

