### PR TITLE
Improve lynx sync and homing behavior

### DIFF
--- a/drivers/focuser/focuslynxbase.h
+++ b/drivers/focuser/focuslynxbase.h
@@ -45,7 +45,7 @@
 #define HUB_SETTINGS_TAB "Device"
 
 #define VERSION                 1
-#define SUBVERSION              45
+#define SUBVERSION              46
 
 class FocusLynxBase : public INDI::Focuser
 {
@@ -101,8 +101,6 @@ class FocusLynxBase : public INDI::Focuser
 
         void setFocusTarget(const char *target);
         const char *getFocusTarget();
-        bool checkIfAbsoluteFocuser();
-        bool SyncMandatory(bool enable);
         virtual void debugTriggered(bool enable) override;
 
         // Device
@@ -226,12 +224,7 @@ class FocusLynxBase : public INDI::Focuser
         IText HFocusNameT[1] {};
         ITextVectorProperty HFocusNameTP;
 
-        // Request mandatory action of sync from user
-        ISwitch SyncMandatoryS[2];
-        ISwitchVectorProperty SyncMandatorySP;
-
-        bool isAbsolute;
-        bool isSynced;
+        bool canHome;
         bool isHoming;
         // TODO add property for this.
         bool m_HomeOnStart {false};


### PR DESCRIPTION
Requesting review for the following changes to the Lynx driver

1. Removes the required sync before move from all Lynx focusers as they are all absolute
2. Use the controllers returned device ID to determine support for Home vs Sync
3. Disable syncing for homing focusers

This should fix #1554 

Please let me know if there are any required or requested changes, I am learning the layout and style for INDI drivers.

So far I have tested this on a FocusLynx hub with a DirectSync and TCF-S 2 as well as a ThirdLynx and a TCF-LSI.