### PR TITLE
spec_autosetup: switch from setup to autosetup in the spec file

### DIFF
--- a/spec/libindi.spec
+++ b/spec/libindi.spec
@@ -66,7 +66,8 @@ Requires: %{name}-libs%{?_isa} = %{version}-%{release}
 Static library needed to develop a %{name} application
 
 %prep
-%setup
+%autosetup -p1 -n %{name}-master
+
 # For Fedora we want to put udev rules in {_udevrulesdir}
 sed -i 's|/lib/udev/rules.d|%{_udevrulesdir}|g' CMakeLists.txt
 chmod -x drivers/telescope/pmc8driver.h


### PR DESCRIPTION
This fixes a path naming problem 
Branch COPR build: https://copr.fedorainfracloud.org/coprs/xsnrg/libindi-bleeding/build/3140371/