### PR TITLE
CCD drivers: snooping for standard epoch positions and issues with fast exposure mode fixed

### DIFF
--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -530,6 +530,11 @@ class CCD : public DefaultDevice, GuiderInterface
         // J2000 Position
         double J2000RA;
         double J2000DE;
+        bool J2000Valid;
+
+        // exposure information
+	char exposureStartTime[MAXINDINAME];
+	double exposureDuration;
 
         double primaryFocalLength, primaryAperture, guiderFocalLength, guiderAperture;
         bool InExposure;
@@ -592,6 +597,14 @@ class CCD : public DefaultDevice, GuiderInterface
          */
         INumberVectorProperty EqNP;
         INumber EqN[2];
+
+        /**
+         * @brief J200EqNP Snoop property to read the equatorial J2000 coordinates of the mount.
+         * ActiveDeviceTP defines snoop devices and the driver listens to this property emitted
+         * by the mount driver if specified. It is important to generate a proper FITS header.
+         */
+        INumberVectorProperty J2000EqNP;
+        INumber J2000EqN[2];
 
         /**
          * @brief ActiveDeviceTP defines 4 devices the camera driver can listen to (snoop) for


### PR DESCRIPTION
-  CCD drivers now also snoop for standard epoch positions (indi property EQUATORIAL_COORD)
- CCD drivers: conversion of epoch of day position (indi property EQUATORIAL_EOD_COORD) to standard epoch position (if no standard epoch position given) and calculation of ALT/AZ coordinates moved to addFITSKeywords such that they are updated during fast exposure
- CCD drivers: backup of exposure start time and duration before a new exposure is started in fast exposure mode. (Previously the fits keyword contained the exposure information of the next frame in fast exposure mode.)