### PR TITLE
Fix invalid substitution in udev rules file

### DIFF
--- a/drivers/auxiliary/99-indi_auxiliary.rules
+++ b/drivers/auxiliary/99-indi_auxiliary.rules
@@ -1,7 +1,7 @@
 # Increase usbfs memory to 256MB IF it was less than that.
 # This is general rule for all cameras
 ACTION=="add", SUBSYSTEM=="usb", RUN+="/bin/sh -c 'test -f /sys/module/usbcore/parameters/usbfs_memory_mb && \
-test $(cat /sys/module/usbcore/parameters/usbfs_memory_mb) -lt 256 && \
+test $$(cat /sys/module/usbcore/parameters/usbfs_memory_mb) -lt 256 && \
 echo 256 > /sys/module/usbcore/parameters/usbfs_memory_mb'"
 # All FTDI chips
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="134a", MODE="0666"


### PR DESCRIPTION
udevd complained with the following:

```
Invalid value "/bin/sh -c 'test -f /sys/module/usbcore/parameters/usbfs_memory_mb && test $(cat /sys/module/usbcore/parameters/usbfs_memory_mb) -lt 256 && echo 256 > /sys/module/usbcore/parameters/usbfs_memory_mb'" for RUN (char 76: invalid substitution type), ignoring.
```

The command substitution was interpreted as a udev substitution, it can be escaped with a second dollar sign.