### PR TITLE
Added manualSlewing flag to sustain tracking suppression during manual slew

### DIFF
--- a/drivers/telescope/celestrongps.cpp
+++ b/drivers/telescope/celestrongps.cpp
@@ -653,6 +653,8 @@ bool CelestronGPS::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
     switch (command)
     {
         case MOTION_START:
+            TrackState = SCOPE_SLEWING;
+            manualSlewing = true;
             if (driver.start_motion(move, rate) == false)
             {
                 LOG_ERROR("Error setting N/S motion direction.");
@@ -663,6 +665,7 @@ bool CelestronGPS::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
             break;
 
         case MOTION_STOP:
+            manualSlewing = false;
             if (driver.stop_motion(move) == false)
             {
                 LOG_ERROR("Error stopping N/S motion.");
@@ -684,6 +687,8 @@ bool CelestronGPS::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
     switch (command)
     {
         case MOTION_START:
+            TrackState = SCOPE_SLEWING;
+            manualSlewing = true;
             if (driver.start_motion(move, rate) == false)
             {
                 LOG_ERROR("Error setting W/E motion direction.");
@@ -694,6 +699,7 @@ bool CelestronGPS::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
             break;
 
         case MOTION_STOP:
+            manualSlewing = false;
             if (driver.stop_motion(move) == false)
             {
                 LOG_ERROR("Error stopping W/E motion.");
@@ -819,7 +825,7 @@ bool CelestronGPS::ReadScopeStatus()
         case SCOPE_SLEWING:
             // are we done?
             bool slewing;
-            if (driver.is_slewing(&slewing) && !slewing)
+            if (driver.is_slewing(&slewing) && !slewing && !manualSlewing)
             {
                 LOG_INFO("Slew complete, tracking...");
                 SetTrackEnabled(true);

--- a/drivers/telescope/celestrongps.cpp
+++ b/drivers/telescope/celestrongps.cpp
@@ -654,7 +654,7 @@ bool CelestronGPS::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
     {
         case MOTION_START:
             TrackState = SCOPE_SLEWING;
-            manualSlewing = true;
+            manualSlewingAlt = true;
             if (driver.start_motion(move, rate) == false)
             {
                 LOG_ERROR("Error setting N/S motion direction.");
@@ -665,7 +665,7 @@ bool CelestronGPS::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
             break;
 
         case MOTION_STOP:
-            manualSlewing = false;
+            manualSlewingAlt = false;
             if (driver.stop_motion(move) == false)
             {
                 LOG_ERROR("Error stopping N/S motion.");
@@ -688,7 +688,7 @@ bool CelestronGPS::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
     {
         case MOTION_START:
             TrackState = SCOPE_SLEWING;
-            manualSlewing = true;
+            manualSlewingAz = true;
             if (driver.start_motion(move, rate) == false)
             {
                 LOG_ERROR("Error setting W/E motion direction.");
@@ -699,7 +699,7 @@ bool CelestronGPS::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
             break;
 
         case MOTION_STOP:
-            manualSlewing = false;
+            manualSlewingAz = false;
             if (driver.stop_motion(move) == false)
             {
                 LOG_ERROR("Error stopping W/E motion.");
@@ -825,7 +825,7 @@ bool CelestronGPS::ReadScopeStatus()
         case SCOPE_SLEWING:
             // are we done?
             bool slewing;
-            if (driver.is_slewing(&slewing) && !slewing && !manualSlewing)
+            if (driver.is_slewing(&slewing) && !slewing && !manualSlewingAlt && !manualSlewingAz)
             {
                 LOG_INFO("Slew complete, tracking...");
                 SetTrackEnabled(true);

--- a/drivers/telescope/celestrongps.h
+++ b/drivers/telescope/celestrongps.h
@@ -178,7 +178,8 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, publi
         ISwitchVectorProperty DSTSettingSP;
 
         bool slewToIndex;
-        bool manualSlewing;
+        bool manualSlewingAlt;
+        bool manualSlewingAz;
 
         size_t numPecBins = 0;
 

--- a/drivers/telescope/celestrongps.h
+++ b/drivers/telescope/celestrongps.h
@@ -178,6 +178,7 @@ class CelestronGPS : public INDI::Telescope, public INDI::GuiderInterface, publi
         ISwitchVectorProperty DSTSettingSP;
 
         bool slewToIndex;
+        bool manualSlewing;
 
         size_t numPecBins = 0;
 


### PR DESCRIPTION
For issue #1592 

May not be the most elegant approach but the Celestron GPS mount implementation needs to suppress tracking for both Goto and manual slewing activity.  The current mechanism relies on the mount to maintain the is_slewing state, but it only does this for Goto, not manual.

I can't find a specific command in the Nextar to check for motor activity so I just created a flag to track manual slew state changes.  This, in combination with the change from 221c10c22cd0d43a57e41375dee00246c31c2111 generally get it working.

There's still a small delay based on the loop tempo, but I couldn't get SetTrackingState(true) to work if I called it immediately after the move command stopped.
