### PR TITLE
fix null pointer dereference

### DIFF
--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -977,7 +977,7 @@ bool V4L2_Driver::setManualExposure(double duration)
             stackMode = STACK_ADDITIVE;
             StackModeSP.sp[ STACK_NONE ].s = ISS_OFF;
             StackModeSP.sp[ STACK_ADDITIVE ].s = ISS_ON;
-            IDSetSwitch(ManualExposureSP, nullptr);
+            if(ManualExposureSP) IDSetSwitch(ManualExposureSP, nullptr);
         }
 
         /* We can't expose as long as requested but we can stack gray frames until the exposure elapses */


### PR DESCRIPTION
 pwc Toucam pro 2 device has no auto exposure control, if stackMode is STACK_NONE and exposure time is out of bounds, the driver crashes.

Tested on my setup (raspberry pi4 / Kernel 5.10.31-V7l+ / Kstars 3.5.2).

Closes #1435