### PR TITLE
Use <stdint.h> for uint* types (fix build on musl)

### DIFF
--- a/base64.c
+++ b/base64.c
@@ -45,7 +45,7 @@
  * Swap bytes in 16-bit value.
  */
 //#define bswap_16(x) __builtin_bswap16 (x);
-#define bswap_16(x) ((__uint16_t) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))
+#define bswap_16(x) ((uint16_t) ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8)))
 
 #include <arpa/inet.h>
 #define  IS_BIG_ENDIAN     (1 == htons(1))

--- a/drivers/focuser/focuslynxbase.cpp
+++ b/drivers/focuser/focuslynxbase.cpp
@@ -2821,7 +2821,7 @@ bool FocusLynxBase::SyncFocuser(uint32_t ticks)
 /************************************************************************************
  *
 * ***********************************************************************************/
-//bool FocusLynxBase::setMaxTravel(u_int16_t travel)
+//bool FocusLynxBase::setMaxTravel(uint16_t travel)
 bool FocusLynxBase::SetFocuserMaxPosition(uint32_t ticks)
 {
     char cmd[LYNX_MAX] = {0};
@@ -2886,7 +2886,7 @@ bool FocusLynxBase::SetFocuserMaxPosition(uint32_t ticks)
 /************************************************************************************
  *
 * ***********************************************************************************/
-bool FocusLynxBase::setStepSize(u_int16_t stepsize)
+bool FocusLynxBase::setStepSize(uint16_t stepsize)
 {
     char cmd[LYNX_MAX] = {0};
     int errcode = 0;

--- a/drivers/focuser/focuslynxbase.h
+++ b/drivers/focuser/focuslynxbase.h
@@ -28,6 +28,7 @@
 #include "connectionplugins/connectiontcp.h"
 
 #include <map>
+#include <stdint.h>
 #include <termios.h>
 #include <unistd.h>
 #include <memory>
@@ -154,7 +155,7 @@ class FocusLynxBase : public INDI::Focuser
         // Set functions
 
         // Position
-        bool setStepSize(u_int16_t stepsize);
+        bool setStepSize(uint16_t stepsize);
 
         // Temperature
         bool setTemperatureCompensation(bool enable);

--- a/drivers/rotator/gemini.h
+++ b/drivers/rotator/gemini.h
@@ -23,6 +23,7 @@
 #include "indifocuser.h"
 #include "indirotatorinterface.h"
 
+#include <stdint.h>
 #include <map>
 
 class Gemini : public INDI::Focuser, public INDI::RotatorInterface
@@ -132,7 +133,7 @@ class Gemini : public INDI::Focuser, public INDI::RotatorInterface
         // Set functions
 
         // Position
-        bool setFocusPosition(u_int16_t position);
+        bool setFocusPosition(uint16_t position);
 
         // Temperature
         bool setTemperatureCompensation(bool enable);

--- a/drivers/telescope/celestrondriver.h
+++ b/drivers/telescope/celestrondriver.h
@@ -28,10 +28,7 @@
 #include <string>
 #include "indicom.h"
 
-#ifdef __FreeBSD__
 #include <stdint.h>
-typedef uint8_t u_int8_t;
-#endif
 
 //#include <thread>
 //#include <condition_variable>
@@ -312,8 +309,8 @@ class CelestronDriver
 
         // get and set guide rate
         // 0 to 255 corresponding to 0 to 100% sidereal
-        bool get_guide_rate(CELESTRON_AXIS axis, u_int8_t  * rate);
-        bool set_guide_rate(CELESTRON_AXIS axis, u_int8_t  rate);
+        bool get_guide_rate(CELESTRON_AXIS axis, uint8_t  * rate);
+        bool set_guide_rate(CELESTRON_AXIS axis, uint8_t  rate);
 
         // Pointing state, pier side, returns 'E' or 'W'
         bool get_pier_side(char * sop);


### PR DESCRIPTION
<stdint.h> is already being used in some places, as are its
types, e.g. uint8_t, but in some places, non-standard types
like u_int16_t were being mix-and-matched.

Consistently use the <stdint.h> types to fix build on e.g.
musl.

Bug: https://bugs.gentoo.org/829487
Signed-off-by: Sam James <sam@gentoo.org>