### PR TITLE
Fix typo in cron schedule for docker build containers.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - '.github/docker/*'
   schedule:
-    cron: '0 7 */7 * *'
+    - cron: '0 7 */7 * *'
 
 jobs:
   build:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
     paths:
       - '.github/docker/*'
+      - '.github/workflows/docker.yml'
   schedule:
     - cron: '0 7 */7 * *'
 


### PR DESCRIPTION
This MR fixes an unfortunate array hyphen missing from the cron schedule rebuilding docker containers, as more than one schedule can be set up.