### PR TITLE
Fix warnings - MacOS

### DIFF
--- a/indidriver.c
+++ b/indidriver.c
@@ -44,7 +44,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 
 static pthread_mutex_t stdout_mutex = PTHREAD_MUTEX_INITIALIZER;
 int verbose;      /* chatty */
-char *me = NULL;  /* a.out name */
+char *me = "";  /* a.out name */
 
 #define MAXRBUF 2048
 

--- a/scripts/indi-core-package-build.sh
+++ b/scripts/indi-core-package-build.sh
@@ -8,5 +8,7 @@ make DESTDIR=../../packages/indi-core-package install
 popd
 
 pushd packages
-tar -cvf indi-core-package.tar indi-core-package --{owner,group}=root
+command -v bsdtar >/dev/null 2>&1 && \
+    bsdtar --gid 0 --uid 0   -cvf indi-core-package.tar indi-core-package || \
+    tar --{owner,group}=root -cvf indi-core-package.tar indi-core-package
 popd

--- a/scripts/indi-core-package-install.sh
+++ b/scripts/indi-core-package-install.sh
@@ -2,4 +2,6 @@
 
 set -e
 
-$(command -v sudo) tar -hxvf packages/indi-core-package.tar --strip-components=1 -C /
+command -v bsdtar >/dev/null 2>&1 && \
+    $(command -v sudo) bsdtar -xvf packages/indi-core-package.tar --strip-components=1 -C / || \
+    $(command -v sudo)   tar -hxvf packages/indi-core-package.tar --strip-components=1 -C /

--- a/test/celestrondriver/test_celestrondriver.cpp
+++ b/test/celestrondriver/test_celestrondriver.cpp
@@ -225,25 +225,25 @@ TEST(CelestronDriverTest, trimDecAngle) {
 }
 
 TEST(CelestronDriverTest, dd2nex) {
-    ASSERT_EQ(0x0000, dd2nex(0.0));
-    ASSERT_EQ(0x2000, dd2nex(45.0));
-    ASSERT_EQ(0xc000, dd2nex(270.0));
-    ASSERT_EQ(0x0000, dd2nex(360.0));
-    ASSERT_EQ(0x12ce, dd2nex(26.4441));
+    ASSERT_EQ(0x0000U, dd2nex(0.0));
+    ASSERT_EQ(0x2000U, dd2nex(45.0));
+    ASSERT_EQ(0xc000U, dd2nex(270.0));
+    ASSERT_EQ(0x0000U, dd2nex(360.0));
+    ASSERT_EQ(0x12ceU, dd2nex(26.4441));
 
-    ASSERT_EQ(0x12ce, dd2nex(360 + 26.4441));
-    ASSERT_EQ(0xc000, dd2nex(-90.0));
+    ASSERT_EQ(0x12ceU, dd2nex(360 + 26.4441));
+    ASSERT_EQ(0xc000U, dd2nex(-90.0));
 }
 
 TEST(CelestronDriverTest, dd2pnex) {
-    ASSERT_EQ(0x00000000, dd2pnex(0.0));
-    ASSERT_EQ(0x20000000, dd2pnex(45.0));
-    ASSERT_EQ(0xc0000000, dd2pnex(270.0));
-    ASSERT_EQ(0x00000000, dd2pnex(360.0));
-    ASSERT_EQ(0x12ab0500, dd2pnex(26.25193834305));
+    ASSERT_EQ(0x00000000U, dd2pnex(0.0));
+    ASSERT_EQ(0x20000000U, dd2pnex(45.0));
+    ASSERT_EQ(0xc0000000U, dd2pnex(270.0));
+    ASSERT_EQ(0x00000000U, dd2pnex(360.0));
+    ASSERT_EQ(0x12ab0500U, dd2pnex(26.25193834305));
 
-    ASSERT_EQ(0x12ab0500, dd2pnex(360 + 26.25193834305));
-    ASSERT_EQ(0xc0000000, dd2pnex(-90.0));
+    ASSERT_EQ(0x12ab0500U, dd2pnex(360 + 26.25193834305));
+    ASSERT_EQ(0xc0000000U, dd2pnex(-90.0));
 }
 
 TEST(CelestronDriverTest, nex2dd) {

--- a/test/core/test_base64.cpp
+++ b/test/core/test_base64.cpp
@@ -28,48 +28,53 @@
 
 TEST(CORE_BASE64, Test_to64frombits)
 {
-    int len = 0, size = sizeof("FOOBARBAZ") - 1 * 4 / 3 + 4 + 1;
-    const unsigned char convert[] = "FOOBARBAZ";
-    unsigned char *p_outbuf       = nullptr;
+    const char   inp_msg[] = "FOOBARBAZ";
+    const size_t inp_len   = sizeof(inp_msg) - 1;
 
-    p_outbuf = (unsigned char *)calloc(1, size);
-    ASSERT_TRUE(p_outbuf);
+    const char   out_msg[] = "Rk9PQkFSQkFa";
+    const size_t out_len   = sizeof(out_msg) - 1;
 
-    len = to64frombits_s(p_outbuf, convert, sizeof(convert) - 1, (size_t) size);
-    ASSERT_EQ(sizeof("Rk9PQkFSQkFa") - 1, len);
-    ASSERT_STREQ("Rk9PQkFSQkFa", (const char *)p_outbuf);
+    char   res_msg[out_len + 1] = {0,};
+    size_t res_len = 0;
 
-    free(p_outbuf);
+    res_len = to64frombits_s(
+        reinterpret_cast<unsigned char *>(res_msg),
+        reinterpret_cast<const unsigned char *>(inp_msg),
+        inp_len,
+        out_len
+    );
+    ASSERT_EQ(out_len, res_len);
+    ASSERT_STREQ(out_msg, res_msg);
 }
 
 TEST(CORE_BASE64, Test_from64tobits)
 {
-    int len = 0, size = sizeof("Rk9PQkFSQkFa") - 1 * 3 / 4 + 1;
-    const char convert[] = "Rk9PQkFSQkFa";
-    char *p_outbuf       = nullptr;
+    const char   inp_msg[] = "Rk9PQkFSQkFa";
+    const size_t inp_len   = sizeof(inp_msg) - 1;
 
-    p_outbuf = (char *)calloc(1, size);
-    ASSERT_TRUE(p_outbuf);
+    const char   out_msg[] = "FOOBARBAZ";
+    const size_t out_len   = sizeof(out_msg) - 1;
 
-    len = from64tobits(p_outbuf, convert);
-    ASSERT_EQ(sizeof("FOOBARBAZ") - 1, len);
-    ASSERT_STREQ("FOOBARBAZ", (char *)p_outbuf);
+    char   res_msg[out_len + 1] = {0,};
+    size_t res_len = 0;
 
-    free(p_outbuf);
+    res_len = from64tobits(res_msg, inp_msg);
+    ASSERT_EQ(out_len, res_len);
+    ASSERT_STREQ(out_msg, res_msg);
 }
 
 TEST(CORE_BASE64, Test_from64tobits_fast)
 {
-    int len = 0, size = sizeof("Rk9PQkFSQkFa") - 1 * 3 / 4 + 1;
-    const char convert[] = "Rk9PQkFSQkFa";
-    char *p_outbuf       = nullptr;
+    const char   inp_msg[] = "Rk9PQkFSQkFa";
+    const size_t inp_len   = sizeof(inp_msg) - 1;
 
-    p_outbuf = (char *)calloc(1, size);
-    ASSERT_TRUE(p_outbuf);
+    const char   out_msg[] = "FOOBARBAZ";
+    const size_t out_len   = sizeof(out_msg) - 1;
 
-    len = from64tobits_fast(p_outbuf, convert, strlen(convert));
-    ASSERT_EQ(sizeof("FOOBARBAZ") - 1, len);
-    ASSERT_STREQ("FOOBARBAZ", (char *)p_outbuf);
+    char   res_msg[out_len + 1] = {0,};
+    size_t res_len = 0;
 
-    free(p_outbuf);
+    res_len = from64tobits_fast(res_msg, inp_msg, inp_len);
+    ASSERT_EQ(out_len, res_len);
+    ASSERT_STREQ(out_msg, res_msg);
 }

--- a/test/core/test_base64.cpp
+++ b/test/core/test_base64.cpp
@@ -50,7 +50,7 @@ TEST(CORE_BASE64, Test_to64frombits)
 TEST(CORE_BASE64, Test_from64tobits)
 {
     const char   inp_msg[] = "Rk9PQkFSQkFa";
-    const size_t inp_len   = sizeof(inp_msg) - 1;
+    // const size_t inp_len   = sizeof(inp_msg) - 1;
 
     const char   out_msg[] = "FOOBARBAZ";
     const size_t out_len   = sizeof(out_msg) - 1;


### PR DESCRIPTION
MacOS tests finally passed.


Changes:
- bsdtar support
- Refreshed implementation of base64 tests
- Replace nullptr with "" for 'me' variable.

Not all tests respect the global variable "me".

Conversion `const char *` to `std::string`
https://github.com/indilib/indi/blob/a2ebd7db5cc484a6f1383d5dc99a3f85afa211dd/libs/indibase/defaultdevice.cpp#L947-L948

https://github.com/indilib/indi/blob/a2ebd7db5cc484a6f1383d5dc99a3f85afa211dd/libs/indibase/defaultdevice.cpp#L1198-L1201

https://github.com/indilib/indi/blob/a2ebd7db5cc484a6f1383d5dc99a3f85afa211dd/indidriver.c#L47

If 'me' is null then we have an error:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
```
