### PR TITLE
fix rainbow astro focuser driver

### DIFF
--- a/drivers/focuser/rainbowRSF.cpp
+++ b/drivers/focuser/rainbowRSF.cpp
@@ -18,6 +18,30 @@
 
 */
 
+/*
+RSF Focuser protocol is documented here:
+https://github.com/indilib/indi/files/5457979/RSF_focuser_Protocol_200313_EN.pdf
+Currently the following commands are implemented.
+
+Command              Send      Receive     Comment
+
+Get Position         :Fp#      :FpsDDDD#   s is + or -, DDDD from -8000 to 8000
+                               :FS0#       not moving
+                               :FS1#       moving
+
+  NOTE: I found GetPosition returns a float instead of the documented DDDD !!!!!!
+  See the comment in updatePosition() and the parsePosition() function.
+
+Temperature          :Ft1#      :FT1sDD.D# s is + or -, DD.D temp in celcius
+
+Move Absolute        :FmsDDDD#  :FM#       s is + or -, DDDD from -8000 to 8000
+
+Move Relative        :FnsDDDD#  :FM#       s is + or -, DDDD from -8000 to 8000
+                                           neg numbers move away from main mirror
+
+Move Home            :Fh#       :FH#
+*/
+
 #include "rainbowRSF.h"
 #include "indicom.h"
 
@@ -75,6 +99,7 @@ bool RainbowRSF::initProperties()
     FocusRelPosN[0].step = 1000;
 
     addSimulationControl();
+    addDebugControl();
 
     return true;
 }
@@ -142,6 +167,42 @@ bool RainbowRSF::Handshake()
 /////////////////////////////////////////////////////////////////////////////
 ///
 /////////////////////////////////////////////////////////////////////////////
+
+namespace {
+// This accepts 4-digit positions as well a float ones.
+// The doc says it outputs 4-digits, but I've seen floats in the messages.
+bool parsePosition(char *result, int *pos)
+{
+  const int length = strlen(result);
+  if (length < 6) return false;
+  // Check for a decimal/period
+  char *period = strchr(result+3, '.');
+  if (period == nullptr)
+  {
+    // no float
+    int position;
+    if (sscanf(result, ":FP%d#", &position) == 1)
+    {
+        *pos = position;
+        return true;
+    }
+    return false;
+  }
+  else
+  {
+    float position;
+    if (sscanf(result, ":FP%f#", &position) == 1)
+    {
+        // position is a float number between -8 and +8 that needs to be multiplied by 1000.
+        *pos = position * 1000;
+        return true;
+    }
+    return false;
+  }
+}
+}  // namespace
+
+
 bool RainbowRSF::updatePosition()
 {
     char res[DRIVER_LEN] = {0};
@@ -195,15 +256,23 @@ bool RainbowRSF::updatePosition()
     /////////////////////////////////////////////////////////////////////////////
     /// Real Driver
     /////////////////////////////////////////////////////////////////////////////
-    else if (sendCommand(":Fp#", res) == false)
+    else if (sendCommand(":Fp#", res, DRIVER_LEN) == false)
         return false;
 
     int newPosition { 0 };
-    if (sscanf(res, ":FP%d#", &newPosition) == 1)
-    {
+
+    // I found that values can be retured as -06.500 as opposed to the documented NNNN
+    // The below function takes either.
+    // This (original code) would just parse the documented NNNN.
+    // if (sscanf(res, ":FP%s#", &newPosition) == 1)
+    bool ok = parsePosition(res, &newPosition);
+
+    if (ok) {
         FocusAbsPosN[0].value = newPosition + 8000;
 
-        if (FocusAbsPosN[0].value == m_TargetPosition)
+        const int offset = FocusAbsPosN[0].value - m_TargetPosition;
+        constexpr int TOLERANCE = 1;  // Off-by-one position is ok given the resolution of the response.
+        if (std::abs(offset) <= TOLERANCE)
         {
             if (GoHomeSP.s == IPS_BUSY)
             {
@@ -252,7 +321,7 @@ bool RainbowRSF::updateTemperature()
     if (isSimulation())
         strncpy(res, ":FT1+23.5#", DRIVER_LEN);
 
-    else if (sendCommand(":Ft1#", res) == false)
+    else if (sendCommand(":Ft1#", res, DRIVER_LEN) == false)
         return false;
 
     if (sscanf(res, ":FT1%g", &temperature) == 1)
@@ -276,14 +345,15 @@ IPState RainbowRSF::MoveAbsFocuser(uint32_t targetTicks)
     m_TargetPosition = targetTicks;
 
     char cmd[DRIVER_LEN] = {0};
+    char res[DRIVER_LEN] = {0};
     int steps = targetTicks - 8000;
 
     snprintf(cmd, 16, ":Fm%c%04d#", steps >= 0 ? '+' : '-', std::abs(steps));
 
     if (isSimulation() == false)
     {
-        if (sendCommand(cmd) == false)
-            return IPS_ALERT;
+      if (sendCommand(cmd, res, DRIVER_LEN) == false)
+          return IPS_ALERT;
     }
     return IPS_BUSY;
 }
@@ -314,7 +384,8 @@ bool RainbowRSF::findHome()
     {
         m_TargetPosition = homePosition;
         FocusAbsPosNP.s = IPS_BUSY;
-        return sendCommand(":Fh#");
+        char res[DRIVER_LEN] = {0};
+        return sendCommand(":Fh#", res, DRIVER_LEN);
     }
 }
 
@@ -363,28 +434,20 @@ void RainbowRSF::TimerHit()
 /////////////////////////////////////////////////////////////////////////////
 /// Send Command
 /////////////////////////////////////////////////////////////////////////////
-bool RainbowRSF::sendCommand(const char * cmd, char * res, int cmd_len, int res_len)
+bool RainbowRSF::sendCommand(const char * cmd, char * res, int res_len)
 {
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
+    if (cmd == nullptr || res == nullptr || res_len <= 0)
+      return false;
+    const int cmd_len = strlen(cmd);
+    if (cmd_len <= 0)
+      return false;
 
     tcflush(PortFD, TCIOFLUSH);
 
-    if (cmd_len > 0)
-    {
-        char hex_cmd[DRIVER_LEN * 3] = {0};
-        hexDump(hex_cmd, cmd, cmd_len);
-        LOGF_DEBUG("CMD <%s>", hex_cmd);
-        rc = tty_write(PortFD, cmd, cmd_len, &nbytes_written);
-    }
-    else
-    {
-        LOGF_DEBUG("CMD <%s>", cmd);
+    LOGF_DEBUG("CMD <%s>", cmd);
 
-        char formatted_command[DRIVER_LEN] = {0};
-        snprintf(formatted_command, DRIVER_LEN, "%s\r", cmd);
-        rc = tty_write_string(PortFD, formatted_command, &nbytes_written);
-    }
-
+    int nbytes_written = 0;
+    int rc = tty_write(PortFD, cmd, cmd_len, &nbytes_written);
     if (rc != TTY_OK)
     {
         char errstr[MAXRBUF] = {0};
@@ -393,14 +456,12 @@ bool RainbowRSF::sendCommand(const char * cmd, char * res, int cmd_len, int res_
         return false;
     }
 
-    if (res == nullptr)
-        return true;
-
-    if (res_len > 0)
-        rc = tty_read(PortFD, res, res_len, DRIVER_TIMEOUT, &nbytes_read);
-    else
-        rc = tty_nread_section(PortFD, res, DRIVER_LEN, DRIVER_STOP_CHAR, DRIVER_TIMEOUT, &nbytes_read);
-
+    int nbytes_read = 0;
+    rc = tty_nread_section(PortFD, res, DRIVER_LEN, DRIVER_STOP_CHAR,
+                           DRIVER_TIMEOUT, &nbytes_read);
+    if (nbytes_read == DRIVER_LEN)
+        return false;
+    res[nbytes_read] = 0;
     if (rc != TTY_OK)
     {
         char errstr[MAXRBUF] = {0};
@@ -409,32 +470,9 @@ bool RainbowRSF::sendCommand(const char * cmd, char * res, int cmd_len, int res_
         return false;
     }
 
-    if (res_len > 0)
-    {
-        char hex_res[DRIVER_LEN * 3] = {0};
-        hexDump(hex_res, res, res_len);
-        LOGF_DEBUG("RES <%s>", hex_res);
-    }
-    else
-    {
-        // Remove extra \r
-        res[nbytes_read - 1] = 0;
-        LOGF_DEBUG("RES <%s>", res);
-    }
+    LOGF_DEBUG("RES <%s>", res);
 
     tcflush(PortFD, TCIOFLUSH);
 
     return true;
-}
-
-/////////////////////////////////////////////////////////////////////////////////////
-///
-/////////////////////////////////////////////////////////////////////////////////////
-void RainbowRSF::hexDump(char * buf, const char * data, int size)
-{
-    for (int i = 0; i < size; i++)
-        sprintf(buf + 3 * i, "%02X ", static_cast<uint8_t>(data[i]));
-
-    if (size > 0)
-        buf[3 * size - 1] = '\0';
 }

--- a/drivers/focuser/rainbowRSF.h
+++ b/drivers/focuser/rainbowRSF.h
@@ -56,8 +56,7 @@ class RainbowRSF : public INDI::Focuser
         ///////////////////////////////////////////////////////////////////////////////
         /// Communication Functions
         ///////////////////////////////////////////////////////////////////////////////
-        bool sendCommand(const char * cmd, char * res = nullptr, int cmd_len = -1, int res_len = -1);
-        void hexDump(char * buf, const char * data, int size);
+        bool sendCommand(const char * cmd, char * res, int res_len);
 
     private:
 


### PR DESCRIPTION
There were two issues fixed. (1) The doc from Rainbow Astro from which the original driver was written (https://github.com/indilib/indi/files/5457979/RSF_focuser_Protocol_200313_EN.pdf) mis-states the response to the focuser-current-position command, at least on the hardware that I've been testing. Instead of returning  :FPsDDDD# where s is the +/- and DDDD is a 4-digit position, it seems to return something like :FP-06.150# in other words a signed float that's between -8 and 8.0. I've modified the driver to accept either the original format or the floating point one.

Also, probably because of the marginal precision (3 decimal places) which exactly matches the possible position used, I observed off-by-one edge case. I corrected this by accepting off-by-one as "reached destination". Otherwise the driver hangs, because it thinks it's done.

I've also made all args required in the sendCommand() method, which simplifies the code, and I believe makes bugs a little less likely in the future.