### PR TITLE
Fix XML Escape

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,8 @@ include_directories( ${CFITSIO_INCLUDE_DIR})
 
 SET(indiclient_C_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/userio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indiuserio.c
     ${CMAKE_CURRENT_SOURCE_DIR}/base64.c)
 
 SET(indiclient_CXX_SRC
@@ -243,6 +245,8 @@ include_directories( ${CFITSIO_INCLUDE_DIR})
 message(STATUS "Building INDI Client with Qt5 support")
 SET(indiclientqt_C_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/userio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indiuserio.c
     ${CMAKE_CURRENT_SOURCE_DIR}/base64.c)
 SET(indiclientqt_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
@@ -412,6 +416,8 @@ SET(indidriver_C_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/indidrivermain.c
     ${CMAKE_CURRENT_SOURCE_DIR}/eventloop.c
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/userio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indiuserio.c
     ${CMAKE_CURRENT_SOURCE_DIR}/base64.c
     )
 
@@ -1766,7 +1772,9 @@ SET(indi_get_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/eventloop.c
     ${CMAKE_CURRENT_SOURCE_DIR}/base64.c
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/getINDIproperty.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/userio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indiuserio.c)
 
 IF (UNITY_BUILD)
     ENABLE_UNITY_BUILD(indi_get indi_get_SRC 10 c)
@@ -1789,7 +1797,9 @@ SET(indi_set_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/eventloop.c
     ${CMAKE_CURRENT_SOURCE_DIR}/base64.c
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/setINDIproperty.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/userio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indiuserio.c)
 
 IF (UNITY_BUILD)
     ENABLE_UNITY_BUILD(indi_set indi_set_SRC 10 c)
@@ -1813,7 +1823,9 @@ SET(indi_eval_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/base64.c
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/compiler.c
     ${CMAKE_CURRENT_SOURCE_DIR}/tools/evalINDI.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c)
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/userio.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indiuserio.c)
 
 IF (UNITY_BUILD)
     ENABLE_UNITY_BUILD(indi_eval indi_eval_SRC 10 c)

--- a/indiapi.h
+++ b/indiapi.h
@@ -221,7 +221,7 @@ IP_RW  /*!< Read & Write */
  * @struct IText
  * @brief One text descriptor.
  */
-typedef struct
+typedef struct _IText
 {
 /** Index name */
 char name[MAXINDINAME];
@@ -271,7 +271,7 @@ typedef struct _ITextVectorProperty
  * @struct INumber
  * @brief One number descriptor.
  */
-typedef struct
+typedef struct _INumber
 {
     /** Index name */
     char name[MAXINDINAME];
@@ -344,7 +344,7 @@ typedef struct _INumberVectorProperty
  * @struct ISwitch
  * @brief One switch descriptor.
  */
-typedef struct
+typedef struct _ISwitch
 {
     /** Index name */
     char name[MAXINDINAME];
@@ -394,7 +394,7 @@ typedef struct _ISwitchVectorProperty
  * @struct ILight
  * @brief One light descriptor.
  */
-typedef struct
+typedef struct _ILight
 {
     /** Index name */
     char name[MAXINDINAME];

--- a/indiapi.h
+++ b/indiapi.h
@@ -438,7 +438,7 @@ typedef struct _ILightVectorProperty
  * @struct IBLOB
  * @brief One Blob (Binary Large Object) descriptor.
  */
-typedef struct /* one BLOB descriptor */
+typedef struct _IBLOB/* one BLOB descriptor */
 {
     /** Index name */
     char name[MAXINDINAME];

--- a/indidriver.c
+++ b/indidriver.c
@@ -42,6 +42,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 #include <sys/stat.h>
 #include <assert.h>
 
+#include "userio.h"
+#include "indiuserio.h"
+
 static pthread_mutex_t stdout_mutex = PTHREAD_MUTEX_INITIALIZER;
 int verbose;      /* chatty */
 char *me = "";  /* a.out name */
@@ -104,127 +107,17 @@ static void rosc_add_unique(const char *propName, const char *devName, IPerm per
         rosc_add(propName, devName, perm, ptr, type);
 }
 
-
-/* output a string expanding special characters into xml/html escape sequences */
-static void escapeXML_fputs(const char *src, FILE *stream)
-{
-    const char *ptr = src;
-    const char *replacement;
-
-    for(; *ptr; ++ptr)
-    {
-        switch(*ptr)
-        {
-        case  '&': replacement = "&amp;";  break;
-        case '\'': replacement = "&apos;"; break;
-        case  '"': replacement = "&quot;"; break;
-        case  '<': replacement = "&lt;";   break;
-        case  '>': replacement = "&gt;";   break;
-        default:   replacement = NULL;
-        }
-
-        if (replacement != NULL)
-        {
-            fwrite(src, 1, (size_t)(ptr - src), stream);
-            src = ptr + 1;
-            fputs(replacement, stream);
-        }
-    }
-    fwrite(src, 1, (size_t)(ptr - src), stream);
-}
-
-static void escapeXML_vprintf(const char *fmt, va_list ap)
-{
-    char message[MAXINDIMESSAGE];
-    vsnprintf(message, MAXINDIMESSAGE, fmt, ap);
-    escapeXML_fputs(message, stdout);
-}
-
-/* output a string expanding special characters into xml/html escape sequences */
-static size_t escapeXML2(char *dst, const char *src, size_t size)
-{
-    char *ptr = dst; // copy pointer
-
-    // size > 1 - place for null-terminator
-    for(; size > 1 && *src; ++src)
-    {
-        switch (*src)
-        {
-        case '&':
-            if (size < 6) goto finish;
-            strncpy(ptr, "&amp;", 6);
-            ptr += 5;
-            size -= 5;
-            break;
-        case '\'':
-            if (size < 7) goto finish;
-            strncpy(ptr, "&apos;", 7);
-            ptr += 6;
-            size -= 6;
-            break;
-        case '"':
-            if (size < 7) goto finish;
-            strncpy(ptr, "&quot;", 7);
-            ptr += 6;
-            size -= 6;
-            break;
-        case '<':
-            if (size < 5) goto finish;
-            strncpy(ptr, "&lt;", 5);
-            ptr += 4;
-            size -= 4;
-            break;
-        case '>':
-            if (size < 5) goto finish;
-            strncpy(ptr, "&gt;", 5);
-            ptr += 4;
-            size -= 4;
-            break;
-        default:
-            *ptr++ = *src;
-            size -= 1;
-            break;
-        }
-    }
-
-finish:
-    if (size > 0)
-        *ptr = 0;
-    return (size_t)(ptr - dst);
-}
-
-// unused
-#if 0
-/* output a string expanding special characters into xml/html escape sequences */
-/* N.B. You must free the returned buffer after use! */
-static char *escapeXML(const char *src, size_t size)
-{
-    char *dst = malloc(sizeof(char) * size);
-    assert_mem(dst);
-    escapeXML2(dst, src, size);
-    return dst;
-}
-#endif
-
 /* tell Client to delete the property with given name on given device, or
  * entire device if !name
  */
 void IDDeleteVA(const char *dev, const char *name, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
+
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    printf("<delProperty\n  device='%s'\n", dev);
-    if (name)
-        printf(" name='%s'\n", name);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf("/>\n");
+    userio_xmlv1(io, stdout);
+    IUUserIODeleteVA(io, stdout, dev, name, fmt, ap);
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
@@ -243,13 +136,14 @@ void IDDelete(const char *dev, const char *name, const char *fmt, ...)
  */
 void IDSnoopDevice(const char *snooped_device, const char *snooped_property)
 {
+    const userio *io = userio_file();
+
     pthread_mutex_lock(&stdout_mutex);
-    xmlv1();
-    if (snooped_property && snooped_property[0])
-        printf("<getProperties version='%g' device='%s' name='%s'/>\n", INDIV, snooped_device, snooped_property);
-    else
-        printf("<getProperties version='%g' device='%s'/>\n", INDIV, snooped_device);
+
+    userio_xmlv1(io, stdout);
+    IUUserIOGetProperties(io, stdout, snooped_device, snooped_property);
     fflush(stdout);
+
     pthread_mutex_unlock(&stdout_mutex);
 }
 
@@ -258,30 +152,14 @@ void IDSnoopDevice(const char *snooped_device, const char *snooped_property)
  */
 void IDSnoopBLOBs(const char *snooped_device, const char *snooped_property, BLOBHandling bh)
 {
-    const char *how;
-
-    switch (bh)
-    {
-        case B_NEVER:
-            how = "Never";
-            break;
-        case B_ALSO:
-            how = "Also";
-            break;
-        case B_ONLY:
-            how = "Only";
-            break;
-        default:
-            return;
-    }
+    const userio *io = userio_file();
 
     pthread_mutex_lock(&stdout_mutex);
-    xmlv1();
-    if (snooped_property && snooped_property[0])
-        printf("<enableBLOB device='%s' name='%s'>%s</enableBLOB>\n", snooped_device, snooped_property, how);
-    else
-        printf("<enableBLOB device='%s'>%s</enableBLOB>\n", snooped_device, how);
+
+    userio_xmlv1(io, stdout);
+    IUUserIOEnableBLOB(io, stdout, snooped_device, snooped_property, bh);
     fflush(stdout);
+
     pthread_mutex_unlock(&stdout_mutex);
 }
 
@@ -437,12 +315,12 @@ int IUSaveBLOB(IBLOB *bp, int size, int blobsize, char *blob, char *format)
 
 void IUFillSwitch(ISwitch *sp, const char *name, const char *label, ISState s)
 {
-    escapeXML2(sp->name, name, sizeof(sp->name));
+    strncpy(sp->name, name, sizeof(sp->name));
 
     if (label[0])
-        escapeXML2(sp->label, label, sizeof(sp->label));
+        strncpy(sp->label, label, sizeof(sp->label));
     else
-        strncpy(sp->label, sp->name, sizeof(sp->label));
+        strncpy(sp->label, name, sizeof(sp->label));
 
     sp->s   = s;
     sp->svp = NULL;
@@ -451,12 +329,12 @@ void IUFillSwitch(ISwitch *sp, const char *name, const char *label, ISState s)
 
 void IUFillLight(ILight *lp, const char *name, const char *label, IPState s)
 {
-    escapeXML2(lp->name, name, sizeof(lp->name));
+    strncpy(lp->name, name, sizeof(lp->name));
 
     if (label[0])
-        escapeXML2(lp->label, label, sizeof(lp->label));
+        strncpy(lp->label, label, sizeof(lp->label));
     else
-        strncpy(lp->label, lp->name, sizeof(lp->label));
+        strncpy(lp->label, name, sizeof(lp->label));
 
     lp->s   = s;
     lp->lvp = NULL;
@@ -466,14 +344,14 @@ void IUFillLight(ILight *lp, const char *name, const char *label, IPState s)
 void IUFillNumber(INumber *np, const char *name, const char *label, const char *format, double min, double max,
                   double step, double value)
 {
-    escapeXML2(np->name, name, sizeof(np->name));
+    strncpy(np->name, name, sizeof(np->name));
 
     if (label[0])
-        escapeXML2(np->label, label, sizeof(np->label));
+        strncpy(np->label, label, sizeof(np->label));
     else
-        strncpy(np->label, np->name, sizeof(np->label));
+        strncpy(np->label, name, sizeof(np->label));
 
-    strncpy(np->format, format, sizeof(np->format)); // escape unnecessary?
+    strncpy(np->format, format, sizeof(np->format));
 
     np->min   = min;
     np->max   = max;
@@ -486,12 +364,12 @@ void IUFillNumber(INumber *np, const char *name, const char *label, const char *
 
 void IUFillText(IText *tp, const char *name, const char *label, const char *initialText)
 {
-    escapeXML2(tp->name, name, sizeof(tp->name));
+    strncpy(tp->name, name, sizeof(tp->name));
 
     if (label[0])
-        escapeXML2(tp->label, label, sizeof(tp->label));
+        strncpy(tp->label, label, sizeof(tp->label));
     else
-        strncpy(tp->label, tp->name, sizeof(tp->label));
+        strncpy(tp->label, name, sizeof(tp->label));
 
     if (tp->text && tp->text[0])
         free(tp->text);
@@ -509,14 +387,14 @@ void IUFillBLOB(IBLOB *bp, const char *name, const char *label, const char *form
 {
     memset(bp, 0, sizeof(IBLOB));
 
-    escapeXML2(bp->name, name, sizeof(bp->name));
+    strncpy(bp->name, name, sizeof(bp->name));
 
     if (label[0])
-        escapeXML2(bp->label, label, sizeof(bp->label));
+        strncpy(bp->label, label, sizeof(bp->label));
     else
-        strncpy(bp->label, bp->name, sizeof(bp->label));
+        strncpy(bp->label, name, sizeof(bp->label));
 
-    strncpy(bp->format, format, sizeof(bp->format)); // escape unnecessary?
+    strncpy(bp->format, format, sizeof(bp->format));
 
     bp->blob    = 0;
     bp->bloblen = 0;
@@ -530,16 +408,16 @@ void IUFillBLOB(IBLOB *bp, const char *name, const char *label, const char *form
 void IUFillSwitchVector(ISwitchVectorProperty *svp, ISwitch *sp, int nsp, const char *dev, const char *name,
                         const char *label, const char *group, IPerm p, ISRule r, double timeout, IPState s)
 {
-    strncpy(svp->device, dev, sizeof(svp->device)); // escape unnecessary?
+    strncpy(svp->device, dev, sizeof(svp->device));
 
-    escapeXML2(svp->name, name, sizeof(svp->name));
+    strncpy(svp->name, name, sizeof(svp->name));
 
     if (label[0])
-        escapeXML2(svp->label, label, sizeof(svp->label));
+        strncpy(svp->label, label, sizeof(svp->label));
     else
-        strncpy(svp->label, svp->name, sizeof(svp->label));
+        strncpy(svp->label, name, sizeof(svp->label));
 
-    strncpy(svp->group, group, sizeof(svp->group)); // escape unnecessary?
+    strncpy(svp->group, group, sizeof(svp->group));
     svp->timestamp[0] = '\0';
 
     svp->p       = p;
@@ -553,16 +431,16 @@ void IUFillSwitchVector(ISwitchVectorProperty *svp, ISwitch *sp, int nsp, const 
 void IUFillLightVector(ILightVectorProperty *lvp, ILight *lp, int nlp, const char *dev, const char *name,
                        const char *label, const char *group, IPState s)
 {
-    strncpy(lvp->device, dev, sizeof(lvp->device)); // escape unnecessary?
+    strncpy(lvp->device, dev, sizeof(lvp->device));
 
-    escapeXML2(lvp->name, name, sizeof(lvp->name));
+    strncpy(lvp->name, name, sizeof(lvp->name));
 
     if (label[0])
-        escapeXML2(lvp->label, label, sizeof(lvp->label));
+        strncpy(lvp->label, label, sizeof(lvp->label));
     else
-        strncpy(lvp->label, lvp->name, sizeof(lvp->label));
+        strncpy(lvp->label, name, sizeof(lvp->label));
 
-    strncpy(lvp->group, group, sizeof(lvp->group)); // escape unnecessary?
+    strncpy(lvp->group, group, sizeof(lvp->group));
     lvp->timestamp[0] = '\0';
 
     lvp->s   = s;
@@ -573,16 +451,16 @@ void IUFillLightVector(ILightVectorProperty *lvp, ILight *lp, int nlp, const cha
 void IUFillNumberVector(INumberVectorProperty *nvp, INumber *np, int nnp, const char *dev, const char *name,
                         const char *label, const char *group, IPerm p, double timeout, IPState s)
 {
-    strncpy(nvp->device, dev, sizeof(nvp->device)); // escape unnecessary?
+    strncpy(nvp->device, dev, sizeof(nvp->device));
 
-    escapeXML2(nvp->name, name, sizeof(nvp->name));
+    strncpy(nvp->name, name, sizeof(nvp->name));
 
     if (label[0])
-        escapeXML2(nvp->label, label, sizeof(nvp->label));
+        strncpy(nvp->label, label, sizeof(nvp->label));
     else
-        strncpy(nvp->label, nvp->name, sizeof(nvp->label));
+        strncpy(nvp->label, name, sizeof(nvp->label));
 
-    strncpy(nvp->group, group, sizeof(nvp->group)); // escape unnecessary?
+    strncpy(nvp->group, group, sizeof(nvp->group));
     nvp->timestamp[0] = '\0';
 
     nvp->p       = p;
@@ -595,16 +473,16 @@ void IUFillNumberVector(INumberVectorProperty *nvp, INumber *np, int nnp, const 
 void IUFillTextVector(ITextVectorProperty *tvp, IText *tp, int ntp, const char *dev, const char *name,
                       const char *label, const char *group, IPerm p, double timeout, IPState s)
 {
-    strncpy(tvp->device, dev, sizeof(tvp->device)); // escape unnecessary?
+    strncpy(tvp->device, dev, sizeof(tvp->device));
 
-    escapeXML2(tvp->name, name, sizeof(tvp->name));
+    strncpy(tvp->name, name, sizeof(tvp->name));
 
     if (label[0])
-        escapeXML2(tvp->label, label, sizeof(tvp->label));
+        strncpy(tvp->label, label, sizeof(tvp->label));
     else
-        strncpy(tvp->label, tvp->name, sizeof(tvp->label));
+        strncpy(tvp->label, name, sizeof(tvp->label));
 
-    strncpy(tvp->group, group, sizeof(tvp->group)); // escape unnecessary?
+    strncpy(tvp->group, group, sizeof(tvp->group));
     tvp->timestamp[0] = '\0';
 
     tvp->p       = p;
@@ -618,16 +496,16 @@ void IUFillBLOBVector(IBLOBVectorProperty *bvp, IBLOB *bp, int nbp, const char *
                       const char *label, const char *group, IPerm p, double timeout, IPState s)
 {
     memset(bvp, 0, sizeof(IBLOBVectorProperty));
-    strncpy(bvp->device, dev, sizeof(bvp->device)); // escape unnecessary?
+    strncpy(bvp->device, dev, sizeof(bvp->device));
 
-    escapeXML2(bvp->name, name, sizeof(bvp->name));
+    strncpy(bvp->name, name, sizeof(bvp->name));
 
     if (label[0])
-        escapeXML2(bvp->label, label, sizeof(bvp->label));
+        strncpy(bvp->label, label, sizeof(bvp->label));
     else
-        strncpy(bvp->label, bvp->name, sizeof(bvp->label));
+        strncpy(bvp->label, name, sizeof(bvp->label));
 
-    strncpy(bvp->group, group, sizeof(bvp->group)); // escape unnecessary?
+    strncpy(bvp->group, group, sizeof(bvp->group));
     bvp->timestamp[0] = '\0';
 
     bvp->p       = p;
@@ -1563,20 +1441,14 @@ int IUGetConfigText(const char *dev, const char *property, const char *member, c
 /* send client a message for a specific device or at large if !dev */
 void IDMessageVA(const char *dev, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
+
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    printf("<message\n");
-    if (dev)
-        printf(" device='%s'\n", dev);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf("/>\n");
+    userio_xmlv1(io, stdout);
+
+    IDUserIOMessageVA(io, stdout, dev, fmt, ap);
+
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
@@ -1670,63 +1542,21 @@ void IUSaveConfigTag(FILE *fp, int ctag, const char *dev, int silent)
     if (!fp)
         return;
 
-    /* Opening tag */
-    if (ctag == 0)
-    {
-        fprintf(fp, "<INDIDriver>\n");
-        if (silent != 1)
-            IDMessage(dev, "[INFO] Saving device configuration...");
-    }
-    /* Closing tag */
-    else
-    {
-        fprintf(fp, "</INDIDriver>\n");
-        if (silent != 1)
-            IDMessage(dev, "[INFO] Device configuration saved.");
-    }
+    IUUserIOConfigTag(userio_file(), fp, ctag, dev, silent);
 }
 
 /* tell client to create a text vector property */
 void IDDefTextVA(const ITextVectorProperty *tvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<defTextVector\n");
-    printf("  device='%s'\n", tvp->device);
-    printf("  name='%s'\n", tvp->name);
-    printf("  label='%s'\n", tvp->label);
-    printf("  group='%s'\n", tvp->group);
-    printf("  state='%s'\n", pstateStr(tvp->s));
-    printf("  perm='%s'\n", permStr(tvp->p));
-    printf("  timeout='%g'\n", tvp->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < tvp->ntp; i++)
-    {
-        IText *tp = &tvp->tp[i];
-        printf("  <defText\n");
-        printf("    name='%s'\n", tp->name);
-        printf("    label='%s'>\n", tp->label);
-        printf("      %s\n", tp->text ? tp->text : "");
-        printf("  </defText>\n");
-    }
-
-    printf("</defTextVector>\n");
+    userio_xmlv1(io, stdout);
+    IUUserIODefTextVA(io, stdout, tvp, fmt, ap);
+    fflush(stdout);
 
     /* Add this property to insure proper sanity check */
     rosc_add_unique(tvp->name, tvp->device, tvp->p, tvp, INDI_TEXT);
-
-    indi_locale_C_numeric_pop(orig);
-    fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
@@ -1740,150 +1570,61 @@ void IDDefText(const ITextVectorProperty *tvp, const char *fmt, ...)
 }
 
 /* tell client to create a new numeric vector property */
-void IDDefNumberVA(const INumberVectorProperty *n, const char *fmt, va_list ap)
+void IDDefNumberVA(const INumberVectorProperty *nvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<defNumberVector\n");
-    printf("  device='%s'\n", n->device);
-    printf("  name='%s'\n", n->name);
-    printf("  label='%s'\n", n->label);
-    printf("  group='%s'\n", n->group);
-    printf("  state='%s'\n", pstateStr(n->s));
-    printf("  perm='%s'\n", permStr(n->p));
-    printf("  timeout='%g'\n", n->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < n->nnp; i++)
-    {
-        INumber *np = &n->np[i];
-
-        printf("  <defNumber\n");
-        printf("    name='%s'\n", np->name);
-        printf("    label='%s'\n", np->label);
-        printf("    format='%s'\n", np->format);
-        printf("    min='%.20g'\n", np->min);
-        printf("    max='%.20g'\n", np->max);
-        printf("    step='%.20g'>\n", np->step);
-        printf("      %.20g\n", np->value);
-
-        printf("  </defNumber>\n");
-    }
-
-    printf("</defNumberVector>\n");
+    userio_xmlv1(io, stdout);
+    IUUserIODefNumberVA(io, stdout, nvp, fmt, ap);
+    fflush(stdout);
 
     /* Add this property to insure proper sanity check */
-    rosc_add_unique(n->name, n->device, n->p, n, INDI_NUMBER);
-
-    indi_locale_C_numeric_pop(orig);
-    fflush(stdout);
+    rosc_add_unique(nvp->name, nvp->device, nvp->p, nvp, INDI_NUMBER);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
 
-void IDDefNumber(const INumberVectorProperty *n, const char *fmt, ...)
+void IDDefNumber(const INumberVectorProperty *nvp, const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    IDDefNumberVA(n, fmt, ap);
+    IDDefNumberVA(nvp, fmt, ap);
     va_end(ap);
 }
 
 /* tell client to create a new switch vector property */
-void IDDefSwitchVA(const ISwitchVectorProperty *s, const char *fmt, va_list ap)
+void IDDefSwitchVA(const ISwitchVectorProperty *svp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<defSwitchVector\n");
-    printf("  device='%s'\n", s->device);
-    printf("  name='%s'\n", s->name);
-    printf("  label='%s'\n", s->label);
-    printf("  group='%s'\n", s->group);
-    printf("  state='%s'\n", pstateStr(s->s));
-    printf("  perm='%s'\n", permStr(s->p));
-    printf("  rule='%s'\n", ruleStr(s->r));
-    printf("  timeout='%g'\n", s->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < s->nsp; i++)
-    {
-        ISwitch *sp = &s->sp[i];
-        printf("  <defSwitch\n");
-        printf("    name='%s'\n", sp->name);
-        printf("    label='%s'>\n", sp->label);
-        printf("      %s\n", sstateStr(sp->s));
-        printf("  </defSwitch>\n");
-    }
-
-    printf("</defSwitchVector>\n");
+    userio_xmlv1(io, stdout);
+    IUUserIODefSwitchVA(io, stdout, svp, fmt, ap);
+    fflush(stdout);
 
     /* Add this property to insure proper sanity check */
-    rosc_add_unique(s->name, s->device, s->p, s, INDI_SWITCH);
-
-    indi_locale_C_numeric_pop(orig);
-    fflush(stdout);
+    rosc_add_unique(svp->name, svp->device, svp->p, svp, INDI_SWITCH);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
 
-void IDDefSwitch(const ISwitchVectorProperty *s, const char *fmt, ...)
+void IDDefSwitch(const ISwitchVectorProperty *svp, const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    IDDefSwitchVA(s, fmt, ap);
+    IDDefSwitchVA(svp, fmt, ap);
     va_end(ap);
 }
 
 /* tell client to create a new lights vector property */
 void IDDefLightVA(const ILightVectorProperty *lvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    printf("<defLightVector\n");
-    printf("  device='%s'\n", lvp->device);
-    printf("  name='%s'\n", lvp->name);
-    printf("  label='%s'\n", lvp->label);
-    printf("  group='%s'\n", lvp->group);
-    printf("  state='%s'\n", pstateStr(lvp->s));
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < lvp->nlp; i++)
-    {
-        ILight *lp = &lvp->lp[i];
-        printf("  <defLight\n");
-        printf("    name='%s'\n", lp->name);
-        printf("    label='%s'>\n", lp->label);
-        printf("      %s\n", pstateStr(lp->s));
-        printf("  </defLight>\n");
-    }
-
-    printf("</defLightVector>\n");
+    userio_xmlv1(io, stdout);
+    IUUserIODefLightVA(io, stdout, lvp, fmt, ap);
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
@@ -1898,91 +1639,42 @@ void IDDefLight(const ILightVectorProperty *lvp, const char *fmt, ...)
 }
 
 /* tell client to create a new BLOB vector property */
-void IDDefBLOBVA(const IBLOBVectorProperty *b, const char *fmt, va_list ap)
+void IDDefBLOBVA(const IBLOBVectorProperty *bvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<defBLOBVector\n");
-    printf("  device='%s'\n", b->device);
-    printf("  name='%s'\n", b->name);
-    printf("  label='%s'\n", b->label);
-    printf("  group='%s'\n", b->group);
-    printf("  state='%s'\n", pstateStr(b->s));
-    printf("  perm='%s'\n", permStr(b->p));
-    printf("  timeout='%g'\n", b->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < b->nbp; i++)
-    {
-        IBLOB *bp = &b->bp[i];
-        printf("  <defBLOB\n");
-        printf("    name='%s'\n", bp->name);
-        printf("    label='%s'\n", bp->label);
-        printf("  />\n");
-    }
-
-    printf("</defBLOBVector>\n");
+    userio_xmlv1(io, stdout);
+    IUUserIODefBLOBVA(io, stdout, bvp, fmt, ap);
+    fflush(stdout);
 
     /* Add this property to insure proper sanity check */
-    rosc_add_unique(b->name, b->device, b->p, b, INDI_BLOB);
-
-    indi_locale_C_numeric_pop(orig);
-    fflush(stdout);
+    rosc_add_unique(bvp->name, bvp->device, bvp->p, bvp, INDI_BLOB);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
-void IDDefBLOB(const IBLOBVectorProperty *b, const char *fmt, ...)
+
+void IDDefBLOB(const IBLOBVectorProperty *bvp, const char *fmt, ...)
 {
     va_list ap;
     va_start(ap, fmt);
-    IDDefBLOBVA(b, fmt, ap);
+    IDDefBLOBVA(bvp, fmt, ap);
     va_end(ap);
 }
 
 /* tell client to update an existing text vector property */
 void IDSetTextVA(const ITextVectorProperty *tvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<setTextVector\n");
-    printf("  device='%s'\n", tvp->device);
-    printf("  name='%s'\n", tvp->name);
-    printf("  state='%s'\n", pstateStr(tvp->s));
-    printf("  timeout='%g'\n", tvp->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < tvp->ntp; i++)
-    {
-        IText *tp = &tvp->tp[i];
-        printf("  <oneText name='%s'>\n", tp->name);
-        printf("      %s\n", tp->text ? entityXML(tp->text) : "");
-        printf("  </oneText>\n");
-    }
-
-    printf("</setTextVector>\n");
-    indi_locale_C_numeric_pop(orig);
+    userio_xmlv1(io, stdout);
+    IUUserIOSetTextVA(io, stdout, tvp, fmt, ap);
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
+
 void IDSetText(const ITextVectorProperty *tvp, const char *fmt, ...)
 {
     va_list ap;
@@ -1994,38 +1686,16 @@ void IDSetText(const ITextVectorProperty *tvp, const char *fmt, ...)
 /* tell client to update an existing numeric vector property */
 void IDSetNumberVA(const INumberVectorProperty *nvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<setNumberVector\n");
-    printf("  device='%s'\n", nvp->device);
-    printf("  name='%s'\n", nvp->name);
-    printf("  state='%s'\n", pstateStr(nvp->s));
-    printf("  timeout='%g'\n", nvp->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < nvp->nnp; i++)
-    {
-        INumber *np = &nvp->np[i];
-        printf("  <oneNumber name='%s'>\n", np->name);
-        printf("      %.20g\n", np->value);
-        printf("  </oneNumber>\n");
-    }
-
-    printf("</setNumberVector>\n");
-    indi_locale_C_numeric_pop(orig);
+    userio_xmlv1(io, stdout);
+    IUUserIOSetNumberVA(io, stdout, nvp, fmt, ap);
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
+
 void IDSetNumber(const INumberVectorProperty *nvp, const char *fmt, ...)
 {
     va_list ap;
@@ -2037,38 +1707,16 @@ void IDSetNumber(const INumberVectorProperty *nvp, const char *fmt, ...)
 /* tell client to update an existing switch vector property */
 void IDSetSwitchVA(const ISwitchVectorProperty *svp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<setSwitchVector\n");
-    printf("  device='%s'\n", svp->device);
-    printf("  name='%s'\n", svp->name);
-    printf("  state='%s'\n", pstateStr(svp->s));
-    printf("  timeout='%g'\n", svp->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < svp->nsp; i++)
-    {
-        ISwitch *sp = &svp->sp[i];
-        printf("  <oneSwitch name='%s'>\n", sp->name);
-        printf("      %s\n", sstateStr(sp->s));
-        printf("  </oneSwitch>\n");
-    }
-
-    printf("</setSwitchVector>\n");
-    indi_locale_C_numeric_pop(orig);
+    userio_xmlv1(io, stdout);
+    IUUserIOSetSwitchVA(io, stdout, svp, fmt, ap);
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
+
 void IDSetSwitch(const ISwitchVectorProperty *svp, const char *fmt, ...)
 {
     va_list ap;
@@ -2080,35 +1728,16 @@ void IDSetSwitch(const ISwitchVectorProperty *svp, const char *fmt, ...)
 /* tell client to update an existing lights vector property */
 void IDSetLightVA(const ILightVectorProperty *lvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    printf("<setLightVector\n");
-    printf("  device='%s'\n", lvp->device);
-    printf("  name='%s'\n", lvp->name);
-    printf("  state='%s'\n", pstateStr(lvp->s));
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        escapeXML_vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < lvp->nlp; i++)
-    {
-        ILight *lp = &lvp->lp[i];
-        printf("  <oneLight name='%s'>\n", lp->name);
-        printf("      %s\n", pstateStr(lp->s));
-        printf("  </oneLight>\n");
-    }
-
-    printf("</setLightVector>\n");
+    userio_xmlv1(io, stdout);
+    IUUserIOSetLightVA(io, stdout, lvp, fmt, ap);
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
+
 void IDSetLight(const ILightVectorProperty *lvp, const char *fmt, ...)
 {
     va_list ap;
@@ -2120,80 +1749,16 @@ void IDSetLight(const ILightVectorProperty *lvp, const char *fmt, ...)
 /* tell client to update an existing BLOB vector property */
 void IDSetBLOBVA(const IBLOBVectorProperty *bvp, const char *fmt, va_list ap)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
 
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<setBLOBVector\n");
-    printf("  device='%s'\n", bvp->device);
-    printf("  name='%s'\n", bvp->name);
-    printf("  state='%s'\n", pstateStr(bvp->s));
-    printf("  timeout='%g'\n", bvp->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    if (fmt)
-    {
-        printf("  message='");
-        // #PS: missing escapeXML_fputs ?
-        vprintf(fmt, ap);
-        printf("'\n");
-    }
-    printf(">\n");
-
-    for (int i = 0; i < bvp->nbp; i++)
-    {
-        IBLOB *bp = &bvp->bp[i];
-        unsigned char *encblob;
-        int l;
-
-        printf("  <oneBLOB\n");
-        printf("    name='%s'\n", bp->name);
-        printf("    size='%d'\n", bp->size);
-
-        // If size is zero, we are only sending a state-change
-        if (bp->size == 0)
-        {
-            printf("    enclen='0'\n");
-            printf("    format='%s'>\n", bp->format);
-        }
-        else
-        {
-            size_t sz = 4 * bp->bloblen / 3 + 4;
-            assert_mem(encblob = (unsigned char *)malloc(sz));
-            l = to64frombits_s(encblob, bp->blob, bp->bloblen, sz);
-            if (l == 0) {
-                fprintf(stderr, "%s(%s): Not enough memory for decoding.\n", me, __func__);
-                exit(1);
-            }
-            printf("    enclen='%d'\n", l);
-            printf("    format='%s'>\n", bp->format);
-            size_t written = 0;
-
-            while ((int)written < l)
-            {
-                size_t towrite = ((l - written) > 72) ? 72 : l - written;
-                size_t wr      = fwrite(encblob + written, 1, towrite, stdout);
-
-                if (wr > 0)
-                    written += wr;
-                if ((written % 72) == 0)
-                    fputc('\n', stdout);
-            }
-
-            if ((written % 72) != 0)
-                fputc('\n', stdout);
-
-            free(encblob);
-        }
-
-        printf("  </oneBLOB>\n");
-    }
-
-    printf("</setBLOBVector>\n");
-    indi_locale_C_numeric_pop(orig);
+    userio_xmlv1(io, stdout);
+    IUUserIOSetBLOBVA(io, stdout, bvp, fmt, ap);
     fflush(stdout);
 
     pthread_mutex_unlock(&stdout_mutex);
 }
+
 void IDSetBLOB(const IBLOBVectorProperty *bvp, const char *fmt, ...)
 {
     va_list ap;
@@ -2205,31 +1770,11 @@ void IDSetBLOB(const IBLOBVectorProperty *bvp, const char *fmt, ...)
 /* tell client to update min/max elements of an existing number vector property */
 void IUUpdateMinMax(const INumberVectorProperty *nvp)
 {
+    const userio *io = userio_file();
     pthread_mutex_lock(&stdout_mutex);
-    xmlv1();
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    printf("<setNumberVector\n");
-    printf("  device='%s'\n", nvp->device);
-    printf("  name='%s'\n", nvp->name);
-    printf("  state='%s'\n", pstateStr(nvp->s));
-    printf("  timeout='%g'\n", nvp->timeout);
-    printf("  timestamp='%s'\n", timestamp());
-    printf(">\n");
 
-    for (int i = 0; i < nvp->nnp; i++)
-    {
-        INumber *np = &nvp->np[i];
-        printf("  <oneNumber name='%s'\n", np->name);
-        printf("    min='%g'\n", np->min);
-        printf("    max='%g'\n", np->max);
-        printf("    step='%g'\n", np->step);
-        printf(">\n");
-        printf("      %g\n", np->value);
-        printf("  </oneNumber>\n");
-    }
-
-    printf("</setNumberVector>\n");
-    indi_locale_C_numeric_pop(orig);
+    userio_xmlv1(io, stdout);
+    IUUserIOUpdateMinMax(io, stdout, nvp);
     fflush(stdout);
     pthread_mutex_unlock(&stdout_mutex);
 }

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -64,10 +64,10 @@ static userio io;
 
 INDI::BaseClient::BaseClient() : cServer("localhost"), cPort(7624)
 {
-    #if 0
+    /* #PS: TODO - leftover - sending the blob.
         if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
                 continue;
-    #endif
+    */
     io.write = [](void *user, const void * ptr, size_t count) -> size_t
     {
         BaseClient *self = static_cast<BaseClient *>(user);
@@ -893,7 +893,7 @@ void INDI::BaseClient::sendNewNumber(const char *deviceName, const char *propert
 
 void INDI::BaseClient::sendNewSwitch(ISwitchVectorProperty *svp)
 {
-    svp->s            = IPS_BUSY;
+    svp->s = IPS_BUSY;
     IUUserIONewSwitch(&io, this, svp);
 }
 

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -31,6 +31,8 @@
 #include <algorithm>
 #include <assert.h>
 
+#include "indiuserio.h"
+
 #ifdef _WINDOWS
 #include <WinSock2.h>
 #include <windows.h>
@@ -58,8 +60,28 @@
 #define MAXINDIBUF 49152
 #define DISCONNECTION_DELAY_US 500000
 
+static userio io;
+
 INDI::BaseClient::BaseClient() : cServer("localhost"), cPort(7624)
 {
+    #if 0
+        if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
+                continue;
+    #endif
+    io.write = [](void *user, const void * ptr, size_t count) -> size_t
+    {
+        BaseClient *self = static_cast<BaseClient *>(user);
+        return net_write(self->sockfd, ptr, count);
+    };
+
+    io.vprintf = [](void *user, const char * format, va_list ap) -> int
+    {
+        BaseClient *self = static_cast<BaseClient *>(user);
+        char message[MAXRBUF];
+        vsnprintf(message, MAXRBUF, format, ap);
+        return net_write(self->sockfd, message, strlen(message));
+    };
+
     sConnected = false;
     verbose    = false;
 
@@ -810,23 +832,11 @@ void INDI::BaseClient::newUniversalMessage(std::string message)
     IDLog("%s\n", message.c_str());
 }
 
+
 void INDI::BaseClient::sendNewText(ITextVectorProperty *tvp)
 {
     tvp->s = IPS_BUSY;
-
-    sendString("<newTextVector\n");
-    sendString("  device='%s'\n", tvp->device);
-    sendString("  name='%s'\n>", tvp->name);
-
-    for (int i = 0; i < tvp->ntp; i++)
-    {
-        sendString("  <oneText\n");
-        sendString("    name='%s'>\n", tvp->tp[i].name);
-        sendString("      %s\n", tvp->tp[i].text);
-        sendString("  </oneText>\n");
-    }
-    sendString("</newTextVector>\n");
-
+    IUUserIONewText(&io, this, tvp);
 }
 
 void INDI::BaseClient::sendNewText(const char *deviceName, const char *propertyName, const char *elementName,
@@ -854,22 +864,8 @@ void INDI::BaseClient::sendNewText(const char *deviceName, const char *propertyN
 
 void INDI::BaseClient::sendNewNumber(INumberVectorProperty *nvp)
 {
-    AutoCNumeric locale;
-
     nvp->s = IPS_BUSY;
-
-    sendString("<newNumberVector\n");
-    sendString("  device='%s'\n", nvp->device);
-    sendString("  name='%s'\n>", nvp->name);
-
-    for (int i = 0; i < nvp->nnp; i++)
-    {
-        sendString("  <oneNumber\n");
-        sendString("    name='%s'>\n", nvp->np[i].name);
-        sendString("      %g\n", nvp->np[i].value);
-        sendString("  </oneNumber>\n");
-    }
-    sendString("</newNumberVector>\n");
+    IUUserIONewNumber(&io, this, nvp);
 }
 
 void INDI::BaseClient::sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName,
@@ -898,32 +894,7 @@ void INDI::BaseClient::sendNewNumber(const char *deviceName, const char *propert
 void INDI::BaseClient::sendNewSwitch(ISwitchVectorProperty *svp)
 {
     svp->s            = IPS_BUSY;
-    ISwitch *onSwitch = IUFindOnSwitch(svp);
-
-    sendString("<newSwitchVector\n");
-
-    sendString("  device='%s'\n", svp->device);
-    sendString("  name='%s'>\n", svp->name);
-
-    if (svp->r == ISR_1OFMANY && onSwitch)
-    {
-        sendString("  <oneSwitch\n");
-        sendString("    name='%s'>\n", onSwitch->name);
-        sendString("      %s\n", (onSwitch->s == ISS_ON) ? "On" : "Off");
-        sendString("  </oneSwitch>\n");
-    }
-    else
-    {
-        for (int i = 0; i < svp->nsp; i++)
-        {
-            sendString("  <oneSwitch\n");
-            sendString("    name='%s'>\n", svp->sp[i].name);
-            sendString("      %s\n", (svp->sp[i].s == ISS_ON) ? "On" : "Off");
-            sendString("  </oneSwitch>\n");
-        }
-    }
-
-    sendString("</newSwitchVector>\n");
+    IUUserIONewSwitch(&io, this, svp);
 }
 
 void INDI::BaseClient::sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName)
@@ -950,128 +921,33 @@ void INDI::BaseClient::sendNewSwitch(const char *deviceName, const char *propert
 
 void INDI::BaseClient::startBlob(const char *devName, const char *propName, const char *timestamp)
 {
-    sendString("<newBLOBVector\n");
-    sendString("  device='%s'\n", devName);
-    sendString("  name='%s'\n", propName);
-    sendString("  timestamp='%s'>\n", timestamp);
+    IUUserIONewBLOBStart(&io, this, devName, propName, timestamp);
 }
 
 void INDI::BaseClient::sendOneBlob(IBLOB *bp)
 {
-    char nl = '\n';
-    int rc = 0;
-    size_t sz = 4 * bp->size / 3 + 4;
-    uint8_t *encblob = static_cast<uint8_t*>(malloc(sz));
-    assert_mem(encblob);
-    uint32_t base64Len = to64frombits_s(encblob, reinterpret_cast<const uint8_t *>(bp->blob), bp->size, sz);
-    if (base64Len == 0)
-    {
-        fprintf(stderr, "%s(%s): Not enough memory for decoding.\n", __FILE__, __func__);
-        exit(1);
-    }
-
-    sendString("  <oneBLOB\n");
-    sendString("    name='%s'\n", bp->name);
-    sendString("    size='%ud'\n", bp->size);
-    sendString("    enclen='%d'\n", base64Len);
-    sendString("    format='%s'>\n", bp->format);
-
-    uint32_t written = 0;
-    while (written < base64Len)
-    {
-        // Write 72 chars followed by new line
-        uint8_t towrite = ((base64Len - written) > 72) ? 72 : base64Len - written;
-        ssize_t wr = net_write(sockfd, encblob + written, towrite);
-        if (wr > 0)
-            written += wr;
-        else if (wr < 0)
-        {
-            // If temporary error, continue
-            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
-                continue;
-            else
-            {
-                // Otherwise exist
-                fprintf(stderr, "sendOneBlob: %s\n", strerror(errno));
-                free(encblob);
-                return;
-            }
-        }
-        if ((written % 72) == 0)
-            rc = net_write(sockfd, &nl, 1);
-    }
-
-    if ((written % 72) != 0)
-        rc = net_write(sockfd, &nl, 1);
-
-    free(encblob);
-
-    sendString("   </oneBLOB>\n");
+    IUUserIOBLOBContextOne(
+        &io, this,
+        bp->name, bp->size, bp->bloblen, bp->blob, bp->format
+    );
 }
 
 void INDI::BaseClient::sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat,
                                    void *blobBuffer)
 {
-    char nl = '\n';
-    int rc = 0;
-    size_t sz = 4 * blobSize / 3 + 4;
-    uint8_t *encblob = static_cast<uint8_t*>(malloc(sz));
-    assert_mem(encblob);
-    uint32_t base64Len = to64frombits_s(encblob, reinterpret_cast<const uint8_t *>(blobBuffer), blobSize, sz);
-    if (base64Len == 0)
-    {
-        fprintf(stderr, "%s(%s): Not enough memory for decoding.\n", __FILE__, __func__);
-        exit(1);
-    }
-
-    sendString("  <oneBLOB\n");
-    sendString("    name='%s'\n", blobName);
-    sendString("    size='%ud'\n", blobSize);
-    sendString("    enclen='%d'\n", base64Len);
-    sendString("    format='%s'>\n", blobFormat);
-
-    uint32_t written = 0;
-    while (written < base64Len)
-    {
-        // Write 72 chars followed by new line
-        uint8_t towrite = ((base64Len - written) > 72) ? 72 : base64Len - written;
-        ssize_t wr = net_write(sockfd, encblob + written, towrite);
-        if (wr > 0)
-            written += wr;
-        else if (wr < 0)
-        {
-            // If temporary error, continue
-            if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
-                continue;
-            else
-            {
-                // Otherwise exist
-                fprintf(stderr, "sendOneBlob: %s\n", strerror(errno));
-                free(encblob);
-                return;
-            }
-        }
-        if ((written % 72) == 0)
-            rc = net_write(sockfd, &nl, 1);
-    }
-
-    if ((written % 72) != 0)
-        rc = net_write(sockfd, &nl, 1);
-
-    free(encblob);
-
-    sendString("   </oneBLOB>\n");
+    IUUserIOBLOBContextOne(
+        &io, this,
+        blobName, blobSize, blobSize, blobBuffer, blobFormat
+    );
 }
 
 void INDI::BaseClient::finishBlob()
 {
-    sendString("</newBLOBVector>\n");
+    IUUserIONewBLOBFinish(&io, this);
 }
 
 void INDI::BaseClient::setBLOBMode(BLOBHandling blobH, const char *dev, const char *prop)
 {
-    char blobOpenTag[MAXRBUF];
-
     if (!dev[0])
         return;
 
@@ -1094,23 +970,7 @@ void INDI::BaseClient::setBLOBMode(BLOBHandling blobH, const char *dev, const ch
         bMode->blobMode = blobH;
     }
 
-    if (prop != nullptr)
-        snprintf(blobOpenTag, MAXRBUF, "<enableBLOB device='%s' name='%s'>", dev, prop);
-    else
-        snprintf(blobOpenTag, MAXRBUF, "<enableBLOB device='%s'>", dev);
-
-    switch (blobH)
-    {
-        case B_NEVER:
-            sendString("%sNever</enableBLOB>\n", blobOpenTag);
-            break;
-        case B_ALSO:
-            sendString("%sAlso</enableBLOB>\n", blobOpenTag);
-            break;
-        case B_ONLY:
-            sendString("%sOnly</enableBLOB>\n", blobOpenTag);
-            break;
-    }
+    IUUserIOEnableBLOB(&io, this, dev, prop, blobH);
 }
 
 BLOBHandling INDI::BaseClient::getBLOBMode(const char *dev, const char *prop)

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -435,45 +435,34 @@ void INDI::BaseClient::listenINDI()
     XMLEle *root = nullptr;
     int inode = 0;
 
-    AutoCNumeric locale;
-
     if (cDeviceNames.empty())
     {
-        char cmd[MAXRBUF] = {0};
-        snprintf(cmd, MAXRBUF, "<getProperties version='%g'/>\n", INDIV);
-        sendString(cmd);
+        IUUserIOGetProperties(&io, this, nullptr, nullptr);
         if (verbose)
-            IDLog("%s\n", cmd);
+            IUUserIOGetProperties(userio_file(), stderr, nullptr, nullptr);
     }
     else
     {
-        for (auto oneDevice : cDeviceNames)
+        for (const auto &oneDevice : cDeviceNames)
         {
             // If there are no specific properties to watch, we watch the complete device
             if (cWatchProperties.find(oneDevice) == cWatchProperties.end())
             {
-                char cmd[MAXRBUF] = {0};
-                snprintf(cmd, MAXRBUF, "<getProperties version='%g' device='%s'/>\n", INDIV, oneDevice.c_str());
-                sendString(cmd);
+                IUUserIOGetProperties(&io, this, oneDevice.c_str(), nullptr);
                 if (verbose)
-                    IDLog("%s\n", cmd);
+                    IUUserIOGetProperties(userio_file(), stderr, oneDevice.c_str(), nullptr);
             }
             else
             {
-                for (auto oneProperty : cWatchProperties[oneDevice])
+                for (const auto &oneProperty : cWatchProperties[oneDevice])
                 {
-                    char cmd[MAXRBUF] = {0};
-                    snprintf(cmd, MAXRBUF, "<getProperties version='%g' device='%s' name='%s'/>\n",
-                             INDIV, oneDevice.c_str(), oneProperty.c_str());
-                    sendString(cmd);
+                    IUUserIOGetProperties(&io, this, oneDevice.c_str(), oneProperty.c_str());
                     if (verbose)
-                        IDLog("%s\n", cmd);
+                        IUUserIOGetProperties(userio_file(), stderr, oneDevice.c_str(), oneProperty.c_str());
                 }
             }
         }
     }
-
-    locale.Restore();
 
     FD_ZERO(&rs);
 

--- a/libs/indibase/baseclientqt.cpp
+++ b/libs/indibase/baseclientqt.cpp
@@ -25,6 +25,8 @@
 #include "locale_compat.h"
 #include "indistandardproperty.h"
 
+#include "indiuserio.h"
+
 #include <iostream>
 #include <string>
 #include <algorithm>
@@ -41,8 +43,24 @@
 #pragma warning(disable : 4996)
 #endif
 
+static userio io;
+
 INDI::BaseClientQt::BaseClientQt(QObject *parent) : QObject(parent), cServer("localhost"), cPort(7624)
 {
+    io.write = [](void *user, const void * ptr, size_t count) -> size_t
+    {
+        BaseClientQt *self = static_cast<BaseClientQt *>(user);
+        return self->client_socket.write(static_cast<const char *>(ptr), count);
+    };
+
+    io.vprintf = [](void *user, const char * format, va_list ap) -> int
+    {
+        BaseClientQt *self = static_cast<BaseClientQt *>(user);
+        char message[MAXRBUF];
+        vsnprintf(message, MAXRBUF, format, ap);
+        return self->client_socket.write(message, strlen(message));
+    };
+
     sConnected = false;
     verbose    = false;
     lillp      = nullptr;
@@ -116,28 +134,22 @@ bool INDI::BaseClientQt::connectServer()
 
     serverConnected();
 
-    AutoCNumeric locale;
-
     QString getProp;
     if (cDeviceNames.empty())
     {
-        getProp = QString("<getProperties version='%1'/>\n").arg(QString::number(INDIV));
-
-        client_socket.write(getProp.toLatin1());
-
+        IUUserIOGetProperties(&io, this, nullptr, nullptr);
         if (verbose)
-            std::cerr << getProp.toLatin1().constData() << std::endl;
+            IUUserIOGetProperties(userio_file(), stderr, nullptr, nullptr);
     }
     else
     {
-        for (auto &str : cDeviceNames)
+        for (const auto &oneDevice : cDeviceNames)
         {
-            getProp =
-                QString("<getProperties version='%1' device='%2'/>\n").arg(QString::number(INDIV)).arg(str.c_str());
-
-            client_socket.write(getProp.toLatin1());
+            IUUserIOGetProperties(&io, this, oneDevice.c_str(), nullptr);
             if (verbose)
-                std::cerr << getProp.toLatin1().constData() << std::endl;
+                IUUserIOGetProperties(userio_file(), stderr, oneDevice.c_str(), nullptr);
+
+            // #PS: missing code? see INDI::BaseClient::listenINDI()
         }
     }
 
@@ -507,23 +519,7 @@ void INDI::BaseClientQt::sendNewText(ITextVectorProperty *tvp)
     AutoCNumeric locale;
 
     tvp->s = IPS_BUSY;
-
-    QString prop;
-
-    prop += QString("<newTextVector\n");
-    prop += QString("  device='%1'\n").arg(tvp->device);
-    prop += QString("  name='%1'\n>").arg(tvp->name);
-
-    for (int i = 0; i < tvp->ntp; i++)
-    {
-        prop += QString("  <oneText\n");
-        prop += QString("    name='%1'>\n").arg(tvp->tp[i].name);
-        prop += QString("      %1\n").arg(tvp->tp[i].text);
-        prop += QString("  </oneText>\n");
-    }
-    prop += QString("</newTextVector>\n");
-
-    client_socket.write(prop.toLatin1());
+    IUUserIONewText(&io, this, tvp);
 }
 
 void INDI::BaseClientQt::sendNewText(const char *deviceName, const char *propertyName, const char *elementName,
@@ -554,23 +550,7 @@ void INDI::BaseClientQt::sendNewNumber(INumberVectorProperty *nvp)
     AutoCNumeric locale;
 
     nvp->s = IPS_BUSY;
-
-    QString prop;
-
-    prop += QString("<newNumberVector\n");
-    prop += QString("  device='%1'\n").arg(nvp->device);
-    prop += QString("  name='%1'\n>").arg(nvp->name);
-
-    for (int i = 0; i < nvp->nnp; i++)
-    {
-        prop += QString("  <oneNumber\n");
-        prop += QString("    name='%1'>\n").arg(nvp->np[i].name);
-        prop += QString("      %1\n").arg(QString::number(nvp->np[i].value));
-        prop += QString("  </oneNumber>\n");
-    }
-    prop += QString("</newNumberVector>\n");
-
-    client_socket.write(prop.toLatin1());
+    IUUserIONewNumber(&io, this, nvp);
 }
 
 void INDI::BaseClientQt::sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName,
@@ -598,37 +578,8 @@ void INDI::BaseClientQt::sendNewNumber(const char *deviceName, const char *prope
 
 void INDI::BaseClientQt::sendNewSwitch(ISwitchVectorProperty *svp)
 {
-    svp->s            = IPS_BUSY;
-    ISwitch *onSwitch = IUFindOnSwitch(svp);
-
-    QString prop;
-
-    prop += QString("<newSwitchVector\n");
-
-    prop += QString("  device='%1'\n").arg(svp->device);
-    prop += QString("  name='%1'>\n").arg(svp->name);
-
-    if (svp->r == ISR_1OFMANY && onSwitch)
-    {
-        prop += QString("  <oneSwitch\n");
-        prop += QString("    name='%1'>\n").arg(onSwitch->name);
-        prop += QString("      %1\n").arg((onSwitch->s == ISS_ON) ? "On" : "Off");
-        prop += QString("  </oneSwitch>\n");
-    }
-    else
-    {
-        for (int i = 0; i < svp->nsp; i++)
-        {
-            prop += QString("  <oneSwitch\n");
-            prop += QString("    name='%1'>\n").arg(svp->sp[i].name);
-            prop += QString("      %1\n").arg((svp->sp[i].s == ISS_ON) ? "On" : "Off");
-            prop += QString("  </oneSwitch>\n");
-        }
-    }
-
-    prop += QString("</newSwitchVector>\n");
-
-    client_socket.write(prop.toLatin1());
+    svp->s = IPS_BUSY;
+    IUUserIONewSwitch(&io, this, svp);
 }
 
 void INDI::BaseClientQt::sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName)
@@ -655,108 +606,29 @@ void INDI::BaseClientQt::sendNewSwitch(const char *deviceName, const char *prope
 
 void INDI::BaseClientQt::startBlob(const char *devName, const char *propName, const char *timestamp)
 {
-    QString prop;
-
-    prop += QString("<newBLOBVector\n");
-    prop += QString("  device='%1'\n").arg(devName);
-    prop += QString("  name='%1'\n").arg(propName);
-    prop += QString("  timestamp='%1'>\n").arg(timestamp);
-
-    client_socket.write(prop.toLatin1());
+    IUUserIONewBLOBStart(&io, this, devName, propName, timestamp);
 }
 
 void INDI::BaseClientQt::sendOneBlob(IBLOB *bp)
 {
-    QString prop;
-    unsigned char *encblob;
-    int l;
-
-    size_t sz = 4 * bp->size / 3 + 4; 
-    assert_mem(encblob = static_cast<unsigned char *>(malloc(sz)));
-    l = to64frombits_s(encblob, reinterpret_cast<const unsigned char *>(bp->blob), bp->size, sz);
-    if (l == 0) {
-        fprintf(stderr, "%s(%s): Not enough memory for decoding.\n", __FILE__, __func__);
-        exit(1);
-    }
-
-    prop += QString("  <oneBLOB\n");
-    prop += QString("    name='%1'\n").arg(bp->name);
-    prop += QString("    size='%1'\n").arg(QString::number(bp->size));
-    prop += QString("    enclen='%1'\n").arg(QString::number(l));
-    prop += QString("    format='%1'>\n").arg(bp->format);
-
-    client_socket.write(prop.toLatin1());
-
-    size_t written = 0;
-    size_t towrite = l;
-
-    while ((int)written < l)
-    {
-        towrite   = ((l - written) > 72) ? 72 : l - written;
-        size_t wr = client_socket.write(reinterpret_cast<const char *>(encblob + written), towrite);
-        if (wr > 0)
-            written += wr;
-        if ((written % 72) == 0)
-            client_socket.write("\n");
-    }
-
-    if ((written % 72) != 0)
-        client_socket.write("\n");
-
-    free(encblob);
-
-    client_socket.write("   </oneBLOB>\n");
+    IUUserIOBLOBContextOne(
+        &io, this,
+        bp->name, bp->size, bp->bloblen, bp->blob, bp->format
+    );
 }
 
 void INDI::BaseClientQt::sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat,
                                      void *blobBuffer)
 {
-    unsigned char *encblob;
-    int l;
-
-    size_t sz = 4 * blobSize / 3 + 4;
-    assert_mem(encblob = static_cast<unsigned char *>(malloc(sz)));
-    l = to64frombits_s(encblob, reinterpret_cast<const unsigned char *>(blobBuffer), blobSize, sz);
-    if (l == 0) {
-        fprintf(stderr, "%s(%s): Not enough memory for decoding.\n", __FILE__, __func__);
-        exit(1);
-    }
-
-
-    QString prop;
-
-    prop += QString("  <oneBLOB\n");
-    prop += QString("    name='%1'\n").arg(blobName);
-    prop += QString("    size='%1'\n").arg(QString::number(blobSize));
-    prop += QString("    enclen='%1'\n").arg(QString::number(l));
-    prop += QString("    format='%1'>\n").arg(blobFormat);
-
-    client_socket.write(prop.toLatin1());
-
-    size_t written = 0;
-    size_t towrite = l;
-
-    while ((int)written < l)
-    {
-        towrite   = ((l - written) > 72) ? 72 : l - written;
-        size_t wr = client_socket.write(reinterpret_cast<const char *>(encblob + written), towrite);
-        if (wr > 0)
-            written += wr;
-        if ((written % 72) == 0)
-            client_socket.write("\n");
-    }
-
-    if ((written % 72) != 0)
-        client_socket.write("\n");
-
-    free(encblob);
-
-    client_socket.write("   </oneBLOB>\n");
+    IUUserIOBLOBContextOne(
+        &io, this,
+        blobName, blobSize, blobSize, blobBuffer, blobFormat
+    );
 }
 
 void INDI::BaseClientQt::finishBlob()
 {
-    client_socket.write("</newBLOBVector>\n");
+    IUUserIONewBLOBFinish(&io, this);
 }
 
 void INDI::BaseClientQt::setBLOBMode(BLOBHandling blobH, const char *dev, const char *prop)
@@ -782,28 +654,7 @@ void INDI::BaseClientQt::setBLOBMode(BLOBHandling blobH, const char *dev, const 
 
         bMode->blobMode = blobH;
     }
-
-    QString blobOpenTag;
-    QString blobEnableTag;
-    if (prop != nullptr)
-        blobOpenTag = QString("<enableBLOB device='%1' name='%2'>").arg(dev).arg(prop);
-    else
-        blobOpenTag = QString("<enableBLOB device='%1'>").arg(dev);
-
-    switch (blobH)
-    {
-        case B_NEVER:
-            blobEnableTag = QString("%1Never</enableBLOB>\n").arg(blobOpenTag);
-            break;
-        case B_ALSO:
-            blobEnableTag = QString("%1Also</enableBLOB>\n").arg(blobOpenTag);
-            break;
-        case B_ONLY:
-            blobEnableTag = QString("%1Only</enableBLOB>\n").arg(blobOpenTag);
-            break;
-    }
-
-    client_socket.write(blobEnableTag.toLatin1());
+    IUUserIOEnableBLOB(&io, this, dev, prop, blobH);
 }
 
 BLOBHandling INDI::BaseClientQt::getBLOBMode(const char *dev, const char *prop)

--- a/libs/indibase/baseclientqt.cpp
+++ b/libs/indibase/baseclientqt.cpp
@@ -514,6 +514,11 @@ int INDI::BaseClientQt::messageCmd(XMLEle *root, char *errmsg)
     return (0);
 }
 
+void INDI::BaseClientQt::newUniversalMessage(std::string message)
+{
+    IDLog("%s\n", message.c_str());
+}
+
 void INDI::BaseClientQt::sendNewText(ITextVectorProperty *tvp)
 {
     AutoCNumeric locale;

--- a/libs/indibase/baseclientqt.h
+++ b/libs/indibase/baseclientqt.h
@@ -252,6 +252,13 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
         /**  Process messages */
         int messageCmd(XMLEle *root, char *errmsg);
 
+        /**
+         * @brief newUniversalMessage Universal messages are sent from INDI server without a specific device. It is addressed to the client overall.
+         * @param message content of message.
+         * @note The default implementation simply logs the message to stderr. Override to handle the message.
+         */
+        virtual void newUniversalMessage(std::string message);
+
     private:
         typedef struct
         {

--- a/libs/indicom.c
+++ b/libs/indicom.c
@@ -97,34 +97,6 @@ static int tty_generic_udp_format = 0;
 static int tty_sequence_number = 1;
 static int tty_clear_trailing_lf = 0;
 
-/* output a string expanding special characters into xml/html escape sequences */
-void escapeXML_fputs(const char *src, FILE *stream)
-{
-    const char *ptr = src;
-    const char *replacement;
-
-    for(; *ptr; ++ptr)
-    {
-        switch(*ptr)
-        {
-        case  '&': replacement = "&amp;";  break;
-        case '\'': replacement = "&apos;"; break;
-        case  '"': replacement = "&quot;"; break;
-        case  '<': replacement = "&lt;";   break;
-        case  '>': replacement = "&gt;";   break;
-        default:   replacement = NULL;
-        }
-
-        if (replacement != NULL)
-        {
-            fwrite(src, 1, (size_t)(ptr - src), stream);
-            src = ptr + 1;
-            fputs(replacement, stream);
-        }
-    }
-    fwrite(src, 1, (size_t)(ptr - src), stream);
-}
-
 #if defined(HAVE_LIBNOVA)
 int extractISOTime(const char *timestr, struct ln_date *iso_date)
 {

--- a/libs/indicom.c
+++ b/libs/indicom.c
@@ -79,6 +79,9 @@
 #define PARITY_ODD  2
 #endif
 
+#include "userio.h"
+#include "indiuserio.h"
+
 #if defined(_MSC_VER)
 #define snprintf _snprintf
 #pragma warning(push)
@@ -93,6 +96,34 @@ static int tty_gemini_udp_format = 0;
 static int tty_generic_udp_format = 0;
 static int tty_sequence_number = 1;
 static int tty_clear_trailing_lf = 0;
+
+/* output a string expanding special characters into xml/html escape sequences */
+void escapeXML_fputs(const char *src, FILE *stream)
+{
+    const char *ptr = src;
+    const char *replacement;
+
+    for(; *ptr; ++ptr)
+    {
+        switch(*ptr)
+        {
+        case  '&': replacement = "&amp;";  break;
+        case '\'': replacement = "&apos;"; break;
+        case  '"': replacement = "&quot;"; break;
+        case  '<': replacement = "&lt;";   break;
+        case  '>': replacement = "&gt;";   break;
+        default:   replacement = NULL;
+        }
+
+        if (replacement != NULL)
+        {
+            fwrite(src, 1, (size_t)(ptr - src), stream);
+            src = ptr + 1;
+            fputs(replacement, stream);
+        }
+    }
+    fwrite(src, 1, (size_t)(ptr - src), stream);
+}
 
 #if defined(HAVE_LIBNOVA)
 int extractISOTime(const char *timestr, struct ln_date *iso_date)
@@ -1304,8 +1335,9 @@ const char *permStr(IPerm p)
 /* print the boilerplate comment introducing xml */
 void xmlv1()
 {
-    printf("<?xml version='1.0'?>\n");
+    userio_xmlv1(userio_file(), stdout);
 }
+
 
 /* pull out device and name attributes from root.
  * return 0 if ok else -1 with reason in msg[].
@@ -1429,89 +1461,22 @@ void IUSaveText(IText *tp, const char *newtext)
 
 void IUSaveConfigNumber(FILE *fp, const INumberVectorProperty *nvp)
 {
-    locale_char_t *orig = indi_locale_C_numeric_push();
-    fprintf(fp, "<newNumberVector device='%s' name='%s'>\n", nvp->device, nvp->name);
-
-    for (int i = 0; i < nvp->nnp; i++)
-    {
-        INumber *np = &nvp->np[i];
-        fprintf(fp, "  <oneNumber name='%s'>\n", np->name);
-        fprintf(fp, "      %.20g\n", np->value);
-        fprintf(fp, "  </oneNumber>\n");
-    }
-
-    fprintf(fp, "</newNumberVector>\n");
-    indi_locale_C_numeric_pop(orig);
+    IUUserIONewNumber(userio_file(), fp, nvp);
 }
 
 void IUSaveConfigText(FILE *fp, const ITextVectorProperty *tvp)
 {
-    fprintf(fp, "<newTextVector device='%s' name='%s'>\n", tvp->device, tvp->name);
-
-    for (int i = 0; i < tvp->ntp; i++)
-    {
-        IText *tp = &tvp->tp[i];
-        fprintf(fp, "  <oneText name='%s'>\n", tp->name);
-        fprintf(fp, "      %s\n", tp->text ? tp->text : "");
-        fprintf(fp, "  </oneText>\n");
-    }
-
-    fprintf(fp, "</newTextVector>\n");
+    IUUserIONewText(userio_file(), fp, tvp);
 }
 
 void IUSaveConfigSwitch(FILE *fp, const ISwitchVectorProperty *svp)
 {
-    fprintf(fp, "<newSwitchVector device='%s' name='%s'>\n", svp->device, svp->name);
-
-    for (int i = 0; i < svp->nsp; i++)
-    {
-        ISwitch *sp = &svp->sp[i];
-        fprintf(fp, "  <oneSwitch name='%s'>\n", sp->name);
-        fprintf(fp, "      %s\n", sstateStr(sp->s));
-        fprintf(fp, "  </oneSwitch>\n");
-    }
-
-    fprintf(fp, "</newSwitchVector>\n");
+    IUUserIONewSwitchFull(userio_file(), fp, svp);
 }
 
 void IUSaveConfigBLOB(FILE *fp, const IBLOBVectorProperty *bvp)
 {
-    fprintf(fp, "<newBLOBVector device='%s' name='%s'>\n", bvp->device, bvp->name);
-
-    for (int i = 0; i < bvp->nbp; i++)
-    {
-        IBLOB *bp = &bvp->bp[i];
-        unsigned char *encblob = NULL;
-        int l = 0;
-
-        fprintf(fp, "  <oneBLOB\n");
-        fprintf(fp, "    name='%s'\n", bp->name);
-        fprintf(fp, "    size='%d'\n", bp->size);
-        fprintf(fp, "    format='%s'>\n", bp->format);
-
-        assert_mem(encblob = (unsigned char*)malloc(4 * bp->bloblen / 3 + 4));
-        l = to64frombits_s(encblob, bp->blob, bp->bloblen, bp->bloblen);
-        if (l == 0) {
-            fprintf(stderr, "%s: Not enough memory for decoding.\n", __func__);
-            exit(1);
-        }
-        size_t written = 0;
-
-        while ((int)written < l)
-        {
-            size_t towrite = ((l - written) > 72) ? 72 : l - written;
-            size_t wr      = fwrite(encblob + written, 1, towrite, fp);
-
-            fputc('\n', fp);
-            if (wr > 0)
-                written += wr;
-        }
-        free(encblob);
-
-        fprintf(fp, "  </oneBLOB>\n");
-    }
-
-    fprintf(fp, "</newBLOBVector>\n");
+    IUUserIONewBLOB(userio_file(), fp, bvp);
 }
 
 double rangeHA(double r)

--- a/libs/indiuserio.c
+++ b/libs/indiuserio.c
@@ -1,0 +1,818 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include "indiuserio.h"
+#include "indiapi.h"
+#include "indidevapi.h"
+#include "indicom.h"
+#include "locale_compat.h"
+#include "base64.h"
+
+#include <stdlib.h>
+
+static void s_userio_xml_message_vprintf(const userio *io, void *user, const char *fmt, va_list ap)
+{
+    char message[MAXINDIMESSAGE];
+    if (fmt)
+    {
+        vsnprintf(message, MAXINDIMESSAGE, fmt, ap);
+
+        userio_prints    (io, user, "  message='");
+        userio_xml_escape(io, user, message);
+        userio_prints    (io, user, "'\n");
+    }
+}
+
+
+void IUUserIONumberContext(const userio *io, void *user, const INumberVectorProperty *nvp)
+{
+    for (int i = 0; i < nvp->nnp; i++)
+    {
+        INumber *np = &nvp->np[i];
+        userio_prints    (io, user, "  <oneNumber name='");
+        userio_xml_escape(io, user, np->name);
+        userio_prints    (io, user, "'>\n");
+        userio_printf    (io, user, "      %.20g\n", np->value); // safe
+        userio_prints    (io, user, "  </oneNumber>\n");
+    }
+}
+
+void IUUserIOTextContext(const userio *io, void *user, const ITextVectorProperty *tvp)
+{
+    for (int i = 0; i < tvp->ntp; i++)
+    {
+        IText *tp = &tvp->tp[i];
+        userio_prints    (io, user, "  <oneText name='");
+        userio_xml_escape(io, user, tp->name);
+        userio_prints    (io, user, "'>\n");
+        userio_prints    (io, user, "      ");
+        userio_xml_escape(io, user, tp->text ? tp->text : "");
+        userio_prints    (io, user, "\n");
+        userio_prints    (io, user, "  </oneText>\n");
+    }
+}
+
+
+void IUUserIOSwitchContextFull(const userio *io, void *user, const ISwitchVectorProperty *svp)
+{
+    for (int i = 0; i < svp->nsp; i++)
+    {
+        ISwitch *sp = &svp->sp[i];
+        userio_prints    (io, user, "  <oneSwitch name='");
+        userio_xml_escape(io, user, sp->name);
+        userio_prints    (io, user, "'>\n");
+        userio_printf    (io, user, "      %s\n", sstateStr(sp->s)); // safe
+        userio_prints    (io, user, "  </oneSwitch>\n");
+    }
+}
+
+void IUUserIOSwitchContext(const userio *io, void *user, const ISwitchVectorProperty *svp)
+{
+    ISwitch *onSwitch = IUFindOnSwitch(svp);
+
+    if (svp->r == ISR_1OFMANY && onSwitch)
+    {
+        userio_prints    (io, user, "  <oneSwitch\n");
+        userio_prints    (io, user, "    name='");
+        userio_xml_escape(io, user, onSwitch->name);
+        userio_prints    (io, user, "'>\n");
+        userio_printf    (io, user, "      %s\n", sstateStr(onSwitch->s)); // safe
+        userio_prints    (io, user, "  </oneSwitch>\n");
+    }
+    else
+    {
+        IUUserIOSwitchContextFull(io, user, svp);
+    }
+}
+
+void IUUserIOBLOBContextOne(
+    const userio *io, void *user,
+    const char *name, unsigned int size, unsigned int bloblen, const void *blob, const char *format
+)
+{
+    unsigned char *encblob;
+    int l;
+
+    userio_prints    (io, user, "  <oneBLOB\n");
+    userio_prints    (io, user, "    name='");
+    userio_xml_escape(io, user, name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "    size='%d'\n", size); // safe
+
+    // If size is zero, we are only sending a state-change
+    if (size == 0)
+    {
+        userio_prints    (io, user, "    enclen='0'\n");
+        userio_prints    (io, user, "    format='");
+        userio_xml_escape(io, user, format);
+        userio_prints    (io, user, "'>\n");
+    }
+    else
+    {
+        size_t sz = 4 * bloblen / 3 + 4;
+        assert_mem(encblob = (unsigned char *)malloc(sz)); // #PS: TODO
+        l = to64frombits_s(encblob, blob, bloblen, sz);
+        if (l == 0) {
+            fprintf(stderr, "%s: Not enough memory for decoding.\n", __func__);
+            exit(1);
+        }
+        userio_printf    (io, user, "    enclen='%d'\n", l); // safe
+        userio_prints    (io, user, "    format='");
+        userio_xml_escape(io, user, format);
+        userio_prints    (io, user, "'>\n");
+        size_t written = 0;
+
+        while ((int)written < l)
+        {
+            size_t towrite = ((l - written) > 72) ? 72 : l - written;
+            size_t wr      = userio_write(io, user, encblob + written, towrite);
+
+            written += wr;
+            if ((written % 72) == 0)
+                userio_putc(io, user, '\n');
+        }
+
+        if ((written % 72) != 0)
+            userio_putc(io, user, '\n');
+
+        free(encblob);
+    }
+
+    userio_prints    (io, user, "  </oneBLOB>\n");
+}
+#if 0
+void IUUserIOBLOBContextOne(const userio *io, void *user, const IBLOB *bp)
+{
+    unsigned char *encblob;
+    int l;
+
+    userio_prints    (io, user, "  <oneBLOB\n");
+    userio_prints    (io, user, "    name='");
+    userio_xml_escape(io, user, bp->name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "    size='%d'\n", bp->size); // safe
+
+    // If size is zero, we are only sending a state-change
+    if (bp->size == 0)
+    {
+        userio_prints    (io, user, "    enclen='0'\n");
+        userio_prints    (io, user, "    format='");
+        userio_xml_escape(io, user, bp->format);
+        userio_prints    (io, user, "'>\n");
+    }
+    else
+    {
+        size_t sz = 4 * bp->bloblen / 3 + 4;
+        assert_mem(encblob = (unsigned char *)malloc(sz)); // #PS: TODO
+        l = to64frombits_s(encblob, bp->blob, bp->bloblen, sz);
+        if (l == 0) {
+            fprintf(stderr, "%s: Not enough memory for decoding.\n", __func__);
+            exit(1);
+        }
+        userio_printf    (io, user, "    enclen='%d'\n", l); // safe
+        userio_prints    (io, user, "    format='");
+        userio_xml_escape(io, user, bp->format);
+        userio_prints    (io, user, "'>\n");
+        size_t written = 0;
+
+        while ((int)written < l)
+        {
+            size_t towrite = ((l - written) > 72) ? 72 : l - written;
+            size_t wr      = userio_write(io, user, encblob + written, towrite);
+
+            written += wr;
+            if ((written % 72) == 0)
+                userio_putc(io, user, '\n');
+        }
+
+        if ((written % 72) != 0)
+            userio_putc(io, user, '\n');
+
+        free(encblob);
+    }
+
+    userio_prints    (io, user, "  </oneBLOB>\n");
+}
+#endif
+void IUUserIOBLOBContext(const userio *io, void *user, const IBLOBVectorProperty *bvp)
+{
+    for (int i = 0; i < bvp->nbp; i++)
+    {
+        IBLOB *bp = &bvp->bp[i];
+        IUUserIOBLOBContextOne(
+            io, user,
+            bp->name, bp->size, bp->bloblen, bp->blob, bp->format
+        );
+    }
+}
+
+void IUUserIOLightContext(const userio *io, void *user, const ILightVectorProperty *lvp)
+{
+    for (int i = 0; i < lvp->nlp; i++)
+    {
+        ILight *lp = &lvp->lp[i];
+        userio_prints    (io, user, "  <oneLight name='");
+        userio_xml_escape(io, user, lp->name);
+        userio_prints    (io, user, "'>\n");
+        userio_printf    (io, user, "      %s\n", pstateStr(lp->s)); // safe
+        userio_prints    (io, user, "  </oneLight>\n");
+    }
+}
+
+void IUUserIONewNumber(const userio *io, void *user, const INumberVectorProperty *nvp)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+
+    userio_prints    (io, user, "<newNumberVector device='");
+    userio_xml_escape(io, user, nvp->device);
+    userio_prints    (io, user, "' name='");
+    userio_xml_escape(io, user, nvp->name);
+    userio_prints    (io, user, "'>\n");
+
+    IUUserIONumberContext(io, user, nvp);
+
+    userio_prints    (io, user, "</newNumberVector>\n");
+
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIONewText(const userio *io, void *user, const ITextVectorProperty *tvp)
+{
+    userio_prints    (io, user, "<newTextVector device='");
+    userio_xml_escape(io, user, tvp->device);
+    userio_prints    (io, user, "' name='");
+    userio_xml_escape(io, user, tvp->name);
+    userio_prints    (io, user, "'>\n");
+
+    IUUserIOTextContext(io, user, tvp);
+
+    userio_prints    (io, user, "</newTextVector>\n");
+}
+
+void IUUserIONewSwitchFull(const userio *io, void *user, const ISwitchVectorProperty *svp)
+{
+    userio_prints    (io, user, "<newSwitchVector device='");
+    userio_xml_escape(io, user, svp->device);
+    userio_prints    (io, user, "' name='");
+    userio_xml_escape(io, user, svp->name);
+    userio_prints    (io, user, "'>\n");
+    IUUserIOSwitchContextFull(io, user, svp);
+    userio_prints    (io, user, "</newSwitchVector>\n");
+}
+
+void IUUserIONewSwitch(const userio *io, void *user, const ISwitchVectorProperty *svp)
+{
+    userio_prints    (io, user, "<newSwitchVector device='");
+    userio_xml_escape(io, user, svp->device);
+    userio_prints    (io, user, "' name='");
+    userio_xml_escape(io, user, svp->name);
+    userio_prints    (io, user, "'>\n");
+    IUUserIOSwitchContext(io, user, svp);
+    userio_prints    (io, user, "</newSwitchVector>\n");
+}
+
+void IUUserIONewBLOB(const userio *io, void *user, const IBLOBVectorProperty *bvp)
+{
+    IUUserIONewBLOBStart(io, user, bvp->device, bvp->name, NULL);
+    
+    IUUserIOBLOBContext(io, user, bvp);
+
+    IUUserIONewBLOBFinish(io, user);
+}
+
+void IUUserIONewBLOBStart(
+    const userio *io, void *user,
+    const char *dev, const char *name, const char *timestamp
+)
+{
+    userio_prints    (io, user, "<newBLOBVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, dev);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, name);
+    userio_prints    (io, user, "'\n");
+    if (timestamp != NULL)
+    {
+        userio_prints    (io, user, "  timestamp='");
+        userio_xml_escape(io, user, timestamp);
+    }
+    userio_prints    (io, user, "'>\n");
+}
+
+void IUUserIONewBLOBFinish(const userio *io, void *user)
+{
+    userio_prints    (io, user, "</newBLOBVector>\n");
+}
+
+void IUUserIODeleteVA(
+    const userio *io, void *user,
+    const char *dev, const char *name, const char *fmt, va_list ap
+)
+{
+    userio_prints    (io, user, "<delProperty\n  device='");
+    userio_xml_escape(io, user, dev);
+    userio_prints    (io, user, "'\n");
+    if (name)
+    {
+        userio_prints    (io, user, " name='");
+        userio_xml_escape(io, user, name);
+        userio_prints    (io, user, "'\n");
+    }
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+
+    userio_prints    (io, user, "/>\n");
+}
+
+void IUUserIOGetProperties(
+    const userio *io, void *user,
+    const char *dev, const char *name
+)
+{
+    userio_printf    (io, user, "<getProperties version='%g' device='", INDIV); // safe
+    userio_xml_escape(io, user, dev);
+    if (name && name[0])
+    {
+        userio_prints    (io, user, "' name='");
+        userio_xml_escape(io, user, name);
+    }
+    userio_prints    (io, user, "'/>\n");
+}
+
+// temporary
+static const char *s_BLOBHandlingtoString(BLOBHandling bh)
+{
+    switch (bh)
+    {
+    case B_NEVER: return "Never";
+    case B_ALSO:  return "Also";
+    case B_ONLY:  return "Only";
+    default:      return "Unknown";
+    }
+}
+
+void IUUserIOEnableBLOB(
+    const userio *io, void *user,
+    const char *dev, const char *name, BLOBHandling blobH
+)
+{
+    userio_prints(io, user, "<enableBLOB device='");
+    userio_xml_escape(io, user, dev);
+    if (name != NULL)
+    {
+        userio_prints(io, user, "' name='");
+        userio_xml_escape(io, user, name);
+    }
+    userio_prints(io, user, "'>");
+    userio_prints(io, user, s_BLOBHandlingtoString(blobH));
+    userio_prints(io, user, "</enableBLOB>\n");
+}
+
+void IDUserIOMessageVA(
+    const userio *io, void *user,
+    const char *dev, const char *fmt, va_list ap
+)
+{
+    userio_prints    (io, user, "<message\n");
+    if (dev)
+    {
+        userio_prints    (io, user, " device='");
+        userio_xml_escape(io, user, dev);
+        userio_prints    (io, user, "'\n");
+    }
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, "/>\n");
+}
+
+void IDUserIOMessage(
+    const userio *io, void *user,
+    const char *dev, const char *fmt, ...
+)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    IDUserIOMessageVA(io, user, dev, fmt, ap);
+    va_end(ap);
+}
+
+void IUUserIOConfigTag(
+    const userio *io, void *user,
+    int ctag, const char *dev, int silent
+)
+{
+    /* Opening tag */
+    if (ctag == 0)
+    {
+        userio_prints    (io, user, "<INDIDriver>\n");
+        if (silent != 1)
+            IDUserIOMessage(io, user, dev, "[INFO] Saving device configuration...");
+    }
+    /* Closing tag */
+    else
+    {
+        userio_prints    (io, user, "</INDIDriver>\n");
+        if (silent != 1)
+            IDUserIOMessage(io, user, dev, "[INFO] Device configuration saved.");
+    }
+}
+
+void IUUserIODefTextVA(
+    const userio *io, void *user,
+    const ITextVectorProperty *tvp, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<defTextVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, tvp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, tvp->name);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  label='");
+    userio_xml_escape(io, user, tvp->label);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  group='");
+    userio_xml_escape(io, user, tvp->group);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(tvp->s)); // safe
+    userio_printf    (io, user, "  perm='%s'\n", permStr(tvp->p)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", tvp->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    for (int i = 0; i < tvp->ntp; i++)
+    {
+        IText *tp = &tvp->tp[i];
+        userio_prints    (io, user, "  <defText\n");
+        userio_prints    (io, user, "    name='");
+        userio_xml_escape(io, user, tp->name);
+        userio_prints    (io, user, "'\n");
+        userio_prints    (io, user, "    label='");
+        userio_xml_escape(io, user, tp->label);
+        userio_prints    (io, user, "'>\n");
+        userio_prints    (io, user, "      ");
+        userio_xml_escape(io, user, tp->text ? tp->text : "");
+        userio_prints    (io, user, "\n");
+        userio_prints    (io, user, "  </defText>\n");
+    }
+
+    userio_prints    (io, user, "</defTextVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIODefNumberVA(
+    const userio *io, void *user,
+    const INumberVectorProperty *n, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<defNumberVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, n->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, n->name);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  label='");
+    userio_xml_escape(io, user, n->label);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  group='");
+    userio_xml_escape(io, user, n->group);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(n->s)); // safe
+    userio_printf    (io, user, "  perm='%s'\n", permStr(n->p)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", n->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    for (int i = 0; i < n->nnp; i++)
+    {
+        INumber *np = &n->np[i];
+
+        userio_prints    (io, user, "  <defNumber\n");
+        userio_prints    (io, user, "    name='");
+        userio_xml_escape(io, user, np->name);
+        userio_prints    (io, user, "'\n");
+        userio_prints    (io, user, "    label='");
+        userio_xml_escape(io, user, np->label);
+        userio_prints    (io, user, "'\n");
+        userio_prints    (io, user, "    format='");
+        userio_xml_escape(io, user, np->format);
+        userio_prints    (io, user, "'\n");
+        userio_printf    (io, user, "    min='%.20g'\n", np->min); // safe
+        userio_printf    (io, user, "    max='%.20g'\n", np->max); // safe
+        userio_printf    (io, user, "    step='%.20g'>\n", np->step); // safe
+        userio_printf    (io, user, "      %.20g\n", np->value); // safe
+
+        userio_prints    (io, user, "  </defNumber>\n");
+    }
+
+    userio_prints    (io, user, "</defNumberVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIODefSwitchVA(
+    const userio *io, void *user,
+    const ISwitchVectorProperty *s, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<defSwitchVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, s->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, s->name);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  label='");
+    userio_xml_escape(io, user, s->label);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  group='");
+    userio_xml_escape(io, user, s->group);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(s->s)); // safe
+    userio_printf    (io, user, "  perm='%s'\n", permStr(s->p)); // safe
+    userio_printf    (io, user, "  rule='%s'\n", ruleStr(s->r)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", s->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    for (int i = 0; i < s->nsp; i++)
+    {
+        ISwitch *sp = &s->sp[i];
+        userio_prints    (io, user, "  <defSwitch\n");
+        userio_prints    (io, user, "    name='");
+        userio_xml_escape(io, user, sp->name);
+        userio_prints    (io, user, "'\n");
+        userio_prints    (io, user, "    label='");
+        userio_xml_escape(io, user, sp->label);
+        userio_prints    (io, user, "'>\n");
+        userio_printf    (io, user, "      %s\n", sstateStr(sp->s)); // safe
+        userio_prints    (io, user, "  </defSwitch>\n");
+    }
+
+    userio_prints    (io, user, "</defSwitchVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIODefLightVA(
+    const userio *io, void *user,
+    const ILightVectorProperty *lvp, const char *fmt, va_list ap
+)
+{
+    userio_prints    (io, user, "<defLightVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, lvp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, lvp->name);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  label='");
+    userio_xml_escape(io, user, lvp->label);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  group='");
+    userio_xml_escape(io, user, lvp->group);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(lvp->s)); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    for (int i = 0; i < lvp->nlp; i++)
+    {
+        ILight *lp = &lvp->lp[i];
+        userio_prints    (io, user, "  <defLight\n");
+        userio_prints    (io, user, "    name='");
+        userio_xml_escape(io, user, lp->name);
+        userio_prints    (io, user, "'\n");
+        userio_prints    (io, user, "    label='");
+        userio_xml_escape(io, user, lp->label);
+        userio_prints    (io, user, "'>\n");
+        userio_printf    (io, user, "      %s\n", pstateStr(lp->s)); // safe
+        userio_prints    (io, user, "  </defLight>\n");
+    }
+
+    userio_prints    (io, user, "</defLightVector>\n");
+}
+
+void IUUserIODefBLOBVA(
+    const userio *io, void *user,
+    const IBLOBVectorProperty *b, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<defBLOBVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, b->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, b->name);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  label='");
+    userio_xml_escape(io, user, b->label);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  group='");
+    userio_xml_escape(io, user, b->group);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(b->s)); // safe
+    userio_printf    (io, user, "  perm='%s'\n", permStr(b->p)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", b->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    for (int i = 0; i < b->nbp; i++)
+    {
+        IBLOB *bp = &b->bp[i];
+        userio_prints    (io, user, "  <defBLOB\n");
+        userio_prints    (io, user, "    name='");
+        userio_xml_escape(io, user, bp->name);
+        userio_prints    (io, user, "'\n");
+        userio_prints    (io, user, "    label='");
+        userio_xml_escape(io, user, bp->label);
+        userio_prints    (io, user, "'>\n");
+        userio_prints    (io, user, "  />\n");
+    }
+
+    userio_prints    (io, user, "</defBLOBVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIOSetTextVA(
+    const userio *io, void *user,
+    const ITextVectorProperty *tvp, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<setTextVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, tvp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, tvp->name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(tvp->s)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", tvp->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    IUUserIOTextContext(io, user, tvp);
+
+    userio_prints    (io, user, "</setTextVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIOSetNumberVA(
+    const userio *io, void *user,
+    const INumberVectorProperty *nvp, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<setNumberVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, nvp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, nvp->name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(nvp->s)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", nvp->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    IUUserIONumberContext(io, user, nvp);
+
+    userio_prints    (io, user, "</setNumberVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIOSetSwitchVA(
+    const userio *io, void *user,
+    const ISwitchVectorProperty *svp, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<setSwitchVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, svp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, svp->name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(svp->s)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", svp->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    IUUserIOSwitchContext(io, user, svp);
+
+    userio_prints    (io, user, "</setSwitchVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIOSetLightVA(
+    const userio *io, void *user,
+    const ILightVectorProperty *lvp, const char *fmt, va_list ap
+)
+{
+    userio_prints    (io, user, "<setLightVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, lvp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, lvp->name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(lvp->s)); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    IUUserIOLightContext(io, user, lvp);
+
+    userio_prints    (io, user, "</setLightVector>\n");
+}
+
+void IUUserIOSetBLOBVA(
+    const userio *io, void *user,
+    const IBLOBVectorProperty *bvp, const char *fmt, va_list ap
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<setBLOBVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, bvp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, bvp->name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(bvp->s)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", bvp->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    s_userio_xml_message_vprintf(io, user, fmt, ap);
+    userio_prints    (io, user, ">\n");
+
+    IUUserIOBLOBContext(io, user, bvp);
+
+    userio_prints    (io, user, "</setBLOBVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}
+
+void IUUserIOUpdateMinMax(
+    const userio *io, void *user,
+    const INumberVectorProperty *nvp
+)
+{
+    locale_char_t *orig = indi_locale_C_numeric_push();
+    userio_prints    (io, user, "<setNumberVector\n");
+    userio_prints    (io, user, "  device='");
+    userio_xml_escape(io, user, nvp->device);
+    userio_prints    (io, user, "'\n");
+    userio_prints    (io, user, "  name='");
+    userio_xml_escape(io, user, nvp->name);
+    userio_prints    (io, user, "'\n");
+    userio_printf    (io, user, "  state='%s'\n", pstateStr(nvp->s)); // safe
+    userio_printf    (io, user, "  timeout='%g'\n", nvp->timeout); // safe
+    userio_printf    (io, user, "  timestamp='%s'\n", timestamp()); // safe
+    userio_prints    (io, user, ">\n");
+
+    for (int i = 0; i < nvp->nnp; i++)
+    {
+        INumber *np = &nvp->np[i];
+        userio_prints    (io, user, "  <oneNumber name='");
+        userio_xml_escape(io, user, np->name);
+        userio_prints    (io, user, "'\n");
+        userio_printf    (io, user, "    min='%g'\n", np->min); // safe
+        userio_printf    (io, user, "    max='%g'\n", np->max); // safe
+        userio_printf    (io, user, "    step='%g'\n", np->step); // safe
+        userio_prints    (io, user, ">\n");
+        userio_printf    (io, user, "      %g\n", np->value); // safe
+        userio_prints    (io, user, "  </oneNumber>\n");
+    }
+
+    userio_prints    (io, user, "</setNumberVector>\n");
+    indi_locale_C_numeric_pop(orig);
+}

--- a/libs/indiuserio.c
+++ b/libs/indiuserio.c
@@ -658,7 +658,7 @@ void IUUserIODefBLOBVA(
         userio_prints    (io, user, "'\n");
         userio_prints    (io, user, "    label='");
         userio_xml_escape(io, user, bp->label);
-        userio_prints    (io, user, "'>\n");
+        userio_prints    (io, user, "'\n");
         userio_prints    (io, user, "  />\n");
     }
 

--- a/libs/indiuserio.c
+++ b/libs/indiuserio.c
@@ -345,14 +345,21 @@ void IUUserIOGetProperties(
     const char *dev, const char *name
 )
 {
-    userio_printf    (io, user, "<getProperties version='%g' device='", INDIV); // safe
-    userio_xml_escape(io, user, dev);
+    userio_printf    (io, user, "<getProperties version='%g'", INDIV); // safe
+    // special case for INDI::BaseClient::listenINDI INDI::BaseClientQt::connectServer
+    if (dev && dev[0])
+    {
+        userio_prints    (io, user, " device='");
+        userio_xml_escape(io, user, dev);
+        userio_prints    (io, user, "'");
+    }
     if (name && name[0])
     {
-        userio_prints    (io, user, "' name='");
+        userio_prints    (io, user, " name='");
         userio_xml_escape(io, user, name);
+        userio_prints    (io, user, "'");
     }
-    userio_prints    (io, user, "'/>\n");
+    userio_prints    (io, user, "/>\n");
 }
 
 // temporary

--- a/libs/indiuserio.c
+++ b/libs/indiuserio.c
@@ -683,7 +683,7 @@ void IUUserIOSetSwitchVA(
     s_userio_xml_message_vprintf(io, user, fmt, ap);
     userio_prints    (io, user, ">\n");
 
-    IUUserIOSwitchContext(io, user, svp);
+    IUUserIOSwitchContextFull(io, user, svp);
 
     userio_prints    (io, user, "</setSwitchVector>\n");
     indi_locale_C_numeric_pop(orig);

--- a/libs/indiuserio.h
+++ b/libs/indiuserio.h
@@ -31,9 +31,11 @@ struct _IBLOBVectorProperty;
 struct _ILightVectorProperty;
 
 struct _IBLOB;
+struct _ISwitch;
 
 void IUUserIOTextContext(const userio *io, void *user, const struct _ITextVectorProperty *tvp);
 void IUUserIONumberContext(const userio *io, void *user, const struct _INumberVectorProperty *nvp);
+void IUUserIOSwitchContextOne(const userio *io, void *user, const struct _ISwitch *sp);
 void IUUserIOSwitchContextFull(const userio *io, void *user, const ISwitchVectorProperty *svp);
 void IUUserIOSwitchContext(const userio *io, void *user, const struct _ISwitchVectorProperty *svp);
 void IUUserIOBLOBContext(const userio *io, void *user, const struct _IBLOBVectorProperty *bvp);

--- a/libs/indiuserio.h
+++ b/libs/indiuserio.h
@@ -1,0 +1,89 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include "userio.h"
+#include "indidevapi.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct _ITextVectorProperty;
+struct _INumberVectorProperty;
+struct _ISwitchVectorProperty;
+struct _IBLOBVectorProperty;
+struct _ILightVectorProperty;
+
+struct _IBLOB;
+
+void IUUserIOTextContext(const userio *io, void *user, const struct _ITextVectorProperty *tvp);
+void IUUserIONumberContext(const userio *io, void *user, const struct _INumberVectorProperty *nvp);
+void IUUserIOSwitchContextFull(const userio *io, void *user, const ISwitchVectorProperty *svp);
+void IUUserIOSwitchContext(const userio *io, void *user, const struct _ISwitchVectorProperty *svp);
+void IUUserIOBLOBContext(const userio *io, void *user, const struct _IBLOBVectorProperty *bvp);
+void IUUserIOLightContext(const userio *io, void *user, const struct _ILightVectorProperty *lvp);
+
+
+void IUUserIONewText(const userio *io, void *user, const struct _ITextVectorProperty *tvp);
+void IUUserIONewNumber(const userio *io, void *user, const struct _INumberVectorProperty *nvp);
+void IUUserIONewSwitchFull(const userio *io, void *user, const ISwitchVectorProperty *svp);
+void IUUserIONewSwitch(const userio *io, void *user, const struct _ISwitchVectorProperty *svp);
+void IUUserIONewBLOB(const userio *io, void *user, const struct _IBLOBVectorProperty *bvp);
+
+void IUUserIONewBLOBStart(const userio *io, void *user, const char *dev, const char *name, const char *timestamp);
+
+void IUUserIOBLOBContextOne(
+    const userio *io, void *user,
+    const char *name, unsigned int size, unsigned int bloblen, const void *blob, const char *format
+);
+void IUUserIONewBLOBFinish(const userio *io, void *user);
+
+void IUUserIOEnableBLOB(
+    const userio *io, void *user,
+    const char *dev, const char *name, BLOBHandling blobH
+);
+
+// Define
+void IUUserIODefTextVA(const userio *io, void *user, const struct _ITextVectorProperty *tvp, const char *fmt, va_list ap);
+void IUUserIODefNumberVA(const userio *io, void *user, const struct _INumberVectorProperty *n, const char *fmt, va_list ap);
+void IUUserIODefSwitchVA(const userio *io, void *user, const struct _ISwitchVectorProperty *s, const char *fmt, va_list ap);
+void IUUserIODefLightVA(const userio *io, void *user, const struct _ILightVectorProperty *lvp, const char *fmt, va_list ap);
+void IUUserIODefBLOBVA(const userio *io, void *user, const struct _IBLOBVectorProperty *b, const char *fmt, va_list ap);
+
+// Setup
+void IUUserIOSetTextVA(const userio *io, void *user, const struct _ITextVectorProperty *tvp, const char *fmt, va_list ap);
+void IUUserIOSetNumberVA(const userio *io, void *user, const struct _INumberVectorProperty *nvp, const char *fmt, va_list ap);
+void IUUserIOSetSwitchVA(const userio *io, void *user, const struct _ISwitchVectorProperty *svp, const char *fmt, va_list ap);
+void IUUserIOSetLightVA(const userio *io, void *user, const struct _ILightVectorProperty *lvp, const char *fmt, va_list ap);
+void IUUserIOSetBLOBVA(const userio *io, void *user, const struct _IBLOBVectorProperty *bvp, const char *fmt, va_list ap);
+
+void IUUserIOUpdateMinMax(const userio *io, void *user, const struct _INumberVectorProperty *nvp);
+
+void IUUserIODeleteVA(const userio *io, void *user, const char *dev, const char *name, const char *fmt, va_list ap);
+
+void IUUserIOGetProperties(const userio *io, void *user, const char *dev, const char *name);
+
+void IDUserIOMessage(const userio *io, void *user, const char *dev, const char *fmt, ...);
+void IDUserIOMessageVA(const userio *io, void *user, const char *dev, const char *fmt, va_list ap);
+
+void IUUserIOConfigTag(const userio *io, void *user, int ctag, const char *dev, int silent);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libs/userio.c
+++ b/libs/userio.c
@@ -1,0 +1,106 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include "userio.h"
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+static size_t s_file_write(void *user, const void * ptr, size_t count)
+{
+    return fwrite(ptr, 1, count, (FILE *)user);
+}
+
+static int s_file_printf(void *user, const char * format, va_list arg)
+{
+    return vfprintf((FILE *)user, format, arg);
+}
+
+static const struct userio s_userio_file = {
+    .write = s_file_write,
+    .vprintf = s_file_printf,
+};
+
+const struct userio *userio_file()
+{
+    return &s_userio_file;
+}
+
+int userio_printf(const struct userio *io, void *user, const char * format, ...)
+{
+    int ret;
+    va_list ap;
+    va_start(ap, format);
+    ret = io->vprintf(user, format, ap);
+    va_end(ap);
+    return ret;
+}
+
+int userio_vprintf(const struct userio *io, void *user, const char * format, va_list arg)
+{
+    return io->vprintf(user, format, arg);
+}
+
+size_t userio_write(const struct userio *io, void *user, const void * ptr, size_t count)
+{
+    return io->write(user, ptr, count);
+}
+
+int userio_prints(const struct userio *io, void *user, const char *str)
+{
+    return io->write(user, str, strlen(str));
+}
+
+int userio_putc(const struct userio *io, void *user, int ch)
+{
+    char c = ch;
+    return io->write(user, &c, sizeof(c));
+}
+
+size_t userio_xml_escape(const struct userio *io, void *user, const char *src)
+{
+    size_t total = 0;
+    const char *ptr = src;
+    const char *replacement;
+
+    for(; *ptr; ++ptr)
+    {
+        switch(*ptr)
+        {
+        case  '&': replacement = "&amp;";  break;
+        case '\'': replacement = "&apos;"; break;
+        case  '"': replacement = "&quot;"; break;
+        case  '<': replacement = "&lt;";   break;
+        case  '>': replacement = "&gt;";   break;
+        default:   replacement = NULL;
+        }
+
+        if (replacement != NULL)
+        {
+            total += userio_write(io, user, src, (size_t)(ptr - src));
+            src = ptr + 1;
+            total += userio_write(io, user, replacement, strlen(replacement));
+        }
+    }
+    total += userio_write(io, user, src, (size_t)(ptr - src));
+    return total;
+}
+
+void userio_xmlv1(const userio *io, void *user)
+{
+    userio_prints(io, user, "<?xml version='1.0'?>\n");
+}

--- a/libs/userio.h
+++ b/libs/userio.h
@@ -1,0 +1,54 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include <stdarg.h>
+
+#ifdef _WINDOWS
+#include <windows.h>
+#else
+#include <sys/types.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct userio
+{
+    size_t (*write)(void *user, const void * ptr, size_t count);
+    int (*vprintf)(void *user, const char * format, va_list arg);
+} userio;
+
+const struct userio *userio_file();
+
+int userio_printf(const struct userio *io, void *user, const char * format, ...);
+int userio_vprintf(const struct userio *io, void *user, const char * format, va_list arg);
+
+size_t userio_write(const struct userio *io, void *user, const void * ptr, size_t count);
+
+int userio_putc(const struct userio *io, void *user, int ch);
+
+// extras
+int userio_prints(const struct userio *io, void *user, const char *str);
+size_t userio_xml_escape(const struct userio *io, void *user, const char *src);
+void userio_xmlv1(const userio *io, void *user);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Hi!

I moved the XML build to a separate file, indiuserio.c.
Changes:
- A secure XML leak (https://github.com/indilib/indi/issues/1412)
- Fewer calls to printf
- Fewer intermediary buffers
- Single function implementations


To minimize the number of buffers, and not to repeat the implementation for streams, sockets etc, I created a 'userio' (User Input-Output). Currently, it is an introduction to further development.

With a userio, you can write a universal code (INDI Style):
```cpp
void IUUserIOTextContext(const userio *io, void *user, const ITextVectorProperty *tvp)
{
    for (int i = 0; i < tvp->ntp; i++)
    {
        IText *tp = &tvp->tp[i];
        userio_prints    (io, user, "  <oneText name='");
        userio_xml_escape(io, user, tp->name);
        userio_prints    (io, user, "'>\n");
        userio_prints    (io, user, "      ");
        userio_xml_escape(io, user, tp->text ? tp->text : "");
        userio_prints    (io, user, "\n");
        userio_prints    (io, user, "  </oneText>\n");
    }
}
```

Now, you can define what functions are to be triggered:
```cpp
userio ioBaseClient;
/* ... */
ioBaseClient.write = [](void *user, const void * ptr, size_t count) -> size_t
{
    BaseClient *self = static_cast<BaseClient *>(user);
    return net_write(self->sockfd, ptr, count);
};

ioBaseClient.vprintf = [](void *user, const char * format, va_list ap) -> int
{
    BaseClient *self = static_cast<BaseClient *>(user);
    char message[MAXRBUF];
    vsnprintf(message, MAXRBUF, format, ap);
    return net_write(self->sockfd, message, strlen(message));
};
/* ... */
```

And finally, calling:
```cpp
FILE *fp;
/* ... */

IUUserIONewNumber(userio_file(), fp, nvp); // to file
IUUserIONewNumber(userio_file(), stdout, nvp); // to stdout
IUUserIONewNumber(&ioBaseClient, this, nvp); // send via BaseClient

```


Now I can make a button with any name!

```cpp
IUFillSwitchVector(
    &RainSP, RainS, 2, getDeviceName(),
    "Control \"'& &amp;lt; ", // brutal test
    "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0,
    IPS_IDLE
);
```
![image](https://user-images.githubusercontent.com/73316926/113529788-b3f15b80-95c4-11eb-83dc-df6a42b3a230.png)


On days, I'll add the rest.
@knro will you take a look?
You will always catch something ;)
