### PR TITLE
Initial implementation for capture format and encode format

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -116,6 +116,9 @@ bool CCDSim::initProperties()
 {
     INDI::CCD::initProperties();
 
+    CaptureFormat format = {"INDI_MONO", "Mono", 16, true};
+    addCaptureFormat(format);
+
     IUFillNumber(&SimulatorSettingsN[SIM_XRES], "SIM_XRES", "CCD X resolution", "%4.0f", 512, 8192, 512, 1280);
     IUFillNumber(&SimulatorSettingsN[SIM_YRES], "SIM_YRES", "CCD Y resolution", "%4.0f", 512, 8192, 512, 1024);
     IUFillNumber(&SimulatorSettingsN[SIM_XSIZE], "SIM_XSIZE", "CCD X Pixel Size", "%4.2f", 1, 30, 5, 5.2);
@@ -1569,5 +1572,11 @@ bool CCDSim::loadNextImage()
     }
 
     fits_close_file(fptr, &status);
+    return true;
+}
+
+bool CCDSim::SetCaptureFormat(uint8_t index)
+{
+    INDI_UNUSED(index);
     return true;
 }

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -111,8 +111,9 @@ class CCDSim : public INDI::CCD, public INDI::FilterInterface
         virtual int SetTemperature(double temperature) override;
         virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
         virtual bool UpdateCCDBin(int hor, int ver) override;
-
         virtual bool UpdateGuiderBin(int hor, int ver) override;
+
+        virtual bool SetCaptureFormat(uint8_t index) override;
 
         virtual bool StartStreaming() override;
         virtual bool StopStreaming() override;

--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -139,9 +139,8 @@ V4L2_Driver::~V4L2_Driver()
 
 void V4L2_Driver::updateFrameSize()
 {
-    if (ISS_ON == ImageColorS[IMAGE_GRAYSCALE].s)
-        frameBytes =
-            PrimaryCCD.getSubW() * PrimaryCCD.getSubH() * (PrimaryCCD.getBPP() / 8 + (PrimaryCCD.getBPP() % 8 ? 1 : 0));
+    if (CaptureFormatSP.findOnSwitchIndex() == IMAGE_MONO)
+        frameBytes = PrimaryCCD.getSubW() * PrimaryCCD.getSubH() * (PrimaryCCD.getBPP() / 8 + (PrimaryCCD.getBPP() % 8 ? 1 : 0));
     else
         frameBytes = PrimaryCCD.getSubW() * PrimaryCCD.getSubH() *
                      (PrimaryCCD.getBPP() / 8 + (PrimaryCCD.getBPP() % 8 ? 1 : 0)) * 3;
@@ -165,13 +164,17 @@ bool V4L2_Driver::initProperties()
     IUFillTextVector(&PortTP, PortT, NARRAY(PortT), getDeviceName(), INDI::SP::DEVICE_PORT, "Ports", OPTIONS_TAB, IP_RW, 0,
                      IPS_IDLE);
 
-    /* Color space */
-    int configColor = IMAGE_GRAYSCALE;
-    IUGetConfigOnSwitchIndex(getDeviceName(), "CCD_COLOR_SPACE", &configColor);
-    IUFillSwitch(&ImageColorS[IMAGE_GRAYSCALE], "CCD_COLOR_GRAY", "Gray", configColor == IMAGE_GRAYSCALE ? ISS_ON : ISS_OFF);
-    IUFillSwitch(&ImageColorS[IMAGE_COLOR], "CCD_COLOR_RGB", "Color", configColor == IMAGE_COLOR ? ISS_ON : ISS_OFF);
-    IUFillSwitchVector(&ImageColorSP, ImageColorS, NARRAY(ImageColorS), getDeviceName(), "CCD_COLOR_SPACE",
-                       "Image Type", IMAGE_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+
+    // Capture format.
+    CaptureFormat mono = {"INDI_MONO", "Mono", 8};
+    CaptureFormat color = {"INDI_RGB", "RGB", 8, true};
+    addCaptureFormat(mono);
+    addCaptureFormat(color);
+    if (CaptureFormatSP[IMAGE_RGB].getState() == ISS_ON)
+    {
+        PrimaryCCD.setNAxis(3);
+        updateFrameSize();
+    }
 
     /* Image depth */
     IUFillSwitch(&ImageDepthS[0], "8 bits", "", ISS_ON);
@@ -265,7 +268,6 @@ void V4L2_Driver::ISGetProperties(const char * dev)
     {
         defineProperty(&camNameTP);
 
-        defineProperty(&ImageColorSP);
         defineProperty(&InputsSP);
         defineProperty(&CaptureFormatsSP);
 
@@ -306,7 +308,6 @@ bool V4L2_Driver::updateProperties()
         defineProperty(&camNameTP);
         getBasicData();
 
-        defineProperty(&ImageColorSP);
         defineProperty(&InputsSP);
         defineProperty(&CaptureFormatsSP);
 
@@ -386,7 +387,6 @@ bool V4L2_Driver::updateProperties()
 
         deleteProperty(camNameTP.name);
 
-        deleteProperty(ImageColorSP.name);
         deleteProperty(InputsSP.name);
         deleteProperty(CaptureFormatsSP.name);
 
@@ -618,44 +618,6 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
         return true;
     }
 
-    /* Image Type */
-    if (strcmp(name, ImageColorSP.name) == 0)
-    {
-        if (Streamer->isRecording())
-        {
-            LOG_WARN("Can not set Image type (GRAY/COLOR) while recording.");
-            return false;
-        }
-
-        IUResetSwitch(&ImageColorSP);
-        IUUpdateSwitch(&ImageColorSP, states, names, n);
-        ImageColorSP.s = IPS_OK;
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
-        {
-            //PrimaryCCD.setBPP(8);
-            PrimaryCCD.setNAxis(2);
-        }
-        else
-        {
-            //PrimaryCCD.setBPP(32);
-            //PrimaryCCD.setBPP(8);
-            PrimaryCCD.setNAxis(3);
-        }
-
-        updateFrameSize();
-#if 0
-        INDI_PIXEL_FORMAT pixelFormat;
-        uint8_t pixelDepth = 8;
-        if (getPixelFormat(v4l_base->fmt.fmt.pix.pixelformat, pixelFormat, pixelDepth))
-            Streamer->setPixelFormat(pixelFormat, pixelDepth);
-#endif
-        Streamer->setPixelFormat((ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON) ? INDI_MONO : INDI_RGB, 8);
-        IDSetSwitch(&ImageColorSP, nullptr);
-
-        saveConfig(true, ImageColorSP.name);
-        return true;
-    }
-
     /* Image Depth */
     if (strcmp(name, ImageDepthSP.name) == 0)
     {
@@ -746,7 +708,7 @@ bool V4L2_Driver::ISNewSwitch(const char * dev, const char * name, ISState * sta
     /* ColorProcessing */
     if (strcmp(name, ColorProcessingSP.name) == 0)
     {
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        if (CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON)
         {
             IUUpdateSwitch(&ColorProcessingSP, states, names, n);
             v4l_base->setColorProcessing(ColorProcessingS[0].s == ISS_ON, ColorProcessingS[1].s == ISS_ON,
@@ -1010,7 +972,7 @@ bool V4L2_Driver::setManualExposure(double duration)
     if (nullptr == AbsExposureN)
     {
         /* We don't have an absolute exposure control but we can stack gray frames until the exposure elapses */
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
+        if (CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
         {
             //use frame interval as frame duration instead of max exposure time.
             if(FrameRatesSP.sp != nullptr)
@@ -1044,7 +1006,7 @@ bool V4L2_Driver::setManualExposure(double duration)
     /* Then if we have an exposure control, check the requested exposure duration */
     else if (AbsExposureN->max < ticks)
     {
-        if( ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON && stackMode == STACK_NONE )
+        if( CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON && stackMode == STACK_NONE )
         {
             LOG_WARN("Requested manual exposure is out of device bounds auto set stackMode to ADDITIVE" );
             stackMode = STACK_ADDITIVE;
@@ -1054,7 +1016,7 @@ bool V4L2_Driver::setManualExposure(double duration)
         }
 
         /* We can't expose as long as requested but we can stack gray frames until the exposure elapses */
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
+        if (CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON && stackMode != STACK_NONE && stackMode != STACK_RESET_DARK)
         {
             if( AbsExposureN->value != AbsExposureN->max )
             {
@@ -1278,7 +1240,7 @@ void V4L2_Driver::lxtimerCallback(void * userpointer)
 
 bool V4L2_Driver::UpdateCCDBin(int hor, int ver)
 {
-    if (ImageColorS[IMAGE_COLOR].s == ISS_ON)
+    if (CaptureFormatSP[IMAGE_RGB].getState() == ISS_ON)
     {
         if (hor == 1 && ver == 1)
         {
@@ -1411,7 +1373,7 @@ void V4L2_Driver::newFrame()
         unsigned char * buffer = nullptr;
 
         std::unique_lock<std::mutex> guard(ccdBufferLock);
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        if (CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON)
         {
             V4LFrame->Y = v4l_base->getY();
             totalBytes  = width * height * (dbpp / 8);
@@ -1509,20 +1471,20 @@ void V4L2_Driver::newFrame()
         PrimaryCCD.setExposureLeft(remaining);
 
         // Stack Mono frames
-        if ((stackMode) && !(lx->isEnabled()) && !(ImageColorS[1].s == ISS_ON))
+        if ((stackMode) && !(lx->isEnabled()) && CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON)
         {
             stackFrame();
         }
 
         /* FIXME: stacking does not account for transfer time, so we'll miss the last frames probably */
-        if ((stackMode) && !(lx->isEnabled()) && !(ImageColorS[1].s == ISS_ON) &&
+        if ((stackMode) && !(lx->isEnabled()) && CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON &&
                 (timercmp(&elapsed_exposure, &exposure_duration, < )))
             return; // go on stacking
 
         struct timeval const current_exposure = getElapsedExposure();
 
         //IDLog("Copying frame.\n");
-        if (ImageColorS[IMAGE_GRAYSCALE].s == ISS_ON)
+        if (CaptureFormatSP[IMAGE_MONO].getState() == ISS_ON)
         {
             if (!stackMode)
             {
@@ -1949,7 +1911,6 @@ bool V4L2_Driver::saveConfigItems(FILE * fp)
 
     IUSaveConfigText(fp, &PortTP);
     IUSaveConfigSwitch(fp, &StackModeSP);
-    IUSaveConfigSwitch(fp, &ImageColorSP);
 
     if (ImageAdjustNP.nnp > 0)
         IUSaveConfigNumber(fp, &ImageAdjustNP);
@@ -2078,4 +2039,16 @@ bool V4L2_Driver::getPixelFormat(uint32_t v4l2format, INDI_PIXEL_FORMAT &pixelFo
     }
 }
 
+bool V4L2_Driver::SetCaptureFormat(uint8_t index)
+{
+    if (Streamer->isRecording())
+    {
+        LOG_WARN("Can not set Image type (GRAY/COLOR) while recording.");
+        return false;
+    }
 
+    PrimaryCCD.setNAxis(index == IMAGE_MONO ? 2 : 3);
+    updateFrameSize();
+    Streamer->setPixelFormat(index == 0 ? INDI_MONO : INDI_RGB, 8);
+    return true;
+}

--- a/drivers/video/v4l2driver.h
+++ b/drivers/video/v4l2driver.h
@@ -75,7 +75,7 @@ public:
         virtual bool AbortExposure() override;
         virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
         virtual bool UpdateCCDBin(int hor, int ver) override;
-
+        virtual bool SetCaptureFormat(uint8_t index) override;
         virtual bool saveConfigItems(FILE *fp) override;
 
         virtual bool StartStreaming() override;
@@ -98,6 +98,12 @@ public:
             float *darkFrame;
         } img_t;
 
+        enum
+        {
+            IMAGE_MONO = 0,
+            IMAGE_RGB
+        };
+
         enum stackmodes
         {
             STACK_NONE       = 0,
@@ -110,12 +116,6 @@ public:
         /* Switches */
 
         ISwitch *CompressS;
-        ISwitch ImageColorS[2];
-        enum
-        {
-            IMAGE_GRAYSCALE,
-            IMAGE_COLOR
-        };
         ISwitch ImageDepthS[2];
         ISwitch StackModeS[5];
         ISwitch ColorProcessingS[3];
@@ -132,7 +132,6 @@ public:
 
         /* Switch vectors */
         ISwitchVectorProperty *CompressSP;      /* Compress stream switch */
-        ISwitchVectorProperty ImageColorSP;     /* Color or grey switch */
         ISwitchVectorProperty ImageDepthSP;     /* 8 bits or 16 bits switch */
         ISwitchVectorProperty StackModeSP;      /* StackMode switch */
         ISwitchVectorProperty InputsSP;         /* Select input switch */

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -354,13 +354,13 @@ bool CCD::initProperties()
     CaptureFormatSP.fill(getDeviceName(), "CCD_CAPTURE_FORMAT", "Format", IMAGE_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 60,
                          IPS_IDLE);
 
-    m_ConfigEncodeFormatIndex = ENCODE_FORMAT_FITS;
+    m_ConfigEncodeFormatIndex = FORMAT_FITS;
     IUGetConfigOnSwitchIndex(getDeviceName(), "CCD_ENCODER_FORMAT", &m_ConfigEncodeFormatIndex);
-    EncodeFormatSP[ENCODE_FORMAT_FITS].fill("ENCODE_FORMAT_FITS", "FITS",
-                                            m_ConfigEncodeFormatIndex == ENCODE_FORMAT_FITS ? ISS_ON : ISS_OFF);
-    EncodeFormatSP[ENCODE_FORMAT_NATIVE].fill("ENCODE_FORMAT_NATIVE", "Native",
-            m_ConfigEncodeFormatIndex == ENCODE_FORMAT_NATIVE ? ISS_ON : ISS_OFF);
-    EncodeFormatSP.fill(getDeviceName(), "CCD_ENCODE_FORMAT", "Encode", IMAGE_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 60,
+    EncodeFormatSP[FORMAT_FITS].fill("FORMAT_FITS", "FITS",
+                                     m_ConfigEncodeFormatIndex == FORMAT_FITS ? ISS_ON : ISS_OFF);
+    EncodeFormatSP[FORMAT_NATIVE].fill("FORMAT_NATIVE", "Native",
+                                       m_ConfigEncodeFormatIndex == FORMAT_NATIVE ? ISS_ON : ISS_OFF);
+    EncodeFormatSP.fill(getDeviceName(), "CCD_TRANSFER_FORMAT", "Encode", IMAGE_SETTINGS_TAB, IP_RW, ISR_1OFMANY, 60,
                         IPS_IDLE);
 
     /**********************************************/
@@ -1631,8 +1631,11 @@ bool CCD::ISNewSwitch(const char * dev, const char * name, ISState * states, cha
                 CaptureFormatSP.setState(IPS_OK);
             else
             {
-                CaptureFormatSP.reset();
-                CaptureFormatSP[previousIndex].setState(ISS_ON);
+                if (previousIndex >= 0)
+                {
+                    CaptureFormatSP.reset();
+                    CaptureFormatSP[previousIndex].setState(ISS_ON);
+                }
                 CaptureFormatSP.setState(IPS_ALERT);
             }
             CaptureFormatSP.apply();
@@ -2175,7 +2178,7 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
 
     if (sendImage || saveImage)
     {
-        if (EncodeFormatSP[ENCODE_FORMAT_FITS].getState() == ISS_ON)
+        if (EncodeFormatSP[FORMAT_FITS].getState() == ISS_ON)
         {
             void * memptr;
             size_t memsize;
@@ -2385,7 +2388,7 @@ bool CCD::uploadFile(CCDChip * targetChip, const void * fitsData, size_t totalBy
 
     if (targetChip->SendCompressed)
     {
-        if (EncodeFormatSP[ENCODE_FORMAT_FITS].getState() == ISS_ON && !strcmp(targetChip->getImageExtension(), "fits"))
+        if (EncodeFormatSP[FORMAT_FITS].getState() == ISS_ON && !strcmp(targetChip->getImageExtension(), "fits"))
         {
             fpstate	fpvar;
             fp_init (&fpvar);

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -700,8 +700,8 @@ class CCD : public DefaultDevice, GuiderInterface
         INDI::PropertySwitch EncodeFormatSP {2};
         enum
         {
-            ENCODE_FORMAT_FITS,     /*!< Save Image as FITS format  */
-            ENCODE_FORMAT_NATIVE    /*!< Save Image as the native format of the camera itself. */
+            FORMAT_FITS,     /*!< Save Image as FITS format  */
+            FORMAT_NATIVE    /*!< Save Image as the native format of the camera itself. */
         };
 
         ISwitch UploadS[3];


### PR DESCRIPTION
+ CCD_CAPTURE_FORMAT is a list of native formats supported by the camera.
+ CCD_TRANSFER_FORMAT is how the capture format is encoded and uploaded to client. This is handled by INDI::CCD and not the driver. Currently supported formats are FITS and NATIVE. Native indicates that native camera capture format (e.g. jpg) should not be transcoded and transferred to client as-is.