### PR TITLE
Fix blob id conflit

### DIFF
--- a/indiserver.cpp
+++ b/indiserver.cpp
@@ -1769,11 +1769,8 @@ void Fifo::processLine(const char * line)
         {
             if (dp == nullptr) continue;
 
-            log(fmt("dp->name: %s - tDriver: %s\n", dp->name.c_str(), tDriver));
             if (dp->name == tDriver)
             {
-                log(fmt("name: %s - dp->dev[0]: %s\n", tName, dp->dev.empty() ? "" : dp->dev.begin()->c_str()));
-
                 /* If device name is given, check against it before shutting down */
                 if (tName[0] && !dp->isHandlingDevice(tName))
                     continue;

--- a/libs/indibase/sharedblob_parse.cpp
+++ b/libs/indibase/sharedblob_parse.cpp
@@ -41,12 +41,13 @@ static uint64_t idGenerator = rand();
 
     std::string allocateBlobUid(int fd)
     {
+        std::lock_guard<std::mutex> lock(attachedBlobMutex);
+
         std::stringstream ss;
-        ss << idGenerator;
+        ss << idGenerator++;
 
         std::string id = ss.str();
 
-        std::lock_guard<std::mutex> lock(attachedBlobMutex);
         receivedFds[id] = fd;
         return id;
     }


### PR DESCRIPTION
Fix a bug in the way shared blob are handled into client, currently leading to one thread freeing all blobs  (and leaking others).
