### PR TITLE
The driver for the Planewave Delta-T was not working

### DIFF
--- a/drivers/auxiliary/planewave_delta.cpp
+++ b/drivers/auxiliary/planewave_delta.cpp
@@ -707,7 +707,7 @@ bool DeltaT::sendCommand(const char * cmd, char * res, uint32_t cmd_len, uint32_
     hexDump(hex_res, res, res_len);
     LOGF_DEBUG("RES <%s>", hex_res);
 
-    uint8_t chk = calculateCheckSum(res, res_len);
+    char chk = calculateCheckSum(res, res_len);
 
     if (res_len > 0 && chk != res[res_len - 1])
     {


### PR DESCRIPTION
The driver for the Planewave Delta-T was not working, it always displayed "Invalid Checksum", even tho the checksum was correct. Changing the type of the checksum from `uint8_t` to `char` fixed everything, and the driver is now working properly