### PR TITLE
Fixing location accuracy and date&time for RST-135

### DIFF
--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -420,18 +420,18 @@ int getCalendarDate(int fd, char *date)
     }
     else
     {
-        LOGF_INFO("Date response length: %d", len);
+        LOGF_WARN("Date response length: %d", len);
         if (len == 12)
         {
             /* Rainbowastro format includes ":GC" so has to skip 3 characters */
             /* format is :GCMM/DD/YY# = 12 characters*/
-            LOG_INFO("Rainbowastro detected");
+            LOG_WARN("Rainbowastro detected");
             nbytes_read = sscanf(date + 3, "%d%*c%d%*c%d", &mm, &dd, &yy);
         }
         else
         {
             /* Meade format is MM/DD/YY */
-            LOG_INFO("Meade detected");
+            LOG_WARN("Meade detected");
             nbytes_read = sscanf(date, "%d%*c%d%*c%d", &mm, &dd, &yy);
         }
         if (nbytes_read < 3)

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -420,15 +420,18 @@ int getCalendarDate(int fd, char *date)
     }
     else
     {
+        LOG_INFO("Date response length: %d", len);
         if (len == 12)
         {
             /* Rainbowastro format includes ":GC" so has to skip 3 characters */
-            /* format is :GCMM/DD/YY */
+            /* format is :GCMM/DD/YY# = 12 characters*/
+            LOG_INFO("Rainbowastro detected");
             nbytes_read = sscanf(date + 3, "%d%*c%d%*c%d", &mm, &dd, &yy);
         }
         else
         {
             /* Meade format is MM/DD/YY */
+            LOG_INFO("Meade detected");
             nbytes_read = sscanf(date, "%d%*c%d%*c%d", &mm, &dd, &yy);
         }
         if (nbytes_read < 3)

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -420,17 +420,8 @@ int getCalendarDate(int fd, char *date)
     }
     else
     {
-        if (len > 10)
-        {
-            /* Rainbowastro format includes ":GC" so has to skip 3 characters */
-            /* format is :GCMM/DD/YY# = 12 characters*/
-            nbytes_read = sscanf(date + 3, "%d%*c%d%*c%d", &mm, &dd, &yy);
-        }
-        else
-        {
-            /* Meade format is MM/DD/YY */
-            nbytes_read = sscanf(date, "%d%*c%d%*c%d", &mm, &dd, &yy);
-        }
+        /* Meade format is MM/DD/YY */
+        nbytes_read = sscanf(date, "%d%*c%d%*c%d", &mm, &dd, &yy);
         if (nbytes_read < 3)
             return -1;
         /* We consider years 50 or more to be in the last century, anything less in the 21st century.*/

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -420,7 +420,7 @@ int getCalendarDate(int fd, char *date)
     }
     else
     {
-        LOG_INFO("Date response length: %d", len);
+        LOGF_INFO("Date response length: %d", len);
         if (len == 12)
         {
             /* Rainbowastro format includes ":GC" so has to skip 3 characters */

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -375,19 +375,19 @@ int isSlewComplete(int fd)
         return error_type;
 
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "RES <%s>", data);
-/* update for slewComplete
-
+/* update for slewComplete 
+   
    The below should handle classic lx200, autostar and autostar 2
    classic returns string of 33 bytes, and non space (0x20) before terminator is not done yet
    autostar and autostar 2 return a few bytes, with '#' terminator
-      first char
+      first char 
 */
     for(i=0;i<33;i++) {
 	if(data[i] == '#') return 1;
 	if(data[i] != 0x20) return 0;
     }
     return 1;
-/* out for slewComplete update
+/* out for slewComplete update 
     if (data[0] == '#')
         return 1;
     else
@@ -567,37 +567,37 @@ int getSiteLatitudeAlt(int fd, int *dd, int *mm, double *ssf, const char *cmd)
     char read_buffer[RB_MAX_LEN]={0};
     int error_type;
     int nbytes_write = 0, nbytes_read = 0;
-
+    
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "CMD <%s>", cmd);
-
+    
     /* Add mutex */
     std::unique_lock<std::mutex> guard(lx200CommsLock);
-
+    
     tcflush(fd, TCIFLUSH);
-
+    
     if ((error_type = tty_write_string(fd, cmd, &nbytes_write)) != TTY_OK)
         return error_type;
-
+    
     error_type = tty_nread_section(fd, read_buffer, RB_MAX_LEN, '#', LX200_TIMEOUT, &nbytes_read);
-
+    
     tcflush(fd, TCIFLUSH);
-
+    
     if (nbytes_read < 1)
         return error_type;
-
+    
     read_buffer[nbytes_read - 1] = '\0';
-
+    
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "RES <%s>", read_buffer);
-
+    
     *ssf = 0.0;
     if (sscanf(read_buffer, "%d%*c%d:%lf", dd, mm, ssf) < 2)
     {
         DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Unable to parse %s response", cmd);
         return -1;
     }
-
+    
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "VAL [%d,%d,%.1lf]", *dd, *mm, *ssf);
-
+    
     int new_geo_format;
     switch (nbytes_read) {
         case 9:
@@ -617,7 +617,7 @@ int getSiteLatitudeAlt(int fd, int *dd, int *mm, double *ssf, const char *cmd)
         DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Updated geographic precision from setting %d to %d", geo_format, new_geo_format);
         geo_format = new_geo_format;
     }
-
+    
     return 0;
 }
 
@@ -637,31 +637,31 @@ int getSiteLongitudeAlt(int fd, int *ddd, int *mm, double *ssf, const char *cmd)
     //  emulation, high precision
     // Extended emulation, high precision    sDDD*MM:SS# (sign, degrees, arcminutes, arcseconds)
     // Any emulation, ultra precision        sDDD:MM:SS.S# (sign, degrees, arcminutes, arcseconds, tenths of arcsecond)
-
+    
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "<%s>", __FUNCTION__);
     char read_buffer[RB_MAX_LEN]={0};
     int error_type;
     int nbytes_write = 0, nbytes_read = 0;
-
+    
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "CMD <%s>", cmd);
-
+    
     /* Add mutex */
     std::unique_lock<std::mutex> guard(lx200CommsLock);
-
+    
     if ((error_type = tty_write_string(fd, cmd, &nbytes_write)) != TTY_OK)
         return error_type;
-
+    
     error_type = tty_nread_section(fd, read_buffer, RB_MAX_LEN, '#', LX200_TIMEOUT, &nbytes_read);
-
+    
     tcflush(fd, TCIFLUSH);
-
+    
     if (nbytes_read < 1)
         return error_type;
-
+    
     read_buffer[nbytes_read - 1] = '\0';
-
+    
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "RES <%s>", read_buffer);
-
+    
     *ssf = 0.0;
     if (sscanf(read_buffer, "%d%*c%d:%lf", ddd, mm, ssf) < 2)
     {
@@ -669,9 +669,9 @@ int getSiteLongitudeAlt(int fd, int *ddd, int *mm, double *ssf, const char *cmd)
         return -1;
     }
     *ddd *= -1.0; // Convert LX200Longitude to CartographicLongitude
-
+    
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "VAL in CartographicLongitude format [%d,%d,%.1lf]", *ddd, *mm, *ssf);
-
+    
     int new_geo_format;
     switch (nbytes_read) {
         case 10:
@@ -691,7 +691,7 @@ int getSiteLongitudeAlt(int fd, int *ddd, int *mm, double *ssf, const char *cmd)
         DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Updated geographic precision from setting %d to %d", geo_format, new_geo_format);
         geo_format = new_geo_format;
     }
-
+    
     return 0;
 }
 
@@ -950,7 +950,7 @@ int setObjectRA(int fd, double ra)
             break;
         default:
             DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Unknown controller_format <%d>", eq_format);
-            return -1;
+            return -1;            
     }
 
     return (setStandardProcedure(fd, read_buffer));
@@ -995,7 +995,7 @@ int setObjectDEC(int fd, double dec)
             break;
         default:
             DEBUGFDEVICE(lx200Name, DBG_SCOPE, "Unknown controller_format <%d>", eq_format);
-            return -1;
+            return -1;            
     }
 
     return (setStandardProcedure(fd, read_buffer));
@@ -1380,12 +1380,12 @@ int setPreciseTrackFreq(int fd, double trackF)
 {
 	DEBUGFDEVICE(lx200Name, DBG_SCOPE, "<%s>", __FUNCTION__);
 	char read_buffer[RB_MAX_LEN]={0};
-
+	
 	snprintf(read_buffer, sizeof(read_buffer), ":ST %08.5f#", trackF);
 
 /* Add mutex */
 /*    std::unique_lock<std::mutex> guard(lx200CommsLock); */
-
+	
 	return (setStandardProcedure(fd, read_buffer));
 }
 
@@ -1421,7 +1421,7 @@ int Slew(int fd)
 
     DEBUGFDEVICE(lx200Name, DBG_SCOPE, "RES <%c>", slewNum[0]);
 
-    error_type = slewNum[0] - '0';
+    error_type = slewNum[0] - '0'; 
     if ((error_type >= 0) && (error_type <= 9)) {
         return error_type;
     } else {
@@ -1534,7 +1534,7 @@ int HaltMovement(int fd, int direction)
                 return error_type;
             break;
         default:
-            return -1;
+            return -1;            
     }
 
     tcflush(fd, TCIFLUSH);
@@ -1622,7 +1622,7 @@ int selectSite(int fd, int siteNum)
                 return error_type;
             break;
         default:
-            return -1;
+            return -1;            
     }
 
     tcflush(fd, TCIFLUSH);

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -420,18 +420,15 @@ int getCalendarDate(int fd, char *date)
     }
     else
     {
-        LOGF_WARN("Date response length: %d", len);
-        if (len == 12)
+        if (len > 10)
         {
             /* Rainbowastro format includes ":GC" so has to skip 3 characters */
             /* format is :GCMM/DD/YY# = 12 characters*/
-            LOG_WARN("Rainbowastro detected");
             nbytes_read = sscanf(date + 3, "%d%*c%d%*c%d", &mm, &dd, &yy);
         }
         else
         {
             /* Meade format is MM/DD/YY */
-            LOG_WARN("Meade detected");
             nbytes_read = sscanf(date, "%d%*c%d%*c%d", &mm, &dd, &yy);
         }
         if (nbytes_read < 3)

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1231,6 +1231,7 @@ bool Rainbow::getLocalTime(char *timeString)
     {
         double ctime = 0;
         int h, m, s;
+        char response[DRIVER_LEN] = {0};
         //getLocalTime24(PortFD, &ctime);
         if (!sendCommand(":GL#", response))
             return false;

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1235,20 +1235,20 @@ bool Rainbow::getLocalTime(char *timeString)
         //getLocalTime24(PortFD, &ctime);
         if (!sendCommand(":GL#", response))
             return false;
-        LOG_INFO("Time received: %s", response);
+        LOGF_INFO("Time received: %s", response);
 
         if (sscanf(response + 3, "%d:%d:%d", &h, &m, &s) != 3)
         {
             LOG_WARN("Failed to get time from device.");
             return false;
         }
-        LOG_INFO("Hours scanned: %d", h);
-        LOG_INFO("Minutes scanned: %d", m);
-        LOG_INFO("Seconds scanned: %d", s);
+        LOGF_INFO("Hours scanned: %d", h);
+        LOGF_INFO("Minutes scanned: %d", m);
+        LOGF_INFO("Seconds scanned: %d", s);
         getSexComponents(ctime, &h, &m, &s);
-        LOG_INFO("Hours after getSexComponents: %d", h);
-        LOG_INFO("Minutes after getSexComponents: %d", m);
-        LOG_INFO("Seconds after getSexComponents: %d", s);
+        LOGF_INFO("Hours after getSexComponents: %d", h);
+        LOGF_INFO("Minutes after getSexComponents: %d", m);
+        LOGF_INFO("Seconds after getSexComponents: %d", s);
         snprintf(timeString, MAXINDINAME, "%02d:%02d:%02d", h, m, s);
     }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1218,7 +1218,7 @@ void Rainbow::addGuideTimer(Direction direction, uint32_t ms)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Get Time from RST-135
+/// Get Time from mount
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::getLocalTime(char *timeString)
 {
@@ -1246,7 +1246,7 @@ bool Rainbow::getLocalTime(char *timeString)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Get Date from RST-135
+/// Get Date from mount
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::getLocalDate(char *dateString)
 {
@@ -1275,7 +1275,7 @@ bool Rainbow::getLocalDate(char *dateString)
             else
                 strncpy(mell_prefix, "20", 3);
             /* We need to have it in YYYY-MM-DD ISO format */
-            snprintf(response + 3, 32, "%s%02d-%02d-%02d", mell_prefix, yy, mm, dd);
+            snprintf(dateString, 32, "%s%02d-%02d-%02d", mell_prefix, yy, mm, dd);
         }
     }
 
@@ -1283,7 +1283,7 @@ bool Rainbow::getLocalDate(char *dateString)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// GET UTC offset from RST-135
+/// GET UTC offset from mount
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::getUTFOffset(double *offset)
 {
@@ -1311,7 +1311,7 @@ bool Rainbow::getUTFOffset(double *offset)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Get Time and Date from RST-135
+/// Get Time and Date from mount
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::sendScopeTime()
 {
@@ -1381,7 +1381,7 @@ bool Rainbow::sendScopeTime()
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Get Location from RST-135
+/// Get Location from mount
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::sendScopeLocation()
 {

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1236,7 +1236,7 @@ bool Rainbow::getLocalTime(char *timeString)
         if (!sendCommand(":GL#", response))
             return false;
 
-        if (sscanf(response + 3, "%d%:%d%:%d", &h, &m, &s) != 3)
+        if (sscanf(response + 3, "%d:%d:%d", &h, &m, &s) != 3)
         {
             LOG_WARN("Failed to get time from device.");
             return false;

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1375,9 +1375,9 @@ bool Rainbow::sendScopeLocation()
     else
     {
         if (dd > 0)
-            LocationNP.np[LOCATION_LATITUDE].value = dd + mm / 60.0;
+            LocationNP.np[LOCATION_LATITUDE].value = dd + mm / 60.0 + ssf / 3600.0;
         else
-            LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0;
+            LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0 + ssf / 3600.0;
     }
 
     // Longitude
@@ -1392,9 +1392,9 @@ bool Rainbow::sendScopeLocation()
     else
     {
         if (dd > 0)
-            LocationNP.np[LOCATION_LONGITUDE].value = 360.0 - (dd + mm / 60.0);
+            LocationNP.np[LOCATION_LONGITUDE].value = 360.0 - (dd + mm / 60.0 + ssf / 3600.0);
         else
-            LocationNP.np[LOCATION_LONGITUDE].value = (dd - mm / 60.0) * -1.0;
+            LocationNP.np[LOCATION_LONGITUDE].value = (dd - mm / 60.0 - ssf / 3600.0) * -1.0;
 
     }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1218,7 +1218,7 @@ void Rainbow::addGuideTimer(Direction direction, uint32_t ms)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Send Time
+/// Get Time from RST-135
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::getLocalTime(char *timeString)
 {
@@ -1231,7 +1231,15 @@ bool Rainbow::getLocalTime(char *timeString)
     {
         double ctime = 0;
         int h, m, s;
-        getLocalTime24(PortFD, &ctime);
+        //getLocalTime24(PortFD, &ctime);
+        if (!sendCommand(":GL#", response))
+            return false;
+
+        if (sscanf(response + 3, "%d%:%d%:%d", &h, &m, &s) != 3)
+        {
+            LOG_WARN("Failed to get time from device.");
+            return false;
+        }
         getSexComponents(ctime, &h, &m, &s);
         snprintf(timeString, MAXINDINAME, "%02d:%02d:%02d", h, m, s);
     }
@@ -1240,7 +1248,7 @@ bool Rainbow::getLocalTime(char *timeString)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Send Time
+/// Get Date from RST-135
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::getLocalDate(char *dateString)
 {
@@ -1251,14 +1259,14 @@ bool Rainbow::getLocalDate(char *dateString)
     }
     else
     {
-        getCalendarDate(PortFD, dateString);
+        getCalendarDate(PortFD, dateString); // skipping of serial command in answer is handled in lx200driver.cpp
     }
 
     return true;
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Send Time
+/// GET UTC offset from RST-135
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::getUTFOffset(double *offset)
 {
@@ -1276,7 +1284,7 @@ bool Rainbow::getUTFOffset(double *offset)
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Send Time
+/// Get Time and Date from RST-135
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::sendScopeTime()
 {
@@ -1346,7 +1354,7 @@ bool Rainbow::sendScopeTime()
 }
 
 /////////////////////////////////////////////////////////////////////////////
-/// Send Location
+/// Get Location from RST-135
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::sendScopeLocation()
 {

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1235,20 +1235,20 @@ bool Rainbow::getLocalTime(char *timeString)
         //getLocalTime24(PortFD, &ctime);
         if (!sendCommand(":GL#", response))
             return false;
-        LOGF_INFO("Time received: %s", response);
+        LOGF_WARN("Time received: %s", response);
 
         if (sscanf(response + 3, "%d:%d:%d", &h, &m, &s) != 3)
         {
             LOG_WARN("Failed to get time from device.");
             return false;
         }
-        LOGF_INFO("Hours scanned: %d", h);
-        LOGF_INFO("Minutes scanned: %d", m);
-        LOGF_INFO("Seconds scanned: %d", s);
+        LOGF_WARN("Hours scanned: %d", h);
+        LOGF_WARN("Minutes scanned: %d", m);
+        LOGF_WARN("Seconds scanned: %d", s);
         getSexComponents(ctime, &h, &m, &s);
-        LOGF_INFO("Hours after getSexComponents: %d", h);
-        LOGF_INFO("Minutes after getSexComponents: %d", m);
-        LOGF_INFO("Seconds after getSexComponents: %d", s);
+        LOGF_WARN("Hours after getSexComponents: %d", h);
+        LOGF_WARN("Minutes after getSexComponents: %d", m);
+        LOGF_WARN("Seconds after getSexComponents: %d", s);
         snprintf(timeString, MAXINDINAME, "%02d:%02d:%02d", h, m, s);
     }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1235,20 +1235,12 @@ bool Rainbow::getLocalTime(char *timeString)
         //getLocalTime24(PortFD, &ctime);
         if (!sendCommand(":GL#", response))
             return false;
-        LOGF_WARN("Time received: %s", response);
 
         if (sscanf(response + 3, "%d:%d:%d", &h, &m, &s) != 3)
         {
             LOG_WARN("Failed to get time from device.");
             return false;
         }
-        LOGF_WARN("Hours scanned: %d", h);
-        LOGF_WARN("Minutes scanned: %d", m);
-        LOGF_WARN("Seconds scanned: %d", s);
-        getSexComponents(ctime, &h, &m, &s);
-        LOGF_WARN("Hours after getSexComponents: %d", h);
-        LOGF_WARN("Minutes after getSexComponents: %d", m);
-        LOGF_WARN("Seconds after getSexComponents: %d", s);
         snprintf(timeString, MAXINDINAME, "%02d:%02d:%02d", h, m, s);
     }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1257,8 +1257,6 @@ bool Rainbow::getLocalDate(char *dateString)
     }
     else
     {
-        getCalendarDate(PortFD, dateString); // skipping of serial command in answer is handled in lx200driver.cpp
-
         int dd, mm, yy;
         char response[DRIVER_LEN] = {0};
         char mell_prefix[3]={0};

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1287,7 +1287,7 @@ bool Rainbow::getUTFOffset(double *offset)
     }
 
     // LX200 TimeT Offset is defined at the number of hours added to LOCAL TIME to get TimeT. This is contrary to the normal definition.
-    *offset = lx200_utc_offset * -1;
+    *offset = rst135_utc_offset * -1;
     return true;
 }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1258,6 +1258,27 @@ bool Rainbow::getLocalDate(char *dateString)
     else
     {
         getCalendarDate(PortFD, dateString); // skipping of serial command in answer is handled in lx200driver.cpp
+
+        int dd, mm, yy;
+        char response[DRIVER_LEN] = {0};
+        char mell_prefix[3]={0};
+        if (!sendCommand(":GC#", response))
+            return false;
+
+        if (sscanf(response + 3, "%d%*c%d%*c%d", &mm, &dd, &yy) != 3)
+        {
+            LOG_WARN("Failed to get date from device.");
+            return false;
+        }
+        else
+        {
+            if (yy > 50)
+                strncpy(mell_prefix, "19", 3);
+            else
+                strncpy(mell_prefix, "20", 3);
+            /* We need to have it in YYYY-MM-DD ISO format */
+            snprintf(response + 3, 32, "%s%02d-%02d-%02d", mell_prefix, yy, mm, dd);
+        }
     }
 
     return true;

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1235,13 +1235,20 @@ bool Rainbow::getLocalTime(char *timeString)
         //getLocalTime24(PortFD, &ctime);
         if (!sendCommand(":GL#", response))
             return false;
+        LOG_INFO("Time received: %s", response);
 
         if (sscanf(response + 3, "%d:%d:%d", &h, &m, &s) != 3)
         {
             LOG_WARN("Failed to get time from device.");
             return false;
         }
+        LOG_INFO("Hours scanned: %d", h);
+        LOG_INFO("Minutes scanned: %d", m);
+        LOG_INFO("Seconds scanned: %d", s);
         getSexComponents(ctime, &h, &m, &s);
+        LOG_INFO("Hours after getSexComponents: %d", h);
+        LOG_INFO("Minutes after getSexComponents: %d", m);
+        LOG_INFO("Seconds after getSexComponents: %d", s);
         snprintf(timeString, MAXINDINAME, "%02d:%02d:%02d", h, m, s);
     }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1229,10 +1229,8 @@ bool Rainbow::getLocalTime(char *timeString)
     }
     else
     {
-        double ctime = 0;
         int h, m, s;
         char response[DRIVER_LEN] = {0};
-        //getLocalTime24(PortFD, &ctime);
         if (!sendCommand(":GL#", response))
             return false;
 
@@ -1276,8 +1274,18 @@ bool Rainbow::getUTFOffset(double *offset)
         return true;
     }
 
-    int lx200_utc_offset = 0;
-    getUTCOffset(PortFD, &lx200_utc_offset);
+    int rst135_utc_offset = 0;
+
+    char response[DRIVER_LEN] = {0};
+    if (!sendCommand(":GG#", response))
+        return false;
+
+    if (sscanf(response + 3, "%d", &rst135_utc_offset) != 1)
+    {
+        LOG_WARN("Failed to get UTC offset from device.");
+        return false;
+    }
+
     // LX200 TimeT Offset is defined at the number of hours added to LOCAL TIME to get TimeT. This is contrary to the normal definition.
     *offset = lx200_utc_offset * -1;
     return true;

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -1412,7 +1412,7 @@ bool Rainbow::sendScopeLocation()
         if (dd > 0)
             LocationNP.np[LOCATION_LATITUDE].value = dd + mm / 60.0 + ssf / 3600.0;
         else
-            LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0 + ssf / 3600.0;
+            LocationNP.np[LOCATION_LATITUDE].value = dd - mm / 60.0 - ssf / 3600.0;
     }
 
     // Longitude


### PR DESCRIPTION
same as https://github.com/indilib/indi/pull/1478 but al changes are implemented directly into rainbow.cpp.
lx200driver.cpp has been reverted.

fixed:

- location accuracy is now received in arcsec resolution
- date & time & UTC offset are received properly now 
- I renamed a lot of "title" comments because I found them misleading

not fixed:

location in mount gets overwritten when Ekos is started from scratch
Ongoing discussion in: https://indilib.org/forum/ekos/9645-rst-135-location-issue.html