### PR TITLE
Update lx200pulsar2.cpp

### DIFF
--- a/drivers/telescope/lx200pulsar2.cpp
+++ b/drivers/telescope/lx200pulsar2.cpp
@@ -933,7 +933,7 @@ bool getSiteLatitudeLongitude(const int fd, double *lat, double *lon)
 {
     *lat = 0.0;
     *lon = 0.0;
-    char response[16]; response[15] = LX200Pulsar2::Null;
+    char response[32]; response[31] = LX200Pulsar2::Null;
 
     bool success = PulsarTX::sendReceive(fd, "#:YGl#", response);
     if (success)


### PR DESCRIPTION
The response buffer on line 936 was too small which caused stack smashing on ARM hardware.
Doubling the size of the buffer fixed this.