### PR TITLE
Fix rare crash when doing base64 encoding

### DIFF
--- a/indiserver.cpp
+++ b/indiserver.cpp
@@ -2361,6 +2361,9 @@ void MsgQueue::writeToFd()
         {
             consumeHeadMsg();
             mp = headMsg();
+            if (mp == nullptr) {
+                return;
+            }
         }
     }
     while(nsend == 0);


### PR DESCRIPTION
race condition in server code when handling async processing