### PR TITLE
Replace gethostbyname with getaddrinfo

### DIFF
--- a/indiserver.c
+++ b/indiserver.c
@@ -683,31 +683,38 @@ static void startRemoteDvr(DvrInfo *dp)
  */
 static int openINDIServer(char host[], int indi_port)
 {
-    struct sockaddr_in serv_addr;
-    struct hostent *hp;
-    int sockfd;
+    struct addrinfo *result, *ptr;
+    struct addrinfo hints = {};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
 
     /* lookup host address */
-    hp = gethostbyname(host);
-    if (!hp)
-    {
-        fprintf(stderr, "gethostbyname(%s): %s\n", host, strerror(errno));
+    int len = snprintf(NULL, 0, "%d", indi_port);
+    char *indi_port_str = malloc(len + 1 );
+    snprintf(indi_port_str, len + 1, "%d", indi_port);
+    int ret = getaddrinfo(host, indi_port_str, &hints, &result);
+    if (ret != 0) {
+        fprintf(stderr, "getaddrinfo(%s): %s\n", host, gai_strerror(ret));
         Bye();
+    }
+    free(indi_port_str);
+
+    for (ptr = result; ptr != NULL; ptr = ptr->ai_next) {
+        if (ptr->ai_family == AF_INET || ptr->ai_family == AF_INET6) {
+            break;
+        }
     }
 
     /* create a socket to the INDI server */
-    (void)memset((char *)&serv_addr, 0, sizeof(serv_addr));
-    serv_addr.sin_family      = AF_INET;
-    serv_addr.sin_addr.s_addr = ((struct in_addr *)(hp->h_addr_list[0]))->s_addr;
-    serv_addr.sin_port        = htons(indi_port);
-    if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+    int sockfd;
+    if ((sockfd = socket(ptr->ai_family, SOCK_STREAM, 0)) < 0)
     {
         fprintf(stderr, "socket(%s,%d): %s\n", host, indi_port, strerror(errno));
         Bye();
     }
 
     /* connect */
-    if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+    if (connect(sockfd, ptr->ai_addr, ptr->ai_addrlen) < 0)
     {
         fprintf(stderr, "connect(%s,%d): %s\n", host, indi_port, strerror(errno));
         Bye();

--- a/tools/getINDIproperty.c
+++ b/tools/getINDIproperty.c
@@ -280,33 +280,40 @@ static void addSearchDef(char *dev, char *prop, char *ele)
  */
 static void openINDIServer(void)
 {
-    struct sockaddr_in serv_addr;
-    struct hostent *hp;
-    int sockfd;
+    struct addrinfo *result, *ptr;
+    struct addrinfo hints = {};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
 
     /* lookup host address */
-    hp = gethostbyname(host);
-    if (!hp)
-    {
-        herror("gethostbyname");
+    int len = snprintf(NULL, 0, "%d", port);
+    char *indi_port_str = malloc(len + 1 );
+    snprintf(indi_port_str, len + 1, "%d", port);
+    int ret = getaddrinfo(host, indi_port_str, &hints, &result);
+    if (ret != 0) {
+        fprintf(stderr, "getaddrinfo(%s): %s\n", host, gai_strerror(ret));
         exit(2);
+    }
+    free(indi_port_str);
+
+    for (ptr = result; ptr != NULL; ptr = ptr->ai_next) {
+        if (ptr->ai_family == AF_INET || ptr->ai_family == AF_INET6) {
+            break;
+        }
     }
 
     /* create a socket to the INDI server */
-    (void)memset((char *)&serv_addr, 0, sizeof(serv_addr));
-    serv_addr.sin_family      = AF_INET;
-    serv_addr.sin_addr.s_addr = ((struct in_addr *)(hp->h_addr_list[0]))->s_addr;
-    serv_addr.sin_port        = htons(port);
-    if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+    int sockfd;
+    if ((sockfd = socket(ptr->ai_family, SOCK_STREAM, 0)) < 0)
     {
-        perror("socket");
+        fprintf(stderr, "socket(%s,%d): %s\n", host, port, strerror(errno));
         exit(2);
     }
 
     /* connect */
-    if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+    if (connect(sockfd, ptr->ai_addr, ptr->ai_addrlen) < 0)
     {
-        perror("connect");
+        fprintf(stderr, "connect(%s,%d): %s\n", host, port, strerror(errno));
         exit(2);
     }
 

--- a/tools/setINDIproperty.c
+++ b/tools/setINDIproperty.c
@@ -318,33 +318,40 @@ static int crackSpec(int *acp, char **avp[])
  */
 static void openINDIServer(FILE **rfpp, FILE **wfpp)
 {
-    struct sockaddr_in serv_addr;
-    struct hostent *hp;
-    int sockfd;
+    struct addrinfo *result, *ptr;
+    struct addrinfo hints = {};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
 
     /* lookup host address */
-    hp = gethostbyname(host);
-    if (!hp)
-    {
-        perror("gethostbyname");
+    int len = snprintf(NULL, 0, "%d", port);
+    char *indi_port_str = malloc(len + 1 );
+    snprintf(indi_port_str, len + 1, "%d", port);
+    int ret = getaddrinfo(host, indi_port_str, &hints, &result);
+    if (ret != 0) {
+        fprintf(stderr, "getaddrinfo(%s): %s\n", host, gai_strerror(ret));
         exit(2);
+    }
+    free(indi_port_str);
+
+    for (ptr = result; ptr != NULL; ptr = ptr->ai_next) {
+        if (ptr->ai_family == AF_INET || ptr->ai_family == AF_INET6) {
+            break;
+        }
     }
 
     /* create a socket to the INDI server */
-    (void)memset((char *)&serv_addr, 0, sizeof(serv_addr));
-    serv_addr.sin_family      = AF_INET;
-    serv_addr.sin_addr.s_addr = ((struct in_addr *)(hp->h_addr_list[0]))->s_addr;
-    serv_addr.sin_port        = htons(port);
-    if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
+    int sockfd;
+    if ((sockfd = socket(ptr->ai_family, SOCK_STREAM, 0)) < 0)
     {
-        perror("socket");
+        fprintf(stderr, "socket(%s,%d): %s\n", host, port, strerror(errno));
         exit(2);
     }
 
     /* connect */
-    if (connect(sockfd, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0)
+    if (connect(sockfd, ptr->ai_addr, ptr->ai_addrlen) < 0)
     {
-        perror("connect");
+        fprintf(stderr, "connect(%s,%d): %s\n", host, port, strerror(errno));
         exit(2);
     }
 


### PR DESCRIPTION
As per the man page (`man 3 gethostbyname`), both `gethostbyname` and `gethostbyaddr` are obsolete functions that should be replaced by `getaddrinfo` and `getnameinfo`.

What's been tested:
- [x] compile against latest master :heavy_check_mark: 
- [x] compile against latest stable (1.9.0) :heavy_check_mark: 
- [x] test with hardware (tried with Nikon + ASI, all good. Capturing image, stopping server, restarting server, no issues) :heavy_check_mark: 

I've opened the PR before the "real world scenario test", so I can get a code review in the meanwhile :)