### PR TITLE
Send command at start to flush serial line for Pulsar/Rigel dome

### DIFF
--- a/drivers/dome/rigel_dome.cpp
+++ b/drivers/dome/rigel_dome.cpp
@@ -122,6 +122,9 @@ bool RigelDome::getStartupValues()
 * ***********************************************************************************/
 bool RigelDome::Handshake()
 {
+    char res[DRIVER_LEN] = {0};
+    sendCommand("PULSAR", res); // send dummy command to flush serial line
+
     bool rc = readShutterStatus();
     if (rc)
     {


### PR DESCRIPTION
When first started rigel dome would crash on unhandled exception thrown
from std::stoi() as it receive "E,1" because drive unit had some garbage
in input buffer.