### PR TITLE
Add libtheora-dev to pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ sudo apt-get install -y \
   libusb-1.0-0-dev \
   libdc1394-22-dev \
   libboost-regex-dev \
-  libcurl4-gnutls-dev
+  libcurl4-gnutls-dev \
+  libtheora-dev
 ```
 
 ## Create Project Directory


### PR DESCRIPTION
I believe libtheora-dev is also a pre-requisite, I went through compilation yesterday and saw a missing warning about it

PS: now that I look better, it seems libtheora-dev is optional, but also for example rtl-sdr is optional but presented in the pre-requisites. Not sure if it would be better to make a new section for optional dependencies?