### PR TITLE
Force using hour angle when mount is slewing

### DIFF
--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -855,7 +855,9 @@ bool Dome::ISSnoopDevice(XMLEle * root)
                 mountEquatorialCoords.declination = de;
                 LOGF_DEBUG("Calling Update mount to anticipate goto target: %g - DEC: %g",
                            mountEquatorialCoords.rightascension, mountEquatorialCoords.declination);
+                UseHourAngle = true;
                 UpdateMountCoords();
+                UseHourAngle = false;
             }
         }
 
@@ -1301,13 +1303,7 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
 
     if (OTASideSP.s == IPS_OK)
     {
-        if(OTASideS[DM_OTA_SIDE_EAST].s == ISS_ON)
-            OTASide = -1;
-        else if(OTASideS[DM_OTA_SIDE_WEST].s == ISS_ON)
-            OTASide = 1;
-        else if(OTASideS[DM_OTA_SIDE_MOUNT].s == ISS_ON)
-            OTASide = mountOTASide;
-        else if(OTASideS[DM_OTA_SIDE_HA].s == ISS_ON)
+        if(OTASideS[DM_OTA_SIDE_HA].s == ISS_ON || UseHourAngle)
         {
             // Note if the telescope points West, OTA is at east of the pier, and viceversa.
             if(hourAngle > 0)
@@ -1315,6 +1311,13 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
             else
                 OTASide = 1;
         }
+        else if(OTASideS[DM_OTA_SIDE_EAST].s == ISS_ON)
+            OTASide = -1;
+        else if(OTASideS[DM_OTA_SIDE_WEST].s == ISS_ON)
+            OTASide = 1;
+        else if(OTASideS[DM_OTA_SIDE_MOUNT].s == ISS_ON)
+            OTASide = mountOTASide;
+
         LOGF_DEBUG("OTA_SIDE selection: %d", IUFindOnSwitchIndex(&OTASideSP));
     }
 

--- a/libs/indibase/indidome.h
+++ b/libs/indibase/indidome.h
@@ -662,6 +662,7 @@ class Dome : public DefaultDevice
         bool IsMountParked = false;
         bool IsLocked = true;
         bool AutoSyncWarning = false;
+        bool UseHourAngle = false;
 
         const char * ParkDeviceName;
         const std::string ParkDataFileName;


### PR DESCRIPTION
Found problem that dome doesn't rotate until meridian flip is complete.
This is because mount report old pier side when it start meridian flip.
Before 6550c8b04 it used HA to figure pier side when taking this goto
path.