### PR TITLE
Save Alignment Data to mount before sync

### DIFF
--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -230,6 +230,14 @@ bool Rainbow::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
             IDSetSwitch(&HomeSP, nullptr);
             return true;
         }
+        else if (!strcmp(SaveAlignBeforeSyncSP.name, name)) {
+
+            IUUpdateSwitch(&SaveAlignBeforeSyncSP, states, names, n);
+            SaveAlignBeforeSyncSP.s = IPS_OK;
+            saveConfig(true, SaveAlignBeforeSyncSP.name);
+            IDSetSwitch(&SaveAlignBeforeSyncSP, nullptr);
+            return true;
+        }
 
     }
 
@@ -922,19 +930,25 @@ bool Rainbow::Abort()
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::Sync(double ra, double dec)
 {
-    char cmd[DRIVER_LEN] = {0};
 
-    snprintf(cmd, DRIVER_LEN, ":Ck%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
+    char cmd[DRIVER_LEN] = {0};
+    if (SaveAlignBeforeSyncS[0].s == ISS_ON)
+    {
+        snprintf(cmd, DRIVER_LEN, ":CN%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
+    }
+    else
+    {
+        snprintf(cmd, DRIVER_LEN, ":Ck%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
+    }
 
     if (sendCommand(cmd))
     {
         char RAStr[64] = {0}, DecStr[64] = {0};
         fs_sexa(RAStr, ra, 2, 36000);
         fs_sexa(DecStr, dec, 2, 36000);
-        LOGF_INFO("Synced to RA %s DE %s", RAStr, DecStr);
+        LOGF_INFO("Synced to RA %s DE %s%s",RAStr, DecStr, SaveAlignBeforeSyncS[0].s == ISS_ON?", and saved as alignment point.":"");
         return true;
     }
-
     return false;
 }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -29,9 +29,6 @@
 #include <termios.h>
 #include <regex>
 
-#define ALIGNMENT_TAB "Alignment"
-
-
 static std::unique_ptr<Rainbow> scope(new Rainbow());
 
 Rainbow::Rainbow() : INDI::Telescope ()
@@ -88,11 +85,6 @@ bool Rainbow::initProperties()
     IUFillNumberVector(&GuideRateNP, GuideRateN, 1, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
-    // Test Function to send the StarAlign Command to the mount
-    IUFillSwitch(&SaveAlignAfterSlewS[0], "SEND_ALIGN_SLEW_COMPLETED", "Send Align After Slew Completed", ISS_OFF);
-    IUFillSwitchVector(&SaveAlignAfterSlewSP, SaveAlignAfterSlewS, 1, getDeviceName(), "SEND_ALIGN_SLEW_COMPLETED", "Send Align Command After Slew Completed",
-                       ALIGNMENT_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
-
     setDriverInterface(getDriverInterface() | GUIDER_INTERFACE);
 
     initGuiderProperties(getDeviceName(), MOTION_TAB);
@@ -120,8 +112,6 @@ bool Rainbow::updateProperties()
         defineProperty(&GuideWENP);
         defineProperty(&GuideRateNP);
 
-        defineProperty(&SaveAlignAfterSlewSP);
-
     }
     else
     {
@@ -131,7 +121,6 @@ bool Rainbow::updateProperties()
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
         deleteProperty(GuideRateNP.name);
-        deleteProperty(SaveAlignAfterSlewSP.name);
     }
 
     return true;
@@ -239,19 +228,6 @@ bool Rainbow::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
                 LOG_ERROR("Mount failed to move to home position.");
 
             IDSetSwitch(&HomeSP, nullptr);
-            return true;
-        }
-        else if (!strcmp(SaveAlignAfterSlewSP.name, name)) {
-            LOG_DEBUG("SaveAlignAfterSlewSP() - setting switch to null and return true");
-            if (SaveAlignAfterSlewS[0].s == ISS_ON)
-            {
-                SaveAlignAfterSlewS[0].s = ISS_OFF;
-            }
-            else
-            {
-                SaveAlignAfterSlewS[0].s = ISS_ON;
-            }
-            //IDSetSwitch(&SaveAlignAfterSlewSP, nullptr);
             return true;
         }
 
@@ -554,27 +530,6 @@ bool Rainbow::ReadScopeStatus()
                 if (m_GotoType == Horizontal)
                     SetTrackEnabled(true);
                 LOG_INFO("Slew is complete. Tracking...");
-
-                if (SaveAlignAfterSlewS[0].s == ISS_ON)
-                {
-
-                   if (getRA() && getDE())
-                   {
-                       // just a test to introduce a little error for testing
-                       double align_ra = m_CurrentRA + 0.001;
-                       double align_de = m_CurrentDE + 0.001;
-                        LOGF_DEBUG("StarAlign() - RA = %.4f, DEC = %.4f",align_ra, align_de);
-                       StarAlign(align_ra, align_de);
-                   }
-                   else
-                   {
-                       LOG_DEBUG("Error getting the RA and DEC to prepare the star align.");
-                   }
-                }
-                else
-                {
-                    LOG_DEBUG("SaveAlignAfterSlewS is OFF. Not doing anything.");
-                }
             }
         }
         else if (m_SlewErrorCode > 0)
@@ -767,7 +722,6 @@ bool Rainbow::setDE(double de)
     return res[0] == '1';
 }
 
-
 /////////////////////////////////////////////////////////////////////////////
 /// Slew to Equatorial Coordinates
 /////////////////////////////////////////////////////////////////////////////
@@ -788,7 +742,6 @@ bool Rainbow::slewToEquatorialCoords(double ra, double de)
 
     return false;
 }
-
 
 /////////////////////////////////////////////////////////////////////////////
 /// Get Azimuth
@@ -984,28 +937,6 @@ bool Rainbow::Sync(double ra, double dec)
 
     return false;
 }
-
-/////////////////////////////////////////////////////////////////////////////
-/// StarAlign
-/////////////////////////////////////////////////////////////////////////////
-bool Rainbow::StarAlign(double ra, double dec)
-{
-    char cmd[DRIVER_LEN] = {0};
-
-    snprintf(cmd, DRIVER_LEN, ":CN%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
-
-    if (sendCommand(cmd))
-    {
-        char RAStr[64] = {0}, DecStr[64] = {0};
-        fs_sexa(RAStr, ra, 2, 36000);
-        fs_sexa(DecStr, dec, 2, 36000);
-        LOGF_INFO("Star-Aligned to RA %s DE %s", RAStr, DecStr);
-        return true;
-    }
-
-    return false;
-}
-
 
 /////////////////////////////////////////////////////////////////////////////
 /// Set Track Mode

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -88,9 +88,9 @@ bool Rainbow::initProperties()
     IUFillNumberVector(&GuideRateNP, GuideRateN, 1, getDeviceName(), "GUIDE_RATE", "Guiding Rate", MOTION_TAB, IP_RW, 0,
                        IPS_IDLE);
 
-    // Align Star Before Sync
-    IUFillSwitch(&SaveAlignBeforeSyncS[0], "SEND_ALIGN_BEFORE_SYNC", "Save Star Alignment to mount before sync", ISS_OFF);
-    IUFillSwitchVector(&SaveAlignBeforeSyncSP, SaveAlignBeforeSyncS, 1, getDeviceName(), "SEND_ALIGN_BEFORE_SYNC", "Save Star Alignment to mount before sync",
+    // Test Function to send the StarAlign Command to the mount
+    IUFillSwitch(&SaveAlignAfterSlewS[0], "SEND_ALIGN_SLEW_COMPLETED", "Send Align After Slew Completed", ISS_OFF);
+    IUFillSwitchVector(&SaveAlignAfterSlewSP, SaveAlignAfterSlewS, 1, getDeviceName(), "SEND_ALIGN_SLEW_COMPLETED", "Send Align Command After Slew Completed",
                        ALIGNMENT_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
     setDriverInterface(getDriverInterface() | GUIDER_INTERFACE);
@@ -120,7 +120,7 @@ bool Rainbow::updateProperties()
         defineProperty(&GuideWENP);
         defineProperty(&GuideRateNP);
 
-        defineProperty(&SaveAlignBeforeSyncSP);
+        defineProperty(&SaveAlignAfterSlewSP);
 
     }
     else
@@ -131,7 +131,7 @@ bool Rainbow::updateProperties()
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
         deleteProperty(GuideRateNP.name);
-        deleteProperty(SaveAlignBeforeSyncSP.name);
+        deleteProperty(SaveAlignAfterSlewSP.name);
     }
 
     return true;
@@ -241,15 +241,17 @@ bool Rainbow::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
             IDSetSwitch(&HomeSP, nullptr);
             return true;
         }
-        else if (!strcmp(SaveAlignBeforeSyncSP.name, name)) {
-            if (SaveAlignBeforeSyncS[0].s == ISS_ON)
+        else if (!strcmp(SaveAlignAfterSlewSP.name, name)) {
+            LOG_DEBUG("SaveAlignAfterSlewSP() - setting switch to null and return true");
+            if (SaveAlignAfterSlewS[0].s == ISS_ON)
             {
-                SaveAlignBeforeSyncS[0].s = ISS_OFF;
+                SaveAlignAfterSlewS[0].s = ISS_OFF;
             }
             else
             {
-                SaveAlignBeforeSyncS[0].s = ISS_ON;
+                SaveAlignAfterSlewS[0].s = ISS_ON;
             }
+            //IDSetSwitch(&SaveAlignAfterSlewSP, nullptr);
             return true;
         }
 
@@ -553,6 +555,26 @@ bool Rainbow::ReadScopeStatus()
                     SetTrackEnabled(true);
                 LOG_INFO("Slew is complete. Tracking...");
 
+                if (SaveAlignAfterSlewS[0].s == ISS_ON)
+                {
+
+                   if (getRA() && getDE())
+                   {
+                       // just a test to introduce a little error for testing
+                       double align_ra = m_CurrentRA + 0.001;
+                       double align_de = m_CurrentDE + 0.001;
+                        LOGF_DEBUG("StarAlign() - RA = %.4f, DEC = %.4f",align_ra, align_de);
+                       StarAlign(align_ra, align_de);
+                   }
+                   else
+                   {
+                       LOG_DEBUG("Error getting the RA and DEC to prepare the star align.");
+                   }
+                }
+                else
+                {
+                    LOG_DEBUG("SaveAlignAfterSlewS is OFF. Not doing anything.");
+                }
             }
         }
         else if (m_SlewErrorCode > 0)
@@ -947,17 +969,8 @@ bool Rainbow::Abort()
 /////////////////////////////////////////////////////////////////////////////
 bool Rainbow::Sync(double ra, double dec)
 {
-
-    if (SaveAlignBeforeSyncS[0].s == ISS_ON)
-    {
-           StarAlign(ra, dec);
-    }
-    else
-    {
-        LOG_DEBUG("SaveAlignBeforeSyncS is OFF. Not doing anything.");
-    }
-
     char cmd[DRIVER_LEN] = {0};
+
     snprintf(cmd, DRIVER_LEN, ":Ck%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
 
     if (sendCommand(cmd))
@@ -986,7 +999,7 @@ bool Rainbow::StarAlign(double ra, double dec)
         char RAStr[64] = {0}, DecStr[64] = {0};
         fs_sexa(RAStr, ra, 2, 36000);
         fs_sexa(DecStr, dec, 2, 36000);
-        LOGF_INFO("Star aligned to RA %s DE %s", RAStr, DecStr);
+        LOGF_INFO("Star-Aligned to RA %s DE %s", RAStr, DecStr);
         return true;
     }
 

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -89,10 +89,9 @@ bool Rainbow::initProperties()
                        IPS_IDLE);
 
     // Align Star Before Sync
-    IUFillSwitch(&SaveAlignBeforeSyncS[INDI_ENABLED], "INDI_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&SaveAlignBeforeSyncS[INDI_DISABLED], "INDI_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&SaveAlignBeforeSyncSP, SaveAlignBeforeSyncS, 2, getDeviceName(), "SEND_ALIGN_BEFORE_SYNC", "Save Star Alignment to mount before sync",
-                       ALIGNMENT_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    IUFillSwitch(&SaveAlignBeforeSyncS[0], "SEND_ALIGN_BEFORE_SYNC", "Save Star Alignment to mount before sync", ISS_OFF);
+    IUFillSwitchVector(&SaveAlignBeforeSyncSP, SaveAlignBeforeSyncS, 1, getDeviceName(), "SEND_ALIGN_BEFORE_SYNC", "Save Star Alignment to mount before sync",
+                       ALIGNMENT_TAB, IP_RW, ISR_NOFMANY, 60, IPS_IDLE);
 
     setDriverInterface(getDriverInterface() | GUIDER_INTERFACE);
 
@@ -243,11 +242,14 @@ bool Rainbow::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
             return true;
         }
         else if (!strcmp(SaveAlignBeforeSyncSP.name, name)) {
-
-            IUUpdateSwitch(&SaveAlignBeforeSyncSP, states, names, n);
-            SaveAlignBeforeSyncSP.s = IPS_OK;
-            saveConfig(true, SaveAlignBeforeSyncSP.name);
-            IDSetSwitch(&SaveAlignBeforeSyncSP, nullptr);
+            if (SaveAlignBeforeSyncS[0].s == ISS_ON)
+            {
+                SaveAlignBeforeSyncS[0].s = ISS_OFF;
+            }
+            else
+            {
+                SaveAlignBeforeSyncS[0].s = ISS_ON;
+            }
             return true;
         }
 
@@ -852,25 +854,25 @@ bool Rainbow::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
 {
     switch (command)
     {
-    case MOTION_START:
-        if (!sendCommand(dir == DIRECTION_NORTH ? ":Mn#" : ":Ms#"))
-        {
-            LOG_ERROR("Error setting N/S motion direction.");
-            return false;
-        }
-        else
-            LOGF_DEBUG("Moving toward %s.", (dir == DIRECTION_NORTH) ? "North" : "South");
-        break;
+        case MOTION_START:
+            if (!sendCommand(dir == DIRECTION_NORTH ? ":Mn#" : ":Ms#"))
+            {
+                LOG_ERROR("Error setting N/S motion direction.");
+                return false;
+            }
+            else
+                LOGF_DEBUG("Moving toward %s.", (dir == DIRECTION_NORTH) ? "North" : "South");
+            break;
 
-    case MOTION_STOP:
-        if (!sendCommand(":Q#"))
-        {
-            LOG_ERROR("Error stopping N/S motion.");
-            return false;
-        }
-        else
-            LOGF_DEBUG("Movement toward %s halted.", (dir == DIRECTION_NORTH) ? "North" : "South");
-        break;
+        case MOTION_STOP:
+            if (!sendCommand(":Q#"))
+            {
+                LOG_ERROR("Error stopping N/S motion.");
+                return false;
+            }
+            else
+                LOGF_DEBUG("Movement toward %s halted.", (dir == DIRECTION_NORTH) ? "North" : "South");
+            break;
     }
 
     return true;
@@ -883,25 +885,25 @@ bool Rainbow::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
 {
     switch (command)
     {
-    case MOTION_START:
-        if (!sendCommand(dir == DIRECTION_WEST ? ":Mw#" : ":Me#"))
-        {
-            LOG_ERROR("Error setting W/E motion direction.");
-            return false;
-        }
-        else
-            LOGF_DEBUG("Moving toward %s.", (dir == DIRECTION_WEST) ? "West" : "East");
-        break;
+        case MOTION_START:
+            if (!sendCommand(dir == DIRECTION_WEST ? ":Mw#" : ":Me#"))
+            {
+                LOG_ERROR("Error setting W/E motion direction.");
+                return false;
+            }
+            else
+                LOGF_DEBUG("Moving toward %s.", (dir == DIRECTION_WEST) ? "West" : "East");
+            break;
 
-    case MOTION_STOP:
-        if (!sendCommand(":Q#"))
-        {
-            LOG_ERROR("Error stopping W/E motion.");
-            return false;
-        }
-        else
-            LOGF_DEBUG("Movement toward %s halted.", (dir == DIRECTION_WEST) ? "West" : "East");
-        break;
+        case MOTION_STOP:
+            if (!sendCommand(":Q#"))
+            {
+                LOG_ERROR("Error stopping W/E motion.");
+                return false;
+            }
+            else
+                LOGF_DEBUG("Movement toward %s halted.", (dir == DIRECTION_WEST) ? "West" : "East");
+            break;
     }
 
     return true;
@@ -946,27 +948,50 @@ bool Rainbow::Abort()
 bool Rainbow::Sync(double ra, double dec)
 {
 
-        char cmd[DRIVER_LEN] = {0};
-        if (SaveAlignBeforeSyncS[0].s == ISS_ON)
-        {
-            snprintf(cmd, DRIVER_LEN, ":CN%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
-        }
-        else
-        {
-            snprintf(cmd, DRIVER_LEN, ":Ck%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
-        }
+    if (SaveAlignBeforeSyncS[0].s == ISS_ON)
+    {
+           StarAlign(ra, dec);
+    }
+    else
+    {
+        LOG_DEBUG("SaveAlignBeforeSyncS is OFF. Not doing anything.");
+    }
 
-        if (sendCommand(cmd))
-        {
-            char RAStr[64] = {0}, DecStr[64] = {0};
-            fs_sexa(RAStr, ra, 2, 36000);
-            fs_sexa(DecStr, dec, 2, 36000);
-            LOGF_INFO("Synced to RA %s DE %s%s",RAStr, DecStr, SaveAlignBeforeSyncS[0].s == ISS_ON?", and saved as alignment point.":"");
-            return true;
-        }
+    char cmd[DRIVER_LEN] = {0};
+    snprintf(cmd, DRIVER_LEN, ":Ck%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
+
+    if (sendCommand(cmd))
+    {
+        char RAStr[64] = {0}, DecStr[64] = {0};
+        fs_sexa(RAStr, ra, 2, 36000);
+        fs_sexa(DecStr, dec, 2, 36000);
+        LOGF_INFO("Synced to RA %s DE %s", RAStr, DecStr);
+        return true;
+    }
+
     return false;
 }
 
+/////////////////////////////////////////////////////////////////////////////
+/// StarAlign
+/////////////////////////////////////////////////////////////////////////////
+bool Rainbow::StarAlign(double ra, double dec)
+{
+    char cmd[DRIVER_LEN] = {0};
+
+    snprintf(cmd, DRIVER_LEN, ":CN%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
+
+    if (sendCommand(cmd))
+    {
+        char RAStr[64] = {0}, DecStr[64] = {0};
+        fs_sexa(RAStr, ra, 2, 36000);
+        fs_sexa(DecStr, dec, 2, 36000);
+        LOGF_INFO("Star aligned to RA %s DE %s", RAStr, DecStr);
+        return true;
+    }
+
+    return false;
+}
 
 
 /////////////////////////////////////////////////////////////////////////////
@@ -976,14 +1001,14 @@ bool Rainbow::SetTrackMode(uint8_t mode)
 {
     switch (mode)
     {
-    case TRACK_SIDEREAL:
-        return sendCommand(":CtR#");
-    case TRACK_SOLAR:
-        return sendCommand(":CtS#");
-    case TRACK_LUNAR:
-        return sendCommand(":CtL#");
-    case TRACK_CUSTOM:
-        return sendCommand(":CtU#");
+        case TRACK_SIDEREAL:
+            return sendCommand(":CtR#");
+        case TRACK_SOLAR:
+            return sendCommand(":CtS#");
+        case TRACK_LUNAR:
+            return sendCommand(":CtL#");
+        case TRACK_CUSTOM:
+            return sendCommand(":CtU#");
 
     }
 
@@ -997,14 +1022,14 @@ bool Rainbow::SetSlewRate(int index)
 {
     switch(index)
     {
-    case SLEW_MAX:
-        return sendCommand(":RS#");
-    case SLEW_FIND:
-        return sendCommand(":RM#");
-    case SLEW_CENTERING:
-        return sendCommand(":RC#");
-    case SLEW_GUIDE:
-        return sendCommand(":RG#");
+        case SLEW_MAX:
+            return sendCommand(":RS#");
+        case SLEW_FIND:
+            return sendCommand(":RM#");
+        case SLEW_CENTERING:
+            return sendCommand(":RC#");
+        case SLEW_GUIDE:
+            return sendCommand(":RG#");
     }
 
     return false;
@@ -1016,16 +1041,16 @@ const std::string Rainbow::getSlewErrorString(uint8_t code)
 {
     switch (code)
     {
-    case 1:
-        return "The altitude of the target is lower than lower limit.";
-    case 2:
-        return "The altitude of the target is higher than upper limit.";
-    case 3:
-        return "Slewing was canceled by user";
-    case 4:
-        return "RA Axis homing failed.";
-    case 5:
-        return "DE Axis homing failed.";
+        case 1:
+            return "The altitude of the target is lower than lower limit.";
+        case 2:
+            return "The altitude of the target is higher than upper limit.";
+        case 3:
+            return "Slewing was canceled by user";
+        case 4:
+            return "RA Axis homing failed.";
+        case 5:
+            return "DE Axis homing failed.";
     }
 
     return "Unknown error";
@@ -1078,30 +1103,30 @@ IPState Rainbow::guide(Direction direction, uint32_t ms)
     // set up pointers to the various things needed
     switch (direction)
     {
-    case North:
-        dc = 'N';
-        moveSP = &MovementNSSP;
-        moveS = MovementNSS[0];
-        guideTID = &m_GuideNSTID;
-        break;
-    case South:
-        dc = 'S';
-        moveSP = &MovementNSSP;
-        moveS = MovementNSS[1];
-        guideTID = &m_GuideNSTID;
-        break;
-    case East:
-        dc = 'E';
-        moveSP = &MovementWESP;
-        moveS = MovementWES[1];
-        guideTID = &m_GuideWETID;
-        break;
-    case West:
-        dc = 'W';
-        moveSP = &MovementWESP;
-        moveS = MovementWES[0];
-        guideTID = &m_GuideWETID;
-        break;
+        case North:
+            dc = 'N';
+            moveSP = &MovementNSSP;
+            moveS = MovementNSS[0];
+            guideTID = &m_GuideNSTID;
+            break;
+        case South:
+            dc = 'S';
+            moveSP = &MovementNSSP;
+            moveS = MovementNSS[1];
+            guideTID = &m_GuideNSTID;
+            break;
+        case East:
+            dc = 'E';
+            moveSP = &MovementWESP;
+            moveS = MovementWES[1];
+            guideTID = &m_GuideWETID;
+            break;
+        case West:
+            dc = 'W';
+            moveSP = &MovementWESP;
+            moveS = MovementWES[0];
+            guideTID = &m_GuideWETID;
+            break;
     }
 
     if (MovementNSSP.s == IPS_BUSY || MovementWESP.s == IPS_BUSY)
@@ -1199,28 +1224,28 @@ void Rainbow::guideTimeout(Direction direction)
     char cmd[DRIVER_LEN] = {0};
     switch(direction)
     {
-    case North:
-    case South:
-        IUResetSwitch(&MovementNSSP);
-        IDSetSwitch(&MovementNSSP, nullptr);
-        GuideNSNP.np[0].value = 0;
-        GuideNSNP.np[1].value = 0;
-        GuideNSNP.s           = IPS_IDLE;
-        m_GuideNSTID            = 0;
-        IDSetNumber(&GuideNSNP, nullptr);
-        snprintf(cmd, DRIVER_LEN, ":Q%c#", direction == North ? 'n' : 's');
-        break;
-    case East:
-    case West:
-        IUResetSwitch(&MovementWESP);
-        IDSetSwitch(&MovementWESP, nullptr);
-        GuideWENP.np[0].value = 0;
-        GuideWENP.np[1].value = 0;
-        GuideWENP.s           = IPS_IDLE;
-        m_GuideWETID            = 0;
-        IDSetNumber(&GuideWENP, nullptr);
-        snprintf(cmd, DRIVER_LEN, ":Q%c#", direction == East ? 'e' : 'w');
-        break;
+        case North:
+        case South:
+            IUResetSwitch(&MovementNSSP);
+            IDSetSwitch(&MovementNSSP, nullptr);
+            GuideNSNP.np[0].value = 0;
+            GuideNSNP.np[1].value = 0;
+            GuideNSNP.s           = IPS_IDLE;
+            m_GuideNSTID            = 0;
+            IDSetNumber(&GuideNSNP, nullptr);
+            snprintf(cmd, DRIVER_LEN, ":Q%c#", direction == North ? 'n' : 's');
+            break;
+        case East:
+        case West:
+            IUResetSwitch(&MovementWESP);
+            IDSetSwitch(&MovementWESP, nullptr);
+            GuideWENP.np[0].value = 0;
+            GuideWENP.np[1].value = 0;
+            GuideWENP.s           = IPS_IDLE;
+            m_GuideWETID            = 0;
+            IDSetNumber(&GuideWENP, nullptr);
+            snprintf(cmd, DRIVER_LEN, ":Q%c#", direction == East ? 'e' : 'w');
+            break;
     }
     sendCommand(cmd);
     LOGF_DEBUG("Guide %c finished", "NSWE"[direction]);
@@ -1233,18 +1258,18 @@ void Rainbow::addGuideTimer(Direction direction, uint32_t ms)
 {
     switch(direction)
     {
-    case North:
-        m_GuideNSTID = IEAddTimer(ms, guideTimeoutHelperN, this);
-        break;
-    case South:
-        m_GuideNSTID = IEAddTimer(ms, guideTimeoutHelperS, this);
-        break;
-    case East:
-        m_GuideWETID = IEAddTimer(ms, guideTimeoutHelperE, this);
-        break;
-    case West:
-        m_GuideWETID = IEAddTimer(ms, guideTimeoutHelperW, this);
-        break;
+        case North:
+            m_GuideNSTID = IEAddTimer(ms, guideTimeoutHelperN, this);
+            break;
+        case South:
+            m_GuideNSTID = IEAddTimer(ms, guideTimeoutHelperS, this);
+            break;
+        case East:
+            m_GuideWETID = IEAddTimer(ms, guideTimeoutHelperE, this);
+            break;
+        case West:
+            m_GuideWETID = IEAddTimer(ms, guideTimeoutHelperW, this);
+            break;
     }
 }
 
@@ -1568,7 +1593,7 @@ std::vector<std::string> Rainbow::split(const std::string &input, const std::str
     // passing -1 as the submatch index parameter performs splitting
     std::regex re(regex);
     std::sregex_token_iterator
-            first{input.begin(), input.end(), re, -1},
-    last;
+    first{input.begin(), input.end(), re, -1},
+          last;
     return {first, last};
 }

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -176,8 +176,8 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         const std::string getSlewErrorString(uint8_t code);
         uint8_t m_SlewErrorCode {0};
 
-        ISwitchVectorProperty SaveAlignBeforeSyncSP;
-        ISwitch SaveAlignBeforeSyncS[1];
+        ISwitchVectorProperty SaveAlignAfterSlewSP;
+        ISwitch SaveAlignAfterSlewS[1];
 
 
         GotoType m_GotoType { Equatorial };

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -35,6 +35,15 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         typedef enum { Equatorial, Horizontal } GotoType;
         typedef enum { North, South, West, East } Direction;
 
+        enum Rainbow_Alignment_State
+        {
+            ALIGN_IDLE,
+            ALIGN_START,
+            ALIGN_END,
+            ALIGN_DELETE_CURRENT,
+            ALIGN_COUNT
+        };
+
     protected:
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
@@ -136,6 +145,13 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         void hexDump(char * buf, const char * data, int size);
         std::vector<std::string> split(const std::string &input, const std::string &regex);
 
+
+        ///////////////////////////////////////////////////////////////////////////////
+        /// StarAlign
+        ///////////////////////////////////////////////////////////////////////////////
+        virtual bool StarAlign(double ra, double dec);
+
+
     private:
 
         // Horizontal Coordinates functions.
@@ -159,6 +175,10 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
 
         const std::string getSlewErrorString(uint8_t code);
         uint8_t m_SlewErrorCode {0};
+
+        ISwitchVectorProperty SaveAlignAfterSlewSP;
+        ISwitch SaveAlignAfterSlewS[1];
+
 
         GotoType m_GotoType { Equatorial };
         double m_CurrentAZ {0}, m_CurrentAL {0};

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -176,8 +176,8 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         const std::string getSlewErrorString(uint8_t code);
         uint8_t m_SlewErrorCode {0};
 
-        ISwitchVectorProperty SaveAlignAfterSlewSP;
-        ISwitch SaveAlignAfterSlewS[1];
+        ISwitchVectorProperty SaveAlignBeforeSyncSP;
+        ISwitch SaveAlignBeforeSyncS[1];
 
 
         GotoType m_GotoType { Equatorial };

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -151,6 +151,9 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         ISwitchVectorProperty HomeSP;
         ISwitch HomeS[1];
 
+        ISwitchVectorProperty SaveAlignBeforeSyncSP;
+        ISwitch SaveAlignBeforeSyncS[2];
+
         INumberVectorProperty HorizontalCoordsNP;
         INumber HorizontalCoordsN[2];
 

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -145,6 +145,13 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         void hexDump(char * buf, const char * data, int size);
         std::vector<std::string> split(const std::string &input, const std::string &regex);
 
+
+        ///////////////////////////////////////////////////////////////////////////////
+        /// StarAlign
+        ///////////////////////////////////////////////////////////////////////////////
+        virtual bool StarAlign(double ra, double dec);
+
+
     private:
 
         // Horizontal Coordinates functions.
@@ -170,7 +177,7 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         uint8_t m_SlewErrorCode {0};
 
         ISwitchVectorProperty SaveAlignBeforeSyncSP;
-        ISwitch SaveAlignBeforeSyncS[2];
+        ISwitch SaveAlignBeforeSyncS[1];
 
 
         GotoType m_GotoType { Equatorial };

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -35,15 +35,6 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         typedef enum { Equatorial, Horizontal } GotoType;
         typedef enum { North, South, West, East } Direction;
 
-        enum Rainbow_Alignment_State
-        {
-            ALIGN_IDLE,
-            ALIGN_START,
-            ALIGN_END,
-            ALIGN_DELETE_CURRENT,
-            ALIGN_COUNT
-        };
-
     protected:
         virtual bool initProperties() override;
         virtual bool updateProperties() override;
@@ -145,13 +136,6 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         void hexDump(char * buf, const char * data, int size);
         std::vector<std::string> split(const std::string &input, const std::string &regex);
 
-
-        ///////////////////////////////////////////////////////////////////////////////
-        /// StarAlign
-        ///////////////////////////////////////////////////////////////////////////////
-        virtual bool StarAlign(double ra, double dec);
-
-
     private:
 
         // Horizontal Coordinates functions.
@@ -175,10 +159,6 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
 
         const std::string getSlewErrorString(uint8_t code);
         uint8_t m_SlewErrorCode {0};
-
-        ISwitchVectorProperty SaveAlignAfterSlewSP;
-        ISwitch SaveAlignAfterSlewS[1];
-
 
         GotoType m_GotoType { Equatorial };
         double m_CurrentAZ {0}, m_CurrentAL {0};

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -145,13 +145,6 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         void hexDump(char * buf, const char * data, int size);
         std::vector<std::string> split(const std::string &input, const std::string &regex);
 
-
-        ///////////////////////////////////////////////////////////////////////////////
-        /// StarAlign
-        ///////////////////////////////////////////////////////////////////////////////
-        virtual bool StarAlign(double ra, double dec);
-
-
     private:
 
         // Horizontal Coordinates functions.
@@ -177,7 +170,7 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         uint8_t m_SlewErrorCode {0};
 
         ISwitchVectorProperty SaveAlignBeforeSyncSP;
-        ISwitch SaveAlignBeforeSyncS[1];
+        ISwitch SaveAlignBeforeSyncS[2];
 
 
         GotoType m_GotoType { Equatorial };


### PR DESCRIPTION
Save Alignment Data to mount before sync.
Users can checked the "Save Star Alignment to mount before sync". This would send the star alignment command before every sync operations. Then use the "Mount Model Tool", choose the "Sync" as the platesolve operation. Then at each sync, the alignment data will save to the mount.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1564: Add Star Alignment option to Rainbow Astro RST-135(E) mount driver](https://issuehunt.io/repos/58881442/issues/1564)
---
</details>
<!-- /Issuehunt content-->