### PR TITLE
OnStep: Update version to 1.13, introduce timeouts based on network o…

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -19,7 +19,7 @@
         </device>
         <device label="LX200 OnStep" manufacturer="OnStep">
             <driver name="LX200 OnStep">indi_lx200_OnStep</driver>
-            <version>1.12</version>
+            <version>1.13</version>
         </device>
         <device label="LX200 TeenAstro" manufacturer="TeenAstro">
             <driver name="LX200 TeenAstro">indi_lx200_TeenAstro</driver>


### PR DESCRIPTION
…r not (2sec & 0.1sec), add input verification where possible.

Also reduce messages to warnings (from error) where an error with the driver or mount is not indicated due to network timeouts. (Communication error = Warning) Messages are still warnings on trying and failing to set something. 

This should eliminate almost all communication errors causing driver crashes. 

