### PR TITLE
Build pushes and PRs on master branch only.

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -1,5 +1,13 @@
 name: Linux
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,13 @@
 name: MacOS
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
 
 jobs:
   build:

--- a/.github/workflows/pyindi.yml
+++ b/.github/workflows/pyindi.yml
@@ -1,5 +1,14 @@
 name: PyIndi
-on: [push, pull_request, workflow_dispatch]
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
 
 jobs:
   build:


### PR DESCRIPTION
This PR trggers GitHub build actions for direct pushes to the `master` branch, and PRs targeting the `master` branch.

It retains manual triggers from the Maintainer on any branch, but prevents other builds.