### PR TITLE
Don't tell cfitsio about preallocated buffers

### DIFF
--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -2282,8 +2282,7 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
             addFITSKeywords(targetChip);
 
             fits_write_img(fptr, byte_type, 1, nelements, targetChip->getFrameBuffer(), &status);
-            fits_flush_file(fptr, &status);
-
+            targetChip->finishFITSFile(status);
             if (status)
             {
                 fits_report_error(stderr, status); /* print out any error messages */

--- a/libs/indibase/indiccdchip.cpp
+++ b/libs/indibase/indiccdchip.cpp
@@ -58,14 +58,26 @@ bool CCDChip::openFITSFile(uint32_t size, int &status)
     return (status == 0);
 }
 
-bool CCDChip::closeFITSFile()
+bool CCDChip::finishFITSFile(int &status)
 {
-    int status = 0;
+    fits_flush_file(m_FITSFilePointer, &status);
     fits_close_file(m_FITSFilePointer, &status);
-    m_FITSFilePointer = nullptr;
+    if (status == 0) {
+        m_FITSFilePointer = nullptr;
+    }
+    return (status == 0);
+}
+
+void CCDChip::closeFITSFile()
+{
+    if (m_FITSFilePointer != nullptr) {
+        int status = 0;
+        // Discard error here, the caller can't expect a valid file anymore at that point
+        fits_close_file(m_FITSFilePointer, &status);
+        m_FITSFilePointer = nullptr;
+    }
     IDSharedBlobFree(m_FITSMemoryBlock);
     m_FITSMemoryBlock = nullptr;
-    return (status == 0);
 }
 
 void CCDChip::setFrameType(CCD_FRAME type)

--- a/libs/indibase/indiccdchip.cpp
+++ b/libs/indibase/indiccdchip.cpp
@@ -39,8 +39,8 @@ CCDChip::~CCDChip()
 
 bool CCDChip::openFITSFile(uint32_t size, int &status)
 {
-    m_FITSMemorySize = size;
-    m_FITSMemoryBlock = IDSharedBlobAlloc(m_FITSMemorySize);
+    m_FITSMemorySize = size > 2880 ? 2880 : size;
+    m_FITSMemoryBlock = IDSharedBlobAlloc(size);
     if (m_FITSMemoryBlock == nullptr)
     {
         IDLog("Failed to allocate memory for FITS file.");

--- a/libs/indibase/indiccdchip.h
+++ b/libs/indibase/indiccdchip.h
@@ -57,11 +57,17 @@ class CCDChip
          */
         bool openFITSFile(uint32_t size, int &status);
 
+
         /**
-         * @brief closeFITSFile Close the in-memory FITS File.
+         * @brief Finish any pending write to fits file.
          * @return True if successful, false otherwise.
          */
-        bool closeFITSFile();
+        bool finishFITSFile(int &status);
+
+        /**
+         * @brief closeFITSFile Close the in-memory FITS File.
+         */
+        void closeFITSFile();
 
         /**
          * @brief getXRes Get the horizontal resolution in pixels of the CCD Chip.


### PR DESCRIPTION
Fix for issue #1719

Also make sure the fits is closed from cfitsio, since closing a file in cfitsio will do some realloc on sealed buffer (this error was hidden by the file size never actually growing)
