### PR TITLE
Add STL-style iterators to INDI::PropertyBasic

### DIFF
--- a/libs/indibase/property/indipropertybasic.cpp
+++ b/libs/indibase/property/indipropertybasic.cpp
@@ -281,6 +281,13 @@ WidgetView<T> *PropertyBasic<T>::findWidgetByName(const char *name) const
 }
 
 template <typename T>
+int PropertyBasic<T>::findWidgetIndexByName(const char *name) const
+{
+    auto it = findWidgetByName(name);
+    return it == nullptr ? -1 : it - begin();
+}
+
+template <typename T>
 size_t PropertyBasic<T>::size() const
 {
     D_PTR(const PropertyBasic);

--- a/libs/indibase/property/indipropertybasic.cpp
+++ b/libs/indibase/property/indipropertybasic.cpp
@@ -297,6 +297,22 @@ void PropertyBasic<T>::resize(size_t size)
 }
 
 template <typename T>
+void PropertyBasic<T>::reserve(size_t size)
+{
+    D_PTR(PropertyBasic);
+    d->widgets.reserve(size);
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());
+}
+
+template <typename T>
+void PropertyBasic<T>::shrink_to_fit()
+{
+    D_PTR(PropertyBasic);
+    d->widgets.shrink_to_fit();
+    d->property.setWidgets(d->widgets.data(), d->widgets.size());    
+}
+
+template <typename T>
 void PropertyBasic<T>::push(WidgetView<T> &&item)
 {
     D_PTR(PropertyBasic);
@@ -315,6 +331,20 @@ WidgetView<T> &PropertyBasic<T>::operator[](size_t index) const
 {
     D_PTR(const PropertyBasic);
     return *d->property.at(index);
+}
+
+template <typename T>
+WidgetView<T> *PropertyBasic<T>::begin()
+{
+    D_PTR(PropertyBasic);
+    return d->property.begin();
+}
+
+template <typename T>
+WidgetView<T> *PropertyBasic<T>::end()
+{
+    D_PTR(PropertyBasic);
+    return d->property.end();
 }
 
 template <typename T>

--- a/libs/indibase/property/indipropertybasic.cpp
+++ b/libs/indibase/property/indipropertybasic.cpp
@@ -348,6 +348,20 @@ WidgetView<T> *PropertyBasic<T>::end()
 }
 
 template <typename T>
+const WidgetView<T> *PropertyBasic<T>::begin() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.begin();
+}
+
+template <typename T>
+const WidgetView<T> *PropertyBasic<T>::end() const
+{
+    D_PTR(const PropertyBasic);
+    return d->property.end();
+}
+
+template <typename T>
 PropertyView<T> * PropertyBasic<T>::operator &()
 {
     D_PTR(PropertyBasic);

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -120,6 +120,7 @@ public: // STL-style iterators
 
 public:
     WidgetView<T> *findWidgetByName(const char *name) const;
+    int findWidgetIndexByName(const char *name) const;
 
 protected:
     PropertyBasic(PropertyBasicPrivate &dd);

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -93,11 +93,20 @@ public:
     size_t size() const;
 
 public:
+    void reserve(size_t size);
     void resize(size_t size);
+
+    void shrink_to_fit();
+
     void push(WidgetView<T> &&item);
     void push(const WidgetView<T> &item);
 
     WidgetView<T> &operator[](size_t index) const;
+
+public:
+    WidgetView<T> *begin();
+    WidgetView<T> *end();
+    
     // #PS: TODO begin, end, cbegin, cend, etc
 
 public:

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -24,6 +24,12 @@
 namespace INDI
 {
 
+using WidgetText   = INDI::WidgetView<IText>;
+using WidgetNumber = INDI::WidgetView<INumber>;
+using WidgetSwitch = INDI::WidgetView<ISwitch>;
+using WidgetLight  = INDI::WidgetView<ILight>;
+using WidgetBlob   = INDI::WidgetView<IBLOB>;
+
 template <typename>
 class PropertyBasicPrivateTemplate;
 

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "indiproperty.h"
+#include <algorithm>
 
 namespace INDI
 {
@@ -103,11 +104,19 @@ public:
 
     WidgetView<T> &operator[](size_t index) const;
 
-public:
+public: // STL-style iterators
     WidgetView<T> *begin();
     WidgetView<T> *end();
-    
-    // #PS: TODO begin, end, cbegin, cend, etc
+    const WidgetView<T> *begin() const;
+    const WidgetView<T> *end() const;
+
+    template <typename Predicate>
+    WidgetView<T> *find_if(Predicate pred)
+    { return std::find_if(begin(), end(), pred); }
+
+    template <typename Predicate>
+    const WidgetView<T> *find_if(Predicate pred) const
+    { return std::find_if(begin(), end(), pred); }
 
 public:
     WidgetView<T> *findWidgetByName(const char *name) const;


### PR DESCRIPTION
Hi!

This PR is an extension of INDI::Property family functionality.

Changes:
- Add findWidgetIndexByName method.
- Add reserve / shrink_to_fit - like std::vector.
- Add iterators useful for foreach loops. For example:
```cpp
std::vector<double> oldValues;
for (const auto &it : ControlNP)
    oldValues.push_back(it.getValue());
```
- Add find_if - Now you can find for an item in a readable way. For example:
```cpp
auto sw = ControlSP.find_if([&numCtrlCap](const INDI::WidgetSwitch &it) -> bool {
    return static_cast<const ASI_CONTROL_CAPS *>(it.getAux())->ControlType == numCtrlCap->ControlType;
});

if (sw != ControlSP.end())
    sw->setState(ISS_OFF);
```
