### PR TITLE
Pipes should be closed with pclose(), not fclose()

### DIFF
--- a/drivers/auxiliary/astrometrydriver.cpp
+++ b/drivers/auxiliary/astrometrydriver.cpp
@@ -404,7 +404,7 @@ void AstrometryDriver::runSolver()
             IDSetSwitch(&SolverSP, nullptr);
             pthread_mutex_unlock(&lock);
 
-            fclose(handle);
+            pclose(handle);
             LOG_INFO("Solver complete.");
             return;
         }
@@ -415,14 +415,14 @@ void AstrometryDriver::runSolver()
             SolverSP.s = IPS_IDLE;
             IDSetSwitch(&SolverSP, nullptr);
             pthread_mutex_unlock(&lock);
-            fclose(handle);
+            pclose(handle);
             LOG_INFO("Solver canceled.");
             return;
         }
         pthread_mutex_unlock(&lock);
     }
 
-    fclose(handle);
+    pclose(handle);
 
     pthread_mutex_lock(&lock);
     SolverSP.s = IPS_ALERT;

--- a/drivers/weather/weather_safety_proxy.cpp
+++ b/drivers/weather/weather_safety_proxy.cpp
@@ -271,7 +271,7 @@ IPState WeatherSafetyProxy::executeScript()
     }
     char buf[BUFSIZ];
     size_t byte_count = fread(buf, 1, BUFSIZ - 1, handle);
-    fclose(handle);
+    pclose(handle);
     buf[byte_count] = 0;
     if (byte_count == 0)
     {


### PR DESCRIPTION
GCC 11 warns about this with -Wmismatched-dealloc.