### PR TITLE
Fix Philips Toucam family cameras (pwc driver) ManualExposure switch (label is "Gain, Automatic" )

### DIFF
--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -1787,7 +1787,7 @@ void V4L2_Driver::updateV4L2Controls()
     {
         defineProperty(&Options[i]);
 
-        if (strcmp(Options[i].label, "Exposure, Auto") == 0 || strcmp(Options[i].label, "Auto Exposure") == 0)
+        if (strcmp(Options[i].label, "Exposure, Auto") == 0 || strcmp(Options[i].label, "Auto Exposure") == 0 || strcmp(Options[i].label, "Gain, Automatic")==0)
         {
             ManualExposureSP = Options + i;
             LOGF_DEBUG("- %s (used for manual/auto exposure control)", Options[i].label);


### PR DESCRIPTION
Works on my setup (raspberry pi4 kernel 5.10.31-vl7+ Kstars 3.5.2 Stable) ...
Please review.