### PR TITLE
Fixing pull request #1566 by adding missing property init and update

### DIFF
--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -70,6 +70,12 @@ bool Rainbow::initProperties()
     IUFillSwitchVector(&HomeSP, HomeS, 1, getDeviceName(), "HOME", "Homing", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_IDLE);
 
+    // Star Alignment on Sync
+    IUFillSwitch(&SaveAlignBeforeSyncS[STAR_ALIGNMENT_ENABLED], "STAR_ALIGNMENT_ENABLED", "Enabled", ISS_OFF);
+    IUFillSwitch(&SaveAlignBeforeSyncS[STAR_ALIGNMENT_DISABLED], "STAR_ALIGNMENT_DISABLED", "Disabled", ISS_ON);
+    IUFillSwitchVector(&SaveAlignBeforeSyncSP, SaveAlignBeforeSyncS, 2, getDeviceName(),
+                           "STAR_ALIGNMENT", "Star Alignment", ALIGNMENT_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+
     // Horizontal Coords
     IUFillNumber(&HorizontalCoordsN[AXIS_AZ], "AZ", "Az D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
     IUFillNumber(&HorizontalCoordsN[AXIS_ALT], "ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
@@ -111,7 +117,8 @@ bool Rainbow::updateProperties()
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
         defineProperty(&GuideRateNP);
-
+        
+        defineProperty(&SaveAlignBeforeSyncSP);
     }
     else
     {
@@ -121,6 +128,8 @@ bool Rainbow::updateProperties()
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
         deleteProperty(GuideRateNP.name);
+
+        deleteProperty(SaveAlignBeforeSyncSP.name);
     }
 
     return true;
@@ -932,7 +941,7 @@ bool Rainbow::Sync(double ra, double dec)
 {
 
     char cmd[DRIVER_LEN] = {0};
-    if (SaveAlignBeforeSyncS[0].s == ISS_ON)
+    if (SaveAlignBeforeSyncS[STAR_ALIGNMENT_ENABLED].s == ISS_ON)
     {
         snprintf(cmd, DRIVER_LEN, ":CN%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
     }
@@ -946,7 +955,7 @@ bool Rainbow::Sync(double ra, double dec)
         char RAStr[64] = {0}, DecStr[64] = {0};
         fs_sexa(RAStr, ra, 2, 36000);
         fs_sexa(DecStr, dec, 2, 36000);
-        LOGF_INFO("Synced to RA %s DE %s%s",RAStr, DecStr, SaveAlignBeforeSyncS[0].s == ISS_ON?", and saved as alignment point.":"");
+        LOGF_INFO("Synced to RA %s DE %s%s",RAStr, DecStr, SaveAlignBeforeSyncS[STAR_ALIGNMENT_ENABLED].s == ISS_ON?", and saved as alignment point.":"");
         return true;
     }
     return false;

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -70,12 +70,6 @@ bool Rainbow::initProperties()
     IUFillSwitchVector(&HomeSP, HomeS, 1, getDeviceName(), "HOME", "Homing", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_IDLE);
 
-    // Star Alignment on Sync
-    IUFillSwitch(&StarAlignmentS[STAR_ALIGNMENT_ENABLED], "STAR_ALIGNMENT_ENABLED", "Enabled", ISS_OFF);
-    IUFillSwitch(&StarAlignmentS[STAR_ALIGNMENT_DISABLED], "STAR_ALIGNMENT_DISABLED", "Disabled", ISS_ON);
-    IUFillSwitchVector(&StarAlignmentSP, StarAlignmentS, 2, getDeviceName(),
-                           "STAR_ALIGNMENT", "Alignment on Sync", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
-
     // Horizontal Coords
     IUFillNumber(&HorizontalCoordsN[AXIS_AZ], "AZ", "Az D:M:S", "%10.6m", 0.0, 360.0, 0.0, 0);
     IUFillNumber(&HorizontalCoordsN[AXIS_ALT], "ALT", "Alt  D:M:S", "%10.6m", -90., 90.0, 0.0, 0);
@@ -117,7 +111,6 @@ bool Rainbow::updateProperties()
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
         defineProperty(&GuideRateNP);
-        defineProperty(&StarAlignmentSP);
 
     }
     else
@@ -128,7 +121,6 @@ bool Rainbow::updateProperties()
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
         deleteProperty(GuideRateNP.name);
-        deleteProperty(StarAlignmentSP.name);
     }
 
     return true;
@@ -236,30 +228,6 @@ bool Rainbow::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
                 LOG_ERROR("Mount failed to move to home position.");
 
             IDSetSwitch(&HomeSP, nullptr);
-            return true;
-        }
-        // StarAlignment
-        if (!strcmp(name, StarAlignmentSP.name))
-        {
-            // Find out which state is requested by the client
-            const char *actionName = IUFindOnSwitchName(states, names, n);
-            // If StarAlignmentState is the same state as actionName, then we do nothing. i.e. if actionName is STAR_ALIGNMENT_OFF and our StarAlignment is already off, we return
-            StarAlignmentState = IUFindOnSwitchIndex(&StarAlignmentSP);
-            if (!strcmp(actionName, StarAlignmentS[StarAlignmentState].name))
-            {
-                LOGF_INFO("StarAlignment is already %s", StarAlignmentS[StarAlignmentState].label);
-                StarAlignmentSP.s = IPS_IDLE;
-                IDSetSwitch(&StarAlignmentSP, NULL);
-                return true;
-            }
-            
-            // Otherwise, let us update the switch state
-            IUUpdateSwitch(&StarAlignmentSP, states, names, n);
-            StarAlignmentState = IUFindOnSwitchIndex(&StarAlignmentSP);
-            LOGF_INFO("StarAlignment is now %s", StarAlignmentS[StarAlignmentState].label);
-            StarAlignmentSP.s = IPS_OK;
-            IDSetSwitch(&StarAlignmentSP, NULL);
-            LOGF_INFO("StarAlignmentState =  %d",StarAlignmentState);
             return true;
         }
 
@@ -955,14 +923,15 @@ bool Rainbow::Abort()
 bool Rainbow::Sync(double ra, double dec)
 {
     char cmd[DRIVER_LEN] = {0};
-    snprintf(cmd, DRIVER_LEN, ":C%c%07.3f%c%06.3f#",StarAlignmentState ? 'N' : 'k', ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
+
+    snprintf(cmd, DRIVER_LEN, ":Ck%07.3f%c%06.3f#", ra * 15.0, dec >= 0 ? '+' : '-', std::fabs(dec));
 
     if (sendCommand(cmd))
     {
         char RAStr[64] = {0}, DecStr[64] = {0};
         fs_sexa(RAStr, ra, 2, 36000);
         fs_sexa(DecStr, dec, 2, 36000);
-        LOGF_INFO("Synced %s to RA %s DE %s",StarAlignmentState ? "star alignment point" : "mount", RAStr, DecStr);
+        LOGF_INFO("Synced to RA %s DE %s", RAStr, DecStr);
         return true;
     }
 

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -23,6 +23,9 @@
 #include "inditelescope.h"
 #include "indiguiderinterface.h"
 
+#define ALIGNMENT_TAB "Alignment"
+
+
 class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
 {
     public:
@@ -153,6 +156,7 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
 
         ISwitchVectorProperty SaveAlignBeforeSyncSP;
         ISwitch SaveAlignBeforeSyncS[2];
+        enum { STAR_ALIGNMENT_DISABLED, STAR_ALIGNMENT_ENABLED};
 
         INumberVectorProperty HorizontalCoordsNP;
         INumber HorizontalCoordsN[2];

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -167,11 +167,6 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         int m_GuideNSTID {0};
         int m_GuideWETID {0};
 
-        ISwitch StarAlignmentS[2];
-        ISwitchVectorProperty StarAlignmentSP;
-        enum { STAR_ALIGNMENT_DISABLED, STAR_ALIGNMENT_ENABLED};
-        int StarAlignmentState = 0;
-
         /////////////////////////////////////////////////////////////////////////////
         /// Static Helper Values
         /////////////////////////////////////////////////////////////////////////////

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -24,6 +24,7 @@
 #include "indiguiderinterface.h"
 
 #define ALIGNMENT_TAB "Alignment"
+#define GENERAL_INFO_TAB "General Info"
 
 
 class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
@@ -148,6 +149,10 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         bool setAL(double altitude);
         bool slewToHorizontalCoords(double azimuth, double altitude);
 
+        // Set and get slew speeds
+        bool setSlewSpeedVal(int speedtype, double rate);
+        bool getSlewSpeedVal(int speedtype);
+
         ///////////////////////////////////////////////////////////////////////////////////
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////////
@@ -158,11 +163,31 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         ISwitch SaveAlignBeforeSyncS[2];
         enum { STAR_ALIGNMENT_DISABLED, STAR_ALIGNMENT_ENABLED};
 
+        IText RSTVersionsT[2];
+        ITextVectorProperty RSTVersionsTP;
+        enum { FIRMWARE, SERIALNUMBER };
+
+        ISwitchVectorProperty PullVoltTempSP;
+        ISwitch PullVoltTempS[2];
+        enum { PULL_VOLTTEMP_DISABLED, PULL_VOLTTEMP_ENABLED};
+
+        INumber RSTVoltTempN[4];
+        INumberVectorProperty RSTVoltTempNP;
+        enum { VOLTAGE, BOARD_TEMPERATURE, RA_M_TEMPERATURE, DE_M_TEMPERATURE };
+
+        INumber RSTMotorPowN[2];
+        INumberVectorProperty RSTMotorPowNP;
+        enum { RA_M_POWER, DE_M_POWER };
+
         INumberVectorProperty HorizontalCoordsNP;
         INumber HorizontalCoordsN[2];
 
         INumber GuideRateN[1];
         INumberVectorProperty GuideRateNP;
+
+        INumberVectorProperty SlewSpeedsNP;
+        INumber SlewSpeedsN[3];
+        enum { SLEW_SPEED_MAX, SLEW_SPEED_FIND, SLEW_SPEED_CENTERING };
 
         const std::string getSlewErrorString(uint8_t code);
         uint8_t m_SlewErrorCode {0};

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -167,6 +167,11 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         int m_GuideNSTID {0};
         int m_GuideWETID {0};
 
+        ISwitch StarAlignmentS[2];
+        ISwitchVectorProperty StarAlignmentSP;
+        enum { STAR_ALIGNMENT_DISABLED, STAR_ALIGNMENT_ENABLED};
+        int StarAlignmentState = 0;
+
         /////////////////////////////////////////////////////////////////////////////
         /// Static Helper Values
         /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Pull request #1566 forgot to implement the needed property initialization and updating. This PR fixes that.
Built and tested on RST-135 mount successfully.

Linked to issue #1564.


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#1564: Add Star Alignment option to Rainbow Astro RST-135(E) mount driver](https://issuehunt.io/repos/58881442/issues/1564)
---
</details>
<!-- /Issuehunt content-->