### PR TITLE
Use 8bits samples in the lookup table

### DIFF
--- a/libs/stream/gammalut16.cpp
+++ b/libs/stream/gammalut16.cpp
@@ -48,7 +48,7 @@ void GammaLut16::apply(const uint16_t *source, size_t count, uint8_t *destinatio
 
 void GammaLut16::apply(const uint16_t *first, const uint16_t *last, uint8_t *destination) const
 {
-    const uint16_t *lookUpTable = mLookUpTable.data();
+    const uint8_t *lookUpTable = mLookUpTable.data();
 
     while (first != last)
         *destination++ = lookUpTable[*first++];

--- a/libs/stream/gammalut16.h
+++ b/libs/stream/gammalut16.h
@@ -36,5 +36,5 @@ class GammaLut16
         void apply(const uint16_t *first, const uint16_t *last, uint8_t *destination) const;
 
     protected:
-        std::vector<uint16_t> mLookUpTable;
+        std::vector<uint8_t> mLookUpTable;
 };


### PR DESCRIPTION
Improve probability that the LUT fits in L1 cache of smaller CPUs (esp. ARM)

