### PR TITLE
Ensure INDIPREFIX is cleared only for drivers started from FIFO

### DIFF
--- a/indiserver.cpp
+++ b/indiserver.cpp
@@ -1027,7 +1027,11 @@ int main(int ac, char *av[])
     (new UnixServer(UnixServer::unixSocketPath))->listen();
 #endif
     /* Load up FIFO, if available */
-    if (fifo) fifo->listen();
+    if (fifo) {
+        // New started drivers will not inherit server's prefix anymore
+        unsetenv("INDIPREFIX");
+        fifo->listen();
+    }
 
     /* handle new clients and all io */
     loop.loop();
@@ -1192,8 +1196,6 @@ void LocalDvrInfo::start()
         }
         else
         {
-            if (fifo)
-                unsetenv("INDIPREFIX");
             if (name[0] == '.')
             {
                 executable = std::string(dirname((char*)me)) + "/" + name;


### PR DESCRIPTION
This clears INDIPREFIX once, after arguments are processed. 

Driver started from command line will inherit it, others won't.