### PR TITLE
Fix, use IDMessage to send info message.

### DIFF
--- a/indidriver.c
+++ b/indidriver.c
@@ -1542,7 +1542,21 @@ void IUSaveConfigTag(FILE *fp, int ctag, const char *dev, int silent)
     if (!fp)
         return;
 
-    IUUserIOConfigTag(userio_file(), fp, ctag, dev, silent);
+    IUUserIOConfigTag(userio_file(), fp, ctag);
+
+    if (silent != 1)
+    {
+        /* Opening tag */
+        if (ctag == 0)
+        {
+            IDMessage(dev, "[INFO] Saving device configuration...");
+        }
+        /* Closing tag */
+        else
+        {
+            IDMessage(dev, "[INFO] Device configuration saved.");
+        }
+    }
 }
 
 /* tell client to create a text vector property */

--- a/libs/indiuserio.c
+++ b/libs/indiuserio.c
@@ -367,23 +367,18 @@ void IDUserIOMessage(
 }
 
 void IUUserIOConfigTag(
-    const userio *io, void *user,
-    int ctag, const char *dev, int silent
+    const userio *io, void *user, int ctag
 )
 {
     /* Opening tag */
     if (ctag == 0)
     {
-        userio_prints    (io, user, "<INDIDriver>\n");
-        if (silent != 1)
-            IDUserIOMessage(io, user, dev, "[INFO] Saving device configuration...");
+        userio_prints(io, user, "<INDIDriver>\n");
     }
     /* Closing tag */
     else
     {
-        userio_prints    (io, user, "</INDIDriver>\n");
-        if (silent != 1)
-            IDUserIOMessage(io, user, dev, "[INFO] Device configuration saved.");
+        userio_prints(io, user, "</INDIDriver>\n");
     }
 }
 

--- a/libs/indiuserio.h
+++ b/libs/indiuserio.h
@@ -84,7 +84,7 @@ void IUUserIOGetProperties(const userio *io, void *user, const char *dev, const 
 void IDUserIOMessage(const userio *io, void *user, const char *dev, const char *fmt, ...);
 void IDUserIOMessageVA(const userio *io, void *user, const char *dev, const char *fmt, va_list ap);
 
-void IUUserIOConfigTag(const userio *io, void *user, int ctag, const char *dev, int silent);
+void IUUserIOConfigTag(const userio *io, void *user, int ctag);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Original implementation by introducing Userio:
```cpp
void IUSaveConfigTag(FILE *fp, int ctag, const char *dev, int silent)
{
    if (!fp)
        return;

    /* Opening tag */
    if (ctag == 0)
    {
        fprintf(fp, "<INDIDriver>\n");
        if (silent != 1)
            IDMessage(dev, "[INFO] Saving device configuration...");
    }
    /* Closing tag */
    else
    {
        fprintf(fp, "</INDIDriver>\n");
        if (silent != 1)
            IDMessage(dev, "[INFO] Device configuration saved.");
    }
}
```
