### PR TITLE
Update lx200_OnStep.cpp

### DIFF
--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -1845,7 +1845,12 @@ bool LX200_OnStep::ReadScopeStatus()
             }
             if (strstr(OSStat, "n") && !strstr(OSStat, "N"))
             {
-                IUSaveText(&OnstepStat[1], "Slewing");
+                IUSaveText(&OnstepStat[1], "Slewing"); //Onstep 3.x
+                TrackState = SCOPE_SLEWING;
+            }
+            if (!strstr(OSStat, "n") && !strstr(OSStat, "N"))
+            {
+                IUSaveText(&OnstepStat[1], "Slewing"); //OnStep 4.x
                 TrackState = SCOPE_SLEWING;
             }
             if (strstr(OSStat, "N") && !strstr(OSStat, "n"))
@@ -1911,7 +1916,13 @@ bool LX200_OnStep::ReadScopeStatus()
                 }
                 else if (strstr(OSStat, "n") && !strstr(OSStat, "N")) 
                 {
-                    //set from state above 
+                    //set from state above  - OnStep 3.x
+                    TrackState = SCOPE_SLEWING; 
+                    IUSaveText(&OnstepStat[1], "Slewing");
+                }
+                else if (!strstr(OSStat, "n") && !strstr(OSStat, "N")) 
+                {
+                    //set from state above  - OnStep 4.x
                     TrackState = SCOPE_SLEWING; 
                     IUSaveText(&OnstepStat[1], "Slewing");
                 }

--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -1901,7 +1901,7 @@ bool LX200_OnStep::ReadScopeStatus()
                 TrackState = SCOPE_PARKING;
                 IUSaveText(&OnstepStat[3], "Park in Progress");
             }
-            if (strstr(OSStat, "p"))
+            if (strstr(OSStat, "p")) //jamie - this means unparked so why only idle and tracking when above we could be slewing
             {
                 SetParked(false); //defaults to TrackState=SCOPE_IDLE but we want
                 if (strstr(OSStat, "nN"))   // azwing need to detect if unparked idle or tracking
@@ -1909,8 +1909,18 @@ bool LX200_OnStep::ReadScopeStatus()
                     IUSaveText(&OnstepStat[1], "Idle");
                     TrackState = SCOPE_IDLE;
                 }
-                else TrackState = SCOPE_TRACKING;
-                IUSaveText(&OnstepStat[3], "UnParked");
+                else if (strstr(OSStat, "n") && !strstr(OSStat, "N")) 
+                {
+                    //set from state above 
+                    TrackState = SCOPE_SLEWING; 
+                    IUSaveText(&OnstepStat[1], "Slewing");
+                }
+                else
+                {
+                
+                    TrackState = SCOPE_TRACKING; 
+                    IUSaveText(&OnstepStat[3], "UnParked");
+                }
             }
             // ============= End Parkstatus
 

--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -1843,14 +1843,14 @@ bool LX200_OnStep::ReadScopeStatus()
                 IUSaveText(&OnstepStat[1], "Idle");
                 TrackState = SCOPE_IDLE;
             }
-            if (strstr(OSStat, "n") && !strstr(OSStat, "N"))
+            if (strstr(OSStat, "n") && !strstr(OSStat, "N")) // These conditions are for OnStep 3.x
             {
-                IUSaveText(&OnstepStat[1], "Slewing"); //Onstep 3.x
+                IUSaveText(&OnstepStat[1], "Slewing");
                 TrackState = SCOPE_SLEWING;
             }
-            if (!strstr(OSStat, "n") && !strstr(OSStat, "N"))
+            if (!strstr(OSStat, "n") && !strstr(OSStat, "N")) // These conditions are for OnStep 4.x
             {
-                IUSaveText(&OnstepStat[1], "Slewing"); //OnStep 4.x
+                IUSaveText(&OnstepStat[1], "Slewing");
                 TrackState = SCOPE_SLEWING;
             }
             if (strstr(OSStat, "N") && !strstr(OSStat, "n"))
@@ -1906,7 +1906,7 @@ bool LX200_OnStep::ReadScopeStatus()
                 TrackState = SCOPE_PARKING;
                 IUSaveText(&OnstepStat[3], "Park in Progress");
             }
-            if (strstr(OSStat, "p")) //jamie - this means unparked so why only idle and tracking when above we could be slewing
+            if (strstr(OSStat, "p")) // Jamie Flinn - this means unparked
             {
                 SetParked(false); //defaults to TrackState=SCOPE_IDLE but we want
                 if (strstr(OSStat, "nN"))   // azwing need to detect if unparked idle or tracking
@@ -1914,22 +1914,19 @@ bool LX200_OnStep::ReadScopeStatus()
                     IUSaveText(&OnstepStat[1], "Idle");
                     TrackState = SCOPE_IDLE;
                 }
-                else if (strstr(OSStat, "n") && !strstr(OSStat, "N")) 
+                else if (strstr(OSStat, "n") && !strstr(OSStat, "N")) // These conditions are for OnStep 3.x
                 {
-                    //set from state above  - OnStep 3.x
-                    TrackState = SCOPE_SLEWING; 
+                    TrackState = SCOPE_SLEWING;
                     IUSaveText(&OnstepStat[1], "Slewing");
                 }
-                else if (!strstr(OSStat, "n") && !strstr(OSStat, "N")) 
+                else if (!strstr(OSStat, "n") && !strstr(OSStat, "N")) // These conditions are for OnStep 4.x
                 {
-                    //set from state above  - OnStep 4.x
-                    TrackState = SCOPE_SLEWING; 
+                    TrackState = SCOPE_SLEWING;
                     IUSaveText(&OnstepStat[1], "Slewing");
                 }
                 else
                 {
-                
-                    TrackState = SCOPE_TRACKING; 
+                    TrackState = SCOPE_TRACKING;
                     IUSaveText(&OnstepStat[3], "UnParked");
                 }
             }


### PR DESCRIPTION
Fix for flip unstable slewing, MF and target - This is related to 3 issues all stemming from one area of code - slew state was correctly being set, however it was immediately set to tracking - a side effect of this was target of slew was showing incorrectly AND flip was not succeeding/ending prematurely or having align start while the mount was actually slewing - I have run this through a solid test of east and west targets and parks - could not get get to MF as storms have blown in but this issues were manifest by basic slew so there should be no issue - This is my first push and using Github Desktop - let me know if all is ok or I have killed something