### PR TITLE
Fix crash on connecting to indi_skywatcherAltAzMount without setting telescope and guider info.

### DIFF
--- a/drivers/telescope/skywatcherAPIMount.cpp
+++ b/drivers/telescope/skywatcherAPIMount.cpp
@@ -425,6 +425,12 @@ bool SkywatcherAPIMount::initProperties()
     initGuiderProperties(getDeviceName(), GUIDE_TAB);
     setDriverInterface(getDriverInterface() | GUIDER_INTERFACE);
 
+    //Set default values in parent class
+    IUFindNumber(&ScopeParametersNP, "TELESCOPE_APERTURE")->value = 200;
+    IUFindNumber(&ScopeParametersNP, "TELESCOPE_FOCAL_LENGTH")->value = 2000;
+    IUFindNumber(&ScopeParametersNP, "GUIDER_APERTURE")->value = 30;
+    IUFindNumber(&ScopeParametersNP, "GUIDER_FOCAL_LENGTH")->value = 120;
+
     return true;
 }
 

--- a/libs/stream/jpegutils.c
+++ b/libs/stream/jpegutils.c
@@ -461,7 +461,8 @@ static void guarantee_huff_tables(j_decompress_ptr dinfo)
 int decode_jpeg_raw(unsigned char *jpeg_data, int len, int itype, int ctype, unsigned int width, unsigned int height,
                     unsigned char *raw0, unsigned char *raw1, unsigned char *raw2)
 {
-    int numfields, hsf[3], field, yl, yc;
+    int numfields, hsf[3], field;
+    unsigned int  yl, yc;
     int i, xsl, xsc, xs, hdown;
     unsigned int x, y = 0, vsf[3], xd;
 
@@ -646,7 +647,7 @@ int decode_jpeg_raw(unsigned char *jpeg_data, int len, int itype, int ctype, uns
             /* read raw data */
             jpeg_read_raw_data(&dinfo, scanarray, 8 * vsf[0]);
 
-            for (y = 0; y < 8 * vsf[0]; yl += numfields, y++)
+            for (y = 0; y < 8 * vsf[0] && yl < height; yl += numfields, y++)
             {
                 xd = yl * width;
                 xs = xsl;
@@ -721,7 +722,7 @@ int decode_jpeg_raw(unsigned char *jpeg_data, int len, int itype, int ctype, uns
                     if (vsf[0] == 1)
                     {
                         /* Just copy */
-                        for (y = 0; y < 8 /*&& yc < height */; y++, yc += numfields)
+                        for (y = 0; y < 8 && yc < height; y++, yc += numfields)
                         {
                             xd = yc * width / 2;
 
@@ -735,7 +736,7 @@ int decode_jpeg_raw(unsigned char *jpeg_data, int len, int itype, int ctype, uns
                     else
                     {
                         /* upsample */
-                        for (y = 0; y < 8 /*&& yc < height */; y++)
+                        for (y = 0; y < 8 && yc < height; y++)
                         {
                             xd = yc * width / 2;
 
@@ -767,7 +768,7 @@ int decode_jpeg_raw(unsigned char *jpeg_data, int len, int itype, int ctype, uns
                     if (vsf[0] == 1)
                     {
                         /* Really downsample */
-                        for (y = 0; y < 8 /*&& yc < height/2*/; y += 2, yc += numfields)
+                        for (y = 0; y < 8 && yc < height/2; y += 2, yc += numfields)
                         {
                             xd = yc * width / 2;
 
@@ -782,7 +783,7 @@ int decode_jpeg_raw(unsigned char *jpeg_data, int len, int itype, int ctype, uns
                     else
                     {
                         /* Just copy */
-                        for (y = 0; y < 8 /*&& yc < height/2 */; y++, yc += numfields)
+                        for (y = 0; y < 8 && yc < height/2; y++, yc += numfields)
                         {
                             xd = yc * width / 2;
 


### PR DESCRIPTION
When connecting to indi_skywatcherAltAzMount from ekos, the driver crashes if telescope and guider info ScopeParametersN are not set because their default values are zero. So I set default values for them and avoid the crash.
The set values have no means. Just avoiding zero is needed