### PR TITLE
add lastparked logic

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -53,9 +53,9 @@
             <driver name="AstroPhysics">indi_lx200ap</driver>
             <version>1.0</version>
         </device>
-        <device label="AstroPhysics Testing" manufacturer="Astrophysics">
-            <driver name="AstroPhysics Testing">indi_lx200ap_v2</driver>
-            <version>1.0</version>
+        <device label="AstroPhysics V2" manufacturer="Astrophysics">
+            <driver name="AstroPhysics V2">indi_lx200ap_v2</driver>
+            <version>1.1</version>
         </device>
         <device label="ZWO AM5" manufacturer="ZWO">
             <driver name="LX200 Autostar">indi_lx200autostar</driver>

--- a/drivers/telescope/lx200ap_v2.cpp
+++ b/drivers/telescope/lx200ap_v2.cpp
@@ -731,11 +731,9 @@ bool LX200AstroPhysicsV2::ReadScopeStatus()
 {
     if (!isAPReady())
     {
-        char dbgStr[1000];
-        sprintf(dbgStr, "APStatus: Not ready--Checked %s Initialized %s Time updated %s Location Updated %s",
-                apInitializationChecked ? "Y" : "N", apIsInitialized ? "Y" : "N",
-                apTimeInitialized ? "Y" : "N", apLocationInitialized ? "Y" : "N");
-        LOGF_DEBUG("%s", dbgStr);
+        LOGF_DEBUG("APStatus: Not ready--Checked %s Initialized %s Time updated %s Location Updated %s",
+                   apInitializationChecked ? "Y" : "N", apIsInitialized ? "Y" : "N",
+                   apTimeInitialized ? "Y" : "N", apLocationInitialized ? "Y" : "N");
 
         // hope this return doen't delay the time & location. If it does return true?
         return false;
@@ -796,18 +794,15 @@ bool LX200AstroPhysicsV2::ReadScopeStatus()
             IDSetNumber(&HourangleCoordsNP, nullptr );
         }
     }
-    char dbgStr[1000];
-    sprintf(dbgStr, "APStatus: %s %s stime: %s  RA/DEC: %.3f %.3f",
-            trackStateString(TrackState), apParked ? "Parked" : "Unparked", sTimeStr.c_str(), currentRA, currentDEC);
-    LOGF_DEBUG("%s", dbgStr);
+    LOGF_DEBUG("APStatus: %s %s stime: %s  RA/DEC: %.3f %.3f",
+               trackStateString(TrackState), apParked ? "Parked" : "Unparked", sTimeStr.c_str(), currentRA, currentDEC);
 
     if (TrackState == SCOPE_SLEWING)
     {
         const double dx = fabs(lastRA - currentRA);
         const double dy = fabs(lastDE - currentDEC);
 
-        sprintf(dbgStr, "Slewing... currentRA: %.3f dx: %g currentDE: %.3f dy: %g", currentRA, dx, currentDEC, dy);
-        LOGF_DEBUG("%s", dbgStr);
+        LOGF_DEBUG("Slewing... currentRA: %.3f dx: %g currentDE: %.3f dy: %g", currentRA, dx, currentDEC, dy);
 
         // Note, RA won't hit 0 if it's not tracking, becuase the RA changes when still.
         // Dec might, though.
@@ -841,8 +836,7 @@ bool LX200AstroPhysicsV2::ReadScopeStatus()
 
         const double dx = fabs(lastAZ - currentAz);
         const double dy = fabs(lastAL - currentAlt);
-        sprintf(dbgStr, "Parking... currentAz: %g dx: %g currentAlt: %g dy: %g", currentAz, dx, currentAlt, dy);
-        LOGF_DEBUG("%s", dbgStr);
+        LOGF_DEBUG("Parking... currentAz: %g dx: %g currentAlt: %g dy: %g", currentAz, dx, currentAlt, dy);
 
         // if for some reason we check slew status BEFORE park motion starts make sure we dont consider park
         // action complete too early by checking how far from park position we are!
@@ -872,12 +866,6 @@ bool LX200AstroPhysicsV2::ReadScopeStatus()
     NewRaDec(currentRA, currentDEC);
 
     syncSideOfPier();
-
-    // Hack -- when the ra/dec doen't change, the hour angle info isn't being updated. Not sure how to fix...
-    // This may be unnecessary now with changed to KStars. Hy 3/11/2022.
-    EqN[AXIS_RA].value = currentRA;
-    EqN[AXIS_DE].value = currentDEC;
-    IDSetNumber(&EqNP, nullptr);
 
     return true;
 }

--- a/drivers/telescope/lx200ap_v2.h
+++ b/drivers/telescope/lx200ap_v2.h
@@ -24,9 +24,9 @@
 
 /***********************************************************************
  * This file was copied an modified from lx200ap.h in Jan 2022.
- * 
+ *
  * This is an update of the Wildi and Fulbright A-P drivers.
- * It is currently being tested. 
+ * It is currently being tested.
  * You should not use this unless part of the test group.
 ***********************************************************************/
 
@@ -150,8 +150,8 @@ class LX200AstroPhysicsV2 : public LX200Generic
     private:
         bool ApInitialize();
         bool updateAPLocation(double latitude, double longitude, double elevation);
-        bool recoverFromUnparkedInitialize();
         bool parkInternal();
+        bool isAPReady();
 
 #ifdef no
         bool initMount();
@@ -163,7 +163,6 @@ class LX200AstroPhysicsV2 : public LX200Generic
         bool IsMountInitialized(bool *initialized);
 #endif
         bool IsMountParked(bool *isParked);
-        bool getMountStatus(bool *isParked);
         bool getFirmwareVersion(void);
         bool calcParkPosition(ParkPosition pos, double *parkAlt, double *parkAz);
         void disclaimerMessage(void);
@@ -182,5 +181,10 @@ class LX200AstroPhysicsV2 : public LX200Generic
         //bool motionCommanded=false; // 2020-05-24, wildi, never reset
         //bool mountInitialized=false;
         int rememberSlewRate = { -1 };
-        uint8_t initStatus = MOUNTNOTINITIALIZED;
+
+        bool apIsInitialized = false;
+        bool apLocationInitialized = false;
+        bool apTimeInitialized = false;
+        bool apInitializationChecked = false;
+
 };

--- a/drivers/telescope/lx200apdriver.h
+++ b/drivers/telescope/lx200apdriver.h
@@ -67,6 +67,14 @@ int check_lx200ap_status(int fd, char *parkStatus, char *slewStatus);
 int APParkMount(int fd);
 int APUnParkMount(int fd);
 
+// Make sure the buffer passed in to getApStatusString (statusString) is at least 32 bytes.
+int getApStatusString(int fd, char *statusString);
+bool apStatusParked(char *statusString);
+bool apStatusSlewing(char *statusString);
+int isAPInitialized(int fd, bool *isInitialized);
+
+
+
 // experiment!
 int getAPHourAngle(int fd, double *value);
 


### PR DESCRIPTION
Modify the AstroPhysics V2 driver so that it uses the "LastParked" API logic to recover when mount connects uninitialized.

Also, cleans up the source file--there was a lot of dead code and obsolete comments inherited from previous driver iterations.