### PR TITLE
Disable broken shm support for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,11 @@ OPTION (INDI_BUILD_UNITTESTS "Build INDI tests" OFF)
 OPTION (INDI_BUILD_INTEGTESTS "Build INDI integration tests" OFF)
 OPTION (INDI_BUILD_WEBSOCKET "Build INDI with Websocket support" OFF)
 OPTION (INDI_FAST_BLOB "Build INDI with Fast BLOB support" ON)
+if (UNIX AND NOT APPLE)
+    OPTION(INDI_SHARED_MEMORY "Build INDI with support for UNIX protocol with shared memory" ON)
+elseif (UNIX)
+    OPTION(INDI_SHARED_MEMORY "Build INDI with support for UNIX protocol with shared memory (require shm specific settings)" OFF)
+endif()
 OPTION (INDI_CALCULATE_MINMAX "Calculate and store image minimum and maximum values in FITS header" OFF)
 
 CHECK_FUNCTION_EXISTS(mremap HAVE_MREMAP)
@@ -106,6 +111,16 @@ IF (INDI_FAST_BLOB)
 # Append ENCLEN attribute to outgoing BLOB elements to enable fast parsing by clients
 add_definitions(-DWITH_ENCLEN)
 ENDIF(INDI_FAST_BLOB)
+
+###################################################################################################
+####################################  UNIX protocol / SHM  ########################################
+###################################################################################################
+IF (INDI_SHARED_MEMORY)
+if (APPLE)
+    message(WARNING "Shared memory protocol require specific shared memory settings")
+endif()
+    add_definitions(-DENABLE_INDI_SHARED_MEMORY)
+endif()
 
 ###################################################################################################
 ######################################  Calculate Min/Max #########################################

--- a/integs/IndiClientMock.cpp
+++ b/integs/IndiClientMock.cpp
@@ -20,6 +20,7 @@
 #include <unistd.h>
 
 #include "IndiClientMock.h"
+#include "IndiServerController.h"
 #include "utils.h"
 
 IndiClientMock::IndiClientMock()
@@ -36,6 +37,25 @@ void IndiClientMock::close()
 {
     if (fd != -1) ::close(fd);
     cnx.setFds(-1, -1);
+}
+
+void IndiClientMock::connect(const IndiServerController & server)
+{
+#ifdef ENABLE_INDI_SHARED_MEMORY
+    connectUnix(server);
+#else
+    connectTcp(server);
+#endif
+}
+
+void IndiClientMock::connectUnix(const IndiServerController & server)
+{
+    connectUnix(server.getUnixSocketPath());
+}
+
+void IndiClientMock::connectTcp(const IndiServerController & server)
+{
+    connectTcp("127.0.0.1", server.getTcpPort());
 }
 
 void IndiClientMock::connectUnix(const std::string &path)

--- a/integs/IndiClientMock.h
+++ b/integs/IndiClientMock.h
@@ -23,6 +23,8 @@
 
 #include "ConnectionMock.h"
 
+class IndiServerController;
+
 /**
  * Interface to a mocked connection to indi server
  */
@@ -33,6 +35,11 @@ class IndiClientMock
         ConnectionMock cnx;
         IndiClientMock();
         virtual ~IndiClientMock();
+
+        void connect(const IndiServerController & server);
+        void connectUnix(const IndiServerController & server);
+        void connectTcp(const IndiServerController & server);
+
         void connectUnix(const std::string &path = "/tmp/indiserver");
         void connectTcp(const std::string &host = "127.0.0.1", int port = 7624);
         void associate(int fd);

--- a/integs/IndiServerController.cpp
+++ b/integs/IndiServerController.cpp
@@ -22,6 +22,32 @@
 #include "utils.h"
 #include "IndiServerController.h"
 
-void IndiServerController::start(const std::vector<std::string> args) {
+
+#define TEST_TCP_PORT 17624
+#define TEST_UNIX_SOCKET "/tmp/indi-test-server"
+#define STRINGIFY_TOK(x) #x
+#define TO_STRING(x) STRINGIFY_TOK(x)
+
+void IndiServerController::start(const std::vector<std::string> & args) {
     ProcessController::start("../indiserver", args);
 }
+
+void IndiServerController::startDriver(const std::string & path) {
+    std::vector<std::string> args = { "-p", TO_STRING(TEST_TCP_PORT), "-r", "0", "-vvv" };
+#ifdef ENABLE_INDI_SHARED_MEMORY
+    args.push_back("-u");
+    args.push_back(TEST_UNIX_SOCKET);
+#endif
+    args.push_back(path);
+
+    start(args);
+}
+
+std::string IndiServerController::getUnixSocketPath() const {
+    return TEST_UNIX_SOCKET;
+}
+
+int IndiServerController::getTcpPort() const {
+  return TEST_TCP_PORT;
+}
+

--- a/integs/IndiServerController.h
+++ b/integs/IndiServerController.h
@@ -33,7 +33,12 @@ class IndiServerController : public ProcessController
 {
 
     public:
-        void start(const std::vector<std::string> args);
+        void start(const std::vector<std::string> & args);
+
+        void startDriver(const std::string & driver);
+
+        std::string getUnixSocketPath() const;
+        int getTcpPort() const;
 };
 
 

--- a/integs/TestClientQueries.cpp
+++ b/integs/TestClientQueries.cpp
@@ -31,11 +31,6 @@
 #include "IndiServerController.h"
 #include "IndiClientMock.h"
 
-#define TEST_TCP_PORT 17624
-#define TEST_UNIX_SOCKET "/tmp/indi-test-server"
-#define STRINGIFY_TOK(x) #x
-#define TO_STRING(x) STRINGIFY_TOK(x)
-
 #define PROP_COUNT 5
 
 static void driverSendsProps(DriverMock & fakeDriver) {
@@ -67,7 +62,7 @@ static void startFakeDev1(IndiServerController & indiServer, DriverMock & fakeDr
     std::string fakeDriverPath = getTestExePath("fakedriver");
 
     // Start indiserver with one instance, repeat 0
-    indiServer.start({ "-p", TO_STRING(TEST_TCP_PORT), "-u", TEST_UNIX_SOCKET, "-vvv", "-r", "0", fakeDriverPath.c_str() });
+    indiServer.startDriver(fakeDriverPath);
     fprintf(stderr, "indiserver started\n");
 
     fakeDriver.waitEstablish();
@@ -99,7 +94,7 @@ TEST(TestClientQueries, ServerForwardRequest) {
 
     IndiClientMock indiClient;
 
-    indiClient.connectUnix(TEST_UNIX_SOCKET);
+    indiClient.connect(indiServer);
 
     connectFakeDev1Client(indiServer, fakeDriver, indiClient);
 
@@ -127,7 +122,7 @@ TEST(TestClientQueries, ServerForwardRequestOfHalfDeadClient) {
 
     IndiClientMock indiClient;
 
-    indiClient.connectUnix(TEST_UNIX_SOCKET);
+    indiClient.connect(indiServer);
 
     connectFakeDev1Client(indiServer, fakeDriver, indiClient);
 

--- a/integs/TestIndiSetProp.cpp
+++ b/integs/TestIndiSetProp.cpp
@@ -32,11 +32,6 @@
 #include "ProcessController.h"
 #include "IndiClientMock.h"
 
-#define TEST_TCP_PORT 17624
-#define TEST_UNIX_SOCKET "/tmp/indi-test-server"
-#define STRINGIFY_TOK(x) #x
-#define TO_STRING(x) STRINGIFY_TOK(x)
-
 // Having a large number of properties ensures cases with buffer not empty on exits occur on server side
 #define PROP_COUNT 100
 
@@ -66,7 +61,7 @@ static void startFakeDev1(IndiServerController & indiServer, DriverMock & fakeDr
     std::string fakeDriverPath = getTestExePath("fakedriver");
 
     // Start indiserver with one instance, repeat 0
-    indiServer.start({ "-p", TO_STRING(TEST_TCP_PORT), "-u", TEST_UNIX_SOCKET, "-vvv", "-r", "0", fakeDriverPath.c_str() });
+    indiServer.startDriver(fakeDriverPath);
     fprintf(stderr, "indiserver started\n");
 
     fakeDriver.waitEstablish();
@@ -83,7 +78,7 @@ TEST(TestIndiSetProperties, SetFirstPropertyUntyped) {
     startFakeDev1(indiServer, fakeDriver);
 
     ProcessController indiSetProp;
-    startIndiSetProp(indiSetProp, { "-p", TO_STRING(TEST_TCP_PORT), "-v", "fakedev1.testnumber0.content=8" });
+    startIndiSetProp(indiSetProp, { "-p", std::to_string(indiServer.getTcpPort()), "-v", "fakedev1.testnumber0.content=8" });
 
     driverIsAskedProps(fakeDriver);
 
@@ -111,7 +106,7 @@ TEST(TestIndiSetProperties, SetFirstPropertyTyped) {
     startFakeDev1(indiServer, fakeDriver);
 
     ProcessController indiSetProp;
-    startIndiSetProp(indiSetProp, { "-p", TO_STRING(TEST_TCP_PORT), "-v", "-n", "fakedev1.testnumber0.content=8" });
+    startIndiSetProp(indiSetProp, { "-p", std::to_string(indiServer.getTcpPort()), "-v", "-n", "fakedev1.testnumber0.content=8" });
 
     indiSetProp.join();
     indiSetProp.expectExitCode(0);
@@ -137,7 +132,7 @@ TEST(TestIndiSetProperties, SetLastProperty) {
     startFakeDev1(indiServer, fakeDriver);
 
     ProcessController indiSetProp;
-    startIndiSetProp(indiSetProp, { "-p", TO_STRING(TEST_TCP_PORT), "-v", "fakedev1.testnumber" + std::to_string(PROP_COUNT - 1) + ".content=8" });
+    startIndiSetProp(indiSetProp, { "-p", std::to_string(indiServer.getTcpPort()), "-v", "fakedev1.testnumber" + std::to_string(PROP_COUNT - 1) + ".content=8" });
 
     driverIsAskedProps(fakeDriver);
 
@@ -165,7 +160,7 @@ TEST(TestIndiSetProperties, SetLastPropertyTyped) {
     startFakeDev1(indiServer, fakeDriver);
 
     ProcessController indiSetProp;
-    startIndiSetProp(indiSetProp, { "-p", TO_STRING(TEST_TCP_PORT), "-v", "-n", "fakedev1.testnumber" + std::to_string(PROP_COUNT - 1) + ".content=8" });
+    startIndiSetProp(indiSetProp, { "-p", std::to_string(indiServer.getTcpPort()), "-v", "-n", "fakedev1.testnumber" + std::to_string(PROP_COUNT - 1) + ".content=8" });
 
     indiSetProp.join();
     indiSetProp.expectExitCode(0);


### PR DESCRIPTION
Disable support for shared memory protocol on MACOS by default, since the current mechanism is very limited there (4Mb max) and no evident alternatives seem to be available

It can still be explicitly enabled with -DINDI_SHARED_MEMORY=ON 


