### PR TITLE
Add correctness attributes

### DIFF
--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -66,7 +66,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  @param hostname INDI server host name or IP address.
          *  @param port INDI server port.
          */
-        void setServer(const char *hostname, unsigned int port);
+        [[gnu::nonnull]] void setServer(const char *hostname, unsigned int port);
 
         /** @brief Get the server host name. */
         const char *getHost() const;
@@ -78,7 +78,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  @returns True if the connection is successful, false otherwise.
          *  @note This function blocks until connection is either successull or unsuccessful.
          */
-        bool connectServer();
+        [[nodiscard]] bool connectServer();
 
         /** @brief Disconnect from INDI server.
          *
@@ -86,7 +86,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *
          *  @return True if disconnection is successful, false otherwise.
          */
-        bool disconnectServer(int exit_code = 0);
+        [[nodiscard]] bool disconnectServer(int exit_code = 0);
 
         /** @brief Get status of the connection. */
         bool isServerConnected() const;
@@ -120,7 +120,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *
          *  @param propertyName Property to watch for.
          */
-        void watchProperty(const char *deviceName, const char *propertyName);
+        [[gnu::nonnull]] void watchProperty(const char *deviceName, const char *propertyName);
 
     public:
         /** @brief Add a device to the watch list.
@@ -130,22 +130,22 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  INDI::BaseDevice object to handle them. If no devices are watched, then all devices owned by INDI server
          *  will be created and handled.
          */
-        void watchDevice(const char *deviceName);
+        [[gnu::nonnull]] void watchDevice(const char *deviceName);
 
         /** @brief Connect to INDI driver
          *  @param deviceName Name of the device to connect to.
         */
-        void connectDevice(const char *deviceName);
+        [[gnu::nonnull]] void connectDevice(const char *deviceName);
 
         /** @brief Disconnect INDI driver
          *  @param deviceName Name of the device to disconnect.
          */
-        void disconnectDevice(const char *deviceName);
+        [[gnu::nonnull]] void disconnectDevice(const char *deviceName);
 
         /** @param deviceName Name of device to search for in the list of devices owned by INDI server,
          *  @returns If \e deviceName exists, it returns an instance of the device. Otherwise, it returns NULL.
          */
-        INDI::BaseDevice *getDevice(const char *deviceName);
+        [[gnu::nonnull]] INDI::BaseDevice *getDevice(const char *deviceName);
 
         /** @returns Returns a vector of all devices created in the client. */
         const std::vector<INDI::BaseDevice *> &getDevices() const;
@@ -163,7 +163,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  @param driverInterface ORed DRIVER_INTERFACE values to select the desired class of devices.
          *  @return True if one or more devices are found for the supplied driverInterface, false if no matching devices found.
          */
-        bool getDevices(std::vector<INDI::BaseDevice *> &deviceList, uint16_t driverInterface);
+        [[nodiscard]] bool getDevices(std::vector<INDI::BaseDevice *> &deviceList, uint16_t driverInterface);
 
     public:
         /** @brief Set Binary Large Object policy mode
@@ -181,14 +181,14 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  @param dev name of device, required.
          *  @param prop name of property, optional.
          */
-        void setBLOBMode(BLOBHandling blobH, const char *dev, const char *prop = nullptr);
+        [[gnu::nonnull(2)]] void setBLOBMode(BLOBHandling blobH, const char *dev, const char *prop = nullptr);
 
         /** @brief getBLOBMode Get Binary Large Object policy mode IF set previously by setBLOBMode
          *  @param dev name of device.
          *  @param prop property name, can be NULL to return overall device policy if it exists.
          *  @return BLOB Policy, if not found, it always returns B_ALSO
          */
-        BLOBHandling getBLOBMode(const char *dev, const char *prop = nullptr);
+        [[gnu::nonnull(1)]] BLOBHandling getBLOBMode(const char *dev, const char *prop = nullptr);
 
         /** @brief activate zero-copy delivering of the blob content.
          * When enabled, all blob copy will be avoided when possible (depending on the connection).
@@ -203,24 +203,24 @@ class INDI::BaseClient : public INDI::BaseMediator
         void enableDirectBlobAccess(const char * dev = nullptr, const char * prop = nullptr);
 
         /** @brief Send new Text command to server */
-        void sendNewText(ITextVectorProperty *pp);
+        [[gnu::nonnull]] void sendNewText(ITextVectorProperty *pp);
         /** @brief Send new Text command to server */
-        void sendNewText(const char *deviceName, const char *propertyName, const char *elementName, const char *text);
+        [[gnu::nonnull]] void sendNewText(const char *deviceName, const char *propertyName, const char *elementName, const char *text);
         /** @brief Send new Number command to server */
-        void sendNewNumber(INumberVectorProperty *pp);
+        [[gnu::nonnull]] void sendNewNumber(INumberVectorProperty *pp);
         /** @brief Send new Number command to server */
-        void sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName, double value);
+        [[gnu::nonnull]] void sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName, double value);
         /** @brief Send new Switch command to server */
-        void sendNewSwitch(ISwitchVectorProperty *pp);
+        [[gnu::nonnull]] void sendNewSwitch(ISwitchVectorProperty *pp);
         /** @brief Send new Switch command to server */
-        void sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName);
+        [[gnu::nonnull]] void sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName);
 
         /** @brief Send opening tag for BLOB command to server */
-        void startBlob(const char *devName, const char *propName, const char *timestamp);
+        [[gnu::nonnull]] void startBlob(const char *devName, const char *propName, const char *timestamp);
         /** @brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
-        void sendOneBlob(IBLOB *bp);
+        [[gnu::nonnull]] void sendOneBlob(IBLOB *bp);
         /** @brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
-        void sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat, void *blobBuffer);
+        [[gnu::nonnull]] void sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat, void *blobBuffer);
         /** @brief Send closing tag for BLOB command to server */
         void finishBlob();
 
@@ -228,12 +228,12 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  @param uid This string will server as identifier for the reply
          *  @note reply will be dispatched to newPingReply
          */
-        void sendPingRequest(const char * uid);
+        [[gnu::nonnull]] void sendPingRequest(const char * uid);
 
         /** @brief Send a ping reply for the given uuid
          *  @note This should not be called directly, as it is already handled by baseclient
          */
-        void sendPingReply(const char * uid);
+        [[gnu::nonnull]] void sendPingReply(const char * uid);
 
     protected:
         /** @brief newUniversalMessage Universal messages are sent from INDI server without a specific device. It is addressed to the client overall.

--- a/libs/indibase/baseclient_p.h
+++ b/libs/indibase/baseclient_p.h
@@ -47,10 +47,10 @@ class BaseClientPrivate
          *                Otherwise, CONNECTION will be turned off.
          *  @param deviceName Name of the device to connect to.
          */
-        void setDriverConnection(bool status, const char *deviceName);
+        [[gnu::nonnull]] void setDriverConnection(bool status, const char *deviceName);
 
-        size_t sendData(const void *data, size_t size);
-        void sendString(const char *fmt, ...);
+        [[nodiscard, gnu::nonnull]] size_t sendData(const void *data, size_t size);
+        [[gnu::nonnull, gnu::format(gnu_printf,2,3)]] void sendString(const char *fmt, ...);
 
     public:
         void listenINDI();
@@ -65,23 +65,23 @@ class BaseClientPrivate
 
     public:
         /** @brief Dispatch command received from INDI server to respective devices handled by the client */
-        int dispatchCommand(XMLEle *root, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int dispatchCommand(XMLEle *root, char *errmsg);
 
         /** @brief Remove device */
-        int deleteDevice(const char *devName, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int deleteDevice(const char *devName, char *errmsg);
 
         /** @brief Delete property command */
-        int delPropertyCmd(XMLEle *root, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int delPropertyCmd(XMLEle *root, char *errmsg);
 
         /** @brief Find and return a particular device */
-        INDI::BaseDevice *findDev(const char *devName, char *errmsg);
+        [[nodiscard, gnu::nonnull]] INDI::BaseDevice *findDev(const char *devName, char *errmsg);
         /** @brief Add a new device */
-        INDI::BaseDevice *addDevice(XMLEle *dep, char *errmsg);
+        [[nodiscard, gnu::nonnull]] INDI::BaseDevice *addDevice(XMLEle *dep, char *errmsg);
         /** @brief Find a device, and if it doesn't exist, create it if create is set to 1 */
-        INDI::BaseDevice *findDev(XMLEle *root, int create, char *errmsg);
+        [[nodiscard, gnu::nonnull]] INDI::BaseDevice *findDev(XMLEle *root, int create, char *errmsg);
 
         /**  Process messages */
-        int messageCmd(XMLEle *root, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int messageCmd(XMLEle *root, char *errmsg);
 
     private:
         std::list<int> incomingSharedBuffers; /* During reception, fds accumulate here */
@@ -90,7 +90,7 @@ class BaseClientPrivate
         bool establish(const std::string &target);
 
         // Add an attribute for access to shared blobs
-        bool parseAttachedBlobs(XMLEle * root, std::vector<std::string> &blobs);
+        [[nodiscard, gnu::nonnull]] bool parseAttachedBlobs(XMLEle * root, std::vector<std::string> &blobs);
 
     public:
         BaseClient *parent;

--- a/libs/indibase/baseclientqt.h
+++ b/libs/indibase/baseclientqt.h
@@ -66,7 +66,7 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
             \param hostname INDI server host name or IP address.
             \param port INDI server port.
         */
-        void setServer(const char *hostname, unsigned int port);
+        [[gnu::nonnull(1)]] void setServer(const char *hostname, unsigned int port);
 
         /** \brief Add a device to the watch list.
 
@@ -75,7 +75,7 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
             INDI::BaseDevice object to handle them. If no devices are watched, then all devices owned by INDI server
             will be created and handled.
         */
-        void watchDevice(const char *deviceName);
+        [[gnu::nonnull(1)]] void watchDevice(const char *deviceName);
 
         /**
          * @brief watchProperties Add a property to the watch list. When communicating with INDI server.
@@ -85,7 +85,7 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
          * will call watchDevice(deviceName) as well to limit the traffic to this device.
          * @param propertyName Property to watch for.
          */
-        void watchProperty(const char *deviceName, const char *propertyName);
+        [[gnu::nonnull]] void watchProperty(const char *deviceName, const char *propertyName);
 
         /** \brief Connect to INDI server.
 
@@ -106,17 +106,17 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
         /** \brief Connect to INDI driver
             \param deviceName Name of the device to connect to.
         */
-        void connectDevice(const char *deviceName);
+        [[gnu::nonnull]] void connectDevice(const char *deviceName);
 
         /** \brief Disconnect INDI driver
             \param deviceName Name of the device to disconnect.
         */
-        void disconnectDevice(const char *deviceName);
+        [[gnu::nonnull]] void disconnectDevice(const char *deviceName);
 
         /** \param deviceName Name of device to search for in the list of devices owned by INDI server,
              \returns If \e deviceName exists, it returns an instance of the device. Otherwise, it returns NULL.
         */
-        INDI::BaseDevice *getDevice(const char *deviceName);
+        [[gnu::nonnull]] INDI::BaseDevice *getDevice(const char *deviceName);
 
         /** \returns Returns a vector of all devices created in the client.
         */
@@ -158,7 +158,7 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
           \param dev name of device, required.
           \param prop name of property, optional.
         */
-        void setBLOBMode(BLOBHandling blobH, const char *dev, const char *prop = nullptr);
+        [[gnu::nonnull(2)]] void setBLOBMode(BLOBHandling blobH, const char *dev, const char *prop = nullptr);
 
         /**
          * @brief getBLOBMode Get Binary Large Object policy mode IF set previously by setBLOBMode
@@ -166,10 +166,10 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
          * @param prop property name, can be NULL to return overall device policy if it exists.
          * @return BLOB Policy, if not found, it always returns B_ALSO
          */
-        BLOBHandling getBLOBMode(const char *dev, const char *prop = nullptr);
+        [[gnu::nonnull(1)]] BLOBHandling getBLOBMode(const char *dev, const char *prop = nullptr);
 
         // Update
-        static void *listenHelper(void *context);
+        [[gnu::nonnull]] static void *listenHelper(void *context);
 
         const char *getHost()
         {
@@ -181,24 +181,24 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
         }
 
         /** \brief Send new Text command to server */
-        void sendNewText(ITextVectorProperty *pp);
+        [[gnu::nonnull]] void sendNewText(ITextVectorProperty *pp);
         /** \brief Send new Text command to server */
-        void sendNewText(const char *deviceName, const char *propertyName, const char *elementName, const char *text);
+        [[gnu::nonnull]] void sendNewText(const char *deviceName, const char *propertyName, const char *elementName, const char *text);
         /** \brief Send new Number command to server */
-        void sendNewNumber(INumberVectorProperty *pp);
+        [[gnu::nonnull]] void sendNewNumber(INumberVectorProperty *pp);
         /** \brief Send new Number command to server */
-        void sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName, double value);
+        [[gnu::nonnull]] void sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName, double value);
         /** \brief Send new Switch command to server */
-        void sendNewSwitch(ISwitchVectorProperty *pp);
+        [[gnu::nonnull]] void sendNewSwitch(ISwitchVectorProperty *pp);
         /** \brief Send new Switch command to server */
-        void sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName);
+        [[gnu::nonnull]] void sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName);
 
         /** \brief Send opening tag for BLOB command to server */
-        void startBlob(const char *devName, const char *propName, const char *timestamp);
+        [[gnu::nonnull]] void startBlob(const char *devName, const char *propName, const char *timestamp);
         /** \brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
-        void sendOneBlob(IBLOB *bp);
+        [[gnu::nonnull]] void sendOneBlob(IBLOB *bp);
         /** \brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
-        void sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat, void *blobBuffer);
+        [[gnu::nonnull, gnu::access(read_only, 4,2)]] void sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat, void *blobBuffer);
         /** \brief Send closing tag for BLOB command to server */
         void finishBlob();
 
@@ -234,20 +234,20 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
 
     protected:
         /** \brief Dispatch command received from INDI server to respective devices handled by the client */
-        int dispatchCommand(XMLEle *root, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int dispatchCommand(XMLEle *root, char *errmsg);
 
         /** \brief Remove device */
-        int deleteDevice(const char *devName, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int deleteDevice(const char *devName, char *errmsg);
 
         /** \brief Delete property command */
-        int delPropertyCmd(XMLEle *root, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int delPropertyCmd(XMLEle *root, char *errmsg);
 
         /** \brief Find and return a particular device */
-        INDI::BaseDevice *findDev(const char *devName, char *errmsg);
+        [[gnu::nonnull]] INDI::BaseDevice *findDev(const char *devName, char *errmsg);
         /** \brief Add a new device */
-        INDI::BaseDevice *addDevice(XMLEle *dep, char *errmsg);
+        [[nodiscard, gnu::nonnull]] INDI::BaseDevice *addDevice(XMLEle *dep, char *errmsg);
         /** \brief Find a device, and if it doesn't exist, create it if create is set to 1 */
-        INDI::BaseDevice *findDev(XMLEle *root, int create, char *errmsg);
+        [[nodiscard, gnu::nonnull]] INDI::BaseDevice *findDev(XMLEle *root, int create, char *errmsg);
 
         /**  Process messages */
         int messageCmd(XMLEle *root, char *errmsg);
@@ -274,7 +274,7 @@ class INDI::BaseClientQt : public QObject, public INDI::BaseMediator
              Otherwise, CONNECTION will be turned off.
             \param deviceName Name of the device to connect to.
         */
-        void setDriverConnection(bool status, const char *deviceName);
+        [[gnu::nonnull]] void setDriverConnection(bool status, const char *deviceName);
 
         /**
          * @brief clear Clear devices and blob modes

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -133,7 +133,7 @@ class BaseDevice
          *  @param errmsg buffer to store error message.
          *  @return 0 if successul, -1 otherwise.
          */
-        int removeProperty(const char *name, char *errmsg);
+        [[nodiscard, gnu::nonnull(2)]] int removeProperty(const char *name, char *errmsg);
 
         /** @brief Return a property and its type given its name.
          *  @param name of property to be found.
@@ -144,7 +144,7 @@ class BaseDevice
          *  @note This is a low-level function and should not be called directly unless necessary. Use getXXX instead where XXX
          *  is the property type (Number, Text, Switch..etc).
          */
-        void *getRawProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
+        [[gnu::nonnull]] void *getRawProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
 
         /** @brief Return a property and its type given its name.
          *  @param name of property to be found.
@@ -152,7 +152,7 @@ class BaseDevice
          *  @return If property is found, it is returned. To be used you must use static_cast with given the type of property
          *  returned.
          */
-        Property getProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
+        [[gnu::nonnull]] Property getProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
 
         /** @brief Return a list of all properties in the device. */
         Properties getProperties();
@@ -231,7 +231,7 @@ class BaseDevice
          *  to other clients.
          *  @see An example skeleton file can be found under examples/tutorial_four_sk.xml
          */
-        bool buildSkeleton(const char *filename);
+        [[nodiscard, gnu::nonnull]] bool buildSkeleton(const char *filename);
 
         /** @brief Build a property given the supplied XML element (defXXX)
          *  @param root XML element to parse and build.
@@ -239,13 +239,13 @@ class BaseDevice
          *  @param isDynamic set to true if property is loaded from an XML file.
          *  @return 0 if parsing is successful, -1 otherwise and errmsg is set
          */
-        int buildProp(XMLEle *root, char *errmsg, bool isDynamic = false);
+        [[nodiscard, gnu::nonnull]] int buildProp(XMLEle *root, char *errmsg, bool isDynamic = false);
 
         /** @brief handle SetXXX commands from client */
-        int setValue(XMLEle *root, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int setValue(XMLEle *root, char *errmsg);
 
         /** @brief Parse and store BLOB in the respective vector */
-        int setBLOB(IBLOBVectorProperty *pp, XMLEle *root, char *errmsg);
+        [[nodiscard, gnu::nonnull]] int setBLOB(IBLOBVectorProperty *pp, XMLEle *root, char *errmsg);
 
     protected:
         std::shared_ptr<BaseDevicePrivate> d_ptr;

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -66,7 +66,7 @@ class BaseDevice
         };
 
         /** @brief The DRIVER_INTERFACE enum defines the class of devices the driver implements. A driver may implement one or more interfaces. */
-        enum DRIVER_INTERFACE
+        [[clang::flag_enum]] enum DRIVER_INTERFACE
         {
             GENERAL_INTERFACE       = 0,         /**< Default interface for all INDI devices */
             TELESCOPE_INTERFACE     = (1 << 0),  /**< Telescope interface, must subclass INDI::Telescope */

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -94,37 +94,37 @@ class BaseDevice
 
     public:
         /** @return Return vector number property given its name */
-        INDI::PropertyView<INumber> *getNumber(const char *name) const;
+        [[gnu::nonnull]] INDI::PropertyView<INumber> *getNumber(const char *name) const;
         /** @return Return vector text property given its name */
-        INDI::PropertyView<IText>   *getText(const char *name) const;
+        [[gnu::nonnull]] INDI::PropertyView<IText>   *getText(const char *name) const;
         /** @return Return vector switch property given its name */
-        INDI::PropertyView<ISwitch> *getSwitch(const char *name) const;
+        [[gnu::nonnull]] INDI::PropertyView<ISwitch> *getSwitch(const char *name) const;
         /** @return Return vector light property given its name */
-        INDI::PropertyView<ILight>  *getLight(const char *name) const;
+        [[gnu::nonnull]] INDI::PropertyView<ILight>  *getLight(const char *name) const;
         /** @return Return vector BLOB property given its name */
-        INDI::PropertyView<IBLOB>   *getBLOB(const char *name) const;
+        [[gnu::nonnull]] INDI::PropertyView<IBLOB>   *getBLOB(const char *name) const;
 
     public:
         /** @return Return property state */
-        IPState getPropertyState(const char *name) const;
+        [[gnu::nonnull]] IPState getPropertyState(const char *name) const;
         /** @return Return property permission */
-        IPerm getPropertyPermission(const char *name) const;
+        [[gnu::nonnull]] IPerm getPropertyPermission(const char *name) const;
 
     public:
-        void registerProperty(void *p, INDI_PROPERTY_TYPE type);
+        [[gnu::nonnull]] void registerProperty(void *p, INDI_PROPERTY_TYPE type);
 
         // #PS: will be deprecated / backward compatibility
-        void registerProperty(ITextVectorProperty *property);
-        void registerProperty(INumberVectorProperty *property);
-        void registerProperty(ISwitchVectorProperty *property);
-        void registerProperty(ILightVectorProperty *property);
-        void registerProperty(IBLOBVectorProperty *property);
+        [[gnu::nonnull]] void registerProperty(ITextVectorProperty *property);
+        [[gnu::nonnull]] void registerProperty(INumberVectorProperty *property);
+        [[gnu::nonnull]] void registerProperty(ISwitchVectorProperty *property);
+        [[gnu::nonnull]] void registerProperty(ILightVectorProperty *property);
+        [[gnu::nonnull]] void registerProperty(IBLOBVectorProperty *property);
 
-        void registerProperty(INDI::PropertyView<IText> *property);
-        void registerProperty(INDI::PropertyView<INumber> *property);
-        void registerProperty(INDI::PropertyView<ISwitch> *property);
-        void registerProperty(INDI::PropertyView<ILight> *property);
-        void registerProperty(INDI::PropertyView<IBLOB> *property);
+        [[gnu::nonnull]] void registerProperty(INDI::PropertyView<IText> *property);
+        [[gnu::nonnull]] void registerProperty(INDI::PropertyView<INumber> *property);
+        [[gnu::nonnull]] void registerProperty(INDI::PropertyView<ISwitch> *property);
+        [[gnu::nonnull]] void registerProperty(INDI::PropertyView<ILight> *property);
+        [[gnu::nonnull]] void registerProperty(INDI::PropertyView<IBLOB> *property);
 
         void registerProperty(INDI::Property &property);
 
@@ -163,8 +163,8 @@ class BaseDevice
          *  @param msg Message to add.
          */
         void addMessage(const std::string &msg);
-        void checkMessage(XMLEle *root);
-        void doMessage(XMLEle *msg);
+        [[gnu::nonnull]] void checkMessage(XMLEle *root);
+        [[gnu::nonnull]] void doMessage(XMLEle *msg);
 
         /** @return Returns a specific message. */
         const std::string &messageQueue(size_t index) const;
@@ -177,7 +177,7 @@ class BaseDevice
         bool isConnected() const;
 
         /** @brief Set the driver's mediator to receive notification of news devices and updated property values. */
-        void setMediator(INDI::BaseMediator *mediator);
+        [[gnu::nonnull]] void setMediator(INDI::BaseMediator *mediator);
 
         /** @returns Get the meditator assigned to this driver */
         INDI::BaseMediator *getMediator() const;
@@ -185,13 +185,13 @@ class BaseDevice
         /** @brief Set the device name
          *  @param dev new device name
          */
-        void setDeviceName(const char *dev);
+        [[gnu::nonnull]] void setDeviceName(const char *dev);
 
         /** @return Returns the device name */
         const char *getDeviceName() const;
 
         /** @brief Check that the device name matches the argument. **/
-        bool isDeviceNameMatch(const char *otherName) const;
+        [[gnu::nonnull]] bool isDeviceNameMatch(const char *otherName) const;
 
         /** @brief Check that the device name matches the argument. **/
         bool isDeviceNameMatch(const std::string &otherName) const;

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -149,8 +149,8 @@ class DefaultDevice : public BaseDevice
          * save configuration files.
          * \param nvp The number vector property to be defined
          */
-        void defineNumber(INumberVectorProperty *nvp) __attribute__((deprecated));
-        void defineProperty(INumberVectorProperty *property);
+        [[gnu::nonnull]] void defineNumber(INumberVectorProperty *nvp) __attribute__((deprecated));
+        [[gnu::nonnull]] void defineProperty(INumberVectorProperty *property);
 
         /**
          * \brief Define text vector to client & register it. Alternatively, IDDefText can be
@@ -158,8 +158,8 @@ class DefaultDevice : public BaseDevice
          * configuration files.
          * \param tvp The text vector property to be defined
          */
-        void defineText(ITextVectorProperty *tvp) __attribute__((deprecated));
-        void defineProperty(ITextVectorProperty *property);
+        [[gnu::nonnull]] void defineText(ITextVectorProperty *tvp) __attribute__((deprecated));
+        [[gnu::nonnull]] void defineProperty(ITextVectorProperty *property);
 
         /**
          * \brief Define switch vector to client & register it. Alternatively, IDDefswitch can be
@@ -167,8 +167,8 @@ class DefaultDevice : public BaseDevice
          * configuration files.
          * \param svp The switch vector property to be defined
          */
-        void defineSwitch(ISwitchVectorProperty *svp) __attribute__((deprecated));
-        void defineProperty(ISwitchVectorProperty *property);
+        [[gnu::nonnull]] void defineSwitch(ISwitchVectorProperty *svp) __attribute__((deprecated));
+        [[gnu::nonnull]] void defineProperty(ISwitchVectorProperty *property);
 
         /**
          * \brief Define light vector to client & register it. Alternatively, IDDeflight can be
@@ -176,8 +176,8 @@ class DefaultDevice : public BaseDevice
          * configuration files.
          * \param lvp The light vector property to be defined
          */
-        void defineLight(ILightVectorProperty *lvp) __attribute__((deprecated));
-        void defineProperty(ILightVectorProperty *property);
+        [[gnu::nonnull]] void defineLight(ILightVectorProperty *lvp) __attribute__((deprecated));
+        [[gnu::nonnull]] void defineProperty(ILightVectorProperty *property);
 
         /**
          * \brief Define BLOB vector to client & register it. Alternatively, IDDefBLOB can be
@@ -185,15 +185,15 @@ class DefaultDevice : public BaseDevice
          * save configuration files.
          * \param bvp The BLOB vector property to be defined
          */
-        void defineBLOB(IBLOBVectorProperty *bvp) __attribute__((deprecated));
-        void defineProperty(IBLOBVectorProperty *property);
+        [[gnu::nonnull]] void defineBLOB(IBLOBVectorProperty *bvp) __attribute__((deprecated));
+        [[gnu::nonnull]] void defineProperty(IBLOBVectorProperty *property);
 
         void defineProperty(INDI::Property &property);
         /**
          * \brief Delete a property and unregister it. It will also be deleted from all clients.
          * \param propertyName name of property to be deleted.
          */
-        virtual bool deleteProperty(const char *propertyName);
+        [[nodiscard, gnu::nonnull]] virtual bool deleteProperty(const char *propertyName);
 
     public:
         /**
@@ -254,35 +254,35 @@ class DefaultDevice : public BaseDevice
          * \note This function is called by the INDI framework, do not call it directly. See LX200
          * Generic driver for an example implementation
          */
-        virtual void ISGetProperties(const char *dev);
+        [[gnu::nonnull]] virtual void ISGetProperties(const char *dev);
 
         /**
          * \brief Process the client newSwitch command
          * \note This function is called by the INDI framework, do not call it directly.
          * \returns True if any property was successfully processed, false otherwise.
          */
-        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
 
         /**
          * \brief Process the client newNumber command
          * \note This function is called by the INDI framework, do not call it directly.
          * \returns True if any property was successfully processed, false otherwise.
          */
-        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
 
         /**
          * \brief Process the client newSwitch command
          * \note This function is called by the INDI framework, do not call it directly.
          * \returns True if any property was successfully processed, false otherwise.
          */
-        virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n);
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n);
 
         /**
          * \brief Process the client newBLOB command
          * \note This function is called by the INDI framework, do not call it directly.
          * \returns True if any property was successfully processed, false otherwise.
          */
-        virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
                                char *formats[], char *names[], int n);
 
         /**
@@ -291,7 +291,7 @@ class DefaultDevice : public BaseDevice
          * \note This function is called by the INDI framework, do not call it directly.
          * \returns True if any property was successfully processed, false otherwise.
          */
-        virtual bool ISSnoopDevice(XMLEle *root);
+        [[nodiscard, gnu::nonnull]] virtual bool ISSnoopDevice(XMLEle *root);
 
         /**
          * @return getInterface Return the interface declared by the driver.
@@ -333,7 +333,7 @@ class DefaultDevice : public BaseDevice
          * configuration file are loaded which is the default behavior.
          * \return True if successful, false otherwise.
          */
-        virtual bool loadConfig(bool silent = false, const char *property = nullptr);
+        [[nodiscard]] virtual bool loadConfig(bool silent = false, const char *property = nullptr);
 
         /**
          * \brief Save the current properties in a configuration file
@@ -342,13 +342,13 @@ class DefaultDevice : public BaseDevice
          * file as is.
          * \return True if successful, false otherwise.
          */
-        virtual bool saveConfig(bool silent = false, const char *property = nullptr);
+        [[nodiscard]] virtual bool saveConfig(bool silent = false, const char *property = nullptr);
 
         /**
          * @brief purgeConfig Remove config file from disk.
          * @return True if successful, false otherwise.
          */
-        virtual bool purgeConfig();
+        [[nodiscard]] virtual bool purgeConfig();
 
         /**
          * @brief saveConfigItems Save specific properties in the provide config file handler. Child
@@ -358,20 +358,20 @@ class DefaultDevice : public BaseDevice
          * @param fp Pointer to config file handler
          * @return True if successful, false otherwise.
          */
-        virtual bool saveConfigItems(FILE *fp);
+        [[nodiscard, gnu::nonnull]] virtual bool saveConfigItems(FILE *fp);
 
         /**
          * @brief saveAllConfigItems Save all the drivers' properties in the configuration file
          * @param fp pointer to config file handler
          * @return  True if successful, false otherwise.
          */
-        virtual bool saveAllConfigItems(FILE *fp);
+        [[nodiscard, gnu::nonnull]] virtual bool saveAllConfigItems(FILE *fp);
 
         /**
          * \brief Load the default configuration file
          * \return True if successful, false otherwise.
          */
-        virtual bool loadDefaultConfig();
+        [[nodiscard]] virtual bool loadDefaultConfig();
 
         // Simulatin & Debug
 
@@ -448,14 +448,14 @@ class DefaultDevice : public BaseDevice
          * connection type shall be defined to the client in ISGetProperties()
          * @param newConnection Pointer to new connection plugin
          */
-        void registerConnection(Connection::Interface *newConnection);
+        [[gnu::nonnull]] void registerConnection(Connection::Interface *newConnection);
 
         /**
          * @brief unRegisterConnection Remove connection from existing pool
          * @param existingConnection pointer to connection interface
          * @return True if connection is removed, false otherwise.
          */
-        bool unRegisterConnection(Connection::Interface *existingConnection);
+        [[nodiscard, gnu::nonnull]] bool unRegisterConnection(Connection::Interface *existingConnection);
 
         /** @return Return actively selected connection plugin */
         Connection::Interface *getActiveConnection();
@@ -464,7 +464,7 @@ class DefaultDevice : public BaseDevice
          * @brief setActiveConnection Switch the active connection to the passed connection plugin
          * @param existingConnection pointer to an existing connection to be made active.
          */
-        void setActiveConnection(Connection::Interface *existingConnection);
+        [[gnu::nonnull]] void setActiveConnection(Connection::Interface *existingConnection);
 
     protected: // polling
         /**

--- a/libs/indibase/dsp/dspinterface.h
+++ b/libs/indibase/dsp/dspinterface.h
@@ -79,14 +79,14 @@ class Interface
             DSP_HISTOGRAM,
         } Type;
 
-        virtual void ISGetProperties(const char *dev);
-        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
-        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
-        virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n);
-        virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
+        [[gnu::nonnull]] virtual void ISGetProperties(const char *dev);
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n);
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n);
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n);
+        [[nodiscard, gnu::nonnull]] virtual bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[], char *formats[],
                                char *names[], int n);
-        virtual bool saveConfigItems(FILE *fp);
-        virtual bool updateProperties();
+        [[nodiscard, gnu::nonnull]] virtual bool saveConfigItems(FILE *fp);
+        [[nodiscard]] virtual bool updateProperties();
 
         /**
          * @brief processBLOB Propagate to Callback and generate BLOBs for parent device.

--- a/libs/indibase/indibase.h
+++ b/libs/indibase/indibase.h
@@ -85,53 +85,53 @@ class INDI::BaseMediator
         /** @brief Emmited when a new device is created from INDI server.
          *  @param dp Pointer to the base device instance
          */
-        virtual void newDevice(INDI::BaseDevice *dp) = 0;
+        [[gnu::nonnull]] virtual void newDevice(INDI::BaseDevice *dp) = 0;
 
         /** @brief Emmited when a device is deleted from INDI server.
          *  @param dp Pointer to the base device instance.
          */
-        virtual void removeDevice(INDI::BaseDevice *dp) = 0;
+        [[gnu::nonnull]] virtual void removeDevice(INDI::BaseDevice *dp) = 0;
 
         /** @brief Emmited when a new property is created for an INDI driver.
          *  @param property Pointer to the Property Container
          */
-        virtual void newProperty(INDI::Property *property) = 0;
+        [[gnu::nonnull]] virtual void newProperty(INDI::Property *property) = 0;
 
         /** @brief Emmited when a property is deleted for an INDI driver.
          *  @param property Pointer to the Property Container to remove.
          */
-        virtual void removeProperty(INDI::Property *property) = 0;
+        [[gnu::nonnull]] virtual void removeProperty(INDI::Property *property) = 0;
 
         /** @brief Emmited when a new BLOB value arrives from INDI server.
          *  @param bp Pointer to filled and process BLOB.
          */
-        virtual void newBLOB(IBLOB *bp) = 0;
+        [[gnu::nonnull]] virtual void newBLOB(IBLOB *bp) = 0;
 
         /** @brief Emmited when a new switch value arrives from INDI server.
          *  @param svp Pointer to a switch vector property.
          */
-        virtual void newSwitch(ISwitchVectorProperty *svp) = 0;
+        [[gnu::nonnull]] virtual void newSwitch(ISwitchVectorProperty *svp) = 0;
 
         /** @brief Emmited when a new number value arrives from INDI server.
          *  @param nvp Pointer to a number vector property.
          */
-        virtual void newNumber(INumberVectorProperty *nvp) = 0;
+        [[gnu::nonnull]] virtual void newNumber(INumberVectorProperty *nvp) = 0;
 
         /** @brief Emmited when a new text value arrives from INDI server.
          *  @param tvp Pointer to a text vector property.
          */
-        virtual void newText(ITextVectorProperty *tvp) = 0;
+        [[gnu::nonnull]] virtual void newText(ITextVectorProperty *tvp) = 0;
 
         /** @brief Emmited when a new light value arrives from INDI server.
          *  @param lvp Pointer to a light vector property.
          */
-        virtual void newLight(ILightVectorProperty *lvp) = 0;
+        [[gnu::nonnull]] virtual void newLight(ILightVectorProperty *lvp) = 0;
 
         /** @brief Emmited when a new message arrives from INDI server.
          *  @param dp pointer to the INDI device the message is sent to.
          *  @param messageID ID of the message that can be used to retrieve the message from the device's messageQueue() function.
          */
-        virtual void newMessage(INDI::BaseDevice *dp, int messageID) = 0;
+        [[gnu::nonnull]] virtual void newMessage(INDI::BaseDevice *dp, int messageID) = 0;
 
         /** @brief Emmited when the server is connected. */
         virtual void serverConnected() = 0;

--- a/libs/indibase/indiusbdevice.h
+++ b/libs/indibase/indiusbdevice.h
@@ -51,14 +51,14 @@ class USBDevice
         libusb_device *FindDevice(int, int, int);
 
     public:
-        int WriteInterrupt(unsigned char *, int, int);
-        int ReadInterrupt(unsigned char *, int, int);
-        int WriteBulk(unsigned char *buf, int nbytes, int timeout);
-        int ReadBulk(unsigned char *buf, int nbytes, int timeout);
-        int ControlMessage(unsigned char request_type, unsigned char request, unsigned int value, unsigned int index,
+        [[nodiscard, gnu::nonnull, gnu::access(read_only, 2, 3)]] int WriteInterrupt(unsigned char *, int, int);
+        [[nodiscard, gnu::nonnull, gnu::access(write_only, 2, 3)]] int ReadInterrupt(unsigned char *, int, int);
+        [[nodiscard, gnu::nonnull, gnu::access(read_only, 2, 3)]] int WriteBulk(unsigned char *buf, int nbytes, int timeout);
+        [[nodiscard, gnu::nonnull, gnu::access(write_only, 2, 3)]] int ReadBulk(unsigned char *buf, int nbytes, int timeout);
+        [[nodiscard, gnu::nonnull]] int ControlMessage(unsigned char request_type, unsigned char request, unsigned int value, unsigned int index,
                            unsigned char *data, unsigned char len);
-        int FindEndpoints();
-        int Open();
+        [[nodiscard]] int FindEndpoints();
+        [[nodiscard]] int Open();
         void Close();
         USBDevice();
         USBDevice(libusb_device *dev);

--- a/libs/indibase/indiutility.h
+++ b/libs/indibase/indiutility.h
@@ -41,7 +41,7 @@ int mkpath(std::string path, mode_t mode);
 /**
  * @brief Converts the date and time to string - this function uses 'strftime'
  */
-std::string format_time(const std::tm &tm, const char *format);
+[[gnu::nonnull(2)]] std::string format_time(const std::tm &tm, const char *format);
 
 /**
  * @brief Replaces every occurrence of the string 'search' with the string 'replace'

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -55,11 +55,11 @@ class Property
         ~Property();
 
     public:
-        void setProperty(void *);
+        [[gnu::nonnull]] void setProperty(void *);
         void setType(INDI_PROPERTY_TYPE t);
         void setRegistered(bool r);
         void setDynamic(bool d);
-        void setBaseDevice(BaseDevice *idp);
+        [[gnu::nonnull]] void setBaseDevice(BaseDevice *idp);
 
     public:
         void *getProperty() const;
@@ -70,11 +70,11 @@ class Property
         BaseDevice *getBaseDevice() const;
 
     public: // Convenience Functions
-        void setName(const char *name);
-        void setLabel(const char *label);
-        void setGroupName(const char *groupName);
-        void setDeviceName(const char *deviceName);
-        void setTimestamp(const char *timestamp);
+        [[gnu::nonnull]] void setName(const char *name);
+        [[gnu::nonnull]] void setLabel(const char *label);
+        [[gnu::nonnull]] void setGroupName(const char *groupName);
+        [[gnu::nonnull]] void setDeviceName(const char *deviceName);
+        [[gnu::nonnull]] void setTimestamp(const char *timestamp);
         void setState(IPState state);
         void setPermission(IPerm permission);
         void setTimeout(double timeout);
@@ -93,18 +93,18 @@ class Property
         bool isEmpty() const;
         bool isValid() const;
 
-        bool isNameMatch(const char *otherName) const;
+        [[gnu::nonnull]] bool isNameMatch(const char *otherName) const;
         bool isNameMatch(const std::string &otherName) const;
 
-        bool isLabelMatch(const char *otherLabel) const;
+        [[gnu::nonnull]] bool isLabelMatch(const char *otherLabel) const;
         bool isLabelMatch(const std::string &otherLabel) const;
 
     public:
-        void save(FILE *fp) const;
+        [[gnu::nonnull]] void save(FILE *fp) const;
 
     public:
-        void apply(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
-        void define(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
+        [[gnu::nonnull]] void apply(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
+        [[gnu::nonnull]] void define(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
 
         void apply() const
         {

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -92,27 +92,27 @@ struct PropertyView: PROPERTYVIEW_BASE_ACCESS WidgetTraits<T>::PropertyType
         //~PropertyView()                                        { for(auto &p: *this) {p.clear();} free(widget()); }
 
     public:
-        void setDeviceName(const char *name);                  /* outside implementation */
+        [[gnu::nonnull]] void setDeviceName(const char *name);                  /* outside implementation */
         void setDeviceName(const std::string &name);           /* outside implementation */
 
-        void setName(const char *name);                        /* outside implementation */
+        [[gnu::nonnull]] void setName(const char *name);                        /* outside implementation */
         void setName(const std::string &name);                 /* outside implementation */
 
-        void setLabel(const char *label);                      /* outside implementation */
+        [[gnu::nonnull]] void setLabel(const char *label);                      /* outside implementation */
         void setLabel(const std::string &label);               /* outside implementation */
 
-        void setGroupName(const char *name);                   /* outside implementation */
+        [[gnu::nonnull]] void setGroupName(const char *name);                   /* outside implementation */
         void setGroupName(const std::string &name);            /* outside implementation */
 
         void setPermission(IPerm permission);                  /* outside implementation */
         void setTimeout(double timeout);                       /* outside implementation */
         void setState(IPState state);
 
-        void setTimestamp(const char *timestamp);              /* outside implementation */
+        [[gnu::nonnull]] void setTimestamp(const char *timestamp);              /* outside implementation */
         void setTimestamp(const std::string &timestamp);       /* outside implementation */
 
-        void setAux(void *user);                               /* outside implementation */
-        void setWidgets(WidgetType *w, size_t count);          /* outside implementation */
+        [[gnu::nonnull]] void setAux(void *user);                               /* outside implementation */
+        [[gnu::nonnull, gnu::access(read_only, 2, 3)]] void setWidgets(WidgetType *w, size_t count);          /* outside implementation */
 
         template <size_t N>
         void setWidgets(WidgetType (&w)[N]);                   /* outside implementation */
@@ -222,7 +222,7 @@ struct PropertyView: PROPERTYVIEW_BASE_ACCESS WidgetTraits<T>::PropertyType
         }
 
     public: // only driver side
-        void save(FILE *f) const;                              /* outside implementation */
+        [[gnu::nonnull]] void save(FILE *f) const;                              /* outside implementation */
 
         void vapply(const char *format, va_list args)
         const;   /* outside implementation - only driver side, see indipropertyview_driver.cpp */
@@ -245,46 +245,46 @@ struct PropertyView: PROPERTYVIEW_BASE_ACCESS WidgetTraits<T>::PropertyType
 
     public:
         template <typename X = T, enable_if_is_same_t<X, IText> = true>
-        void fill(
+        [[gnu::nonnull]] void fill(
             const char *device, const char *name, const char *label, const char *group,
             IPerm permission, double timeout, IPState state
         ); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
         template <typename X = T, enable_if_is_same_t<X, INumber> = true>
-        void fill(
+        [[gnu::nonnull]] void fill(
             const char *device, const char *name, const char *label, const char *group,
             IPerm permission, double timeout, IPState state
         ); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
         template <typename X = T, enable_if_is_same_t<X, ISwitch> = true>
-        void fill(
+        [[gnu::nonnull]] void fill(
             const char *device, const char *name, const char *label, const char *group,
             IPerm permission, ISRule rule, double timeout, IPState state
         ); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
         template <typename X = T, enable_if_is_same_t<X, ILight> = true>
-        void fill(
+        [[gnu::nonnull]] void fill(
             const char *device, const char *name, const char *label, const char *group,
             IPState state
         ); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
         template <typename X = T, enable_if_is_same_t<X, IBLOB> = true>
-        void fill(
+        [[gnu::nonnull]] void fill(
             const char *device, const char *name, const char *label, const char *group,
             IPerm permission, double timeout, IPState state
         ); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
     public:
         template <typename X = T, enable_if_is_same_t<X, IText> = true>
-        bool update(const char * const texts[], const char * const names[], int n);
+        [[gnu::nonnull]] bool update(const char * const texts[], const char * const names[], int n);
         /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
         template <typename X = T, enable_if_is_same_t<X, INumber> = true>
-        bool update(const double values[], const char * const names[], int n);
+        [[gnu::nonnull]] bool update(const double values[], const char * const names[], int n);
         /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
         template <typename X = T, enable_if_is_same_t<X, ISwitch> = true>
-        bool update(const ISState states[], const char * const names[], int n);
+        [[gnu::nonnull]] bool update(const ISState states[], const char * const names[], int n);
         /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 
         /*
@@ -293,7 +293,7 @@ struct PropertyView: PROPERTYVIEW_BASE_ACCESS WidgetTraits<T>::PropertyType
         */
 
         template <typename X = T, enable_if_is_same_t<X, IBLOB> = true>
-        bool update(
+        [[gnu::nonnull]] bool update(
             const int sizes[], const int blobsizes[], const char * const blobs[], const char * const formats[],
             const char * const names[], int n
         ); /* outside implementation - only driver side, see indipropertyview_driver.cpp */
@@ -618,7 +618,7 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
         }
 
     public:
-        void fill(const char *name, const char *label, const char *format,
+        [[gnu::nonnull]] void fill(const char *name, const char *label, const char *format,
                   double min, double max, double step, double value)
         ; /* outside implementation - only driver side, see indipropertyview_driver.cpp */
 

--- a/libs/indicom.h
+++ b/libs/indicom.h
@@ -181,7 +181,7 @@ extern "C" {
     \param nbytes_read the number of bytes read.
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_read(int fd, char *buf, int nbytes, int timeout, int *nbytes_read);
+[[nodiscard, gnu::nonnull]] int tty_read(int fd, char *buf, int nbytes, int timeout, int *nbytes_read);
 
 /** \brief read buffer from terminal with a delimiter
     \param fd file descriptor
@@ -196,7 +196,7 @@ int tty_read(int fd, char *buf, int nbytes, int timeout, int *nbytes_read);
     \param nbytes_read the number of bytes read.
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_read_expanded(int fd, char *buf, int nbytes, long timeout_seconds, long timeout_microseconds, int *nbytes_read);
+[[nodiscard, gnu::nonnull]] int tty_read_expanded(int fd, char *buf, int nbytes, long timeout_seconds, long timeout_microseconds, int *nbytes_read);
 
 /** \brief read buffer from terminal with a delimiter
     \param fd file descriptor
@@ -206,7 +206,7 @@ int tty_read_expanded(int fd, char *buf, int nbytes, long timeout_seconds, long 
     \param nbytes_read the number of bytes read.
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_read_section(int fd, char *buf, char stop_char, int timeout, int *nbytes_read);
+[[nodiscard, gnu::nonnull]] int tty_read_section(int fd, char *buf, char stop_char, int timeout, int *nbytes_read);
 
 /** \brief read buffer from terminal with a delimiter
     \param fd file descriptor
@@ -222,7 +222,7 @@ int tty_read_section(int fd, char *buf, char stop_char, int timeout, int *nbytes
     \param nbytes_read the number of bytes read.
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_read_section_expanded(int fd, char *buf, char stop_char, long timeout_seconds, long timeout_microseconds,
+[[nodiscard, gnu::nonnull]] int tty_read_section_expanded(int fd, char *buf, char stop_char, long timeout_seconds, long timeout_microseconds,
                               int *nbytes_read);
 
 /** \brief read buffer from terminal with a delimiter
@@ -234,7 +234,7 @@ int tty_read_section_expanded(int fd, char *buf, char stop_char, long timeout_se
     \param nbytes_read the number of bytes read.
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_nread_section(int fd, char *buf, int nsize, char stop_char, int timeout, int *nbytes_read);
+[[nodiscard, gnu::nonnull]] int tty_nread_section(int fd, char *buf, int nsize, char stop_char, int timeout, int *nbytes_read);
 
 /** \brief Writes a buffer to fd.
     \param fd file descriptor
@@ -243,7 +243,7 @@ int tty_nread_section(int fd, char *buf, int nsize, char stop_char, int timeout,
     \param nbytes_written the number of bytes written
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_write(int fd, const char *buffer, int nbytes, int *nbytes_written);
+[[nodiscard, gnu::nonnull]] int tty_write(int fd, const char *buffer, int nbytes, int *nbytes_written);
 
 /** \brief Writes a null terminated string to fd.
     \param fd file descriptor
@@ -251,7 +251,7 @@ int tty_write(int fd, const char *buffer, int nbytes, int *nbytes_written);
     \param nbytes_written the number of bytes written
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_write_string(int fd, const char *buffer, int *nbytes_written);
+[[nodiscard, gnu::nonnull]] int tty_write_string(int fd, const char *buffer, int *nbytes_written);
 
 /** \brief Establishes a tty connection to a terminal device.
     \param device the device node. e.g. /dev/ttyS0
@@ -263,20 +263,20 @@ int tty_write_string(int fd, const char *buffer, int *nbytes_written);
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
     \author Wildi Markus
 */
-int tty_connect(const char *device, int bit_rate, int word_size, int parity, int stop_bits, int *fd);
+[[nodiscard, gnu::nonnull]] int tty_connect(const char *device, int bit_rate, int word_size, int parity, int stop_bits, int *fd);
 
 /** \brief Closes a tty connection and flushes the bus.
     \param fd the file descriptor to close.
     \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
 */
-int tty_disconnect(int fd);
+[[nodiscard]] int tty_disconnect(int fd);
 
 /** \brief Retrieve the tty error message
     \param err_code the error code return by any TTY function.
     \param err_msg an initialized buffer to hold the error message.
     \param err_msg_len length in bytes of \e err_msg
 */
-void tty_error_msg(int err_code, char *err_msg, int err_msg_len);
+[[gnu::nonnull]] void tty_error_msg(int err_code, char *err_msg, int err_msg_len);
 
 /**
  * @brief tty_set_debug Enable or disable debug which prints verbose information.
@@ -287,10 +287,10 @@ void tty_set_gemini_udp_format(int enabled);
 void tty_set_generic_udp_format(int enabled);
 void tty_clr_trailing_read_lf(int enabled);
 
-int tty_timeout(int fd, int timeout);
+[[nodiscard]]int tty_timeout(int fd, int timeout);
 /*@}*/
 
-int tty_timeout_microseconds(int fd, long timeout_seconds, long timeout_microseconds);
+[[nodiscard]] int tty_timeout_microseconds(int fd, long timeout_seconds, long timeout_microseconds);
 /*@}*/
 
 /**
@@ -314,7 +314,7 @@ int tty_timeout_microseconds(int fd, long timeout_seconds, long timeout_microsec
 
   \return number of characters written to out, not counting final null terminator.
  */
-int fs_sexa(char *out, double a, int w, int fracbase);
+[[gnu::nonnull]] int fs_sexa(char *out, double a, int w, int fracbase);
 
 /** \brief convert sexagesimal string str AxBxC to double.
 
@@ -324,7 +324,7 @@ int fs_sexa(char *out, double a, int w, int fracbase);
     \param dp pointer to a double to store the sexagesimal number.
     \return return 0 if ok, -1 if can't find a thing.
  */
-int f_scansexa(const char *str0, double *dp);
+[[nodiscard, gnu::nonnull]] int f_scansexa(const char *str0, double *dp);
 
 /** \brief Extract ISO 8601 time and store it in a tm struct.
     \param timestr a string containing date and time in ISO 8601 format.


### PR DESCRIPTION
These attributes will hopefully encourage proper defensive programming by, for example, warning when an error code is returned but not checked.