### PR TITLE
Corrections for Pegasus Falcon Rotator:

### DIFF
--- a/drivers/rotator/pegasus_falcon.cpp
+++ b/drivers/rotator/pegasus_falcon.cpp
@@ -191,15 +191,15 @@ bool PegasusFalcon::AbortRotator()
 }
 
 //////////////////////////////////////////////////////////////////////
-///
+/// Command for reverse action ("FN:0" disabled, "FN:1" enabled)
 //////////////////////////////////////////////////////////////////////
 bool PegasusFalcon::ReverseRotator(bool enabled)
 {
     char cmd[DRIVER_LEN] = {0}, res[DRIVER_LEN] = {0};
-    snprintf(cmd, DRIVER_LEN, "FR:%d", enabled ? 1 : 0);
+    snprintf(cmd, DRIVER_LEN, "FN:%d", enabled ? 1 : 0);
     if (sendCommand(cmd, res))
     {
-        return (!strcmp(res, cmd));
+        return (!strncmp(res, cmd, 4)); //Restrict length to 4 chars!
     }
 
     return false;


### PR DESCRIPTION
Replaced serial command  to "FN:0"/"FN:1" in Function "ReverseRotator"
and restricted comparison of "cmd" and "res" to length 4 to produce a
correct return value.