### PR TITLE
Bugfix - INDI::SingleThreadPool - self quit/start deadlock.

### DIFF
--- a/libs/indibase/thread/indisinglethreadpool_p.h
+++ b/libs/indibase/thread/indisinglethreadpool_p.h
@@ -36,8 +36,9 @@ public:
     std::atomic_bool isThreadAboutToQuit {false};
     std::atomic_bool isFunctionAboutToQuit {true};
 
-    std::condition_variable wakeUp;
-    std::mutex runLock;
+    std::condition_variable_any acquire;
+    std::condition_variable_any relased;
+    std::recursive_mutex runLock;
     std::thread thread;
 };
 


### PR DESCRIPTION
Deadlock appeared when function "quit" was called by the same process.
```cpp

static INDI::SingleThreadPool pool;

static void bar(const std::atomic_bool &)
{
    pool.quit(); // there is no thread change, no need to wait
    fprintf(stderr, "bar!\n");
}

static void foo(const std::atomic_bool &)
{
    pool.start(bar); // no thread change, execution priority
}

int main(int, char *[])
{
    pool.start(foo); // start
    pool.start(foo); // wait and run
    pool.quit();     // wait
    return 0;
}
```
Output:
```
bar!
bar!
```