### PR TITLE
Added support for TeenAstro focuser 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1006,6 +1006,14 @@ add_executable(indi_onfocus_focus ${onfocus_SRC})
 target_link_libraries(indi_onfocus_focus indidriver)
 install(TARGETS indi_onfocus_focus RUNTIME DESTINATION bin)
 
+################ TeenAstro Focuser ################
+
+SET(teenastro_focus_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/drivers/focuser/teenastro.cpp)
+
+add_executable(indi_teenastro_focus ${teenastro_focus_SRC})
+target_link_libraries(indi_teenastro_focus indidriver)
+install(TARGETS indi_teenastro_focus RUNTIME DESTINATION bin)
 
 ################ Sesto Senso Focuser ################
 SET(sesto_SRC

--- a/drivers.xml
+++ b/drivers.xml
@@ -339,6 +339,10 @@
             <driver name="OnFocus">indi_onfocus_focus</driver>
             <version>1.0</version>
         </device>
+        <device Label="TeenAstroFocuser" manufacturer="DIY">
+            <driver name="TeenAstroFocuser">indi_teenastro_focus</driver>
+            <version>0.1</version>
+        </device>
         <device label="NightCrawler" manufacturer="MoonLite">
             <driver name="NightCrawler">indi_nightcrawler_focus</driver>
             <version>1.0</version>

--- a/drivers.xml
+++ b/drivers.xml
@@ -339,9 +339,9 @@
             <driver name="OnFocus">indi_onfocus_focus</driver>
             <version>1.0</version>
         </device>
-        <device Label="TeenAstroFocuser" manufacturer="DIY">
+        <device label="TeenAstroFocuser" manufacturer="TeenAstro">
             <driver name="TeenAstroFocuser">indi_teenastro_focus</driver>
-            <version>0.1</version>
+            <version>1.0</version>
         </device>
         <device label="NightCrawler" manufacturer="MoonLite">
             <driver name="NightCrawler">indi_nightcrawler_focus</driver>

--- a/drivers/focuser/teenastro.cpp
+++ b/drivers/focuser/teenastro.cpp
@@ -55,14 +55,12 @@
 #define TAF_res_min 1
 #define TAF_res_max 512
 
-#define TAF_UI_STEPS    20.0
+#define TAF_UI_STEPS    100.0
 #define TAF_STEP(min,max)  (((max)-(min))/(TAF_UI_STEPS))
 
 
-#define TEENASTRO_FOCUSER_TIMEOUT 4
-#define TEENASTRO_FOCUSER_BUFSIZE 128
-
-#define POLLMS_OVERRIDE  1500
+#define TAF_FOCUSER_TIMEOUT 4
+#define TAF_FOCUSER_BUFSIZE 128
 
 // Focuser singleton
 std::unique_ptr<TeenAstroFocuser> teenAstroFocuser(new TeenAstroFocuser());
@@ -73,39 +71,39 @@ std::unique_ptr<TeenAstroFocuser> teenAstroFocuser(new TeenAstroFocuser());
 
 void ISGetProperties(const char *dev)
 {
-         teenAstroFocuser->ISGetProperties(dev);
+	teenAstroFocuser->ISGetProperties(dev);
 }
 
 void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int num)
 {
-         teenAstroFocuser->ISNewSwitch(dev, name, states, names, num);
+	teenAstroFocuser->ISNewSwitch(dev, name, states, names, num);
 }
 
 void ISNewText(	const char *dev, const char *name, char *texts[], char *names[], int num)
 {
-         teenAstroFocuser->ISNewText(dev, name, texts, names, num);
+	teenAstroFocuser->ISNewText(dev, name, texts, names, num);
 }
 
 void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int num)
 {
-         teenAstroFocuser->ISNewNumber(dev, name, values, names, num);
+	teenAstroFocuser->ISNewNumber(dev, name, values, names, num);
 }
 
 void ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[], char *names[], int n)
 {
-   INDI_UNUSED(dev);
-   INDI_UNUSED(name);
-   INDI_UNUSED(sizes);
-   INDI_UNUSED(blobsizes);
-   INDI_UNUSED(blobs);
-   INDI_UNUSED(formats);
-   INDI_UNUSED(names);
-   INDI_UNUSED(n);
+	INDI_UNUSED(dev);
+	INDI_UNUSED(name);
+	INDI_UNUSED(sizes);
+	INDI_UNUSED(blobsizes);
+	INDI_UNUSED(blobs);
+	INDI_UNUSED(formats);
+	INDI_UNUSED(names);
+	INDI_UNUSED(n);
 }
 
 void ISSnoopDevice(XMLEle *root)
 {
-     teenAstroFocuser->ISSnoopDevice(root);
+	teenAstroFocuser->ISSnoopDevice(root);
 }
 
 
@@ -114,7 +112,8 @@ void ISSnoopDevice(XMLEle *root)
 
 TeenAstroFocuser::TeenAstroFocuser()
 {
-    FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_CAN_ABORT | FOCUSER_CAN_SYNC);
+    FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_CAN_ABORT | 
+    	              FOCUSER_CAN_REVERSE  | FOCUSER_CAN_SYNC     | FOCUSER_HAS_VARIABLE_SPEED);
 }
 
 TeenAstroFocuser::~TeenAstroFocuser()
@@ -128,10 +127,8 @@ const char * TeenAstroFocuser::getDefaultName()
 
 bool TeenAstroFocuser::Handshake()
 {
-    sleep(2);
-
-    char resp[TEENASTRO_FOCUSER_BUFSIZE];
-    if(!sendAndReceive(":FV#", resp, TEENASTRO_FOCUSER_BUFSIZE))
+    char resp[TAF_FOCUSER_BUFSIZE];
+    if(!sendAndReceive(":FV#", resp, TAF_FOCUSER_BUFSIZE))
         return false;
     if (strncmp(resp, "$ TeenAstro Focuser ",20))
     {
@@ -139,74 +136,96 @@ bool TeenAstroFocuser::Handshake()
         return false;
     }
 
-    DEBUG(INDI::Logger::DBG_SESSION, "TeenAstroFocuser found, updating parameters...");
+    DEBUGF(INDI::Logger::DBG_DEBUG, "TeenAstroFocuser %s found", &resp[20]);
     return true;
 }
 
 bool TeenAstroFocuser::initProperties()
 {
     INDI::Focuser::initProperties();
-     
-    IUFillText(&DeviceVersionT[0], "VAL", "Version", "unknown");
-    IUFillTextVector(&DeviceVersionTP, DeviceVersionT, 1, getDeviceName(), "DEVICE_VERSION", "Device version", FOCUS_TAB, IP_RO, 60, IPS_IDLE);
+ 
+	strcpy(FocusSyncN[0].label,  "Ticks"); // Rename unit of measure to ticks, to avoid confusion with motor steps,
+	strcpy(FocusMaxPosN[0].label,"Ticks"); // motor microsteps and the effect of the resolution setting.
+	strcpy(FocusRelPosN[0].label,"Ticks"); // Ticks are resolution units.
+	strcpy(FocusAbsPosN[0].label,"Ticks");
 
-    // Configuration
+	strcpy(FocusReverseSP.group, FOCUS_TAB);
+
+	strcpy(FocusSpeedNP.label, "Go-to speed");
+	strcpy(FocusSpeedNP.group, FOCUS_TAB);
+	strcpy(FocusSpeedN[0].label,"1/s");
+	FocusSpeedN[0].min=TAF_speed_min;	
+	FocusSpeedN[0].max=TAF_speed_max;
+	FocusSpeedN[0].step=TAF_STEP(TAF_speed_min, TAF_speed_max);
+
+    // Main control tab
     //
 
-    IUFillNumber(&CfgParkPosN[0], "VAL", "Ticks", "%5.0f", 0, 100000, 1000, 0);
+    IUFillNumber(&CfgParkPosN[0], "VAL", "Ticks", "%.f", 0, 100000, 1000, 0);
     IUFillNumberVector(&CfgParkPosNP, CfgParkPosN, 1, getDeviceName(), "PARK_POS", "Park position", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE );
 
     IUFillSwitch(&GoToParkS[0], "VAL", "Park", ISS_OFF);
     IUFillSwitchVector(&GoToParkSP, GoToParkS, 1, getDeviceName(), "GOTO_PARK", "Go-to park", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE );
 
-    IUFillNumber(&CfgGoToSpeedN[0], "VAL", "1/s", "%3.0f", TAF_speed_min, TAF_speed_max, TAF_STEP(TAF_speed_min, TAF_speed_max), TAF_speed_default);
-    IUFillNumberVector(&CfgGoToSpeedNP, CfgGoToSpeedN, 1, getDeviceName(), "GOTO_SPEED", "Go-to speed", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgGoToAccN[0], "VAL", "1/s^2", "%3.0f", TAF_acc_min, TAF_acc_max, TAF_STEP(TAF_acc_min, TAF_acc_max), TAF_acc_default);
-    IUFillNumberVector(&CfgGoToAccNP, CfgGoToAccN, 1, getDeviceName(), "GOTO_ACCEL", "Go-to accel.", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgManualSpeedN[0], "VAL", "1/s", "%3.0f", TAF_speed_min, TAF_speed_max, TAF_STEP(TAF_speed_min, TAF_speed_max), TAF_speed_default);
-    IUFillNumberVector(&CfgManualSpeedNP, CfgManualSpeedN, 1, getDeviceName(), "MAN_SPEED", "Manual speed", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgManualAccN[0], "VAL", "1/s^2", "%3.0f", TAF_acc_min, TAF_acc_max, TAF_STEP(TAF_acc_min, TAF_acc_max), TAF_acc_default);
-    IUFillNumberVector(&CfgManualAccNP, CfgManualAccN, 1, getDeviceName(), "MAN_ACCEL", "Manual accel.", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgManualDecN[0], "VAL", "1/s^2", "%8.0f", TAF_acc_min, TAF_acc_max, TAF_STEP(TAF_acc_min, TAF_acc_max), TAF_acc_default);
-    IUFillNumberVector(&CfgManualDecNP, CfgManualDecN, 1, getDeviceName(), "MAN_DECEL", "Manual decel.", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    // Motor configuration
-    //
-
-    IUFillNumber(&CfgMotorInvertN[0], "VAL", "0=norm. 1=inv.", "%8.0f", 0, 1, 1, 0);
-    IUFillNumberVector(&CfgMotorInvertNP, CfgMotorInvertN, 1, getDeviceName(), "MOT_INV", "Motor invert", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgMotorStepsPerRevolutionN[0], "VAL", "Steps", "%3.0f", TAF_steprot_min, TAF_steprot_max, TAF_STEP(TAF_steprot_min, TAF_steprot_max), TAF_steprot_default);
-    IUFillNumberVector(&CfgMotorStepsPerRevolutionNP, CfgMotorStepsPerRevolutionN, 1, getDeviceName(), "MOT_STEPS_REV", "Motor steps/rev", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgMotorMicrostepsN[0], "VAL", "Usteps", "%3.0f", TAF_micro_min, TAF_micro_max, TAF_STEP(TAF_micro_min, TAF_micro_max), TAF_micro_default);
-    IUFillNumberVector(&CfgMotorMicrostepsNP, CfgMotorMicrostepsN, 1, getDeviceName(), "MOT_USTEPS", "Motor usteps", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgMotorResolutionN[0], "VAL", "Usteps/tick", "%3.0f", TAF_res_min, TAF_res_max, TAF_STEP(TAF_res_min, TAF_res_max), TAF_res_default);
-    IUFillNumberVector(&CfgMotorResolutionNP, CfgMotorResolutionN, 1, getDeviceName(), "MOT_RES", "Motor resolution", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    IUFillNumber(&CfgMotorCurrentN[0], "VAL", "mA", "%4.0f", TAF_curr_min, TAF_curr_max, TAF_STEP(TAF_curr_min, TAF_curr_max), TAF_curr_default);
-    IUFillNumberVector(&CfgMotorCurrentNP, CfgMotorCurrentN, 1, getDeviceName(), "MOT_CUR", "Motor current", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
-
-    // Status variables
-    //
-    
-    // Current speed
-    IUFillNumber(&CurSpeedN[0], "VAL", "tbd/s", "%3.0f", TAF_speed_min, TAF_speed_max, TAF_STEP(TAF_speed_min, TAF_speed_max), TAF_speed_default);
+    IUFillNumber(&CurSpeedN[0], "VAL", "1/s", "%.f", TAF_speed_min, TAF_speed_max, TAF_STEP(TAF_speed_min, TAF_speed_max), TAF_speed_default);
     IUFillNumberVector(&CurSpeedNP, CurSpeedN, 1, getDeviceName(), "CUR_SPEED", "Current Speed", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE );
 
-    // Temperature
-    IUFillNumber(&TempN[0], "VAL", "°Celsius", "%+2.1f", -50., 50., 0, 0);
+    IUFillNumber(&TempN[0], "VAL", "Celsius", "%+.1f°", -50., 50., 0, 0);
     IUFillNumberVector(&TempNP, TempN, 1, getDeviceName(), "TEMP", "Temperature", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE );
+
+    // Focuser tab: Motion configuration
+    //
+
+    IUFillText(&DeviceVersionT[0], "VAL", "Version", "unknown");
+    IUFillTextVector(&DeviceVersionTP, DeviceVersionT, 1, getDeviceName(), "DEVICE_VERSION", "Device version", FOCUS_TAB, IP_RO, 60, IPS_IDLE);
+
+    IUFillNumber(&CfgGoToAccN[0], "VAL", "1/s^2", "%.f", TAF_acc_min, TAF_acc_max, TAF_STEP(TAF_acc_min, TAF_acc_max), TAF_acc_default);
+    IUFillNumberVector(&CfgGoToAccNP, CfgGoToAccN, 1, getDeviceName(), "GOTO_ACCEL", "Go-to accel.", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
+
+    IUFillNumber(&CfgManualSpeedN[0], "VAL", "1/s", "%.f", TAF_speed_min, TAF_speed_max, TAF_STEP(TAF_speed_min, TAF_speed_max), TAF_speed_default);
+    IUFillNumberVector(&CfgManualSpeedNP, CfgManualSpeedN, 1, getDeviceName(), "MAN_SPEED", "Manual speed", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
+
+    IUFillNumber(&CfgManualAccN[0], "VAL", "1/s^2", "%.f", TAF_acc_min, TAF_acc_max, TAF_STEP(TAF_acc_min, TAF_acc_max), TAF_acc_default);
+    IUFillNumberVector(&CfgManualAccNP, CfgManualAccN, 1, getDeviceName(), "MAN_ACCEL", "Manual accel.", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
+
+    IUFillNumber(&CfgManualDecN[0], "VAL", "1/s^2", "%.f", TAF_acc_min, TAF_acc_max, TAF_STEP(TAF_acc_min, TAF_acc_max), TAF_acc_default);
+    IUFillNumberVector(&CfgManualDecNP, CfgManualDecN, 1, getDeviceName(), "MAN_DECEL", "Manual decel.", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
+
+    // Focuser tab: Motor configuration
+    //
+
+    IUFillNumber(&CfgMotorStepsPerRevolutionN[0], "VAL", "Steps", "%.f", TAF_steprot_min, TAF_steprot_max, TAF_STEP(TAF_steprot_min, TAF_steprot_max), TAF_steprot_default);
+    IUFillNumberVector(&CfgMotorStepsPerRevolutionNP, CfgMotorStepsPerRevolutionN, 1, getDeviceName(), "MOT_STEPS_REV", "Steps/rev.", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
+
+    IUFillSwitch(&CfgMotorMicrostepsS[TAF_MICROS_4],   "4",   "4",   ISS_OFF);
+    IUFillSwitch(&CfgMotorMicrostepsS[TAF_MICROS_8],   "8",   "8",   ISS_OFF);
+    IUFillSwitch(&CfgMotorMicrostepsS[TAF_MICROS_16],  "16",  "16",  ISS_OFF);
+    IUFillSwitch(&CfgMotorMicrostepsS[TAF_MICROS_32],  "32",  "32",  ISS_OFF);
+    IUFillSwitch(&CfgMotorMicrostepsS[TAF_MICROS_64],  "64",  "64",  ISS_OFF);
+    IUFillSwitch(&CfgMotorMicrostepsS[TAF_MICROS_128], "128", "128", ISS_OFF);
+    IUFillSwitchVector(&CfgMotorMicrostepsSP, CfgMotorMicrostepsS, TAF_MICROS_N, getDeviceName(), "MOT_USTEPS", "Microsteps", FOCUS_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE );
+
+    IUFillNumber(&CfgMotorResolutionN[0], "VAL", "Usteps/tick", "%.f", TAF_res_min, TAF_res_max, TAF_STEP(TAF_res_min, TAF_res_max), TAF_res_default);
+    IUFillNumberVector(&CfgMotorResolutionNP, CfgMotorResolutionN, 1, getDeviceName(), "MOT_RES", "Resolution", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
+
+    IUFillNumber(&CfgMotorCurrentN[0], "VAL", "mA", "%.f", TAF_curr_min, TAF_curr_max, TAF_STEP(TAF_curr_min, TAF_curr_max), TAF_curr_default);
+    IUFillNumberVector(&CfgMotorCurrentNP, CfgMotorCurrentN, 1, getDeviceName(), "MOT_CUR", "Motor current", FOCUS_TAB, IP_RW, 60, IPS_IDLE );
+
+    IUFillSwitch(&RebootDeviceS[0], "VAL", "Reboot", ISS_OFF);
+    IUFillSwitchVector(&RebootDeviceSP, RebootDeviceS, 1, getDeviceName(), "REBOOT_DEVICE", "Reboot device", FOCUS_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE );
+
+    IUFillSwitch(&EraseEEPROMS[0], "VAL", "Erase", ISS_OFF);
+    IUFillSwitchVector(&EraseEEPROMSP, EraseEEPROMS, 1, getDeviceName(), "ERASE_EEPROM", "Erase EEPROM", FOCUS_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE );
 
     addDebugControl();
 
     return true;
+}
 
+void TeenAstroFocuser::initPositionPropertiesRanges(uint32_t maxPos)
+{
+    FocusAbsPosN[0].max  = FocusRelPosN[0].max  = FocusSyncN[0].max  = CfgParkPosN[0].max  = maxPos;
+    FocusAbsPosN[0].step = FocusRelPosN[0].step = FocusSyncN[0].step = CfgParkPosN[0].step = maxPos / TAF_UI_STEPS;
 }
 
 bool TeenAstroFocuser::updateProperties()
@@ -214,66 +233,86 @@ bool TeenAstroFocuser::updateProperties()
     INDI::Focuser::updateProperties();
     if (isConnected())
     {
-        defineProperty(&DeviceVersionTP);
-
-        defineProperty(&GoToParkSP);
-        defineProperty(&CfgParkPosNP);
-
-		deleteProperty(FocusSyncNP.name);
-		defineProperty(&FocusSyncNP);
-
-		deleteProperty(FocusMaxPosNP.name);
-		defineProperty(&FocusMaxPosNP);
-
-        defineProperty(&CfgGoToSpeedNP);
-        defineProperty(&CfgGoToAccNP);
-        defineProperty(&CfgManualSpeedNP);
-        defineProperty(&CfgManualAccNP);
-        defineProperty(&CfgManualDecNP);
-
-        defineProperty(&CfgMotorInvertNP);
-        defineProperty(&CfgMotorStepsPerRevolutionNP);
-        defineProperty(&CfgMotorMicrostepsNP);
-        defineProperty(&CfgMotorResolutionNP);
-        defineProperty(&CfgMotorCurrentNP);
-
-        defineProperty(&CurSpeedNP);
-        defineProperty(&TempNP);
-
-        updateDeviceVersion();
-        updateConfig();
-        updateMotorConfig();
+        updateDeviceVersion(); // Update values from device before defining UI controls. 
+        updateConfig();        // This minimizes flicker as changes to FocuserMaxPosNP
+        updateMotorConfig();   // must redraw all positional controls to update their range.
         updateState();
 
-        DEBUG(INDI::Logger::DBG_SESSION, "TeenAstroFocuser ready for use.");
+    	defineMainControlProperties();
+    	defineOtherProperties();
+
+        DEBUG(INDI::Logger::DBG_DEBUG, "TeenAstroFocuser ready for use.");
     }
     else
     {
-        deleteProperty(DeviceVersionTP.name);
-
-        deleteProperty(GoToParkSP.name);
-        deleteProperty(CfgParkPosNP.name);
-
-        deleteProperty(CfgGoToSpeedNP.name);
-        deleteProperty(CfgGoToAccNP.name);
-        deleteProperty(CfgManualSpeedNP.name);
-        deleteProperty(CfgManualAccNP.name);
-        deleteProperty(CfgManualDecNP.name);
-
-        deleteProperty(CfgMotorInvertNP.name);
-        deleteProperty(CfgMotorStepsPerRevolutionNP.name);
-        deleteProperty(CfgMotorMicrostepsNP.name);
-        deleteProperty(CfgMotorResolutionNP.name);
-        deleteProperty(CfgMotorCurrentNP.name);
-
-        deleteProperty(CurSpeedNP.name);
-        deleteProperty(TempNP.name);
-
+    	deleteMainControlProperties();
+    	deleteOtherProperties();
     }
 
     return true;
 }
 
+void TeenAstroFocuser::defineMainControlProperties() 
+{
+	deleteProperty(FocusSyncNP.name);   // remove superclass controls to improve ordering of UI elements
+	deleteProperty(FocusMaxPosNP.name);
+	deleteProperty(FocusAbortSP.name);
+	deleteProperty(FocusRelPosNP.name);
+	deleteProperty(FocusAbsPosNP.name);
+
+	defineProperty(&FocusRelPosNP);
+	defineProperty(&FocusAbsPosNP);
+	defineProperty(&FocusAbortSP);
+    defineProperty(&GoToParkSP);
+    defineProperty(&CfgParkPosNP);
+	defineProperty(&FocusSyncNP); 
+	defineProperty(&FocusMaxPosNP);
+    defineProperty(&CurSpeedNP);
+    defineProperty(&TempNP);
+}
+
+void TeenAstroFocuser::deleteMainControlProperties() 
+{
+    deleteProperty(GoToParkSP.name);
+    deleteProperty(CfgParkPosNP.name);
+    deleteProperty(CurSpeedNP.name);
+    deleteProperty(TempNP.name);
+}
+
+void TeenAstroFocuser::defineOtherProperties() 
+{
+	deleteProperty(FocusReverseSP.name); // Place this on the focuser tab to avoid clutter
+    deleteProperty(FocusSpeedNP.name);
+
+    defineProperty(&DeviceVersionTP);
+    defineProperty(&FocusSpeedNP);
+    defineProperty(&CfgGoToAccNP);
+    defineProperty(&CfgManualSpeedNP);
+    defineProperty(&CfgManualAccNP);
+    defineProperty(&CfgManualDecNP);
+	defineProperty(&FocusReverseSP);
+    defineProperty(&CfgMotorStepsPerRevolutionNP);
+    defineProperty(&CfgMotorMicrostepsSP);
+    defineProperty(&CfgMotorResolutionNP);
+    defineProperty(&CfgMotorCurrentNP);
+    defineProperty(&RebootDeviceSP);
+    defineProperty(&EraseEEPROMSP);
+}
+
+void TeenAstroFocuser::deleteOtherProperties() 
+{
+    deleteProperty(DeviceVersionTP.name);
+    deleteProperty(CfgGoToAccNP.name);
+    deleteProperty(CfgManualSpeedNP.name);
+    deleteProperty(CfgManualAccNP.name);
+    deleteProperty(CfgManualDecNP.name);
+    deleteProperty(CfgMotorStepsPerRevolutionNP.name);
+    deleteProperty(CfgMotorMicrostepsSP.name);
+    deleteProperty(CfgMotorResolutionNP.name);
+    deleteProperty(CfgMotorCurrentNP.name);
+    deleteProperty(EraseEEPROMSP.name);
+    deleteProperty(EraseEEPROMSP.name);
+}
 
 bool TeenAstroFocuser::ISNewSwitch (const char *dev, const char *name, ISState *states, char *names[], int n)
 {
@@ -289,8 +328,42 @@ bool TeenAstroFocuser::ISNewSwitch (const char *dev, const char *name, ISState *
 		IDSetSwitch(&GoToParkSP, NULL);
 		return res;
 	}
+    else if(!strcmp(name, CfgMotorMicrostepsSP.name))
+    {
+    	// parse selected number of usteps from states and labels. Labels are "Vxxx" where xxx is a number
+        uint32_t usteps=0;
+        for(int i=0; i<n; i++)
+        	if(states[i]==ISS_ON)
+        		usteps=atoi(names[i]);
 
-    return INDI::Focuser::ISNewSwitch(dev, name, states, names, n);
+        bool res=setMotorMicrosteps(usteps);
+        if(res)
+            IUUpdateSwitch(&CfgMotorMicrostepsSP, states, names, n);
+		CfgMotorMicrostepsSP.s= res ? IPS_OK : IPS_ALERT;
+		IDSetSwitch(&CfgMotorMicrostepsSP, NULL);
+		return res;
+    }
+	else if(!strcmp(name, RebootDeviceSP.name)) 
+	{
+		RebootDeviceSP.s=IPS_BUSY;
+		IDSetSwitch(&RebootDeviceSP, NULL);
+		bool res=rebootDevice();
+		RebootDeviceS[0].s=ISS_OFF;
+		RebootDeviceSP.s= res ? IPS_OK : IPS_ALERT;
+		IDSetSwitch(&RebootDeviceSP, NULL);
+		return res;
+	} 
+	else if(!strcmp(name, EraseEEPROMSP.name)) 
+	{
+		EraseEEPROMSP.s=IPS_BUSY;
+		IDSetSwitch(&EraseEEPROMSP, NULL);
+		bool res=eraseDeviceEEPROM();
+		EraseEEPROMS[0].s=ISS_OFF;
+		EraseEEPROMSP.s= res ? IPS_OK : IPS_ALERT;
+		IDSetSwitch(&EraseEEPROMSP, NULL);
+		return res;
+	} else 
+	    return INDI::Focuser::ISNewSwitch(dev, name, states, names, n);
 }
 
 bool TeenAstroFocuser::ISNewNumberHelper(INumberVectorProperty *NP, double values[], char *names[], int n, bool res) 
@@ -319,7 +392,13 @@ bool TeenAstroFocuser::ISNewNumber (const char *dev, const char *name, double va
     }
  	else if(!strcmp(name, FocusMaxPosNP.name))
     {
-        bool res=SetFocuserMaxPosition((uint32_t) rint(values[0]));
+    	uint32_t val=(uint32_t) rint(values[0]);
+        bool res=SetFocuserMaxPosition(val);
+        if(res && FocusMaxPosN[0].value!=val) {
+    	    initPositionPropertiesRanges(val);
+			deleteMainControlProperties();      // Force redraw of UI controls as IUUpdateMinMax
+			defineMainControlProperties();    	// does not reliably update the step size.
+        }
         return ISNewNumberHelper(&FocusMaxPosNP, values, names, n, res);
     }
     else if(!strcmp(name, CfgManualSpeedNP.name))
@@ -327,10 +406,10 @@ bool TeenAstroFocuser::ISNewNumber (const char *dev, const char *name, double va
         bool res=setManualSpeed((uint32_t) rint(values[0]));
         return ISNewNumberHelper(&CfgManualSpeedNP, values, names, n, res);
     }
-    else if(!strcmp(name, CfgGoToSpeedNP.name))
+    else if(!strcmp(name, FocusSpeedNP.name))
     {
-        bool res=setGoToSpeed((uint32_t) rint(values[0]));
-        return ISNewNumberHelper(&CfgGoToSpeedNP, values, names, n, res);
+        bool res=SetFocuserSpeed(rint(values[0]));
+        return ISNewNumberHelper(&FocusSpeedNP, values, names, n, res);
     }
     else if(!strcmp(name, CfgGoToAccNP.name))
     {
@@ -347,20 +426,10 @@ bool TeenAstroFocuser::ISNewNumber (const char *dev, const char *name, double va
         bool res=setManualDec((uint32_t) rint(values[0]));
         return ISNewNumberHelper(&CfgManualDecNP, values, names, n, res);
     }
-    else if(!strcmp(name, CfgMotorInvertNP.name))
-    {
-        bool res=setMotorInvert((uint32_t) rint(values[0]));
-        return ISNewNumberHelper(&CfgMotorInvertNP, values, names, n, res);
-    }
     else if(!strcmp(name, CfgMotorStepsPerRevolutionNP.name))
     {
         bool res=setMotorStepsPerRevolution((uint32_t) rint(values[0]));
         return ISNewNumberHelper(&CfgMotorStepsPerRevolutionNP, values, names, n, res);
-    }
-    else if(!strcmp(name, CfgMotorMicrostepsNP.name))
-    {
-        bool res=setMotorMicrosteps((uint32_t) rint(values[0]));
-        return ISNewNumberHelper(&CfgMotorMicrostepsNP, values, names, n, res);
     }
     else if(!strcmp(name, CfgMotorResolutionNP.name))
     {
@@ -373,7 +442,7 @@ bool TeenAstroFocuser::ISNewNumber (const char *dev, const char *name, double va
         return ISNewNumberHelper(&CfgMotorCurrentNP, values, names, n, res);
     }
     else
-        return INDI::Focuser::ISNewNumber(dev, name, values, names, n);  // handle maxPos, sync, ...
+        return INDI::Focuser::ISNewNumber(dev, name, values, names, n);
 }
 
 
@@ -410,9 +479,11 @@ IPState TeenAstroFocuser::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 
 void TeenAstroFocuser::TimerHit()
 {
-	if(isConnected())
-		updateState();
-    SetTimer(POLLMS_OVERRIDE);
+	if(!isConnected())
+		return;
+
+	updateState();
+    SetTimer(getCurrentPollingPeriod());
 }
 
 bool TeenAstroFocuser::AbortFocuser()
@@ -443,7 +514,7 @@ bool TeenAstroFocuser::send(const char *const msg) {
     {
         char errstr[MAXRBUF];
         tty_error_msg(rc, errstr, MAXRBUF);
-        DEBUGF(INDI::Logger::DBG_ERROR, "Send error: %s.", errstr);
+        DEBUGF(INDI::Logger::DBG_ERROR, "send(\"%s\"): %s.", msg, errstr);
         return false;
     }
     return true;
@@ -455,16 +526,16 @@ bool TeenAstroFocuser::sendAndReceive(const char *const msg, char *resp, int buf
         return false;
 
     int nbytes_read=0;
-    int rc = tty_nread_section(PortFD, resp, bufsize, '#', TEENASTRO_FOCUSER_TIMEOUT, &nbytes_read);
+    int rc = tty_nread_section(PortFD, resp, bufsize, '#', TAF_FOCUSER_TIMEOUT, &nbytes_read);
     resp[nbytes_read]='\0';
 	if(rc!=TTY_OK || nbytes_read==0 || resp[nbytes_read-1]!='#')
     {
         char errstr[MAXRBUF];
         tty_error_msg(rc, errstr, MAXRBUF);
-        DEBUGF(INDI::Logger::DBG_ERROR, "sendAndReceive(\"%s\"): got \"%s\": receive error: %s.", msg, resp, errstr);
+        DEBUGF(INDI::Logger::DBG_ERROR, "sendAndReceive(\"%s\") received \"%s\": %s.", msg, resp, errstr);
         return false;
     }
-    DEBUGF(INDI::Logger::DBG_DEBUG, "sendAndReceive(\"%s\"): got \"%s\"", msg, resp);
+    DEBUGF(INDI::Logger::DBG_DEBUG, "sendAndReceive(\"%s\") received \"%s\".", msg, resp);
     return true;
 }
 
@@ -474,24 +545,24 @@ bool TeenAstroFocuser::sendAndReceiveBool(const char *const msg) {
 
     char resp[2];
     int nbytes_read=0;
-    int rc = tty_read(PortFD, resp, 1, TEENASTRO_FOCUSER_TIMEOUT, &nbytes_read);
+    int rc = tty_read(PortFD, resp, 1, TAF_FOCUSER_TIMEOUT, &nbytes_read);
     resp[nbytes_read]='\0';
     if(rc!=TTY_OK || resp[0]!='1')
     {
         char errstr[MAXRBUF];
         tty_error_msg(rc, errstr, MAXRBUF);
-        DEBUGF(INDI::Logger::DBG_ERROR, "sendAndReceiveBool(\"%s\"): got \"%s\": receive error: %s.", msg, resp, errstr);
+        DEBUGF(INDI::Logger::DBG_ERROR, "sendAndReceiveBool(\"%s\") received \"%s\": %s.", msg, resp, errstr);
         return false;
     }
-    DEBUGF(INDI::Logger::DBG_DEBUG, "sendAndReceiveBool(\"%s\"): got \"%s\"", msg, resp);
+    DEBUGF(INDI::Logger::DBG_DEBUG, "sendAndReceiveBool(\"%s\") received \"%s\".", msg, resp);
     return resp[0]=='1';
 }
 
 
 bool TeenAstroFocuser::updateDeviceVersion()
 {
-    char resp[TEENASTRO_FOCUSER_BUFSIZE];
-    if(!sendAndReceive(":FV#", resp, TEENASTRO_FOCUSER_BUFSIZE))
+    char resp[TAF_FOCUSER_BUFSIZE];
+    if(!sendAndReceive(":FV#", resp, TAF_FOCUSER_BUFSIZE))
         return false;
     int len=strlen(resp);
     resp[len-1]=0;
@@ -503,11 +574,11 @@ bool TeenAstroFocuser::updateDeviceVersion()
 
 bool TeenAstroFocuser::updateState()
 {
-    char resp[TEENASTRO_FOCUSER_BUFSIZE];
+    char resp[TAF_FOCUSER_BUFSIZE];
     int pos=-1, speed=-1;
     float temp=-1;
 
-    if(!sendAndReceive(":F?#", resp, TEENASTRO_FOCUSER_BUFSIZE))
+    if(!sendAndReceive(":F?#", resp, TAF_FOCUSER_BUFSIZE))
         return false;
 
     if(sscanf(resp, "?%d %d %f#", &pos, &speed, &temp)<=0)
@@ -522,12 +593,14 @@ bool TeenAstroFocuser::updateState()
     FocusAbsPosN[0].value = pos;
     FocusAbsPosNP.s = speed>0 ? IPS_BUSY : IPS_OK;
     IDSetNumber(&FocusAbsPosNP, NULL);
-    FocusRelPosNP.s = speed>0 ? IPS_BUSY : IPS_OK;
+
+	FocusRelPosNP.s = speed>0 ? IPS_BUSY : IPS_OK;
     IDSetNumber(&FocusRelPosNP, NULL);
 
     CurSpeedN[0].value = speed;
     CurSpeedNP.s = speed>0 ? IPS_BUSY : IPS_OK;
     IDSetNumber(&CurSpeedNP, NULL);
+
     TempN[0].value = temp;
     TempNP.s = (temp==-99) ? IPS_ALERT : IPS_OK;
     IDSetNumber(&TempNP, NULL);
@@ -545,10 +618,10 @@ bool TeenAstroFocuser::isMoving()
 
 bool TeenAstroFocuser::updateConfig() 
 {
-    char resp[TEENASTRO_FOCUSER_BUFSIZE];
+    char resp[TAF_FOCUSER_BUFSIZE];
     int parkPos=-1, maxPos=-1, manualSpeed=-1, goToSpeed=-1, gotoAcc=-1, manAcc=-1, manDec=-1;
 
-    if(!sendAndReceive(":F~#", resp, TEENASTRO_FOCUSER_BUFSIZE))
+    if(!sendAndReceive(":F~#", resp, TAF_FOCUSER_BUFSIZE))
         return false;
 
     if(sscanf(resp, "~%d %d %d %d %d %d %d#", &parkPos, &maxPos, &manualSpeed, &goToSpeed, &gotoAcc, &manAcc, &manDec)<=0)
@@ -557,7 +630,9 @@ bool TeenAstroFocuser::updateConfig()
         return false;
     }
 
-    // Update proper values
+    if(maxPos!=FocusMaxPosN[0].value)
+	    initPositionPropertiesRanges(maxPos);
+
     CfgParkPosN[0].value = parkPos;
     CfgParkPosNP.s = IPS_OK;
     IDSetNumber(&CfgParkPosNP, NULL);
@@ -567,9 +642,9 @@ bool TeenAstroFocuser::updateConfig()
     CfgManualSpeedN[0].value = manualSpeed;
     CfgManualSpeedNP.s = IPS_OK;
     IDSetNumber(&CfgManualSpeedNP, NULL);
-    CfgGoToSpeedN[0].value = goToSpeed;
-    CfgGoToSpeedNP.s = IPS_OK;
-    IDSetNumber(&CfgGoToSpeedNP, NULL);
+    FocusSpeedN[0].value = goToSpeed;
+    FocusSpeedNP.s = IPS_OK;
+    IDSetNumber(&FocusSpeedNP, NULL);
     CfgGoToAccN[0].value = gotoAcc;
     CfgGoToAccNP.s = IPS_OK;
     IDSetNumber(&CfgGoToAccNP, NULL);
@@ -579,20 +654,6 @@ bool TeenAstroFocuser::updateConfig()
     CfgManualDecN[0].value = manDec;
     CfgManualDecNP.s = IPS_OK;
     IDSetNumber(&CfgManualDecNP, NULL);
-
-    // Update UI control maximum values for focuser positions
-    FocusAbsPosN[0].max = maxPos;
-    FocusAbsPosN[0].step = maxPos / TAF_UI_STEPS;
-    IUUpdateMinMax(&FocusAbsPosNP);
-    FocusRelPosN[0].max = maxPos;
-    FocusRelPosN[0].step = maxPos / TAF_UI_STEPS;
-    IUUpdateMinMax(&FocusRelPosNP);
-    FocusSyncN[0].max = maxPos;
-    FocusSyncN[0].step = maxPos / TAF_UI_STEPS;
-    IUUpdateMinMax(&FocusSyncNP);
-    CfgParkPosN[0].max = maxPos;
-    CfgParkPosN[0].step = maxPos / TAF_UI_STEPS;
-    IUUpdateMinMax(&CfgParkPosNP);
 
     return true;
 }
@@ -619,9 +680,9 @@ bool TeenAstroFocuser::setManualSpeed(uint32_t value)
     return setConfigItem('2', value);
 }
 
-bool TeenAstroFocuser::setGoToSpeed(uint32_t value)
+bool TeenAstroFocuser::SetFocuserSpeed(int value)
 {
-    return setConfigItem('3', value);
+    return setConfigItem('3', (uint32_t) value);
 }
 
 bool TeenAstroFocuser::setGoToAcc(uint32_t value)
@@ -642,24 +703,35 @@ bool TeenAstroFocuser::setManualDec(uint32_t value)
 
 bool TeenAstroFocuser::updateMotorConfig() 
 {
-    char resp[TEENASTRO_FOCUSER_BUFSIZE];
-    int invert=-1, log2_micro=-1, resolution=-1, curr_10ma=-1, steprot=-1;
+    char resp[TAF_FOCUSER_BUFSIZE];
+    int reverse=-1, log2_micro=-1, resolution=-1, curr_10ma=-1, steprot=-1;
 
-    if(!sendAndReceive(":FM#", resp, TEENASTRO_FOCUSER_BUFSIZE))
+    if(!sendAndReceive(":FM#", resp, TAF_FOCUSER_BUFSIZE))
         return false;
 
-    if(sscanf(resp, "M%d %d %d %d %d#", &invert, &log2_micro, &resolution, &curr_10ma, &steprot)<=0)
+    if(sscanf(resp, "M%d %d %d %d %d#", &reverse, &log2_micro, &resolution, &curr_10ma, &steprot)<=0)
     {
         DEBUGF(INDI::Logger::DBG_ERROR, "Invalid format: focuser state (%s)", resp);
         return false;
     }
 
-    CfgMotorInvertN[0].value = invert;
-    CfgMotorInvertNP.s = IPS_OK;
-    IDSetNumber(&CfgMotorInvertNP, NULL);
-    CfgMotorMicrostepsN[0].value = 1<<log2_micro;  // TeenAstro device returns and expects log_2(microsteps)
-    CfgMotorMicrostepsNP.s = IPS_OK;
-    IDSetNumber(&CfgMotorMicrostepsNP, NULL);
+    FocusReverseS[0].s=(reverse==0) ? ISS_OFF : ISS_ON;
+    FocusReverseS[1].s=(reverse==0) ? ISS_ON  : ISS_OFF;
+    FocusReverseSP.s  = IPS_OK;
+    IDSetSwitch(&FocusReverseSP, NULL);
+
+    uint32_t micro=(1<<log2_micro); // TeenAstro device returns and expects log_2(microsteps)
+    bool microFound=false;
+    for(int i=0; i<TAF_MICROS_N; i++)
+    {
+    	uint32_t thisMicro=(uint32_t) atoi(CfgMotorMicrostepsS[i].name);
+    	CfgMotorMicrostepsS[i].s= (micro==thisMicro) ? ISS_ON : ISS_OFF;
+    	if(micro==thisMicro)
+    		microFound=true;
+    }
+    CfgMotorMicrostepsSP.s = microFound ? IPS_OK : IPS_ALERT;
+    IDSetSwitch(&CfgMotorMicrostepsSP, NULL);
+
     CfgMotorResolutionN[0].value = resolution;
     CfgMotorResolutionNP.s = IPS_OK;
     IDSetNumber(&CfgMotorResolutionNP, NULL);
@@ -673,9 +745,9 @@ bool TeenAstroFocuser::updateMotorConfig()
     return true;
 }
 
-bool TeenAstroFocuser::setMotorInvert(uint32_t value)
+bool TeenAstroFocuser::ReverseFocuser(bool enable)
 {
-    return setConfigItem('7', value);
+    return setConfigItem('7', enable ? 1 : 0);
 }
 
 bool TeenAstroFocuser::setMotorMicrosteps(uint32_t value)
@@ -725,4 +797,20 @@ bool TeenAstroFocuser::goToPark()
 bool TeenAstroFocuser::stop()
 {
     return send(":FQ#");
+}
+
+bool TeenAstroFocuser::rebootDevice()
+{
+    if(!send(":F!#"))
+    	return false;
+    sleep(3);
+    return updateDeviceVersion() && updateConfig() && updateMotorConfig() && updateState();
+}
+
+bool TeenAstroFocuser::eraseDeviceEEPROM()
+{
+    if(!send(":F$#"))
+    	return false;
+    sleep(1);
+    return updateDeviceVersion() && updateConfig() && updateMotorConfig() && updateState();
 }

--- a/drivers/focuser/teenastro.cpp
+++ b/drivers/focuser/teenastro.cpp
@@ -1,0 +1,499 @@
+/*
+    TeenAstro Focuser
+    Copyright (C) 2021 Markus Noga
+    Derived from the below, and hereby made available under the same license.
+
+    TeenAstroFocuser Focuser
+    Copyright (C) 2018 Paul de Backer (74.0632@gmail.com)
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+#include "teenastro_focus.h"
+#include "indicom.h"
+
+#include <stdio.h>
+#include <termios.h>
+#include <string.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <math.h>
+#include <memory>
+
+#define TEENASTRO_FOCUSER_TIMEOUT 4
+
+#define POLLMS_OVERRIDE  1500
+
+std::unique_ptr<TeenAstroFocuser> teenAstroFocuser(new TeenAstroFocuser());
+
+void ISGetProperties(const char *dev)
+{
+         teenAstroFocuser->ISGetProperties(dev);
+}
+
+void ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int num)
+{
+         teenAstroFocuser->ISNewSwitch(dev, name, states, names, num);
+}
+
+void ISNewText(	const char *dev, const char *name, char *texts[], char *names[], int num)
+{
+         teenAstroFocuser->ISNewText(dev, name, texts, names, num);
+}
+
+void ISNewNumber(const char *dev, const char *name, double values[], char *names[], int num)
+{
+         teenAstroFocuser->ISNewNumber(dev, name, values, names, num);
+}
+
+void ISNewBLOB (const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[], char *names[], int n)
+{
+   INDI_UNUSED(dev);
+   INDI_UNUSED(name);
+   INDI_UNUSED(sizes);
+   INDI_UNUSED(blobsizes);
+   INDI_UNUSED(blobs);
+   INDI_UNUSED(formats);
+   INDI_UNUSED(names);
+   INDI_UNUSED(n);
+}
+
+void ISSnoopDevice (XMLEle *root)
+{
+     teenAstroFocuser->ISSnoopDevice(root);
+}
+
+TeenAstroFocuser::TeenAstroFocuser()
+{
+FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_CAN_ABORT);
+    lastPos = 0;
+}
+
+TeenAstroFocuser::~TeenAstroFocuser()
+{
+}
+
+bool TeenAstroFocuser::initProperties()
+{
+    INDI::Focuser::initProperties();
+    // SetZero
+    IUFillSwitch(&SetZeroS[0], "SETZERO", "Set Current Position to 0", ISS_OFF);
+    IUFillSwitchVector(&SetZeroSP, SetZeroS, 1, getDeviceName(), "Zero Position", "", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    // Maximum Travel
+    IUFillNumber(&MaxPosN[0], "MAXPOS", "Maximum Out Position", "%8.0f", 1., 10000000., 0, 0);
+    IUFillNumberVector(&MaxPosNP, MaxPosN, 1, getDeviceName(), "FOCUS_MAXPOS", "Position", OPTIONS_TAB, IP_RW, 0, IPS_IDLE );
+
+
+    /* Relative and absolute movement */
+    FocusRelPosN[0].min = 0.;
+    FocusRelPosN[0].max = 200.;
+    FocusRelPosN[0].value = 0.;
+    FocusRelPosN[0].step = 10.;
+
+    FocusAbsPosN[0].min = 0.;
+    FocusAbsPosN[0].max = 10000000.;
+    FocusAbsPosN[0].value = 0.;
+    FocusAbsPosN[0].step = 500.;
+
+    addDebugControl();
+
+    return true;
+
+}
+
+bool TeenAstroFocuser::updateProperties()
+{
+    INDI::Focuser::updateProperties();
+    if (isConnected())
+    {
+        defineProperty(&MaxPosNP);
+        defineProperty(&SetZeroSP);
+        GetFocusParams();
+        loadConfig(true);
+
+        DEBUG(INDI::Logger::DBG_SESSION, "TeenAstroFocuser parameters updated, focuser ready for use.");
+    }
+    else
+    {
+        deleteProperty(MaxPosNP.name);
+        deleteProperty(SetZeroSP.name);
+    }
+
+    return true;
+
+}
+
+bool TeenAstroFocuser::Handshake()
+{
+    if (Ack())
+    {
+        DEBUG(INDI::Logger::DBG_SESSION, "TeenAstroFocuser is online. Getting focus parameters...");
+        return true;
+    }
+    return false;
+}
+
+const char * TeenAstroFocuser::getDefaultName()
+{
+    return "TeenAstroFocuser";
+}
+
+bool TeenAstroFocuser::Ack()
+{
+    int nbytes_written=0, nbytes_read=0, rc=-1;
+    char errstr[MAXRBUF];
+    char resp[16];
+    sleep(2);
+    tcflush(PortFD, TCIOFLUSH);
+
+    if ( (rc = tty_write(PortFD, ":IP#", 4, &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "Init error: %s.", errstr);
+        return false;
+    }
+    if ( (rc = tty_read(PortFD, resp, 9, TEENASTRO_FOCUSER_TIMEOUT * 2, &nbytes_read)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "Init error: %s.", errstr);
+        return false;
+    }
+    tcflush(PortFD, TCIOFLUSH);
+    resp[nbytes_read]='\0';
+    if (!strcmp(resp, "On-Focus#"))
+    { 
+        return true;
+    }
+    else
+    {
+        DEBUGF(INDI::Logger::DBG_ERROR, "Ack Response: %s", resp);
+        return false;
+    }
+}
+
+
+bool TeenAstroFocuser::updatePosition()
+{
+    int nbytes_written=0, nbytes_read=0, rc=-1;
+    char errstr[MAXRBUF];
+    char resp[16];
+    int pos=-1;
+
+    tcflush(PortFD, TCIOFLUSH);
+
+    if ( (rc = tty_write(PortFD, ":GP#", 4, &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "updatePosition error: %s.", errstr);
+        return false;
+    }
+
+    if ( (rc = tty_read_section(PortFD, resp, '#', TEENASTRO_FOCUSER_TIMEOUT, &nbytes_read)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "updatePosition error: %s.", errstr);
+        return false;
+    }
+
+    tcflush(PortFD, TCIOFLUSH);
+
+    resp[nbytes_read]='\0';
+
+    rc = sscanf(resp, "%d#", &pos);
+
+    if (rc > 0)
+    {
+        FocusAbsPosN[0].value = pos;
+        IDSetNumber(&FocusAbsPosNP, NULL);
+
+    }
+    else
+    {
+        DEBUGF(INDI::Logger::DBG_ERROR, "Unknown error: focuser position value (%s)", resp);
+        return false;
+    }
+
+  return true;
+}
+
+bool TeenAstroFocuser::updateMaxPos()
+{
+    int nbytes_written=0, nbytes_read=0, rc=-1;
+    char errstr[MAXRBUF];
+    char resp[16];
+    long maxposition;
+
+    tcflush(PortFD, TCIOFLUSH);
+
+    if ( (rc = tty_write(PortFD, ":GM#", 4, &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "updateMaxPosition error: %s.", errstr);
+        return false;
+    }
+
+    if ( (rc = tty_read_section(PortFD, resp, '#', TEENASTRO_FOCUSER_TIMEOUT, &nbytes_read)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "updateMaxPosition error: %s.", errstr);
+        return false;
+    }
+
+    tcflush(PortFD, TCIOFLUSH);
+    resp[nbytes_read]='\0';
+
+    rc = sscanf(resp, "%ld#", &maxposition);
+
+    if (rc > 0)
+    {
+
+        MaxPosN[0].value = maxposition;
+        FocusAbsPosN[0].max = maxposition;
+        IDSetNumber(&FocusAbsPosNP, NULL);
+        IDSetNumber(&MaxPosNP, NULL);
+        return true;
+    }
+
+    DEBUGF(INDI::Logger::DBG_ERROR, "Unknown error: focuser maxposition (%s)", resp);
+    return false;
+}
+
+bool TeenAstroFocuser::isMoving()
+{
+    int nbytes_written=0, nbytes_read=0, rc=-1;
+    char errstr[MAXRBUF];
+    char resp[16];
+
+    tcflush(PortFD, TCIOFLUSH);
+
+    if ( (rc = tty_write(PortFD, ":IS#", 4, &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "isMoving error: %s.", errstr);
+        return false;
+    }
+
+    if ( (rc = tty_read_section(PortFD, resp, '#', TEENASTRO_FOCUSER_TIMEOUT, &nbytes_read)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "isMoving error: %s.", errstr);
+        return false;
+    }
+
+    tcflush(PortFD, TCIOFLUSH);
+
+    resp[nbytes_read]='\0';
+    if (!strcmp(resp, "M#"))
+        return true;
+    else if (!strcmp(resp, "S#"))
+        return false;
+    else
+    {
+        DEBUGF(INDI::Logger::DBG_ERROR, "Unknown error: isMoving value (%s)", resp);
+        return false;
+    }
+
+}
+
+bool TeenAstroFocuser::MoveMyFocuser(uint32_t position)
+{
+    int nbytes_written=0, rc=-1;
+    char errstr[MAXRBUF];
+    char cmd[24];
+
+    snprintf(cmd, 24, ":MA%d#", position);
+  
+    // Set Position
+    if ( (rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "setPosition error: %s.", errstr);
+        return false;
+    }
+    return true;
+}
+
+void TeenAstroFocuser::setZero()
+{
+    int nbytes_written=0, rc=-1;
+    char errstr[MAXRBUF];
+    // Set Zero
+    if ( (rc = tty_write(PortFD, ":SZ#" , 4, &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "set Zero error: %s.", errstr);
+        return;
+    }
+    updateMaxPos();
+    return;
+}
+
+
+bool TeenAstroFocuser::setMaxPos(uint32_t maxPos)
+{
+    int nbytes_written=0, rc=-1;
+    char errstr[MAXRBUF];
+    char cmd[24];
+
+    snprintf(cmd, 24, ":SM%d#", maxPos);
+  
+    // Set Max Out
+    if ( (rc = tty_write(PortFD, cmd, strlen(cmd), &nbytes_written)) != TTY_OK)
+    {
+        tty_error_msg(rc, errstr, MAXRBUF);
+        DEBUGF(INDI::Logger::DBG_ERROR, "setPosition error: %s.", errstr);
+        return false;
+    }
+    updateMaxPos();
+    return true;
+}
+
+bool TeenAstroFocuser::ISNewSwitch (const char *dev, const char *name, ISState *states, char *names[], int n)
+{
+    if(strcmp(dev,getDeviceName())==0)
+    {
+    if (!strcmp(SetZeroSP.name, name))
+        {
+        setZero();
+        IUResetSwitch(&SetZeroSP);
+        SetZeroSP.s = IPS_OK;
+        IDSetSwitch(&SetZeroSP, NULL);
+        return true;
+    }
+        
+    return INDI::Focuser::ISNewSwitch(dev, name, states, names, n);
+    }
+    return false;
+}
+
+bool TeenAstroFocuser::ISNewNumber (const char *dev, const char *name, double values[], char *names[], int n)
+{
+    if(strcmp(dev,getDeviceName())==0)
+    {
+        if (!strcmp (name, MaxPosNP.name))
+        {
+            if (values[0] < FocusAbsPosN[0].value)
+            {
+                DEBUGF(INDI::Logger::DBG_ERROR, "Can't set max position lower than current absolute position ( %8.0f )", FocusAbsPosN[0].value);
+                return false;
+            }
+            IUUpdateNumber(&MaxPosNP, values, names, n);               
+            FocusAbsPosN[0].max = MaxPosN[0].value;
+            setMaxPos(MaxPosN[0].value);
+            MaxPosNP.s = IPS_OK;
+            return true;
+        }
+    }
+
+    return INDI::Focuser::ISNewNumber(dev, name, values, names, n);
+
+}
+
+void TeenAstroFocuser::GetFocusParams ()
+{
+    updatePosition();
+    updateMaxPos();
+}
+
+
+IPState TeenAstroFocuser::MoveAbsFocuser(uint32_t targetTicks)
+{
+    uint32_t targetPos = targetTicks;
+
+    bool rc = false;
+
+    rc = MoveMyFocuser(targetPos);
+
+    if (rc == false)
+        return IPS_ALERT;
+
+    FocusAbsPosNP.s = IPS_BUSY;
+
+    return IPS_BUSY;
+}
+
+IPState TeenAstroFocuser::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
+{
+    uint32_t newPosition=0;
+    bool rc=false;
+
+    if (dir == FOCUS_INWARD)
+        newPosition = uint32_t(FocusAbsPosN[0].value) - ticks;
+    else
+        newPosition = uint32_t(FocusAbsPosN[0].value) + ticks;
+
+    rc = MoveMyFocuser(newPosition);
+
+    if (rc == false)
+        return IPS_ALERT;
+
+    FocusRelPosN[0].value = ticks;
+    FocusRelPosNP.s = IPS_BUSY;
+
+    return IPS_BUSY;
+}
+
+void TeenAstroFocuser::TimerHit()
+{
+    if (isConnected() == false)
+    {
+        SetTimer(POLLMS_OVERRIDE);
+        return;
+    }
+
+    bool rc = updatePosition();
+    if (rc)
+    {
+        if (fabs(lastPos - FocusAbsPosN[0].value) > 5)
+        {
+            IDSetNumber(&FocusAbsPosNP, NULL);
+            lastPos = FocusAbsPosN[0].value;
+        }
+    }
+
+
+    if (FocusAbsPosNP.s == IPS_BUSY || FocusRelPosNP.s == IPS_BUSY)
+    {
+        if (isMoving() == false)
+        {
+            FocusAbsPosNP.s = IPS_OK;
+            FocusRelPosNP.s = IPS_OK;
+            IDSetNumber(&FocusAbsPosNP, NULL);
+            IDSetNumber(&FocusRelPosNP, NULL);
+            lastPos = FocusAbsPosN[0].value;
+            DEBUG(INDI::Logger::DBG_SESSION, "Focuser reached requested position.");
+        }
+    }
+    SetTimer(POLLMS_OVERRIDE);
+
+}
+
+bool TeenAstroFocuser::AbortFocuser()
+{
+    int nbytes_written;
+    if (tty_write(PortFD, ":MH#", 4, &nbytes_written) == TTY_OK)
+    {
+        FocusAbsPosNP.s = IPS_IDLE;
+        FocusRelPosNP.s = IPS_IDLE;
+        IDSetNumber(&FocusAbsPosNP, NULL);
+        IDSetNumber(&FocusRelPosNP, NULL);
+        return true;
+    }
+    else
+        return false;
+}
+
+

--- a/drivers/focuser/teenastro.h
+++ b/drivers/focuser/teenastro.h
@@ -63,6 +63,8 @@ protected:
 
     bool ReverseFocuser(bool enable);
 
+    bool saveConfigItems(FILE *fp);
+
 
     // Sends a command to the focuser. Returns true on success and false on failure.
     bool send(const char *const msg);
@@ -83,8 +85,8 @@ protected:
     // Returns true if focuser is moving, else false.   
     bool isMoving();
 
-    // Updates movement configuration from device. Returns true on success and false on failure.
-    bool updateConfig();
+    // Updates motion configuration from device. Returns true on success and false on failure.
+    bool updateMotionConfig();
 
     // Sets given configuration item on to device to provided value in device native units. Returns true on success and false on failure. 
     bool setConfigItem(char item, uint32_t deviceValue);

--- a/drivers/focuser/teenastro.h
+++ b/drivers/focuser/teenastro.h
@@ -40,7 +40,17 @@ protected:
     bool ISNewNumberHelper(INumberVectorProperty *NP, double values[], char *names[], int n, bool res);
 
     virtual bool initProperties();
+
+    // Initializes value ranges and steps for position UI controls based on maxPos. 
+    // Does not force redraw via deleteMainControlProperties() and defineMainControlProperties()
+    void initPositionPropertiesRanges(uint32_t maxPos);
+
     virtual bool updateProperties();
+    void defineMainControlProperties();
+    void defineOtherProperties();
+    void deleteMainControlProperties();
+    void deleteOtherProperties();
+
     virtual IPState MoveAbsFocuser(uint32_t ticks);
     virtual IPState MoveRelFocuser(FocusDirection dir, uint32_t ticks);
     virtual bool AbortFocuser();
@@ -51,6 +61,7 @@ protected:
 
     bool SetFocuserMaxPosition(uint32_t value);
 
+    bool ReverseFocuser(bool enable);
 
 
     // Sends a command to the focuser. Returns true on success and false on failure.
@@ -78,7 +89,7 @@ protected:
     // Sets given configuration item on to device to provided value in device native units. Returns true on success and false on failure. 
     bool setConfigItem(char item, uint32_t deviceValue);
     bool setParkPos(uint32_t value);
-    bool setGoToSpeed(uint32_t value);
+    bool SetFocuserSpeed(int value); // sets TeenAstro GoTo speed
     bool setManualSpeed(uint32_t value);
     bool setGoToAcc(uint32_t value);
     bool setManualAcc(uint32_t value);
@@ -87,8 +98,6 @@ protected:
     // Updates motor configuration from device. Returns true on success and false on failure.
     bool updateMotorConfig();
 
-    // Sends new motor inversion flag value to device. Returns true on success and false on failure. 
-    bool setMotorInvert(uint32_t value);
     bool setMotorMicrosteps(uint32_t value);
     bool setMotorResolution(uint32_t value);
     bool setMotorCurrent(uint32_t value);
@@ -103,32 +112,47 @@ protected:
     // Stop focuser movement. Returns immediately, true on success else false.
     bool stop();
 
+    // Reboots the device microcontroller
+    bool rebootDevice();
 
-    // UI Elements
-    //
+    // Clears the device EEPROM
+    bool eraseDeviceEEPROM();
 
-    IText DeviceVersionT[1];
-    ITextVectorProperty DeviceVersionTP;
-
-    // Configuration variables
+    // Main control tab
     //
 
     // Focuser park position 
     INumber CfgParkPosN[1];
     INumberVectorProperty CfgParkPosNP;
 
+    // Go to park button
     ISwitch GoToParkS[1];
     ISwitchVectorProperty GoToParkSP;
 
     // Focuser max position is inherited from superclass as FocusMaxPosN, FocusMaxPosNP
-
     // Sync current focuser position to given value inherited from superclass as FocusSyncN, FocusSyncNP
 
-    // Focuser goto speed
-    INumber CfgGoToSpeedN[1];
-    INumberVectorProperty CfgGoToSpeedNP;
+    // Current focuser speed
+    INumber CurSpeedN[1];
+    INumberVectorProperty CurSpeedNP;
 
-    // Focuser high speed
+    // Focuser temperature
+    INumber TempN[1];
+    INumberVectorProperty TempNP;
+
+    // Focuser current position is inherited from superclass as FocusAbsPosN, FocusAbsPosNP
+
+
+    // Focuser configuration tab: motion configuration
+    //
+
+    // Device version string
+    IText DeviceVersionT[1];
+    ITextVectorProperty DeviceVersionTP;
+
+    // Focuser goto speed: FocusSpeedNP and FocusSpeedN[1] from superclass
+
+    // Focuser manual speed
     INumber CfgManualSpeedN[1];
     INumberVectorProperty CfgManualSpeedNP;
 
@@ -145,16 +169,18 @@ protected:
     INumberVectorProperty CfgManualDecNP;
 
 
-    // Motor configuration variables
+    // Focuser configuration tab: motor configuration
     //
 
-    // Configuration element: Invert motor direction
-    INumber CfgMotorInvertN[1];
-    INumberVectorProperty CfgMotorInvertNP;
+    // Reverse motor direction: FocusReverseSP and FocusReverseS[2] from superclass. [0] is enable, [1] is disable (i.e. normal)
 
     // Configuration element: Motor microsteps
-    INumber CfgMotorMicrostepsN[1];
-    INumberVectorProperty CfgMotorMicrostepsNP;
+    enum
+    {
+        TAF_MICROS_4, TAF_MICROS_8, TAF_MICROS_16, TAF_MICROS_32, TAF_MICROS_64, TAF_MICROS_128, TAF_MICROS_N,
+    };
+    ISwitch CfgMotorMicrostepsS[TAF_MICROS_N] {};
+    ISwitchVectorProperty CfgMotorMicrostepsSP;
 
     // Configuration element: Impulse resolution (???)
     INumber CfgMotorResolutionN[1];
@@ -168,18 +194,13 @@ protected:
     INumber CfgMotorStepsPerRevolutionN[1];
     INumberVectorProperty CfgMotorStepsPerRevolutionNP;
 
-    // Status variables
-    //
-    
-    // Status variable: Focuser current position is inherited from superclass as FocusAbsPosN, FocusAbsPosNP
+    // Reboot device microcontroller button
+    ISwitch RebootDeviceS[1];
+    ISwitchVectorProperty RebootDeviceSP;
 
-    // Status variable: Current focuser speed
-    INumber CurSpeedN[1];
-    INumberVectorProperty CurSpeedNP;
-
-    // Status variable: Focuser temperature
-    INumber TempN[1];
-    INumberVectorProperty TempNP;
+    // Erase device EEPROM button
+    ISwitch EraseEEPROMS[1];
+    ISwitchVectorProperty EraseEEPROMSP;    
 };
 
 #endif // TEENASTRROFOCUSER_H

--- a/drivers/focuser/teenastro.h
+++ b/drivers/focuser/teenastro.h
@@ -31,24 +31,33 @@ public:
 
     const char * getDefaultName();
     virtual bool Handshake();
-    virtual bool initProperties();
-    virtual bool updateProperties();
+
     virtual bool ISNewNumber (const char *dev, const char *name, double values[], char *names[], int n);
     virtual bool ISNewSwitch (const char *dev, const char *name, ISState *states, char *names[], int n);
+
+protected:
+    // Helper function to update NP with the values if res is true and display status IPS_OK, else display status IPS_ALERT. Returns res for convenience. 
+    bool ISNewNumberHelper(INumberVectorProperty *NP, double values[], char *names[], int n, bool res);
+
+    virtual bool initProperties();
+    virtual bool updateProperties();
     virtual IPState MoveAbsFocuser(uint32_t ticks);
     virtual IPState MoveRelFocuser(FocusDirection dir, uint32_t ticks);
     virtual bool AbortFocuser();
     virtual void TimerHit();
 
-private:
+    // Syncs device focuser position to given value. Returns true on success else false.
+    virtual bool SyncFocuser(uint32_t value);
 
-    double targetPos, lastPos;
+    bool SetFocuserMaxPosition(uint32_t value);
+
+
 
     // Sends a command to the focuser. Returns true on success and false on failure.
     bool send(const char *const msg);
  
     // Sends a command to the focuser, and waits for a response terminated by '#'. Returns true on success and false on failure.
-    bool sendAndReceive(const char *const msg, char *resp);
+    bool sendAndReceive(const char *const msg, char *resp, int bufsize);
 
     // Sends a command to the focuser, and waits for a single character response. Returns true if successful and response is '1', otherwise false.
     bool sendAndReceiveBool(const char *const msg);
@@ -69,7 +78,6 @@ private:
     // Sets given configuration item on to device to provided value in device native units. Returns true on success and false on failure. 
     bool setConfigItem(char item, uint32_t deviceValue);
     bool setParkPos(uint32_t value);
-    bool setMaxPos(uint32_t value);
     bool setGoToSpeed(uint32_t value);
     bool setManualSpeed(uint32_t value);
     bool setGoToAcc(uint32_t value);
@@ -95,28 +103,26 @@ private:
     // Stop focuser movement. Returns immediately, true on success else false.
     bool stop();
 
-    // Syncs focuser zero position to current position, true on success else false.
-    bool syncZero();
-
 
     // UI Elements
     //
 
-    // UI Element: Sync current position as zero position
-    ISwitch SyncZeroS[1];
-    ISwitchVectorProperty SyncZeroSP;
+    IText DeviceVersionT[1];
+    ITextVectorProperty DeviceVersionTP;
 
     // Configuration variables
     //
-
-    IText CfgDeviceVersionT[1];
-    ITextVectorProperty CfgDeviceVersionTP;
 
     // Focuser park position 
     INumber CfgParkPosN[1];
     INumberVectorProperty CfgParkPosNP;
 
+    ISwitch GoToParkS[1];
+    ISwitchVectorProperty GoToParkSP;
+
     // Focuser max position is inherited from superclass as FocusMaxPosN, FocusMaxPosNP
+
+    // Sync current focuser position to given value inherited from superclass as FocusSyncN, FocusSyncNP
 
     // Focuser goto speed
     INumber CfgGoToSpeedN[1];
@@ -174,7 +180,6 @@ private:
     // Status variable: Focuser temperature
     INumber TempN[1];
     INumberVectorProperty TempNP;
-
 };
 
 #endif // TEENASTRROFOCUSER_H

--- a/drivers/focuser/teenastro.h
+++ b/drivers/focuser/teenastro.h
@@ -32,8 +32,8 @@ public:
     TeenAstroFocuser();
     ~TeenAstroFocuser();
 
-    virtual bool Handshake();
     const char * getDefaultName();
+    virtual bool Handshake();
     virtual bool initProperties();
     virtual bool updateProperties();
     virtual bool ISNewNumber (const char *dev, const char *name, double values[], char *names[], int n);
@@ -46,22 +46,102 @@ public:
 private:
 
     double targetPos, lastPos;
+
+    // Sends a command to the focuser. Returns true on success and false on failure.
+    bool Send(const char *const msg);
  
-    void GetFocusParams();
+    // Sends a command to the focuser, and waits for a response terminated by '#'. Returns true on success and false on failure.
+    bool SendAndReceive(const char *const msg, char *resp);
+
     void setZero();
     bool updateMaxPos();
-    bool updateTemperature();
-    bool updatePosition();
-    bool isMoving();
-    bool Ack();
 
-    bool MoveMyFocuser(uint32_t position);
+    // Updates current state consisting of position, speed, and temperature. Returns true on success and false on failure.
+    bool updateState();   
+    bool isMoving();
+
+    // Updates movement configuration. Returns true on success and false on failure.
+    bool updateConfig();
+
+    // Updates motor configuration. Returns true on success and false on failure.
+    bool updateMotorConfig();
+
+    bool goTo(uint32_t position);
     bool setMaxPos(uint32_t maxPos);
 
-    INumber MaxPosN[1];
-    INumberVectorProperty MaxPosNP;
+    // UI Elements
+    //
+
+    // UI Element: Sync current position as zero position
     ISwitch SetZeroS[1];
     ISwitchVectorProperty SetZeroSP;
+
+    // Configuration variables
+    //
+
+    // Focuser park position 
+    INumber CfgParkPosN[1];
+    INumberVectorProperty CfgParkPosNP;
+
+    // Focuser max position is inherited from superclass as FocusMaxPosN, FocusMaxPosNP
+
+    // Focuser goto speed
+    INumber CfgGoToSpeedN[1];
+    INumberVectorProperty CfgGoToSpeedNP;
+
+    // Focuser high speed
+    INumber CfgManualSpeedN[1];
+    INumberVectorProperty CfgManualSpeedNP;
+
+    // Go-to acceleration
+    INumber CfgGoToAccN[1];
+    INumberVectorProperty CfgGoToAccNP;
+
+    // Manual acceleration
+    INumber CfgManualAccN[1];
+    INumberVectorProperty CfgManualAccNP;
+
+    // Manual deceleration
+    INumber CfgManualDecN[1];
+    INumberVectorProperty CfgManualDecNP;
+
+
+    // Motor configuration variables
+    //
+
+    // Configuration element: Invert motor direction
+    INumber CfgMotorInvertN[1];
+    INumberVectorProperty CfgMotorInvertNP;
+
+    // Configuration element: Motor microsteps
+    INumber CfgMotorMicrostepsN[1];
+    INumberVectorProperty CfgMotorMicrostepsNP;
+
+    // Configuration element: Impulse resolution (???)
+    INumber CfgMotorResolutionN[1];
+    INumberVectorProperty CfgMotorResolutionNP;
+
+    // Configuration element: Motor current
+    INumber CfgMotorCurrentN[1];
+    INumberVectorProperty CfgMotorCurrentNP;
+
+    // Configuration element: Motor steps per revolution
+    INumber CfgMotorStepsPerRevolutionN[1];
+    INumberVectorProperty CfgMotorStepsPerRevolutionNP;
+
+    // Status variables
+    //
+    
+    // Status variable: Focuser current position is inherited from superclass as FocusAbsPosN, FocusAbsPosNP
+
+    // Status variable: Current focuser speed
+    INumber CurSpeedN[1];
+    INumberVectorProperty CurSpeedNP;
+
+    // Status variable: Focuser temperature
+    INumber TempN[1];
+    INumberVectorProperty TempNP;
+
 };
 
 #endif // TEENASTRROFOCUSER_H

--- a/drivers/focuser/teenastro.h
+++ b/drivers/focuser/teenastro.h
@@ -1,10 +1,7 @@
 /*
     TeenAstro Focuser
     Copyright (C) 2021 Markus Noga
-    Derived from the below, and hereby made available under the same license.
 
-    OnFocus Focuser
-    Copyright (C) 2018 Paul de Backer (74.0632@gmail.com)
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
     License as published by the Free Software Foundation; either
@@ -48,36 +45,72 @@ private:
     double targetPos, lastPos;
 
     // Sends a command to the focuser. Returns true on success and false on failure.
-    bool Send(const char *const msg);
+    bool send(const char *const msg);
  
     // Sends a command to the focuser, and waits for a response terminated by '#'. Returns true on success and false on failure.
-    bool SendAndReceive(const char *const msg, char *resp);
+    bool sendAndReceive(const char *const msg, char *resp);
 
-    void setZero();
-    bool updateMaxPos();
+    // Sends a command to the focuser, and waits for a single character response. Returns true if successful and response is '1', otherwise false.
+    bool sendAndReceiveBool(const char *const msg);
 
-    // Updates current state consisting of position, speed, and temperature. Returns true on success and false on failure.
-    bool updateState();   
+
+    // Updates device version string from device
+    bool updateDeviceVersion();
+
+    // Updates current state from device, consisting of position, speed, and temperature. Returns true on success and false on failure.
+    bool updateState();
+
+    // Returns true if focuser is moving, else false.   
     bool isMoving();
 
-    // Updates movement configuration. Returns true on success and false on failure.
+    // Updates movement configuration from device. Returns true on success and false on failure.
     bool updateConfig();
 
-    // Updates motor configuration. Returns true on success and false on failure.
+    // Sets given configuration item on to device to provided value in device native units. Returns true on success and false on failure. 
+    bool setConfigItem(char item, uint32_t deviceValue);
+    bool setParkPos(uint32_t value);
+    bool setMaxPos(uint32_t value);
+    bool setGoToSpeed(uint32_t value);
+    bool setManualSpeed(uint32_t value);
+    bool setGoToAcc(uint32_t value);
+    bool setManualAcc(uint32_t value);
+    bool setManualDec(uint32_t value);
+
+    // Updates motor configuration from device. Returns true on success and false on failure.
     bool updateMotorConfig();
 
+    // Sends new motor inversion flag value to device. Returns true on success and false on failure. 
+    bool setMotorInvert(uint32_t value);
+    bool setMotorMicrosteps(uint32_t value);
+    bool setMotorResolution(uint32_t value);
+    bool setMotorCurrent(uint32_t value);
+    bool setMotorStepsPerRevolution(uint32_t value);
+
+    // Starts movement of focuser towards the given absolute position. Returns immediately, true on success else false.
     bool goTo(uint32_t position);
-    bool setMaxPos(uint32_t maxPos);
+
+    // Starts movement of focuser towards the parking position. Returns immediately, true on success else false.
+    bool goToPark();
+
+    // Stop focuser movement. Returns immediately, true on success else false.
+    bool stop();
+
+    // Syncs focuser zero position to current position, true on success else false.
+    bool syncZero();
+
 
     // UI Elements
     //
 
     // UI Element: Sync current position as zero position
-    ISwitch SetZeroS[1];
-    ISwitchVectorProperty SetZeroSP;
+    ISwitch SyncZeroS[1];
+    ISwitchVectorProperty SyncZeroSP;
 
     // Configuration variables
     //
+
+    IText CfgDeviceVersionT[1];
+    ITextVectorProperty CfgDeviceVersionTP;
 
     // Focuser park position 
     INumber CfgParkPosN[1];

--- a/drivers/focuser/teenastro.h
+++ b/drivers/focuser/teenastro.h
@@ -1,0 +1,67 @@
+/*
+    TeenAstro Focuser
+    Copyright (C) 2021 Markus Noga
+    Derived from the below, and hereby made available under the same license.
+
+    OnFocus Focuser
+    Copyright (C) 2018 Paul de Backer (74.0632@gmail.com)
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+*/
+
+#ifndef TEENASTRO_FOCUSER_H
+#define TEENASTRO_FOCUSER_H
+
+#include "indibase/indifocuser.h"
+
+class TeenAstroFocuser : public INDI::Focuser
+{
+public:
+    TeenAstroFocuser();
+    ~TeenAstroFocuser();
+
+    virtual bool Handshake();
+    const char * getDefaultName();
+    virtual bool initProperties();
+    virtual bool updateProperties();
+    virtual bool ISNewNumber (const char *dev, const char *name, double values[], char *names[], int n);
+    virtual bool ISNewSwitch (const char *dev, const char *name, ISState *states, char *names[], int n);
+    virtual IPState MoveAbsFocuser(uint32_t ticks);
+    virtual IPState MoveRelFocuser(FocusDirection dir, uint32_t ticks);
+    virtual bool AbortFocuser();
+    virtual void TimerHit();
+
+private:
+
+    double targetPos, lastPos;
+ 
+    void GetFocusParams();
+    void setZero();
+    bool updateMaxPos();
+    bool updateTemperature();
+    bool updatePosition();
+    bool isMoving();
+    bool Ack();
+
+    bool MoveMyFocuser(uint32_t position);
+    bool setMaxPos(uint32_t maxPos);
+
+    INumber MaxPosN[1];
+    INumberVectorProperty MaxPosNP;
+    ISwitch SetZeroS[1];
+    ISwitchVectorProperty SetZeroSP;
+};
+
+#endif // TEENASTRROFOCUSER_H


### PR DESCRIPTION
This pull request adds support for the TeenAstro focuser. It supports all currently available INDI focuser capabilities except FOCUSER_HAS_BACKLASH, which is not yet implemented in the TeenAstro focuser device firmware. It also supports all commands supported by the serial protocol of the TeenAstro focuser firmware, except named goto locations as INDI already provides those in the driver.

All controls relating to basic location can be found on the Main Controls tab. The remaining controls can be found on the Focuser tab and include motor settings for direction/steps/microsteps/resolution/current, motion settings for speeds/accelerations, as well as device firmware reboot and EEPROM erase.

Confirmed to work on my RasPi4 and TeenAstro focuser, as well as François Desvallées machine.