### PR TITLE
Remove user choice for CM/CMR.

### DIFF
--- a/drivers/telescope/lx200ap_v2.h
+++ b/drivers/telescope/lx200ap_v2.h
@@ -175,6 +175,7 @@ class LX200AstroPhysicsV2 : public LX200Generic
         bool getWormPosition(void);
         bool getPECState(const char *statusString);
         void processMountStatus(const char *statusString);
+        bool APSync(double ra, double dec, bool recalibrate = true);
 
         ControllerVersion firmwareVersion = MCV_UNKNOWN;
         ServoVersion servoType = GTOCP_UNKNOWN;

--- a/drivers/telescope/lx200apdriver.cpp
+++ b/drivers/telescope/lx200apdriver.cpp
@@ -322,7 +322,6 @@ int APSyncCMR(int fd, char *matchedObject)
     if ((error_type = tty_write_string(fd, cmd, &nbytes_write)) != TTY_OK)
         return error_type;
 
-    /* read_ret = portRead(matchedObject, -1, LX200_TIMEOUT); */
     if ((error_type = tty_read_section(fd, matchedObject, '#', LX200_TIMEOUT, &nbytes_read)) != TTY_OK)
         return error_type;
 
@@ -388,7 +387,8 @@ int getAPWormPosition(int fd, int *position)
     res = tty_read_section(fd, response, '#', LX200_TIMEOUT, &nbytes_read);
     if (res != TTY_OK)
     {
-        DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_ERROR, "getAPWormPosition: read failed.");
+        // This does happen occasionally, not sure why, but isn't critical.
+        // DEBUGDEVICE(lx200ap_name, INDI::Logger::DBG_ERROR, "getAPWormPosition: read failed.");
         return res;
     }
 


### PR DESCRIPTION
Per A-P recommendation, the Sync :CMR# command is now used for all Syncs, except for when unparking from a pre-defined park position, where the :CM# command would be used.