### PR TITLE
INDI::BaseClient - Fix sockets deadlock.

### DIFF
--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -332,7 +332,7 @@ bool INDI::BaseClient::disconnectServer(int exit_code)
     ssize_t ret = write(m_sendFd, &c, sizeof(c));
     if (ret != sizeof(c))
     {
-        IDLog("INDI::BaseClient::disconnectServer: Error. The socket cannot be woken up.\n")
+        IDLog("INDI::BaseClient::disconnectServer: Error. The socket cannot be woken up.\n");
     }
 #endif
     sExitCode = exit_code;

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -328,7 +328,12 @@ bool INDI::BaseClient::disconnectServer(int exit_code)
 #else
     shutdown(sockfd, SHUT_RDWR); // no needed
     size_t c = 1;
-    (void)write(m_sendFd, &c, sizeof(c)); // wakeup 'select' function
+    // wakeup 'select' function
+    ssize_t ret = write(m_sendFd, &c, sizeof(c));
+    if (ret != sizeof(c))
+    {
+        IDLog("INDI::BaseClient::disconnectServer: Error. The socket cannot be woken up.\n")
+    }
 #endif
     sExitCode = exit_code;
     return true;

--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+
 #include "indiapi.h"
 #include "indibase.h"
 
@@ -27,6 +28,8 @@
 #include <set>
 
 #include <atomic>
+#include <mutex>
+#include <condition_variable>
 #include <thread>
 
 #ifdef _WINDOWS
@@ -283,8 +286,6 @@ class INDI::BaseClient : public INDI::BaseMediator
          */
         void clear();
 
-        std::thread listen_thread;
-
 #ifdef _WINDOWS
         SOCKET sockfd;
 #else
@@ -307,11 +308,13 @@ class INDI::BaseClient : public INDI::BaseMediator
         std::string cServer;
         uint32_t cPort;
         std::atomic_bool sConnected;
+        std::atomic_bool sAboutToClose;
+        std::mutex sSocketBusy;
+        std::condition_variable sSocketChanged;
+        int sExitCode;
         bool verbose;
 
         // Parse & FILE buffers for IO
 
-        /* XML parser context */
-        LilXML *lillp {nullptr};
         uint32_t timeout_sec, timeout_us;
 };


### PR DESCRIPTION
https://github.com/indilib/indi/pull/1430 https://github.com/indilib/indi/issues/1424

The function closing the connection is non-blocking.
Closing descriptors only happens on the thread.
The connection opening and closing functions are synchronized - There is no race.
Waiting for a thread to finish with a timeout is only implemented in the destructor.

@knro Can you check it's ok? (on windows)
I found some additional problems but completely unrelated to sockets.

