### PR TITLE
Add timeouts to rainbow focuser

### DIFF
--- a/drivers/focuser/rainbowRSF.cpp
+++ b/drivers/focuser/rainbowRSF.cpp
@@ -23,7 +23,7 @@ This is the Rainbow API. A pdf is in the driver docs folder.
 
 Command              Send      Receive     Comment
 
-Get Position         :Fp#      :FPsDD.DDD# s is + or -, 
+Get Position         :Fp#      :FPsDD.DDD# s is + or -,
                                            sDD.DDD is a float number
                                            range: -08.000 to +08.000
                                            unit millimeters
@@ -100,6 +100,8 @@ bool RainbowRSF::initProperties()
     addSimulationControl();
     addDebugControl();
 
+    timeoutStartSeconds = 0;
+
     return true;
 }
 
@@ -167,23 +169,24 @@ bool RainbowRSF::Handshake()
 ///
 /////////////////////////////////////////////////////////////////////////////
 
-namespace {
+namespace
+{
 bool parsePosition(char *result, int *pos)
 {
-  const int length = strlen(result);
-  if (length < 6) return false;
-  // Check for a decimal/period
-  char *period = strchr(result+3, '.');
-  if (period == nullptr) return false;
+    const int length = strlen(result);
+    if (length < 6) return false;
+    // Check for a decimal/period
+    char *period = strchr(result + 3, '.');
+    if (period == nullptr) return false;
 
-  float position;
-  if (sscanf(result, ":FP%f#", &position) == 1)
-  {
-      // position is a float number between -8 and +8 that needs to be multiplied by 1000.
-      *pos = position * 1000;
-      return true;
-  }
-  return false;
+    float position;
+    if (sscanf(result, ":FP%f#", &position) == 1)
+    {
+        // position is a float number between -8 and +8 that needs to be multiplied by 1000.
+        *pos = position * 1000;
+        return true;
+    }
+    return false;
 }
 }  // namespace
 
@@ -246,13 +249,46 @@ bool RainbowRSF::updatePosition()
 
     int newPosition { 0 };
     bool ok = parsePosition(res, &newPosition);
-    if (ok) {
+    if (ok)
+    {
         FocusAbsPosN[0].value = newPosition + 8000;
 
-        const int offset = FocusAbsPosN[0].value - m_TargetPosition;
         constexpr int TOLERANCE = 1;  // Off-by-one position is ok given the resolution of the response.
-        if (std::abs(offset) <= TOLERANCE)
+        const int offset = std::abs(static_cast<int>(FocusAbsPosN[0].value - m_TargetPosition));
+        bool focuserDone = offset <= TOLERANCE;
+
+        // Try to hit the target position, but if it has been close for a while
+        // then we believe the focuser movement is done. This is needed because it
+        // sometimes stops 1 position away from the target, and occasionally 2 or 3.
+        if (!focuserDone && ((GoHomeSP.s == IPS_BUSY) || (FocusAbsPosNP.s == IPS_BUSY)))
         {
+            struct timeval now;
+            if (0 == gettimeofday(&now, nullptr))
+            {
+                time_t nowSeconds = now.tv_sec;
+                if (timeoutStartSeconds == 0)
+                {
+                    // Waiting for motion completion. Initialize the start time for timeouts.
+                    timeoutStartSeconds = nowSeconds;
+                }
+                else
+                {
+                    const int elapsedSeconds = nowSeconds - timeoutStartSeconds;
+                    if ((elapsedSeconds > 5 && offset < 3) ||
+                            (elapsedSeconds > 10 && offset < 6) ||
+                            (elapsedSeconds > 60))
+                    {
+                        focuserDone = true;
+                        LOGF_INFO("Rainbow focuser timed out: %d seconds, offset %d (target %d, position %d)",
+                                  elapsedSeconds, offset, m_TargetPosition, static_cast<int>(FocusAbsPosN[0].value));
+                    }
+                }
+            }
+        }
+
+        if (focuserDone)
+        {
+            timeoutStartSeconds = 0;
             if (GoHomeSP.s == IPS_BUSY)
             {
                 GoHomeSP.s = IPS_OK;
@@ -276,7 +312,8 @@ bool RainbowRSF::updatePosition()
                 FocusRelPosNP.s = IPS_OK;
 
                 IDSetNumber(&FocusRelPosNP, nullptr);
-                LOG_INFO("Focuser reached target position.");
+                LOGF_INFO("Focuser reached target position %d at %d.",
+                          m_TargetPosition, static_cast<int>(FocusAbsPosN[0].value));
             }
         }
         return true;
@@ -321,6 +358,7 @@ bool RainbowRSF::updateTemperature()
 /////////////////////////////////////////////////////////////////////////////////////
 IPState RainbowRSF::MoveAbsFocuser(uint32_t targetTicks)
 {
+    timeoutStartSeconds = 0;
     m_TargetPosition = targetTicks;
 
     char cmd[DRIVER_LEN] = {0};
@@ -331,14 +369,15 @@ IPState RainbowRSF::MoveAbsFocuser(uint32_t targetTicks)
 
     if (isSimulation() == false)
     {
-      if (sendCommand(cmd, res, DRIVER_LEN) == false)
-          return IPS_ALERT;
+        if (sendCommand(cmd, res, DRIVER_LEN) == false)
+            return IPS_ALERT;
     }
     return IPS_BUSY;
 }
 
 IPState RainbowRSF::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
+    timeoutStartSeconds = 0;
     int reversed = (IUFindOnSwitchIndex(&FocusReverseSP) == INDI_ENABLED) ? -1 : 1;
     int relativeTicks =  ((dir == FOCUS_INWARD) ? -ticks : ticks) * reversed;
     double newPosition = FocusAbsPosN[0].value + relativeTicks;
@@ -361,6 +400,7 @@ bool RainbowRSF::findHome()
     }
     else
     {
+        timeoutStartSeconds = 0;
         m_TargetPosition = homePosition;
         FocusAbsPosNP.s = IPS_BUSY;
         char res[DRIVER_LEN] = {0};
@@ -416,10 +456,10 @@ void RainbowRSF::TimerHit()
 bool RainbowRSF::sendCommand(const char * cmd, char * res, int res_len)
 {
     if (cmd == nullptr || res == nullptr || res_len <= 0)
-      return false;
+        return false;
     const int cmd_len = strlen(cmd);
     if (cmd_len <= 0)
-      return false;
+        return false;
 
     tcflush(PortFD, TCIOFLUSH);
 

--- a/drivers/focuser/rainbowRSF.h
+++ b/drivers/focuser/rainbowRSF.h
@@ -78,7 +78,8 @@ class RainbowRSF : public INDI::Focuser
         const static uint32_t homePosition { 8000 };
 
         // Timer used to timeout when waiting for requested movement to complete.
-        std::unique_ptr<INDI::ElapsedTimer> m_MovementTimer;
+        INDI::ElapsedTimer m_MovementTimer;
+        bool m_MovementTimerActive { false };
 
         /////////////////////////////////////////////////////////////////////////////
         /// Static Helper Values

--- a/drivers/focuser/rainbowRSF.h
+++ b/drivers/focuser/rainbowRSF.h
@@ -22,6 +22,7 @@
 
 #include <memory>
 #include "indifocuser.h"
+#include "indielapsedtimer.h"
 
 class RainbowRSF : public INDI::Focuser
 {
@@ -76,8 +77,8 @@ class RainbowRSF : public INDI::Focuser
 
         const static uint32_t homePosition { 8000 };
 
-        time_t timeoutStartSeconds = 0;
-
+        // Timer used to timeout when waiting for requested movement to complete.
+        std::unique_ptr<INDI::ElapsedTimer> m_MovementTimer;
 
         /////////////////////////////////////////////////////////////////////////////
         /// Static Helper Values

--- a/drivers/focuser/rainbowRSF.h
+++ b/drivers/focuser/rainbowRSF.h
@@ -76,6 +76,8 @@ class RainbowRSF : public INDI::Focuser
 
         const static uint32_t homePosition { 8000 };
 
+        time_t timeoutStartSeconds = 0;
+
 
         /////////////////////////////////////////////////////////////////////////////
         /// Static Helper Values


### PR DESCRIPTION
Increases the tolerance for reaching the focuser position target after waiting for a number of seconds. If the focuser has been busy for 60 seconds then finish no matter what.