### PR TITLE
BaseDevice::getProperty as non-pointer result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,7 @@ SET(indiclient_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclient.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperties.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.cpp
@@ -255,6 +256,7 @@ SET(indiclientqt_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclientqt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperties.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.cpp
@@ -428,6 +430,7 @@ SET(indidriver_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/defaultdevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperties.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.cpp
@@ -1997,6 +2000,7 @@ if (INDI_BUILD_DRIVERS OR INDI_BUILD_CLIENT OR INDI_BUILD_QT5_CLIENT)
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indifilterinterface.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indirotatorinterface.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperties.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertybasic.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertytext.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indipropertynumber.h

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -102,7 +102,7 @@ INDI::PropertyView<IBLOB> *BaseDevice::getBLOB(const char *name) const
 IPState BaseDevice::getPropertyState(const char *name) const
 {
     for (const auto &oneProp : *getProperties())
-        if (!strcmp(name, oneProp->getName()))
+        if (oneProp->isNameMatch(name))
             return oneProp->getState();
 
     return IPS_IDLE;
@@ -111,7 +111,7 @@ IPState BaseDevice::getPropertyState(const char *name) const
 IPerm BaseDevice::getPropertyPermission(const char *name) const
 {
     for (const auto &oneProp : *getProperties())
-        if (!strcmp(name, oneProp->getName()))
+        if (oneProp->isNameMatch(name))
             return oneProp->getPermission();
 
     return IP_RO;
@@ -136,7 +136,7 @@ INDI::Property BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE type
         if (!oneProp->getRegistered())
             continue;
 
-        if (!strcmp(name, oneProp->getName()))
+        if (oneProp->isNameMatch(name))
             return oneProp;
     }
 

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -127,7 +127,7 @@ void *BaseDevice::getRawProperty(const char *name, INDI_PROPERTY_TYPE type) cons
     return prop != nullptr ? prop->getProperty() : nullptr;
 }
 
-INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE type) const
+INDI::Property BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE type) const
 {
     D_PTR(const BaseDevice);
     std::lock_guard<std::mutex> lock(d->m_Lock);
@@ -141,10 +141,10 @@ INDI::Property *BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE typ
             continue;
 
         if (!strcmp(name, oneProp->getName()))
-            return oneProp;
+            return *oneProp;
     }
 
-    return nullptr;
+    return INDI::Property();
 }
 
 int BaseDevice::removeProperty(const char *name, char *errmsg)

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -143,6 +143,18 @@ INDI::Property BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE type
     return INDI::Property();
 }
 
+BaseDevice::Properties BaseDevice::getProperties()
+{
+    D_PTR(BaseDevice);
+    return d->pAll;
+}
+
+const BaseDevice::Properties BaseDevice::getProperties() const
+{
+    D_PTR(const BaseDevice);
+    return d->pAll;
+}
+
 int BaseDevice::removeProperty(const char *name, char *errmsg)
 {
     D_PTR(BaseDevice);
@@ -1032,18 +1044,6 @@ uint16_t BaseDevice::getDriverInterface()
         return atoi(driverInterface->text);
 
     return 0;
-}
-
-const BaseDevice::Properties BaseDevice::getProperties() const
-{
-    D_PTR(const BaseDevice);
-    return d->pAll;
-}
-
-BaseDevice::Properties BaseDevice::getProperties()
-{
-    D_PTR(BaseDevice);
-    return d->pAll;
 }
 
 void BaseDevice::setMediator(INDI::BaseMediator *mediator)

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -25,6 +25,12 @@
 #include "indistandardproperty.h"
 #include "locale_compat.h"
 
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
+#include "indipropertyblob.h"
+
 #include <cerrno>
 #include <cassert>
 #include <cstdlib>
@@ -101,18 +107,18 @@ INDI::PropertyView<IBLOB> *BaseDevice::getBLOB(const char *name) const
 
 IPState BaseDevice::getPropertyState(const char *name) const
 {
-    for (const auto &oneProp : *getProperties())
-        if (oneProp->isNameMatch(name))
-            return oneProp->getState();
+    for (const auto &oneProp : getProperties())
+        if (oneProp.isNameMatch(name))
+            return oneProp.getState();
 
     return IPS_IDLE;
 }
 
 IPerm BaseDevice::getPropertyPermission(const char *name) const
 {
-    for (const auto &oneProp : *getProperties())
-        if (oneProp->isNameMatch(name))
-            return oneProp->getPermission();
+    for (const auto &oneProp : getProperties())
+        if (oneProp.isNameMatch(name))
+            return oneProp.getPermission();
 
     return IP_RO;
 }
@@ -128,15 +134,15 @@ INDI::Property BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE type
     D_PTR(const BaseDevice);
     std::lock_guard<std::mutex> lock(d->m_Lock);
 
-    for (const auto &oneProp : *getProperties())
+    for (const auto &oneProp : getProperties())
     {
-        if (type != oneProp->getType() && type != INDI_UNKNOWN)
+        if (type != oneProp.getType() && type != INDI_UNKNOWN)
             continue;
 
-        if (!oneProp->getRegistered())
+        if (!oneProp.getRegistered())
             continue;
 
-        if (oneProp->isNameMatch(name))
+        if (oneProp.isNameMatch(name))
             return oneProp;
     }
 
@@ -158,30 +164,35 @@ const BaseDevice::Properties BaseDevice::getProperties() const
 int BaseDevice::removeProperty(const char *name, char *errmsg)
 {
     D_PTR(BaseDevice);
+    int result = INDI_PROPERTY_INVALID;
+
     std::lock_guard<std::mutex> lock(d->m_Lock);
-#if 0
-    for (auto oneProp : d->pAll)
+
+    d->pAll.erase_if([&name, &result](INDI::Property &prop) -> bool
     {
-        if (!strcmp(name, oneProp->getName()))
+        if (prop.isNameMatch(name))
         {
-            d->pAll.erase(std::remove(d->pAll.begin(), d->pAll.end(), oneProp), d->pAll.end());
             // JM 2021-04-28: delete later. We perform the actual delete after 100ms to give clients a chance to remove the object.
             // This is necessary when rapid define-delete-define sequences are made.
             // This HACK is not ideal. We need to start using std::shared_ptr for this purpose soon, but this will be a major change to the
             // interface. Perhaps for INDI 2.0
-            std::thread t([oneProp]()
+            std::thread([prop]
             {
-
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));
-                delete oneProp;
-            });
-            t.detach();
-            return 0;
+            }).detach();
+            result = 0;
+            return true;
         }
-    }
-#endif
-    snprintf(errmsg, MAXRBUF, "Error: Property %s not found in device %s.", name, getDeviceName());
-    return INDI_PROPERTY_INVALID;
+        else
+        {
+            return false;
+        }
+    });
+
+    if (result != 0)
+        snprintf(errmsg, MAXRBUF, "Error: Property %s not found in device %s.", name, getDeviceName());
+
+    return result;
 }
 
 bool BaseDevice::buildSkeleton(const char *filename)
@@ -268,8 +279,7 @@ int BaseDevice::buildProp(XMLEle *root, char *errmsg)
     XMLEle *ep    = nullptr;
     char *rtag, *rname, *rdev;
 
-    INDI::Property *indiProp = nullptr;
-    int n = 0;
+    INDI::Property indiProp;
 
     rtag = tagXMLEle(root);
 
@@ -280,8 +290,7 @@ int BaseDevice::buildProp(XMLEle *root, char *errmsg)
     if (d->deviceName.empty())
         d->deviceName = rdev;
 
-    //if (getProperty(rname, type) != nullptr)
-    if (getProperty(rname) != nullptr)
+    if (getProperty(rname).isValid())
         return INDI_PROPERTY_DUPLICATED;
 
     if (strcmp(rtag, "defLightVector") && crackIPerm(findXMLAttValu(root, "perm"), &perm) < 0)
@@ -300,9 +309,7 @@ int BaseDevice::buildProp(XMLEle *root, char *errmsg)
     {
         AutoCNumeric locale;
 
-        INumberVectorProperty *nvp = new INumberVectorProperty;
-
-        INumber *np = nullptr;
+        INDI::PropertyNumber nvp {0};
 
         /* pull out each name/value pair */
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
@@ -310,52 +317,40 @@ int BaseDevice::buildProp(XMLEle *root, char *errmsg)
             if (strcmp(tagXMLEle(ep), "defNumber"))
                 continue;
 
-            np = static_cast<INumber *>(realloc(np, (n + 1) * sizeof(INumber)));
-            INumber *it = &np[n];
-            memset(it, 0, sizeof(*it));
-            it->nvp = nvp;
-
-            strncpy(it->name, findXMLAttValu(ep, "name"), MAXINDINAME);
-            if (*it->name == '\0')
+            INDI::WidgetView<INumber> np;
+            np.setName(findXMLAttValu(ep, "name"));
+            if (np.getName()[0] == '\0')
                 continue;
 
-            if (f_scansexa(pcdataXMLEle(ep), &(it->value)) < 0)
+            double value;
+            if (f_scansexa(pcdataXMLEle(ep), &value) < 0)
             {
                 IDLog("%s: Bad format %s\n", rname, pcdataXMLEle(ep));
                 continue;
             }
 
-            strncpy(it->label,  findXMLAttValu(ep, "label" ), MAXINDILABEL );
-            strncpy(it->format, findXMLAttValu(ep, "format"), MAXINDIFORMAT);
+            np.setValue(value);
+            np.setLabel(findXMLAttValu(ep, "label"));
+            np.setFormat(findXMLAttValu(ep, "format"));
 
-            it->min  = atof(findXMLAttValu(ep, "min"));
-            it->max  = atof(findXMLAttValu(ep, "max"));
-            it->step = atof(findXMLAttValu(ep, "step"));
-            ++n;
+            np.setMin(atof(findXMLAttValu(ep, "min")));
+            np.setMax(atof(findXMLAttValu(ep, "max")));
+            np.setStep(atof(findXMLAttValu(ep, "step")));
+
+            nvp.push(std::move(np));
         }
 
-        if (n > 0)
-        {
-            nvp->nnp = n;
-            nvp->np  = np;
-
-            indiProp = new INDI::Property(nvp);
-        }
-        else
-        {
-            IDLog("%s: newNumberVector with no valid members\n", rname);
-            delete (nvp);
-            free (np);
-        }
+        indiProp = nvp;
     }
     else if (!strcmp(rtag, "defSwitchVector"))
     {
-        ISwitchVectorProperty *svp = new ISwitchVectorProperty;
 
-        ISwitch *sp = nullptr;
+        ISRule rule = ISR_1OFMANY;
+        if (crackISRule(findXMLAttValu(root, "rule"), &rule) < 0)
+            rule = ISR_1OFMANY;
 
-        if (crackISRule(findXMLAttValu(root, "rule"), (&svp->r)) < 0)
-            svp->r = ISR_1OFMANY;
+        INDI::PropertySwitch svp {0};
+        svp.setRule(rule);
 
         /* pull out each name/value pair */
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
@@ -363,39 +358,26 @@ int BaseDevice::buildProp(XMLEle *root, char *errmsg)
             if (strcmp(tagXMLEle(ep), "defSwitch"))
                 continue;
 
-            sp = static_cast<ISwitch *>(realloc(sp, (n + 1) * sizeof(ISwitch)));
-            ISwitch *it = &sp[n];
-            memset(it, 0, sizeof(*it));
-            it->svp = svp;
-
-            strncpy(it->name, findXMLAttValu(ep, "name"), MAXINDINAME);
-            if (*it->name == '\0')
+            INDI::WidgetView<ISwitch> sp;
+            sp.setName(findXMLAttValu(ep, "name"));
+            if (sp.getName()[0] == '\0')
                 continue;
 
-            crackISState(pcdataXMLEle(ep), &(it->s));
+            ISState state;
+            crackISState(pcdataXMLEle(ep), &state);
 
-            strncpy(it->label, findXMLAttValu(ep, "label"), MAXINDILABEL);
-            ++n;
+            sp.setState(state);
+            sp.setLabel(findXMLAttValu(ep, "label"));
+
+            svp.push(std::move(sp));
         }
 
-        if (n > 0)
-        {
-            svp->nsp = n;
-            svp->sp  = sp;
-            indiProp = new INDI::Property(svp);
-        }
-        else
-        {
-            IDLog("%s: newSwitchVector with no valid members\n", rname);
-            delete (svp);
-            free (sp);
-        }
+        indiProp = svp;
     }
 
     else if (!strcmp(rtag, "defTextVector"))
     {
-        ITextVectorProperty *tvp = new ITextVectorProperty;
-        IText *tp                = nullptr;
+        INDI::PropertyText tvp {0};
 
         // pull out each name/value pair
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
@@ -403,40 +385,22 @@ int BaseDevice::buildProp(XMLEle *root, char *errmsg)
             if (strcmp(tagXMLEle(ep), "defText"))
                 continue;
 
-            tp = static_cast<IText *>(realloc(tp, (n + 1) * sizeof(IText)));
-            memset(&tp[n], 0, sizeof(tp[n]));
-
-            WidgetView<IText> *it = static_cast<WidgetView<IText>*>(&tp[n]);
-
-            it->setParent(tvp);
-            it->setName(findXMLAttValu(ep, "name"));
-
-            if (it->getName()[0] == '\0')
+            INDI::WidgetView<IText> tp;
+            tp.setName(findXMLAttValu(ep, "name"));
+            if (tp.getName()[0] == '\0')
                 continue;
 
-            it->setText(pcdataXMLEle(ep), pcdatalenXMLEle(ep));
-            it->setLabel(findXMLAttValu(ep, "label"));
-            ++n;
+            tp.setText(pcdataXMLEle(ep), pcdatalenXMLEle(ep));
+            tp.setLabel(findXMLAttValu(ep, "label"));
+
+            tvp.push(std::move(tp));
         }
 
-        if (n > 0)
-        {
-            tvp->ntp = n;
-            tvp->tp  = tp;
-
-            indiProp = new INDI::Property(tvp);
-        }
-        else
-        {
-            IDLog("%s: newTextVector with no valid members\n", rname);
-            delete (tvp);
-            free (tp);
-        }
+        indiProp = tvp;
     }
     else if (!strcmp(rtag, "defLightVector"))
     {
-        ILightVectorProperty *lvp = new ILightVectorProperty;
-        ILight *lp                = nullptr;
+        INDI::PropertyLight lvp {0};
 
         /* pull out each name/value pair */
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
@@ -444,108 +408,87 @@ int BaseDevice::buildProp(XMLEle *root, char *errmsg)
             if (strcmp(tagXMLEle(ep), "defLight"))
                 continue;
 
-            lp = static_cast<ILight *>(realloc(lp, (n + 1) * sizeof(ILight)));
-            ILight *it = &lp[n];
-            memset(it, 0, sizeof(*it));
-            it->lvp = lvp;
-
-            strncpy(it->name, findXMLAttValu(ep, "name"), MAXINDINAME);
-            if (*it->name == '\0')
+            INDI::WidgetView<ILight> lp;
+            lp.setName(findXMLAttValu(ep, "name"));
+            if (lp.getName()[0] == '\0')
                 continue;
 
-            crackIPState(pcdataXMLEle(ep), &(it->s));
+            IPState state;
+            crackIPState(pcdataXMLEle(ep), &state);
+            lp.setState(state);
+            lp.setLabel(findXMLAttValu(ep, "label"));
 
-            strncpy(it->label, findXMLAttValu(ep, "label"), MAXINDILABEL);
-            ++n;
+            lvp.push(std::move(lp));
         }
 
-        if (n > 0)
-        {
-            lvp->nlp = n;
-            lvp->lp  = lp;
-
-            indiProp  = new INDI::Property(lvp);
-        }
-        else
-        {
-            IDLog("%s: newLightVector with no valid members\n", rname);
-            delete (lvp);
-            free (lp);
-        }
+        indiProp = lvp;
     }
     else if (!strcmp(rtag, "defBLOBVector"))
     {
-        IBLOBVectorProperty *bvp = new IBLOBVectorProperty;
-        IBLOB *bp                = nullptr;
+        INDI::PropertyBlob bvp {0};
 
         /* pull out each name/value pair */
-        for (n = 0, ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
+        for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
         {
             if (strcmp(tagXMLEle(ep), "defBLOB"))
                 continue;
 
-            bp = static_cast<IBLOB *>(realloc(bp, (n + 1) * sizeof(IBLOB)));
-            IBLOB *it = &bp[n];
-            memset(it, 0, sizeof(*it));
-            it->bvp = bvp;
-
-            strncpy(it->name, findXMLAttValu(ep, "name"), MAXINDINAME);
-            if (*it->name == '\0')
+            INDI::WidgetView<IBLOB> bp;
+            bp.setName(findXMLAttValu(ep, "name"));
+            if (bp.getName()[0] == '\0')
                 continue;
 
-            strncpy(it->label,  findXMLAttValu(ep, "label" ), MAXINDILABEL );
-            strncpy(it->format, findXMLAttValu(ep, "format"), MAXINDIBLOBFMT);
-            ++n;
+            bp.setLabel(findXMLAttValu(ep, "label"));
+            bp.setFormat(findXMLAttValu(ep, "format"));
+
+            bvp.push(std::move(bp));
         }
 
-        if (n > 0)
-        {
-            bvp->nbp = n;
-            bvp->bp  = bp;
-
-            indiProp  = new INDI::Property(bvp);
-        }
-        else
-        {
-            IDLog("%s: newBLOBVector with no valid members\n", rname);
-            delete (bvp);
-            free (bp);
-        }
+        indiProp = bvp;
     }
 
-    if (indiProp)
+    if (!indiProp.isValid())
     {
-        indiProp->setBaseDevice(this);
-        indiProp->setDynamic(true);
-        indiProp->setDeviceName(getDeviceName());
-        indiProp->setName(rname);
-        indiProp->setLabel(findXMLAttValu(root, "label"));
-        indiProp->setGroupName(findXMLAttValu(root, "group"));
-        indiProp->setPermission(perm);
-        indiProp->setState(state);
-        indiProp->setTimeout(atoi(findXMLAttValu(root, "timeout")));
-
-        std::unique_lock<std::mutex> lock(d->m_Lock);
-        d->pAll.push_back(*indiProp);
-        lock.unlock();
-
-        //IDLog("Adding number property %s to list.\n", indiProp->getName());
-        if (d->mediator)
-            d->mediator->newProperty(indiProp);
+        IDLog("%s: invalid name '%s'\n", rname, rtag);
+        return 0;
     }
+
+    if (indiProp.isEmpty())
+    {
+        IDLog("%s: %s with no valid members\n", rname, rtag);
+        return 0;
+    }
+
+    indiProp.setBaseDevice(this);
+    //indiProp.setDynamic(true);
+    indiProp.setDeviceName(getDeviceName());
+    indiProp.setName(rname);
+    indiProp.setLabel(findXMLAttValu(root, "label"));
+    indiProp.setGroupName(findXMLAttValu(root, "group"));
+    indiProp.setPermission(perm);
+    indiProp.setState(state);
+    indiProp.setTimeout(atoi(findXMLAttValu(root, "timeout")));
+
+    std::unique_lock<std::mutex> lock(d->m_Lock);
+    d->pAll.push_back(indiProp);
+    lock.unlock();
+
+    //IDLog("Adding number property %s to list.\n", indiProp->getName());
+    if (d->mediator)
+        d->mediator->newProperty(indiProp);
 
     return (0);
 }
 
 bool BaseDevice::isConnected() const
 {
-    ISwitchVectorProperty *svp = getSwitch(INDI::SP::CONNECTION);
+    auto svp = getSwitch(INDI::SP::CONNECTION);
     if (!svp)
         return false;
 
-    ISwitch *sp = IUFindSwitch(svp, "CONNECT");
+    auto sp = svp->findWidgetByName("CONNECT");
 
-    return sp && sp->s == ISS_ON && svp->s == IPS_OK;
+    return sp && sp->getState() == ISS_ON && svp->getState() == IPS_OK;
 }
 
 /*
@@ -597,34 +540,34 @@ int BaseDevice::setValue(XMLEle *root, char *errmsg)
 
     if (!strcmp(rtag, "setNumberVector"))
     {
-        INumberVectorProperty *nvp = getNumber(name);
-        if (nvp == nullptr)
+        auto nvp = getNumber(name);
+        if (!nvp)
         {
             snprintf(errmsg, MAXRBUF, "INDI: Could not find property %s in %s", name, getDeviceName());
             return -1;
         }
 
         if (stateSet)
-            nvp->s = state;
+            nvp->setState(state);
 
         if (timeoutSet)
-            nvp->timeout = timeout;
+            nvp->setTimeout(timeout);
 
         AutoCNumeric locale;
 
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
         {
-            INumber *np = IUFindNumber(nvp, findXMLAttValu(ep, "name"));
+            auto np = nvp->findWidgetByName(findXMLAttValu(ep, "name"));
             if (!np)
                 continue;
 
-            np->value = atof(pcdataXMLEle(ep));
+            np->setValue(atof(pcdataXMLEle(ep)));
 
             // Permit changing of min/max
             if (findXMLAtt(ep, "min"))
-                np->min = atof(findXMLAttValu(ep, "min"));
+                np->setMin(atof(findXMLAttValu(ep, "min")));
             if (findXMLAtt(ep, "max"))
-                np->max = atof(findXMLAttValu(ep, "max"));
+                np->setMax(atof(findXMLAttValu(ep, "max")));
         }
 
         locale.Restore();
@@ -636,23 +579,23 @@ int BaseDevice::setValue(XMLEle *root, char *errmsg)
     }
     else if (!strcmp(rtag, "setTextVector"))
     {
-        ITextVectorProperty *tvp = getText(name);
-        if (tvp == nullptr)
+        auto tvp = getText(name);
+        if (!tvp)
             return -1;
 
         if (stateSet)
-            tvp->s = state;
+            tvp->setState(state);
 
         if (timeoutSet)
-            tvp->timeout = timeout;
+            tvp->setTimeout(timeout);
 
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
         {
-            IText *tp = IUFindText(tvp, findXMLAttValu(ep, "name"));
+            auto tp = tvp->findWidgetByName(findXMLAttValu(ep, "name"));
             if (!tp)
                 continue;
 
-            IUSaveText(tp, pcdataXMLEle(ep));
+            tp->setText(pcdataXMLEle(ep));
         }
 
         if (d->mediator)
@@ -663,24 +606,24 @@ int BaseDevice::setValue(XMLEle *root, char *errmsg)
     else if (!strcmp(rtag, "setSwitchVector"))
     {
         ISState swState;
-        ISwitchVectorProperty *svp = getSwitch(name);
-        if (svp == nullptr)
+        auto svp = getSwitch(name);
+        if (!svp)
             return -1;
 
         if (stateSet)
-            svp->s = state;
+            svp->setState(state);
 
         if (timeoutSet)
-            svp->timeout = timeout;
+            svp->setTimeout(timeout);
 
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
         {
-            ISwitch *sp = IUFindSwitch(svp, findXMLAttValu(ep, "name"));
+            auto sp = svp->findWidgetByName(findXMLAttValu(ep, "name"));
             if (!sp)
                 continue;
 
             if (crackISState(pcdataXMLEle(ep), &swState) == 0)
-                sp->s = swState;
+                sp->setState(swState);
         }
 
         if (d->mediator)
@@ -691,22 +634,22 @@ int BaseDevice::setValue(XMLEle *root, char *errmsg)
     else if (!strcmp(rtag, "setLightVector"))
     {
         IPState lState;
-        ILightVectorProperty *lvp = getLight(name);
+        auto lvp = getLight(name);
 
-        if (lvp == nullptr)
+        if (!lvp)
             return -1;
 
         if (stateSet)
-            lvp->s = state;
+            lvp->setState(state);
 
         for (ep = nextXMLEle(root, 1); ep != nullptr; ep = nextXMLEle(root, 0))
         {
-            ILight *lp = IUFindLight(lvp, findXMLAttValu(ep, "name"));
+            auto lp = lvp->findWidgetByName(findXMLAttValu(ep, "name"));
             if (!lp)
                 continue;
 
             if (crackIPState(pcdataXMLEle(ep), &lState) == 0)
-                lp->s = lState;
+                lp->setState(lState);
         }
 
         if (d->mediator)
@@ -716,16 +659,16 @@ int BaseDevice::setValue(XMLEle *root, char *errmsg)
     }
     else if (!strcmp(rtag, "setBLOBVector"))
     {
-        IBLOBVectorProperty *bvp = getBLOB(name);
+        auto bvp = getBLOB(name);
 
-        if (bvp == nullptr)
+        if (!bvp)
             return -1;
 
         if (stateSet)
-            bvp->s = state;
+            bvp->setState(state);
 
         if (timeoutSet)
-            bvp->timeout = timeout;
+            bvp->setTimeout(timeout);
 
         return setBLOB(bvp, root, errmsg);
     }
@@ -941,16 +884,14 @@ void BaseDevice::registerProperty(INDI::Property &property)
 
 const char *BaseDevice::getDriverName() const
 {
-    ITextVectorProperty *driverInfo = getText("DRIVER_INFO");
+    auto driverInfo = getText("DRIVER_INFO");
 
-    if (driverInfo == nullptr)
+    if (!driverInfo)
         return nullptr;
 
-    IText *driverName = IUFindText(driverInfo, "DRIVER_NAME");
-    if (driverName)
-        return driverName->text;
+    auto driverName = driverInfo->findWidgetByName("DRIVER_NAME");
 
-    return nullptr;
+    return driverName ? driverName->getText() : nullptr;
 }
 
 
@@ -1006,44 +947,38 @@ void BaseDevice::registerProperty(PropertyView<IBLOB> *property)
 
 const char *BaseDevice::getDriverExec() const
 {
-    ITextVectorProperty *driverInfo = getText("DRIVER_INFO");
+    auto driverInfo = getText("DRIVER_INFO");
 
-    if (driverInfo == nullptr)
+    if (!driverInfo)
         return nullptr;
 
-    IText *driverExec = IUFindText(driverInfo, "DRIVER_EXEC");
-    if (driverExec)
-        return driverExec->text;
+    auto driverExec = driverInfo->findWidgetByName("DRIVER_EXEC");
 
-    return nullptr;
+    return driverExec ? driverExec->getText() : nullptr;
 }
 
 const char *BaseDevice::getDriverVersion() const
 {
-    ITextVectorProperty *driverInfo = getText("DRIVER_INFO");
+    auto driverInfo = getText("DRIVER_INFO");
 
-    if (driverInfo == nullptr)
+    if (!driverInfo)
         return nullptr;
 
-    IText *driverVersion = IUFindText(driverInfo, "DRIVER_VERSION");
-    if (driverVersion)
-        return driverVersion->text;
+    auto driverVersion = driverInfo->findWidgetByName("DRIVER_VERSION");
 
-    return nullptr;
+    return driverVersion ? driverVersion->getText() : nullptr;
 }
 
 uint16_t BaseDevice::getDriverInterface()
 {
-    ITextVectorProperty *driverInfo = getText("DRIVER_INFO");
+    auto driverInfo = getText("DRIVER_INFO");
 
-    if (driverInfo == nullptr)
+    if (!driverInfo)
         return 0;
 
-    IText *driverInterface = IUFindText(driverInfo, "DRIVER_INTERFACE");
-    if (driverInterface)
-        return atoi(driverInterface->text);
+    auto driverInterface = driverInfo->findWidgetByName("DRIVER_INTERFACE");
 
-    return 0;
+    return driverInterface ? atoi(driverInterface->getText()) : 0;
 }
 
 void BaseDevice::setMediator(INDI::BaseMediator *mediator)

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -151,7 +151,7 @@ public:
      *  @return If property is found, it is returned. To be used you must use static_cast with given the type of property
      *  returned.
      */
-    Property *getProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
+    Property getProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
 
     /** @brief Return a list of all properties in the device. */
     Properties *getProperties();

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -20,6 +20,7 @@
 
 #include "indibase.h"
 #include "indiproperty.h"
+#include "indiproperties.h"
 #include "indiutility.h"
 
 #include <string>
@@ -45,8 +46,8 @@ class BaseDevice
 {
     DECLARE_PRIVATE(BaseDevice)
 public:
-    //typedef std::deque<INDI::Property> Properties; // future
-    typedef std::vector<INDI::Property*> Properties;
+    typedef INDI::Properties Properties;
+    // typedef std::vector<INDI::Property*> Properties;
 
     /*! INDI error codes. */
     enum INDI_ERROR
@@ -154,8 +155,8 @@ public:
     Property getProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
 
     /** @brief Return a list of all properties in the device. */
-    Properties *getProperties();
-    const Properties *getProperties() const;
+    Properties getProperties();
+    const Properties getProperties() const;
 
 public:
     /** @brief Add message to the driver's message queue.

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -832,7 +832,7 @@ void DefaultDevice::ISGetProperties(const char *dev)
 
 void DefaultDevice::resetProperties()
 {
-    for (const auto &oneProperty : *getProperties())
+    for (auto &oneProperty : *getProperties())
     {
         oneProperty->setState(IPS_IDLE);
         oneProperty->apply();

--- a/libs/indibase/property/indiproperties.cpp
+++ b/libs/indibase/property/indiproperties.cpp
@@ -134,6 +134,30 @@ Properties::const_iterator Properties::end() const
     return d->properties.end();
 }
 
+Properties::iterator Properties::erase(iterator pos)
+{
+    D_PTR(Properties);
+    return d->properties.erase(pos);
+}
+
+Properties::iterator Properties::erase(const_iterator pos)
+{
+    D_PTR(Properties);
+    return d->properties.erase(pos);
+}
+
+Properties::iterator Properties::erase(iterator first, iterator last)
+{
+    D_PTR(Properties);
+    return d->properties.erase(first, last);
+}
+
+Properties::iterator Properties::erase(const_iterator first, const_iterator last)
+{
+    D_PTR(Properties);
+    return d->properties.erase(first, last);
+}
+
 #ifdef INDI_PROPERTIES_BACKWARD_COMPATIBILE
 INDI::Properties Properties::operator *()
 {

--- a/libs/indibase/property/indiproperties.cpp
+++ b/libs/indibase/property/indiproperties.cpp
@@ -1,0 +1,192 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include "indiproperties.h"
+#include "indiproperties_p.h"
+
+namespace INDI
+{
+
+PropertiesPrivate::PropertiesPrivate()
+{ }
+
+PropertiesPrivate::~PropertiesPrivate()
+{ }
+
+Properties::Properties()
+    : d_ptr(new PropertiesPrivate)
+{ }
+
+Properties::~Properties()
+{ }
+
+Properties::Properties(std::shared_ptr<PropertiesPrivate> dd)
+    : d_ptr(dd)
+{ }
+
+void Properties::push_back(const INDI::Property &property)
+{
+    D_PTR(Properties);
+    d->properties.push_back(property);
+}
+
+void Properties::push_back(INDI::Property &&property)
+{
+    D_PTR(Properties);
+    d->properties.push_back(std::move(property));
+}
+
+void Properties::clear()
+{
+    D_PTR(Properties);
+    d->properties.clear();
+}
+
+Properties::size_type Properties::size() const
+{
+    D_PTR(const Properties);
+    return d->properties.size();
+}
+
+Properties::reference Properties::at(size_type pos)
+{
+    D_PTR(Properties);
+    return d->properties.at(pos);
+}
+
+Properties::const_reference Properties::at(size_type pos) const
+{
+    D_PTR(const Properties);
+    return d->properties.at(pos);
+}
+
+Properties::reference Properties::operator[](Properties::size_type pos)
+{
+    D_PTR(Properties);
+    return d->properties.at(pos);
+}
+
+Properties::const_reference Properties::operator[](Properties::size_type pos) const
+{
+    D_PTR(const Properties);
+    return d->properties.at(pos);
+}
+
+Properties::reference Properties::front()
+{
+    D_PTR(Properties);
+    return d->properties.front();
+}
+
+Properties::const_reference Properties::front() const
+{
+    D_PTR(const Properties);
+    return d->properties.front();
+}
+
+Properties::reference Properties::back()
+{
+    D_PTR(Properties);
+    return d->properties.back();
+}
+
+Properties::const_reference Properties::back() const
+{
+    D_PTR(const Properties);
+    return d->properties.back();
+}
+
+Properties::iterator Properties::begin()
+{
+    D_PTR(Properties);
+    return d->properties.begin();
+}
+
+Properties::iterator Properties::end()
+{
+    D_PTR(Properties);
+    return d->properties.end();
+}
+
+Properties::const_iterator Properties::begin() const
+{
+    D_PTR(const Properties);
+    return d->properties.begin();
+}
+
+Properties::const_iterator Properties::end() const
+{
+    D_PTR(const Properties);
+    return d->properties.end();
+}
+
+#ifdef INDI_PROPERTIES_BACKWARD_COMPATIBILE
+INDI::Properties Properties::operator *()
+{
+    return *this;
+}
+
+const INDI::Properties Properties::operator *() const
+{
+    return *this;
+}
+
+Properties *Properties::operator->()
+{
+    return this;
+}
+
+const Properties *Properties::operator->() const
+{
+    return this;
+}
+
+Properties::operator Properties *()
+{
+    D_PTR(Properties);
+    return &d->self;
+}
+
+Properties::operator const Properties *() const
+{
+    D_PTR(const Properties);
+    return &d->self;
+}
+
+Properties::operator std::vector<INDI::Property *> *()
+{
+    D_PTR(Properties);
+    d->propertiesBC.resize(0);
+    d->propertiesBC.reserve(d->properties.size());
+    for (auto &it: d->properties)
+        d->propertiesBC.push_back(&it);
+
+    return &d->propertiesBC;
+}
+
+Properties::operator const std::vector<INDI::Property *> *() const
+{
+    D_PTR(const Properties);
+    d->propertiesBC.resize(0);
+    d->propertiesBC.reserve(d->properties.size());
+    for (auto &it: d->properties)
+        d->propertiesBC.push_back(const_cast<INDI::Property *>(&it));
+
+    return &d->propertiesBC;
+}
+#endif
+}

--- a/libs/indibase/property/indiproperties.h
+++ b/libs/indibase/property/indiproperties.h
@@ -1,0 +1,96 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include "indiproperty.h"
+#include "indimacros.h"
+#include <vector>
+#include <deque>
+
+#define INDI_PROPERTIES_BACKWARD_COMPATIBILE
+namespace INDI
+{
+
+class PropertiesPrivate;
+class Properties
+{
+    DECLARE_PRIVATE(Properties)
+
+public:
+    using iterator        = std::deque<INDI::Property>::iterator;
+    using const_iterator  = std::deque<INDI::Property>::const_iterator;
+    using reference       = std::deque<INDI::Property>::reference;
+    using const_reference = std::deque<INDI::Property>::const_reference;
+    using size_type       = std::deque<INDI::Property>::size_type;
+
+public:
+    Properties();
+    ~Properties();
+
+public:
+    void push_back(const INDI::Property &property);
+    void push_back(INDI::Property &&property);
+    void clear();
+
+public:
+    bool empty() const;
+
+public:
+    size_type size() const;
+
+public:
+    reference at(size_type pos);
+    const_reference at(size_type pos) const;
+
+    reference operator[](size_type pos);
+    const_reference operator[](size_type pos) const;
+
+    reference front();
+    const_reference front() const;
+
+    reference back();
+    const_reference back() const;
+
+public:
+    iterator begin();
+    iterator end();
+
+    const_iterator begin() const;
+    const_iterator end() const;
+
+public:
+#ifdef INDI_PROPERTIES_BACKWARD_COMPATIBILE
+    INDI::Properties operator *();
+    const INDI::Properties operator *() const;
+
+    Properties *operator->();
+    const Properties *operator->() const;
+
+    operator std::vector<INDI::Property *> *();
+    operator const std::vector<INDI::Property *> *() const;
+
+    operator Properties *();
+    operator const Properties *() const;
+#endif
+
+protected:
+    std::shared_ptr<PropertiesPrivate> d_ptr;
+    Properties(std::shared_ptr<PropertiesPrivate> dd);
+};
+
+}

--- a/libs/indibase/property/indiproperties.h
+++ b/libs/indibase/property/indiproperties.h
@@ -21,6 +21,7 @@
 #include "indimacros.h"
 #include <vector>
 #include <deque>
+#include <algorithm>
 
 #define INDI_PROPERTIES_BACKWARD_COMPATIBILE
 namespace INDI
@@ -74,6 +75,15 @@ public:
     const_iterator end() const;
 
 public:
+    iterator erase(iterator pos);
+    iterator erase(const_iterator pos);
+    iterator erase(iterator first, iterator last);
+    iterator erase(const_iterator first, const_iterator last);
+
+    template<typename Predicate>
+    iterator erase_if(Predicate predicate);
+
+public:
 #ifdef INDI_PROPERTIES_BACKWARD_COMPATIBILE
     INDI::Properties operator *();
     const INDI::Properties operator *() const;
@@ -92,5 +102,11 @@ protected:
     std::shared_ptr<PropertiesPrivate> d_ptr;
     Properties(std::shared_ptr<PropertiesPrivate> dd);
 };
+
+template<typename Predicate>
+inline Properties::iterator Properties::erase_if(Predicate predicate)
+{
+    return erase(std::remove_if(begin(), end(), predicate), end());
+}
 
 }

--- a/libs/indibase/property/indiproperties_p.h
+++ b/libs/indibase/property/indiproperties_p.h
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2021 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include "indiproperties.h"
+
+namespace INDI
+{
+
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+template <typename T>
+static inline std::shared_ptr<T> make_shared_weak(T *object)
+{
+    return std::shared_ptr<T>(object, [](T*){});
+}
+#endif
+
+class PropertiesPrivate
+{
+public:
+    PropertiesPrivate();
+    virtual ~PropertiesPrivate();
+
+public:
+    std::deque<INDI::Property> properties;
+#ifdef INDI_PROPERTIES_BACKWARD_COMPATIBILE
+    mutable std::vector<INDI::Property *> propertiesBC;
+    Properties self {make_shared_weak(this)};
+#endif    
+};
+
+}

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -61,6 +61,18 @@ PropertyPrivate::PropertyPrivate(IBLOBVectorProperty *property)
     , registered(property != nullptr)
 { }
 
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+Property::operator INDI::Property *()
+{
+    D_PTR(Property);
+    return isValid() ? &d->self : nullptr;
+}
+
+INDI::Property* Property::operator->()
+{
+    return this;
+}
+#endif
 
 #define PROPERTY_CASE(CODE) \
     switch (d->property != nullptr ? d->type : INDI_UNKNOWN) \
@@ -117,6 +129,10 @@ Property::~Property()
 
 Property::Property(PropertyPrivate &dd)
     : d_ptr(&dd)
+{ }
+
+Property::Property(std::shared_ptr<PropertyPrivate> dd)
+    : d_ptr(dd)
 { }
 
 void Property::setProperty(void *p)
@@ -294,11 +310,6 @@ bool Property::isValid() const
 {
     D_PTR(const Property);
     return d->type != INDI_UNKNOWN;
-}
-
-Property::operator bool() const
-{
-    return isValid();
 }
 
 bool Property::isNameMatch(const char *otherName) const

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -190,6 +190,20 @@ INDI_PROPERTY_TYPE Property::getType() const
     return d->property != nullptr ? d->type : INDI_UNKNOWN;
 }
 
+const char *Property::getTypeAsString() const
+{
+    switch (getType())
+    {
+    case INDI_NUMBER: return "INDI_NUMBER";
+    case INDI_SWITCH: return "INDI_SWITCH";
+    case INDI_TEXT: return "INDI_TEXT";
+    case INDI_LIGHT: return "INDI_LIGHT";
+    case INDI_BLOB: return "INDI_BLOB";
+    case INDI_UNKNOWN: return "INDI_UNKNOWN";
+    }
+    return "INDI_UNKNOWN";
+}
+
 bool Property::getRegistered() const
 {
     D_PTR(const Property);

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -62,15 +62,26 @@ PropertyPrivate::PropertyPrivate(IBLOBVectorProperty *property)
 { }
 
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+INDI::Property* Property::operator->()
+{
+    return this;
+}
+
+const INDI::Property* Property::operator->() const
+{
+    return this;
+}
+
 Property::operator INDI::Property *()
 {
     D_PTR(Property);
     return isValid() ? &d->self : nullptr;
 }
 
-INDI::Property* Property::operator->()
+Property::operator const INDI::Property *() const
 {
-    return this;
+    D_PTR(const Property);
+    return isValid() ? &d->self : nullptr;
 }
 #endif
 

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -117,8 +117,11 @@ public:
 
 public:
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
-    operator INDI::Property *();
     INDI::Property* operator->();
+    const INDI::Property* operator->() const;
+
+    operator INDI::Property *();
+    operator const INDI::Property *() const;
 #endif
 
 protected:

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -64,6 +64,7 @@ public:
 public:
     void *getProperty() const;
     INDI_PROPERTY_TYPE getType() const;
+    const char *getTypeAsString() const;
     bool getRegistered() const;
     bool isDynamic() const;
     BaseDevice *getBaseDevice() const;

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -28,7 +28,7 @@
 #include <memory>
 #include <cstdarg>
 
-
+#define INDI_PROPERTY_BACKWARD_COMPATIBILE
 namespace INDI
 {
 class BaseDevice;
@@ -91,7 +91,6 @@ public: // Convenience Functions
 public:
     bool isEmpty() const;
     bool isValid() const;
-    operator bool() const;
 
     bool isNameMatch(const char *otherName) const;
     bool isNameMatch(const std::string &otherName) const;
@@ -116,8 +115,15 @@ public:
     INDI::PropertyView<ILight>  *getLight() const;
     INDI::PropertyView<IBLOB>   *getBLOB() const;
 
+public:
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+    operator INDI::Property *();
+    INDI::Property* operator->();
+#endif
+
 protected:
     std::shared_ptr<PropertyPrivate> d_ptr;
+    Property(std::shared_ptr<PropertyPrivate> dd);
     Property(PropertyPrivate &dd);
 };
 

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -19,9 +19,18 @@
 #pragma once
 
 #include "indibase.h"
-
+#include "indiproperty.h"
+#include <memory>
 namespace INDI
 {
+
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+template <typename T>
+static inline std::shared_ptr<T> make_shared_weak(T *object)
+{
+    return std::shared_ptr<T>(object, [](T*){});
+}
+#endif
 
 class BaseDevice;
 class PropertyPrivate
@@ -41,6 +50,10 @@ public:
     PropertyPrivate(IBLOBVectorProperty *property);
 
     virtual ~PropertyPrivate();
+
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+    Property self {make_shared_weak(this)};
+#endif
 };
 
 }

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -260,6 +260,10 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
 
 public:
     WidgetView()                                           { memset(this, 0, sizeof(*this)); }
+    WidgetView(const WidgetView &other): Type(other)       { this->text = nullptr; setText(other.text); }
+    WidgetView(WidgetView &&other): Type(other)            { memset(static_cast<Type*>(&other), 0, sizeof(other)); }
+    WidgetView &operator=(const WidgetView &other)         { return *this = WidgetView(other); }
+    WidgetView &operator=(WidgetView &&other)              { std::swap(static_cast<Type&>(other), static_cast<Type&>(*this)); return *this; }
     ~WidgetView()                                          { free(this->text); }
     void clear()                                           { free(this->text); memset(this, 0, sizeof(*this)); }
     // bool isNull() const                                    { return reinterpret_cast<const void*>(this) == nullptr; }
@@ -312,6 +316,10 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
 
 public:
     WidgetView()                                           { memset(this, 0, sizeof(*this)); }
+    WidgetView(const WidgetView &other): Type(other)       { }
+    WidgetView(WidgetView &&other): Type(other)            { memset(static_cast<Type*>(&other), 0, sizeof(other)); }
+    WidgetView &operator=(const WidgetView &other)         { return *this = WidgetView(other); }
+    WidgetView &operator=(WidgetView &&other)              { std::swap(static_cast<Type&>(other), static_cast<Type&>(*this)); return *this; }
     ~WidgetView()                                          { }
     void clear()                                           { memset(this, 0, sizeof(*this)); }
     // bool isNull() const                                    { return reinterpret_cast<const void*>(this) == nullptr; }
@@ -375,6 +383,10 @@ struct WidgetView<ISwitch>: PROPERTYVIEW_BASE_ACCESS ISwitch
 
 public:
     WidgetView()                                           { memset(this, 0, sizeof(*this)); }
+    WidgetView(const WidgetView &other): Type(other)       { }
+    WidgetView(WidgetView &&other): Type(other)            { memset(static_cast<Type*>(&other), 0, sizeof(other)); }
+    WidgetView &operator=(const WidgetView &other)         { return *this = WidgetView(other); }
+    WidgetView &operator=(WidgetView &&other)              { std::swap(static_cast<Type&>(other), static_cast<Type&>(*this)); return *this; }
     ~WidgetView()                                          { }
     void clear()                                           { memset(this, 0, sizeof(*this)); }
     // bool isNull() const                                    { return reinterpret_cast<const void*>(this) == nullptr; }
@@ -428,6 +440,10 @@ struct WidgetView<ILight>: PROPERTYVIEW_BASE_ACCESS ILight
 
 public:
     WidgetView()                                           { memset(this, 0, sizeof(*this)); }
+    WidgetView(const WidgetView &other): Type(other)       { }
+    WidgetView(WidgetView &&other): Type(other)            { memset(static_cast<Type*>(&other), 0, sizeof(other)); }
+    WidgetView &operator=(const WidgetView &other)         { return *this = WidgetView(other); }
+    WidgetView &operator=(WidgetView &&other)              { std::swap(static_cast<Type&>(other), static_cast<Type&>(*this)); return *this; }
     ~WidgetView()                                          { }
     void clear()                                           { memset(this, 0, sizeof(*this)); }
     // bool isNull() const                                    { return reinterpret_cast<const void*>(this) == nullptr; }
@@ -481,8 +497,12 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
 
 public:
     WidgetView()                                           { memset(this, 0, sizeof(*this)); }
-    ~WidgetView()                                          { free(this->blob); }
-    void clear()                                           { free(this->blob); memset(this, 0, sizeof(*this)); }
+    WidgetView(const WidgetView &other): Type(other)       { }
+    WidgetView(WidgetView &&other): Type(other)            { memset(static_cast<Type*>(&other), 0, sizeof(other)); }
+    WidgetView &operator=(const WidgetView &other)         { return *this = WidgetView(other); }
+    WidgetView &operator=(WidgetView &&other)              { std::swap(static_cast<Type&>(other), static_cast<Type&>(*this)); return *this; }
+    ~WidgetView()                                          { /* free(this->blob); */ }
+    void clear()                                           { /* free(this->blob); */ memset(this, 0, sizeof(*this)); }
     // bool isNull() const                                    { return reinterpret_cast<const void*>(this) == nullptr; }
 
 public: // setters

--- a/libs/lx/Lx.cpp
+++ b/libs/lx/Lx.cpp
@@ -562,8 +562,8 @@ int Lx::stopLxSerial()
 
 INDI::Property *Lx::findbyLabel(INDI::DefaultDevice *dev, char *label)
 {
-    for(const auto &oneProperty: *dev->getProperties())
-        if (!strcmp(oneProperty->getLabel(), label))
+    for(auto &oneProperty: *dev->getProperties())
+        if (oneProperty->isLabelMatch(label))
             return oneProperty;
     return nullptr;
 }


### PR DESCRIPTION
Hi!

I have an idea of how to get rid of completely raw pointers in the future.

Linked: https://github.com/indilib/indi/issues/1449

### Current implementation
For example:
https://github.com/indilib/indi/blob/07e51770a2d5c1853d931b66656ab3836b0941b5/libs/indibase/basedevice.h#L147-L155

Current usage example:
```cpp
INDI::Property *pointerProperty = device->getProperty("HELLO");
```
If the BaseDevice object is destroyed, the pointer expires.


### Current solution
This problem can be solved already when using the function, e.g. like this:
```cpp
INDI::Property sharedProperty = *device->getProperty("HELLO");
```

### Idiot-proof solution
The current possibility to solve the problem is not ideal because you have to remember this '_Current solution_'.

`INDI::Property` have a built-in `std::shared_ptr` that enables secure data sharing. A nice solution would be for the function to return an object, not a pointer.

```cpp
Property getProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const; 
```

Unfortunately, this breaks the backward compatibility.

However, the conversion to pointer operator can take care of this.
```cpp
Property::operator INDI::Property *()
{
    return
        /* 1 */ isValid() ?
        /* 2 */ THIS :
        /* 3 */ nullptr;
}
```

1. Return `nullptr` if Property is invalid - `type == INDI_UNKNOWN`
    This is very important (backward compatibility), for comparing a pointer to nullptr.
     `INDI::Property() == nullptr` returns `true` and `INDI::PropertySwitch() == nullptr` returns `false`
2. `this` cannot be used. The function returns the object, the operator returns the address to it, and then the object is destroyed. We have a pointer to nowhere. The solution is to create an `Property` object that stores shared data (already exists) and place it in the data.
3. See 1. ;)

### Finally
You can use new ```Property BaseDevice::getProperty(....)``` function!

Old unsafe way:
```cpp
INDI::Property *prop = device->getProperty("UNSAFE");
if (prop != nullptr)
    std::cout << prop->getStateAsString() << std::endl;
```

Ane new safe way:
```cpp
INDI::Property prop = device->getProperty("SAFE");
if (prop != nullptr) // or prop.isValid()
    std::cout << prop.getStateAsString() << std::endl;
```

Or (preferred)
```cpp
auto prop = device->getProperty("SAFE");
if (prop.isValid())
    std::cout << prop.getStateAsString() << std::endl;
```

## Give it a try!
It is really safe even if you don't check if the object exists.
```cpp
#include <indibase.h>
#include <indiproperty.h>
#include <iostream>

int main(int, char*[])
{
    std::cout << INDI::BaseDevice().getProperty("non-exist").getStateAsString() << std::endl; // prints "Alert"
    return 0;
}
```

### What's next
I think I can rewrite most of the functions this way, we can add `deprecated` at a later stage.
Operators will spit out warnings to migrate completely to a safe form of function handling.

The case with virtual functions is a bit worse. Of course, all mechanisms will work, but it will require changes, e.g.
```cpp
class Foo: public INDI::BaseMediator
{
public:
    // void newProperty(INDI::Property *property) override; // old API
    void newProperty(INDI::Property property) override; // new API
```
The transition will be simple, it doesn't require changing the implementation of the function.
Remember `INDI::Property property` still behaves like a pointer.

## To Merge Or Not To Merge
I would definitely ask you to check if everything is ok.
@knro you are a specialist, I'll be glad if you find _(or don't find)_ a problem. ;)

If everything is OK, I will keep developing the concept. You can then think about making changes gradually.