### PR TITLE
fix issue reading worm position

### DIFF
--- a/drivers/telescope/lx200apdriver.cpp
+++ b/drivers/telescope/lx200apdriver.cpp
@@ -447,7 +447,7 @@ int getAPWormPosition(int fd, int *position)
     }
 
     tcflush(fd, TCIFLUSH);
-    if (nbytes_read > 2)
+    if (nbytes_read > 1)
     {
         response[nbytes_read - 1] = '\0';
         response[3] = '\0';


### PR DESCRIPTION
It turns out the get worm position command can return, e.g. 4#, where I expected more characters.
This change allows that 1-digit response.