### PR TITLE
Script: Developer build update

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ sudo make install
 
 ## Build indi-core (script)
 
-You can use the `developer-build.bash` script for faster building.
+**Alternatively**, you can use the `developer-build.bash` script for faster build and less stress on your SSD or HDD.
 
 ```bash
 cd ~/Projects/indi
@@ -108,16 +108,38 @@ By default, this script builds the `indi-core` inside machine's `RAM`, i.e. `/de
 However, you can change the target build directory using the `-o` option, for instance:
 
 ```bash
-cd ~/Projects/indi
 ./developer-build.bash -o /path/to/new/build/dir
 ```
 
-Also, this script checks if the target build directory is a subdirectory of `/dev/shm`.
-If so, the build process aborts if there is less than `1Gb` free space in `RAM`.
-One can reset this limitation with changing the `NEED_MEMORY` variable to his/her liking.
+Also, this script checks if the target build directory has at least `512MB` of memory available and aborts if this is not the case.
+You can force skip this test with the `-f` option:
 
-In addition, this script creates a soft symbolic link file named `build` from the build directory to the source directory.
-This helps with accessing the build directory by simply following the link inside the source folder like any other directory, i.e. `cd ~/Projects/indi/build`.
+```bash
+./developer-build.bash -f
+```
+
+Furthermore, this script executes `make` in *parallel* by default.
+If you are having problems or need to use fewer CPU cores, please adjust using the `-j` option.
+For example, to disable parallel execution:
+
+```bash
+./developer-build.bash -j1
+```
+
+This script creates a soft symbolic link file named `build` to the target build directory.
+This helps easier access by simply following the symbolic link:
+
+```bash
+cd ~/Projects/indi/build
+```
+
+Lastly, you could give all the options and arguments at once.
+For instance, if you want to build in `~/indi-build` directory, skip the memory check, and run make using `8` cores, call the script with the following options:
+
+```bash
+cd ~/Projects/indi
+./developer-build.bash -o ~/indi-build -f -j8
+```
 
 ## Build indi-core (Qt Creator)
 

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ cd ~/Projects/indi
 ```
 
 By default, this script builds the `indi-core` inside machine's `RAM`, i.e. `/dev/shm`.
-To change the default build directory, just pass in the desired directory after calling the script, for instance:
+However, you can change the target build directory using the `-o` option, for instance:
 
 ```bash
 cd ~/Projects/indi
-./developer-build.bash /path/to/new/build/dir
+./developer-build.bash -o /path/to/new/build/dir
 ```
 
 Also, this script checks if the target build directory is a subdirectory of `/dev/shm`.

--- a/developer-build.bash
+++ b/developer-build.bash
@@ -28,6 +28,7 @@
 # needs gracefully.
 
 TOP_DIR=$PWD
+NEED_MEMORY=524288
 BUILD_LINK=$TOP_DIR/build
 BUILD_DIR=/dev/shm/indi-build
 
@@ -35,45 +36,73 @@ BUILD_DIR=/dev/shm/indi-build
 
 
 
-while getopts ":o:" opt; do
+# A useful short tutorial on getopt:
+# https://wiki.bash-hackers.org/howto/getopts_tutorial
+while getopts ":o:f" opt; do
   case $opt in
-    o) BUILD_DIR="$OPTARG"
-    ;;
-    \?) echo "Invalid option -$OPTARG" >&2
-    ;;
+    o)
+        BUILD_DIR="$OPTARG"
+        ;;
+    f)
+        NEED_MEMORY=""
+        ;;
+    \?)
+        echo "Invalid option -$OPTARG" >&2
+        exit 1
+        ;;
+    :)
+        echo "Option -$OPTARG requires an argument." >&2
+        exit 1
+        ;;
+  esac
+
+  # Check if another option is mistakenly passed as an argument
+  case $OPTARG in
+  -*)
+        echo "Option '-$opt' requires an argument."
+        exit 1
+        ;;
   esac
 done
 
-echo ">>> Target build directory: $BUILD_DIR"
 
-case $BUILD_DIR/ in
-    /dev/shm/*)
-    # Build directory is in RAM
-    # ONLY continue if there is at least 1GB of RAM available
-    NEED_MEMORY=1000000
-    FREE_MEMORY=$(free | awk '$1 == "Mem:" {print $NF}')
 
-    if [ $FREE_MEMORY -lt $NEED_MEMORY ]; then
-        echo "*** Not enough memory available in RAM (current "\
-             "$FREE_MEMORY, need $NEED_MEMORY)"
+
+
+# Create the build directory if it is not available already
+if [ ! -d $BUILD_DIR ]; then
+    mkdir -p $BUILD_DIR >&2
+
+    # Exit in case of receiving errors from mkdir
+    if [ ! $? -eq 0 ]; then
+        echo "*** Please fix the issue with build directory '$BUILD_DIR' and try again."
+        echo "*** OR create the directory yourself and re-run the script."
         exit 1
     fi
-    ;;
-
-    *)
-    # Build directory is not in RAM
-    ;;
-esac
-
-
-
-
-
-# Create the build directory and a symbolic link for quick access
-if [ ! -d $BUILD_DIR ]; then
-    mkdir -p $BUILD_DIR
 fi
 
+echo ">>> Target build directory: $BUILD_DIR"
+
+
+
+
+
+# Check for available free space in the build directory
+FREE_MEMORY=$(df $BUILD_DIR | awk 'END{print $4}')
+
+if [ -z $NEED_MEMORY ]; then
+    echo ">>> Skipping free memory check. Available: $FREE_MEMORY"
+elif [ $FREE_MEMORY -lt $NEED_MEMORY ]; then
+    echo "*** Not enough memory available in '$BUILD_DIR'"
+    echo "*** (current $FREE_MEMORY, need $NEED_MEMORY)"
+    exit 1
+fi
+
+
+
+
+
+# Create the symbolic link
 if [ ! -h $BUILD_LINK ]; then
     echo ">>> Creating a symbolic link for quick access:"
     ln -s $BUILD_DIR $BUILD_LINK

--- a/developer-build.bash
+++ b/developer-build.bash
@@ -35,10 +35,14 @@ BUILD_DIR=/dev/shm/indi-build
 
 
 
-if [ ! x"$1" = x"" ]; then
-    # Take the option given as the new build directory
-    BUILD_DIR="$1"
-fi
+while getopts ":o:" opt; do
+  case $opt in
+    o) BUILD_DIR="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
 
 echo ">>> Target build directory: $BUILD_DIR"
 


### PR DESCRIPTION
This version of the bash script takes three arguments:
1. `-j` will specify number of `x` jobs in `make -jx`, uses the maximum cores available by default.
2. `-o` will specify path to the target build directory
3. `-f` will skip checking for free memory available

The new `-j` argument is necessary because the `make -j` will freeze virtual machines. To determine the os type, I have used the output from `uname` function. The output starts with `Linux` for GNU/Linux systems, and with `Darwin` for macOS. The script will use `-j1` for other types of systems by default, unless specified otherwise by the user.

The new `-f` argument is necessary because there might be enough free RAM in `docker` containers, but the `/dev/shm/` directory can be limited. Mine was limited to a mere `64MB`. I used `--shm-size=1g` to increase the `/dev/shm/` size in my container. However, the script should have anticipated that and warned me *before* throwing the error complaining *no more space left on disk*.

Also, checking for free space shouldn't be limited only to RAM and `/dev/shm/`. So, the free space available in the specified target build will be determined using the `df` command, and warn the user unless the `-f` option is passed.

The new `-o` option is there so the user can pass the target directory without worrying about argument position in command line.