### PR TITLE
Fix FocusLynx GetConfig for focusers without HomeOnStart

### DIFF
--- a/drivers/focuser/focuslynxbase.cpp
+++ b/drivers/focuser/focuslynxbase.cpp
@@ -1029,7 +1029,7 @@ bool FocusLynxBase::getFocusConfig()
         return false;
     }
     // If END, then ignore
-    else if (strcmp(response, "END"))
+    else if (strncmp(response, "END", 3))
     {
         int homeOnStart;
         rc = sscanf(response, "%16[^=]=%d", key, &homeOnStart);
@@ -1040,7 +1040,7 @@ bool FocusLynxBase::getFocusConfig()
     }
 
     // If last response was END, then ignore
-    if (strcmp(response, "END"))
+    if (strncmp(response, "END", 3))
     {
         // END is reached
         memset(response, 0, sizeof(response));

--- a/drivers/focuser/focuslynxbase.h
+++ b/drivers/focuser/focuslynxbase.h
@@ -45,7 +45,7 @@
 #define HUB_SETTINGS_TAB "Device"
 
 #define VERSION                 1
-#define SUBVERSION              44
+#define SUBVERSION              45
 
 class FocusLynxBase : public INDI::Focuser
 {


### PR DESCRIPTION
The END from devices that did not support HomeOnStart would contain a '\10' or other characters from the last response on the end, causing them to fail the strcmp check for a match with END. When they failed the driver would timeout trying to read the next line (which would never come). Other end checks (~line 1062 as an example) would set the last byte to '\0' so they would pass. In this case the response may be used for processing so instead of setting the last character as a '\0' this checks the first 3 characters as a response key will never start with END .

This was tested on Ubuntu 20.04 with a ThirdLynx and FocusLynx controller. Both controllers were tested with firmware from before and after the addition of HomeOnStart being an option.