### PR TITLE
Add object azimuth and altitude to FITS headers

### DIFF
--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -564,6 +564,8 @@ class CCD : public DefaultDevice, GuiderInterface
         double Airmass;
         double Latitude;
         double Longitude;
+        double Azimuth;
+        double Altitude;
 
         // Temperature Control
         double m_TargetTemperature {0};


### PR DESCRIPTION
This info is used for example by NormalizeScaleGradient-script in PixInsight.

Also adds a bit of precision to some values.