### PR TITLE
Fix indimacros include path on baseclient.h

### DIFF
--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -20,11 +20,11 @@
 
 #include "indiapi.h"
 #include "indibase.h"
+#include "indimacros.h"
 
 #include <string>
 #include <vector>
 
-#include <indimacros.h>
 #include <memory>
 
 // #define MAXRBUF 2048 // #PS: defined in indibase.h


### PR DESCRIPTION
This fixes #1501 . Verified on:

* openSUSE Tumbleweed x86_64
* openSUSE Tumbleweed aarch64
* openSUSE Leap x86_64
* openSUSE Leap aarch64

https://build.opensuse.org/package/show/Application:Astrophotography/libindi