### PR TITLE
Fix Celestron focuser crash after calibration

### DIFF
--- a/drivers/focuser/celestron.cpp
+++ b/drivers/focuser/celestron.cpp
@@ -33,7 +33,12 @@
 
 static std::unique_ptr<CelestronSCT> celestronSCT(new CelestronSCT());
 
-CelestronSCT::CelestronSCT()
+CelestronSCT::CelestronSCT() :
+  backlashMove(false),
+  finalPosition(0),
+  calibrateInProgress(false),
+  calibrateState(0),
+  focuserIsCalibrated(false)
 {
     // Can move in Absolute & Relative motions, can AbortFocuser motion.
     // CR variable speed and sync removed
@@ -448,7 +453,6 @@ void CelestronSCT::TimerHit()
             calibrateInProgress = false;
             CalibrateS[1].s = ISS_OFF;
             CalibrateSP.s = IPS_OK;
-            //CalibrateStateT[0].text = (char *)msg;
             IUSaveText(&CalibrateStateT[0], msg);
             IDSetSwitch(&CalibrateSP, nullptr);
             IDSetText(&CalibrateStateTP, nullptr);
@@ -467,7 +471,7 @@ void CelestronSCT::TimerHit()
                 calibrateState = state;
                 char str[20];
                 snprintf(str, 20, "Calibrate state %i", state);
-                CalibrateStateT[0].text = str;
+                IUSaveText(&CalibrateStateT[0], str);
                 IDSetText(&CalibrateStateTP, nullptr);
             }
         }


### PR DESCRIPTION
The Celestron SCT Focuser driver may crash after focuser calibration has completed. In `TimerHit()`, `text` for an `IText` is set to the address of a stack char array. When calibration is complete and we call `IUSaveText()`, we call `realloc()` on this (now out of scope) stack memory. Correct behaviour is to use `IUSaveText()`, which will `strcpy()` to heap alloc'd memory, with a `realloc` if necessary (to create or resize the string).

We should also initialise all member variables in the constructor to avoid branch on uninitialised, which otherwise happens when we, e.g., check `calibrateInProgress` before setting it, and `backlashmove` before setting it. Running under Linux with `valgrind` now shows no memory errors.