### PR TITLE
usbfs_memory_mb_fix: exit with TRUE even if the memory is already set

### DIFF
--- a/drivers/auxiliary/99-indi_auxiliary.rules
+++ b/drivers/auxiliary/99-indi_auxiliary.rules
@@ -2,7 +2,7 @@
 # This is general rule for all cameras
 ACTION=="add", SUBSYSTEM=="usb", RUN+="/bin/sh -c 'test -f /sys/module/usbcore/parameters/usbfs_memory_mb && \
 test $$(cat /sys/module/usbcore/parameters/usbfs_memory_mb) -lt 256 && \
-echo 256 > /sys/module/usbcore/parameters/usbfs_memory_mb'"
+echo 256 > /sys/module/usbcore/parameters/usbfs_memory_mb||true'"
 # All FTDI chips
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="134a", MODE="0666"
 # More FTDI chips


### PR DESCRIPTION
… at or above 256M to prevent logging an error.

Tested by resetting memory below 256M, plugging and unplugging a USB device repeatedly. Then leaving at 256M, and plugging and unplugging repeatedly. The error is gone and the memory is still set correctly.