### PR TITLE
Feature: INDI::Property onUpdate event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2143,6 +2143,7 @@ if (INDI_BUILD_DRIVERS OR INDI_BUILD_CLIENT OR INDI_BUILD_QT5_CLIENT)
         ${CMAKE_CURRENT_SOURCE_DIR}/indidevapi.h
         ${CMAKE_CURRENT_SOURCE_DIR}/base64.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/lilxml.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indililxml.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indicom.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/json.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ SET(indiclient_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclient.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/watchdeviceproperty.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/sharedblob_parse.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperties.cpp
@@ -469,6 +470,7 @@ SET(indidriver_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/defaultdevice.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/watchdeviceproperty.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/sharedblob_parse.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperties.cpp

--- a/drivers/agent/agent_imager.cpp
+++ b/drivers/agent/agent_imager.cpp
@@ -436,8 +436,8 @@ bool Imager::ISSnoopDevice(XMLEle *root)
 bool Imager::Connect()
 {
     setServer("localhost", 7624); // TODO configuration options
-    watchDevice(controlledCCD);
-    watchDevice(controlledFilterWheel);
+    BaseClient::watchDevice(controlledCCD);
+    BaseClient::watchDevice(controlledFilterWheel);
     connectServer();
     setBLOBMode(B_ALSO, controlledCCD, nullptr);
 

--- a/examples/tutorial_five/dome.cpp
+++ b/examples/tutorial_five/dome.cpp
@@ -24,6 +24,7 @@
 */
 
 #include "dome.h"
+#include <inditimer.h>
 
 #include <memory>
 #include <cstring>
@@ -68,38 +69,47 @@ bool Dome::initProperties()
     mShutterSwitch[0].fill("Open", "", ISS_ON);
     mShutterSwitch[1].fill("Close", "", ISS_OFF);
     mShutterSwitch.fill(getDeviceName(), "Shutter Door", "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    mShutterSwitch.onUpdate([this](){
-
-        mShutterSwitch.setState(IPS_BUSY);
+    mShutterSwitch.onUpdate([this]()
+    {
         if (mShutterSwitch[0].getState() == ISS_ON)
-        {
-            if (mRainLight[0].getState() == IPS_ALERT)
-            {
-                mShutterSwitch.setState(IPS_ALERT);
-                mShutterSwitch[0].setState(ISS_OFF);
-                mShutterSwitch[1].setState(ISS_ON);
-                mShutterSwitch.apply("It is raining, cannot open Shutter.");
-                return;
-            }
-            mShutterSwitch.apply("Shutter is opening.");
-        }
+            openShutter();
         else
-            mShutterSwitch.apply("Shutter is closing.");
-        
-        sleep(5);
-
-        mShutterSwitch.setState(IPS_OK);
-
-        if (mShutterSwitch[0].getState() == ISS_ON)
-            mShutterSwitch.apply("Shutter is open.");
-        else
-            mShutterSwitch.apply("Shutter is closed.");
+            closeShutter();
 
     });
     // We init here the property we wish to "snoop" from the target device
     mRainLight[0].fill("Status", "", IPS_IDLE);
-    // Make sure to set the device name to "Rain Detector" since we are snooping on rain detector device.
-    mRainLight.fill("Rain Detector", "Rain Alert", "", MAIN_CONTROL_TAB, IPS_IDLE);
+
+    // wait for "Rain Detector" driver
+    watchDevice("Rain Detector", [this](INDI::BaseDevice device)
+    {
+        // wait for "Rain Alert" property available
+        device.watchProperty("Rain Alert", [this](INDI::PropertyLight rain)
+        {
+            mRainLight = rain; // we have real rainLight property, override mRainLight
+            static IPState oldRainState = rain[0].getState();
+
+            rain.onUpdate([this, rain]()
+            {
+                IPState newRainState = rain[0].getState();
+                if (newRainState == IPS_ALERT)
+                {
+                    // If dome is open, then close it */
+                    if (mShutterSwitch[0].getState() == ISS_ON)
+                        closeShutter();
+                    else
+                        IDMessage(getDeviceName(), "Rain Alert Detected! Dome is already closed.");
+                }
+                
+                if (newRainState != IPS_ALERT && oldRainState == IPS_ALERT)
+                {
+                    IDMessage(getDeviceName(), "Rain threat passed. Opening the dome is now safe.");
+                }
+
+                oldRainState = newRainState;
+            });
+        });
+    });
 
     return true;
 }
@@ -114,46 +124,12 @@ bool Dome::updateProperties()
     INDI::DefaultDevice::updateProperties();
 
     if (isConnected())
-    {
         defineProperty(mShutterSwitch);
-        /* Let's listen for Rain Alert property in the device Rain */
-        IDSnoopDevice("Rain Detector", "Rain Alert");
-    }
     else
         // We're disconnected
         deleteProperty(mShutterSwitch);
 
     return true;
-}
-
-
-/********************************************************************************************
-** We received snooped property update from rain detector device
-*********************************************************************************************/
-bool Dome::ISSnoopDevice(XMLEle *root)
-{
-    IPState old_state = mRainLight[0].getState();
-
-    /* If the "Rain Alert" property gets updated in the Rain device, we will receive a notification. We need to process the new values of Rain Alert and update the local version
-       of the property.*/
-    if (IUSnoopLight(root, &mRainLight) == 0)
-    {
-        // If the dome is connected and rain is Alert */
-        if (mRainLight[0].getState() == IPS_ALERT)
-        {
-            // If dome is open, then close it */
-            if (mShutterSwitch[0].getState() == ISS_ON)
-                closeShutter();
-            else
-                IDMessage(getDeviceName(), "Rain Alert Detected! Dome is already closed.");
-        }
-        else if (old_state == IPS_ALERT && mRainLight[0].getState() != IPS_ALERT)
-            IDMessage(getDeviceName(), "Rain threat passed. Opening the dome is now safe.");
-
-        return true;
-    }
-
-    return false;
 }
 
 /********************************************************************************************
@@ -162,13 +138,39 @@ bool Dome::ISSnoopDevice(XMLEle *root)
 void Dome::closeShutter()
 {
     mShutterSwitch.setState(IPS_BUSY);
-    mShutterSwitch.apply("Rain Alert! Shutter is closing...");
+    mShutterSwitch.apply("Shutter is closing...");
 
-    sleep(5);
+    INDI::Timer::singleShot(5000 /* ms */, [this](){
+        mShutterSwitch[0].setState(ISS_OFF);
+        mShutterSwitch[1].setState(ISS_ON);
 
-    mShutterSwitch[0].setState(ISS_OFF);
-    mShutterSwitch[1].setState(ISS_ON);
+        mShutterSwitch.setState(IPS_OK);
+        mShutterSwitch.apply("Shutter is closed.");
+    });
+}
 
-    mShutterSwitch.setState(IPS_OK);
-    mShutterSwitch.apply("Shutter is closed.");
+/********************************************************************************************
+** Open shutter
+*********************************************************************************************/
+void Dome::openShutter()
+{
+    if (mRainLight[0].getState() == IPS_ALERT)
+    {
+        mShutterSwitch.setState(IPS_ALERT);
+        mShutterSwitch[0].setState(ISS_OFF);
+        mShutterSwitch[1].setState(ISS_ON);
+        mShutterSwitch.apply("It is raining, cannot open Shutter.");
+        return;
+    }
+
+    mShutterSwitch.setState(IPS_BUSY);
+    mShutterSwitch.apply("Shutter is opening...");
+
+    INDI::Timer::singleShot(5000 /* ms */, [this](){
+        mShutterSwitch[0].setState(ISS_ON);
+        mShutterSwitch[1].setState(ISS_OFF);
+
+        mShutterSwitch.setState(IPS_OK);
+        mShutterSwitch.apply("Shutter is open.");
+    });
 }

--- a/examples/tutorial_five/dome.h
+++ b/examples/tutorial_five/dome.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "defaultdevice.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
 
 class Dome : public INDI::DefaultDevice
 {
@@ -34,7 +36,6 @@ class Dome : public INDI::DefaultDevice
 
     protected:
         // General device functions
-        bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
         bool ISSnoopDevice(XMLEle *root) override;
         bool Connect() override;
         bool Disconnect() override;
@@ -45,9 +46,6 @@ class Dome : public INDI::DefaultDevice
     private:
         void closeShutter();
 
-        ISwitch ShutterS[2];
-        ISwitchVectorProperty ShutterSP;
-
-        ILight RainL[1];
-        ILightVectorProperty RainLP;
+        INDI::PropertySwitch mShutterSwitch {2};
+        INDI::PropertyLight  mRainLight {1};
 };

--- a/examples/tutorial_five/dome.h
+++ b/examples/tutorial_five/dome.h
@@ -25,18 +25,21 @@
 
 #pragma once
 
-#include "defaultdevice.h"
-#include "indipropertyswitch.h"
-#include "indipropertylight.h"
+#include <defaultdevice.h>
+#include <indipropertyswitch.h>
+#include <indipropertylight.h>
 
 class Dome : public INDI::DefaultDevice
 {
     public:
         Dome() = default;
 
+    public:
+        void closeShutter();
+        void openShutter();
+
     protected:
         // General device functions
-        bool ISSnoopDevice(XMLEle *root) override;
         bool Connect() override;
         bool Disconnect() override;
         const char *getDefaultName() override;
@@ -44,8 +47,6 @@ class Dome : public INDI::DefaultDevice
         bool updateProperties() override;
 
     private:
-        void closeShutter();
-
         INDI::PropertySwitch mShutterSwitch {2};
         INDI::PropertyLight  mRainLight {1};
 };

--- a/examples/tutorial_five/raindetector.h
+++ b/examples/tutorial_five/raindetector.h
@@ -20,9 +20,9 @@
 
 #pragma once
 
-#include "defaultdevice.h"
-#include "indipropertylight.h"
-#include "indipropertyswitch.h"
+#include <defaultdevice.h>
+#include <indipropertylight.h>
+#include <indipropertyswitch.h>
 
 class RainDetector : public INDI::DefaultDevice
 {

--- a/examples/tutorial_five/raindetector.h
+++ b/examples/tutorial_five/raindetector.h
@@ -21,6 +21,8 @@
 #pragma once
 
 #include "defaultdevice.h"
+#include "indipropertylight.h"
+#include "indipropertyswitch.h"
 
 class RainDetector : public INDI::DefaultDevice
 {
@@ -29,7 +31,6 @@ class RainDetector : public INDI::DefaultDevice
 
     protected:
         // General device functions
-        bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
         bool Connect() override;
         bool Disconnect() override;
         const char *getDefaultName() override;
@@ -37,9 +38,6 @@ class RainDetector : public INDI::DefaultDevice
         bool updateProperties() override;
 
     private:
-        ILight RainL[1];
-        ILightVectorProperty RainLP;
-
-        ISwitch RainS[2];
-        ISwitchVectorProperty RainSP;
+        INDI::PropertyLight  mRainLight  {1};
+        INDI::PropertySwitch mRainSwitch {2};
 };

--- a/examples/tutorial_four/simpleskeleton.h
+++ b/examples/tutorial_four/simpleskeleton.h
@@ -30,24 +30,19 @@
     \note Please note that if you create your own skeleton file, you must append _sk postfix to your skeleton file name.
 */
 
-#include "defaultdevice.h"
+#include <defaultdevice.h>
 
 class SimpleSkeleton : public INDI::DefaultDevice
 {
     public:
         SimpleSkeleton() = default;
-        ~SimpleSkeleton() = default;
 
     protected:
-        void ISGetProperties(const char *dev) override;
-        bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-        bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
-        bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-        bool ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsizes[], char *blobs[],
-                       char *formats[], char *names[], int n) override;
-
-        const char *getDefaultName() override;
-        bool initProperties() override;
+        // General device functions
         bool Connect() override;
         bool Disconnect() override;
+        const char *getDefaultName() override;
+        bool initProperties() override;
+
+        void ISGetProperties(const char *dev) override;
 };

--- a/examples/tutorial_six/tutorial_client.cpp
+++ b/examples/tutorial_six/tutorial_client.cpp
@@ -48,21 +48,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 
 static const char MYCCD[] = "Simple CCD";
 
-static std::unique_ptr<MyClient> camera_client(new MyClient());
-
-int main(int /*argc*/, char **/*argv*/)
+int main(int, char *[])
 {
-    camera_client->setServer("localhost", 7624);
+    MyClient myClient;
+    myClient.setServer("localhost", 7624);
 
-    camera_client->connectServer();
+    myClient.connectServer();
 
-    camera_client->setBLOBMode(B_ALSO, MYCCD, nullptr);
+    myClient.setBLOBMode(B_ALSO, MYCCD, nullptr);
 
-    camera_client->enableDirectBlobAccess(MYCCD, nullptr);
+    myClient.enableDirectBlobAccess(MYCCD, nullptr);
 
-    std::cout << "Press any key to terminate the client.\n";
-    std::string term;
-    std::cin >> term;
+    std::cout << "Press Enter key to terminate the client.\n";
+    std::cin.ignore();
 }
 
 /**************************************************************************************

--- a/examples/tutorial_six/tutorial_client.cpp
+++ b/examples/tutorial_six/tutorial_client.cpp
@@ -39,22 +39,20 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 
 #include "tutorial_client.h"
 
-#include "indibase/basedevice.h"
+#include <basedevice.h>
 
 #include <cstring>
 #include <fstream>
 #include <iostream>
 #include <memory>
 
-#define MYCCD "Simple CCD"
+static const char MYCCD[] = "Simple CCD";
 
 static std::unique_ptr<MyClient> camera_client(new MyClient());
 
 int main(int /*argc*/, char **/*argv*/)
 {
     camera_client->setServer("localhost", 7624);
-
-    camera_client->watchDevice(MYCCD);
 
     camera_client->connectServer();
 
@@ -72,98 +70,94 @@ int main(int /*argc*/, char **/*argv*/)
 ***************************************************************************************/
 MyClient::MyClient()
 {
-    ccd_simulator = nullptr;
+    // wait for the availability of the device
+    watchDevice(MYCCD, [this](INDI::BaseDevice device)
+    {
+        mCcdSimulator = device; // save device
+        // wait for the availability of the "CONNECTION" property
+        device.watchProperty("CONNECTION", [this](INDI::Property)
+        {
+            IDLog("Connecting to INDI Driver...\n");
+            connectDevice(MYCCD);
+        });
+
+        // wait for the availability of the "CCD_TEMPERATURE" property
+        device.watchProperty("CCD_TEMPERATURE", [this](INDI::PropertyNumber property)
+        {
+            if (mCcdSimulator.isConnected())
+            {
+                IDLog("CCD is connected.\n");
+                setTemperature(-20);
+            }
+
+            // call a handler function if property changes
+            property.onUpdate([property, this]()
+            {
+                IDLog("Receving new CCD Temperature: %g C\n", property[0].getValue());
+                if (property[0].getValue() == -20)
+                {
+                    IDLog("CCD temperature reached desired value!\n");
+                    takeExposure(1);
+                }
+            });
+        });
+
+        // wait for the availability of the "CCD1" property
+        device.watchProperty("CCD1", [](INDI::PropertyBlob property)
+        {
+            // call a handler function if property changes
+            property.onUpdate([property]()
+            {
+                // Save FITS file to disk
+                std::ofstream myfile;
+
+                myfile.open("ccd_simulator.fits", std::ios::out | std::ios::binary);
+
+                myfile.write(static_cast<char *>(property[0].getBlob()), property[0].getBlobLen());
+
+                myfile.close();
+
+                IDLog("Received image, saved as mCcdSimulator.fits\n");
+            });
+        });
+    });
 }
 
 /**************************************************************************************
 **
 ***************************************************************************************/
-void MyClient::setTemperature()
+void MyClient::setTemperature(double value)
 {
-    INumberVectorProperty *ccd_temperature = nullptr;
+    INDI::PropertyNumber ccdTemperature = mCcdSimulator.getProperty("CCD_TEMPERATURE");
 
-    ccd_temperature = ccd_simulator->getNumber("CCD_TEMPERATURE");
-
-    if (ccd_temperature == nullptr)
+    if (!ccdTemperature.isValid())
     {
         IDLog("Error: unable to find CCD Simulator CCD_TEMPERATURE property...\n");
         return;
     }
 
-    ccd_temperature->np[0].value = -20;
-    sendNewNumber(ccd_temperature);
+    IDLog("Setting temperature to %g C.\n", value);
+    ccdTemperature[0].setValue(value);
+    sendNewProperty(ccdTemperature);
 }
 
 /**************************************************************************************
 **
 ***************************************************************************************/
-void MyClient::takeExposure()
+void MyClient::takeExposure(double seconds)
 {
-    INumberVectorProperty *ccd_exposure = nullptr;
+    INDI::PropertyNumber ccdExposure = mCcdSimulator.getProperty("CCD_EXPOSURE");
 
-    ccd_exposure = ccd_simulator->getNumber("CCD_EXPOSURE");
-
-    if (ccd_exposure == nullptr)
+    if (!ccdExposure.isValid())
     {
         IDLog("Error: unable to find CCD Simulator CCD_EXPOSURE property...\n");
         return;
     }
 
     // Take a 1 second exposure
-    IDLog("Taking a 1 second exposure.\n");
-    ccd_exposure->np[0].value = 1;
-    sendNewNumber(ccd_exposure);
-}
-
-/**************************************************************************************
-**
-***************************************************************************************/
-void MyClient::newDevice(INDI::BaseDevice *dp)
-{
-    if (strcmp(dp->getDeviceName(), MYCCD) == 0)
-        IDLog("Receiving %s Device...\n", dp->getDeviceName());
-
-    ccd_simulator = dp;
-}
-
-/**************************************************************************************
-**
-*************************************************************************************/
-void MyClient::newProperty(INDI::Property *property)
-{
-    if (strcmp(property->getDeviceName(), MYCCD) == 0 && strcmp(property->getName(), "CONNECTION") == 0)
-    {
-        connectDevice(MYCCD);
-        return;
-    }
-
-    if (strcmp(property->getDeviceName(), MYCCD) == 0 && strcmp(property->getName(), "CCD_TEMPERATURE") == 0)
-    {
-        if (ccd_simulator->isConnected())
-        {
-            IDLog("CCD is connected. Setting temperature to -20 C.\n");
-            setTemperature();
-        }
-        return;
-    }
-}
-
-/**************************************************************************************
-**
-***************************************************************************************/
-void MyClient::newNumber(INumberVectorProperty *nvp)
-{
-    // Let's check if we get any new values for CCD_TEMPERATURE
-    if (strcmp(nvp->name, "CCD_TEMPERATURE") == 0)
-    {
-        IDLog("Receving new CCD Temperature: %g C\n", nvp->np[0].value);
-
-        if (nvp->np[0].value == -20)
-        {
-            IDLog("CCD temperature reached desired value!\n");
-            takeExposure();
-        }
-    }
+    IDLog("Taking a %g second exposure.\n", seconds);
+    ccdExposure[0].setValue(seconds);
+    sendNewProperty(ccdExposure);
 }
 
 /**************************************************************************************
@@ -171,26 +165,14 @@ void MyClient::newNumber(INumberVectorProperty *nvp)
 ***************************************************************************************/
 void MyClient::newMessage(INDI::BaseDevice *dp, int messageID)
 {
-    if (strcmp(dp->getDeviceName(), MYCCD) != 0)
+    if (!dp->isDeviceNameMatch(MYCCD))
         return;
 
-    IDLog("Recveing message from Server:\n\n########################\n%s\n########################\n\n",
+    IDLog("Recveing message from Server:\n"
+          "\n"
+          "########################\n"
+          "%s\n"
+          "########################\n"
+          "\n",
           dp->messageQueue(messageID).c_str());
-}
-
-/**************************************************************************************
-**
-***************************************************************************************/
-void MyClient::newBLOB(IBLOB *bp)
-{
-    // Save FITS file to disk
-    std::ofstream myfile;
-
-    myfile.open("ccd_simulator.fits", std::ios::out | std::ios::binary);
-
-    myfile.write(static_cast<char *>(bp->blob), bp->bloblen);
-
-    myfile.close();
-
-    IDLog("Received image, saved as ccd_simulator.fits\n");
 }

--- a/examples/tutorial_six/tutorial_client.cpp
+++ b/examples/tutorial_six/tutorial_client.cpp
@@ -46,7 +46,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 #include <iostream>
 #include <memory>
 
-static const char MYCCD[] = "Simple CCD";
 
 int main(int, char *[])
 {
@@ -55,9 +54,9 @@ int main(int, char *[])
 
     myClient.connectServer();
 
-    myClient.setBLOBMode(B_ALSO, MYCCD, nullptr);
+    myClient.setBLOBMode(B_ALSO, "Simple CCD", nullptr);
 
-    myClient.enableDirectBlobAccess(MYCCD, nullptr);
+    myClient.enableDirectBlobAccess("Simple CCD", nullptr);
 
     std::cout << "Press Enter key to terminate the client.\n";
     std::cin.ignore();
@@ -69,14 +68,14 @@ int main(int, char *[])
 MyClient::MyClient()
 {
     // wait for the availability of the device
-    watchDevice(MYCCD, [this](INDI::BaseDevice device)
+    watchDevice("Simple CCD", [this](INDI::BaseDevice device)
     {
         mCcdSimulator = device; // save device
         // wait for the availability of the "CONNECTION" property
         device.watchProperty("CONNECTION", [this](INDI::Property)
         {
             IDLog("Connecting to INDI Driver...\n");
-            connectDevice(MYCCD);
+            connectDevice("Simple CCD");
         });
 
         // wait for the availability of the "CCD_TEMPERATURE" property
@@ -163,7 +162,7 @@ void MyClient::takeExposure(double seconds)
 ***************************************************************************************/
 void MyClient::newMessage(INDI::BaseDevice *dp, int messageID)
 {
-    if (!dp->isDeviceNameMatch(MYCCD))
+    if (!dp->isDeviceNameMatch("Simple CCD"))
         return;
 
     IDLog("Recveing message from Server:\n"

--- a/examples/tutorial_six/tutorial_client.h
+++ b/examples/tutorial_six/tutorial_client.h
@@ -51,5 +51,5 @@ class MyClient : public INDI::BaseClient
         void newMessage(INDI::BaseDevice *dp, int messageID) override;
 
     private:
-        INDI::BaseDevice mCcdSimulator;
+        INDI::BaseDevice mSimpleCCD;
 };

--- a/examples/tutorial_six/tutorial_client.h
+++ b/examples/tutorial_six/tutorial_client.h
@@ -35,6 +35,7 @@
 */
 
 #include "baseclient.h"
+#include <basedevice.h>
 
 class MyClient : public INDI::BaseClient
 {
@@ -42,23 +43,13 @@ class MyClient : public INDI::BaseClient
         MyClient();
         ~MyClient() = default;
 
-        void setTemperature();
-        void takeExposure();
+    public:
+        void setTemperature(double value);
+        void takeExposure(double seconds);
 
     protected:
-        void newDevice(INDI::BaseDevice *dp) override;
-        void removeDevice(INDI::BaseDevice */*dp*/) override {}
-        void newProperty(INDI::Property *property) override;
-        void removeProperty(INDI::Property */*property*/) override {}
-        void newBLOB(IBLOB *bp) override;
-        void newSwitch(ISwitchVectorProperty */*svp*/) override {}
-        void newNumber(INumberVectorProperty *nvp) override;
         void newMessage(INDI::BaseDevice *dp, int messageID) override;
-        void newText(ITextVectorProperty */*tvp*/) override {}
-        void newLight(ILightVectorProperty */*lvp*/) override {}
-        void serverConnected() override {}
-        void serverDisconnected(int /*exit_code*/) override {}
 
     private:
-        INDI::BaseDevice *ccd_simulator;
+        INDI::BaseDevice mCcdSimulator;
 };

--- a/libs/indibase/alignment/MapPropertiesToInMemoryDatabase.cpp
+++ b/libs/indibase/alignment/MapPropertiesToInMemoryDatabase.cpp
@@ -31,24 +31,24 @@ void MapPropertiesToInMemoryDatabase::InitProperties(Telescope *pTelescope)
     IUFillNumberVector(&AlignmentPointSetEntryV, AlignmentPointSetEntry, 6, pTelescope->getDeviceName(),
                        "ALIGNMENT_POINT_MANDATORY_NUMBERS", "Mandatory sync point numeric fields", ALIGNMENT_TAB, IP_RW,
                        60, IPS_IDLE);
-    pTelescope->registerProperty(&AlignmentPointSetEntryV, INDI_NUMBER);
+    pTelescope->registerProperty(&AlignmentPointSetEntryV);
 
     IUFillBLOB(&AlignmentPointSetPrivateBinaryData, "ALIGNMENT_POINT_ENTRY_PRIVATE", "Private binary data",
                "alignmentPrivateData");
     IUFillBLOBVector(&AlignmentPointSetPrivateBinaryDataV, &AlignmentPointSetPrivateBinaryData, 1,
                      pTelescope->getDeviceName(), "ALIGNMENT_POINT_OPTIONAL_BINARY_BLOB",
                      "Optional sync point binary data", ALIGNMENT_TAB, IP_RW, 60, IPS_IDLE);
-    pTelescope->registerProperty(&AlignmentPointSetPrivateBinaryDataV, INDI_BLOB);
+    pTelescope->registerProperty(&AlignmentPointSetPrivateBinaryDataV);
 
     IUFillNumber(&AlignmentPointSetSize, "ALIGNMENT_POINTSET_SIZE", "Size", "%g", 0, 100000, 0, 0);
     IUFillNumberVector(&AlignmentPointSetSizeV, &AlignmentPointSetSize, 1, pTelescope->getDeviceName(),
                        "ALIGNMENT_POINTSET_SIZE", "Current Set", ALIGNMENT_TAB, IP_RO, 60, IPS_IDLE);
-    pTelescope->registerProperty(&AlignmentPointSetSizeV, INDI_NUMBER);
+    pTelescope->registerProperty(&AlignmentPointSetSizeV);
 
     IUFillNumber(&AlignmentPointSetPointer, "ALIGNMENT_POINTSET_CURRENT_ENTRY", "Pointer", "%g", 0, 100000, 0, 0);
     IUFillNumberVector(&AlignmentPointSetPointerV, &AlignmentPointSetPointer, 1, pTelescope->getDeviceName(),
                        "ALIGNMENT_POINTSET_CURRENT_ENTRY", "Current Set", ALIGNMENT_TAB, IP_RW, 60, IPS_IDLE);
-    pTelescope->registerProperty(&AlignmentPointSetPointerV, INDI_NUMBER);
+    pTelescope->registerProperty(&AlignmentPointSetPointerV);
 
     IUFillSwitch(&AlignmentPointSetAction[0], "APPEND", "Add entries at end of set", ISS_ON);
     IUFillSwitch(&AlignmentPointSetAction[1], "INSERT", "Insert entries at current index", ISS_OFF);
@@ -63,13 +63,13 @@ void MapPropertiesToInMemoryDatabase::InitProperties(Telescope *pTelescope)
     IUFillSwitch(&AlignmentPointSetAction[8], "SAVE DATABASE", "Save the alignment database to local storage", ISS_OFF);
     IUFillSwitchVector(&AlignmentPointSetActionV, AlignmentPointSetAction, 9, pTelescope->getDeviceName(),
                        "ALIGNMENT_POINTSET_ACTION", "Action to take", ALIGNMENT_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
-    pTelescope->registerProperty(&AlignmentPointSetActionV, INDI_SWITCH);
+    pTelescope->registerProperty(&AlignmentPointSetActionV);
 
     IUFillSwitch(&AlignmentPointSetCommit, "ALIGNMENT_POINTSET_COMMIT", "OK", ISS_OFF);
     IUFillSwitchVector(&AlignmentPointSetCommitV, &AlignmentPointSetCommit, 1, pTelescope->getDeviceName(),
                        "ALIGNMENT_POINTSET_COMMIT", "Execute the action", ALIGNMENT_TAB, IP_RW, ISR_ATMOST1, 60,
                        IPS_IDLE);
-    pTelescope->registerProperty(&AlignmentPointSetCommitV, INDI_SWITCH);
+    pTelescope->registerProperty(&AlignmentPointSetCommitV);
 }
 
 void MapPropertiesToInMemoryDatabase::ProcessBlobProperties(Telescope *pTelescope, const char *name, int sizes[],

--- a/libs/indibase/alignment/MathPluginManagement.cpp
+++ b/libs/indibase/alignment/MathPluginManagement.cpp
@@ -70,19 +70,19 @@ void MathPluginManagement::InitProperties(Telescope *ChildTelescope)
             }
         }
     }
-    ChildTelescope->registerProperty(&AlignmentSubsystemMathPluginsV, INDI_SWITCH);
+    ChildTelescope->registerProperty(&AlignmentSubsystemMathPluginsV);
 
     IUFillSwitch(&AlignmentSubsystemMathPluginInitialise, "ALIGNMENT_SUBSYSTEM_MATH_PLUGIN_INITIALISE", "OK", ISS_OFF);
     IUFillSwitchVector(&AlignmentSubsystemMathPluginInitialiseV, &AlignmentSubsystemMathPluginInitialise, 1,
                        ChildTelescope->getDeviceName(), "ALIGNMENT_SUBSYSTEM_MATH_PLUGIN_INITIALISE",
                        "(Re)Initialise Plugin", ALIGNMENT_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
-    ChildTelescope->registerProperty(&AlignmentSubsystemMathPluginInitialiseV, INDI_SWITCH);
+    ChildTelescope->registerProperty(&AlignmentSubsystemMathPluginInitialiseV);
 
     IUFillSwitch(&AlignmentSubsystemActive, "ALIGNMENT SUBSYSTEM ACTIVE", "Alignment Subsystem Active", ISS_OFF);
     IUFillSwitchVector(&AlignmentSubsystemActiveV, &AlignmentSubsystemActive, 1, ChildTelescope->getDeviceName(),
                        "ALIGNMENT_SUBSYSTEM_ACTIVE", "Activate alignment subsystem", ALIGNMENT_TAB, IP_RW, ISR_ATMOST1,
                        60, IPS_IDLE);
-    ChildTelescope->registerProperty(&AlignmentSubsystemActiveV, INDI_SWITCH);
+    ChildTelescope->registerProperty(&AlignmentSubsystemActiveV);
 
     // The following property is used for configuration purposes only and is not exposed to the client.
     IUFillText(&AlignmentSubsystemCurrentMathPlugin, "ALIGNMENT_SUBSYSTEM_CURRENT_MATH_PLUGIN", "Current Math Plugin",

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -1392,6 +1392,11 @@ void INDI::BaseClient::sendOneBlob(INDI::WidgetView<IBLOB> *blob)
     );
 }
 
+void INDI::BaseClient::sendOneBlob(IBLOB *bp)
+{
+    sendOneBlob(static_cast<INDI::WidgetView<IBLOB>*>(bp));
+}
+
 void INDI::BaseClient::sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat,
                                    void *blobBuffer)
 {

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -109,7 +109,7 @@ BaseClientPrivate::~BaseClientPrivate()
 
 void BaseClientPrivate::clear()
 {
-    watchDevice.clear();
+    watchDevice.clearDevices();
     blobModes.clear();
     directBlobAccess.clear();
 }
@@ -665,7 +665,7 @@ void BaseClientPrivate::listenINDI()
         parent->serverDisconnected(exit_code);
 
         clear();
-        watchDevice.clear();
+        watchDevice.clearDevices();
         sSocketChanged.notify_all();
     }
 }

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -78,12 +78,6 @@ namespace INDI
 
 BaseClientPrivate::BaseClientPrivate(BaseClient *parent)
     : parent(parent)
-    , cServer("localhost")
-    , cPort(7624)
-    , sConnected(false)
-    , verbose(false)
-    , timeout_sec(3)
-    , timeout_us(0)
 {
     io.write = [](void *user, const void * ptr, size_t count) -> size_t
     {

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -1248,11 +1248,39 @@ void INDI::BaseClient::newPingReply(std::string uid)
     IDLog("Ping reply %s\n", uid.c_str());
 }
 
-void INDI::BaseClient::sendNewText(ITextVectorProperty *tvp)
+void INDI::BaseClient::sendNewProperty(INDI::Property pp)
 {
     D_PTR(BaseClient);
-    tvp->s = IPS_BUSY;
-    IUUserIONewText(&io, d, tvp);
+    pp.setState(IPS_BUSY);
+    // #PS: TODO more generic
+    switch (pp.getType())
+    {
+        case INDI_NUMBER:
+            IUUserIONewNumber(&io, d, pp.getNumber());
+            break;
+        case INDI_SWITCH:
+            IUUserIONewSwitch(&io, d, pp.getSwitch());
+            break;
+        case INDI_TEXT:
+            IUUserIONewText(&io, d, pp.getText());
+            break;
+        case INDI_LIGHT:
+            IDLog("Light type is not supported to send\n");
+            break;
+        case INDI_BLOB:
+            IUUserIONewBLOB(&io, d, pp.getBLOB());
+            break;
+        case INDI_UNKNOWN:
+            IDLog("Unknown type of property to send\n");
+            break;
+    }
+}
+
+void INDI::BaseClient::sendNewText(INDI::Property pp)
+{
+    D_PTR(BaseClient);
+    pp.setState(IPS_BUSY);
+    IUUserIONewText(&io, d, pp.getText());
 }
 
 void INDI::BaseClient::sendNewText(const char *deviceName, const char *propertyName, const char *elementName,
@@ -1278,11 +1306,11 @@ void INDI::BaseClient::sendNewText(const char *deviceName, const char *propertyN
     sendNewText(tvp);
 }
 
-void INDI::BaseClient::sendNewNumber(INumberVectorProperty *nvp)
+void INDI::BaseClient::sendNewNumber(INDI::Property pp)
 {
     D_PTR(BaseClient);
-    nvp->s = IPS_BUSY;
-    IUUserIONewNumber(&io, d, nvp);
+    pp.setState(IPS_BUSY);
+    IUUserIONewNumber(&io, d, pp.getNumber());
 }
 
 void INDI::BaseClient::sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName,
@@ -1320,11 +1348,11 @@ void INDI::BaseClient::sendPingRequest(const char * uuid)
     IUUserIOPingRequest(&io, d, uuid);
 }
 
-void INDI::BaseClient::sendNewSwitch(ISwitchVectorProperty *svp)
+void INDI::BaseClient::sendNewSwitch(INDI::Property pp)
 {
     D_PTR(BaseClient);
-    svp->s = IPS_BUSY;
-    IUUserIONewSwitch(&io, d, svp);
+    pp.setState(IPS_BUSY);
+    IUUserIONewSwitch(&io, d, pp.getSwitch());
 }
 
 void INDI::BaseClient::sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName)
@@ -1355,12 +1383,12 @@ void INDI::BaseClient::startBlob(const char *devName, const char *propName, cons
     IUUserIONewBLOBStart(&io, d, devName, propName, timestamp);
 }
 
-void INDI::BaseClient::sendOneBlob(IBLOB *bp)
+void INDI::BaseClient::sendOneBlob(INDI::WidgetView<IBLOB> *blob)
 {
     D_PTR(BaseClient);
     IUUserIOBLOBContextOne(
         &io, d,
-        bp->name, bp->size, bp->bloblen, bp->blob, bp->format
+        blob->getName(), blob->getSize(), blob->getBlobLen(), blob->getBlob(), blob->getFormat()
     );
 }
 

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -1331,3 +1331,37 @@ bool INDI::BaseClient::getDevices(std::vector<INDI::BaseDevice *> &deviceList, u
 
     return (deviceList.size() > 0);
 }
+
+
+void INDI::BaseClient::newDevice(INDI::BaseDevice *)
+{ }
+
+void INDI::BaseClient::removeDevice(INDI::BaseDevice *)
+{ }
+
+void INDI::BaseClient::newProperty(INDI::Property *)
+{ }
+
+void INDI::BaseClient::removeProperty(INDI::Property *)
+{ }
+
+void INDI::BaseClient::newBLOB(IBLOB *)
+{ }
+
+void INDI::BaseClient::newSwitch(ISwitchVectorProperty *)
+{ }
+
+void INDI::BaseClient::newNumber(INumberVectorProperty *)
+{ }
+
+void INDI::BaseClient::newText(ITextVectorProperty *)
+{ }
+
+void INDI::BaseClient::newLight(ILightVectorProperty *)
+{ }
+
+void INDI::BaseClient::newMessage(INDI::BaseDevice *, int)
+{ }
+
+void INDI::BaseClient::serverConnected()
+{ }

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -799,12 +799,12 @@ int BaseClientPrivate::dispatchCommand(const INDI::LilXmlElement &root, char *er
     {
         if (root.tagName() == "defBLOBVector")
         {
-            return dp->buildProp(root.handle(), errmsg);
+            return dp->buildProp(root, errmsg);
         }
 
         if (root.tagName() == "setBLOBVector")
         {
-            return dp->setValue(root.handle(), errmsg);
+            return dp->setValue(root, errmsg);
         }
         // Ignore everything else
         return 0;
@@ -835,7 +835,7 @@ int BaseClientPrivate::dispatchCommand(const INDI::LilXmlElement &root, char *er
 
     if (defVectors.find(root.tagName()) != defVectors.end())
     {
-        return dp->buildProp(root.handle(), errmsg);
+        return dp->buildProp(root, errmsg);
     }
 
     static const std::set<std::string> setVectors{
@@ -845,7 +845,7 @@ int BaseClientPrivate::dispatchCommand(const INDI::LilXmlElement &root, char *er
 
     if (setVectors.find(root.tagName()) != setVectors.end())
     {
-        return dp->setValue(root.handle(), errmsg);
+        return dp->setValue(root, errmsg);
     }
 
     return INDI_DISPATCH_ERROR;

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -943,6 +943,13 @@ INDI::BaseDevice *BaseClientPrivate::addDevice(const INDI::LilXmlElement &root, 
 
     parent->newDevice(dp);
 
+    // watchDevice event
+    auto it = cDeviceNamesCallback.find(dp->getDeviceName());
+    if (it != cDeviceNamesCallback.end())
+    {
+        it->second(dp);
+    }
+
     /* ok */
     return dp;
 }
@@ -1150,6 +1157,13 @@ void INDI::BaseClient::watchDevice(const char *deviceName)
 {
     D_PTR(BaseClient);
     d->cDeviceNames.insert(deviceName);
+}
+
+void INDI::BaseClient::watchDevice(const char *deviceName, const std::function<void(INDI::BaseDevice *)> &callback)
+{
+    D_PTR(BaseClient);
+    d->cDeviceNamesCallback[deviceName] = callback;
+    watchDevice(deviceName);
 }
 
 void INDI::BaseClient::watchProperty(const char *deviceName, const char *propertyName)

--- a/libs/indibase/baseclient.cpp
+++ b/libs/indibase/baseclient.cpp
@@ -665,7 +665,7 @@ void BaseClientPrivate::listenINDI()
         parent->serverDisconnected(exit_code);
 
         clear();
-        watchDevice.clearDevices();
+        watchDevice.unwatchDevices();
         sSocketChanged.notify_all();
     }
 }
@@ -1023,19 +1023,19 @@ void INDI::BaseClient::setServer(const char *hostname, unsigned int port)
 void INDI::BaseClient::watchDevice(const char *deviceName)
 {
     D_PTR(BaseClient);
-    d->watchDevice[deviceName]; // create empty map field
+    d->watchDevice.watchDevice(deviceName);
 }
 
 void INDI::BaseClient::watchDevice(const char *deviceName, const std::function<void (BaseDevice)> &callback)
 {
     D_PTR(BaseClient);
-    d->watchDevice[deviceName].newDeviceCallback = callback;
+    d->watchDevice.watchDevice(deviceName, callback);
 }
 
 void INDI::BaseClient::watchProperty(const char *deviceName, const char *propertyName)
 {
     D_PTR(BaseClient);
-    d->watchDevice[deviceName].properties.insert(propertyName);
+    d->watchDevice.watchProperty(deviceName, propertyName);
 }
 
 bool INDI::BaseClient::connectServer()

--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -134,7 +134,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  will be created and handled.
          */
         void watchDevice(const char *deviceName);
-        void watchDevice(const char *deviceName, const std::function<void(INDI::BaseDevice *)> &callback);
+        void watchDevice(const char *deviceName, const std::function<void (BaseDevice)> &callback);
 
         /** @brief Connect to INDI driver
          *  @param deviceName Name of the device to connect to.
@@ -152,7 +152,7 @@ class INDI::BaseClient : public INDI::BaseMediator
         INDI::BaseDevice *getDevice(const char *deviceName);
 
         /** @returns Returns a vector of all devices created in the client. */
-        const std::vector<INDI::BaseDevice *> &getDevices() const;
+        std::vector<INDI::BaseDevice *> getDevices() const;
 
         /** @brief getDevices Returns list of devices that belong to a particular @ref INDI::BaseDevice::DRIVER_INTERFACE "DRIVER_INTERFACE" class.
          *

--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -23,6 +23,8 @@
 #include "indibase.h"
 #include "indimacros.h"
 
+#include "indiproperty.h"
+
 #include <string>
 #include <vector>
 #include <functional>
@@ -204,23 +206,26 @@ class INDI::BaseClient : public INDI::BaseMediator
          */
         void enableDirectBlobAccess(const char * dev = nullptr, const char * prop = nullptr);
 
+        /** @brief Send new Property command to server */
+        void sendNewProperty(INDI::Property pp);
+
         /** @brief Send new Text command to server */
-        void sendNewText(ITextVectorProperty *pp);
+        void sendNewText(INDI::Property pp); // deprecated, use sendNewProperty
         /** @brief Send new Text command to server */
         void sendNewText(const char *deviceName, const char *propertyName, const char *elementName, const char *text);
         /** @brief Send new Number command to server */
-        void sendNewNumber(INumberVectorProperty *pp);
+        void sendNewNumber(INDI::Property pp); // deprecated, use sendNewProperty
         /** @brief Send new Number command to server */
         void sendNewNumber(const char *deviceName, const char *propertyName, const char *elementName, double value);
         /** @brief Send new Switch command to server */
-        void sendNewSwitch(ISwitchVectorProperty *pp);
+        void sendNewSwitch(INDI::Property pp); // deprecated, use sendNewProperty
         /** @brief Send new Switch command to server */
         void sendNewSwitch(const char *deviceName, const char *propertyName, const char *elementName);
 
         /** @brief Send opening tag for BLOB command to server */
         void startBlob(const char *devName, const char *propName, const char *timestamp);
         /** @brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
-        void sendOneBlob(IBLOB *bp);
+        void sendOneBlob(INDI::WidgetView<IBLOB> *blob);
         /** @brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
         void sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat, void *blobBuffer);
         /** @brief Send closing tag for BLOB command to server */

--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -254,6 +254,19 @@ class INDI::BaseClient : public INDI::BaseMediator
          */
         virtual void newPingReply(std::string uid);
 
+    protected: // override INDI::BaseMediator methods, when they are not needed
+        virtual void newDevice(INDI::BaseDevice *dp) override;
+        virtual void removeDevice(INDI::BaseDevice *dp) override;
+        virtual void newProperty(INDI::Property *property) override;
+        virtual void removeProperty(INDI::Property *property) override;
+        virtual void newBLOB(IBLOB *bp) override;
+        virtual void newSwitch(ISwitchVectorProperty *svp) override;
+        virtual void newNumber(INumberVectorProperty *nvp) override;
+        virtual void newText(ITextVectorProperty *tvp) override;
+        virtual void newLight(ILightVectorProperty *lvp) override;
+        virtual void newMessage(INDI::BaseDevice *dp, int messageID) override;
+        virtual void serverConnected() override;
+
     protected:
         std::unique_ptr<INDI::BaseClientPrivate> d_ptr;
 };

--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -134,7 +134,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  will be created and handled.
          */
         void watchDevice(const char *deviceName);
-        void watchDevice(const char *deviceName, const std::function<void (BaseDevice)> &callback);
+        void watchDevice(const char *deviceName, const std::function<void (INDI::BaseDevice)> &callback);
 
         /** @brief Connect to INDI driver
          *  @param deviceName Name of the device to connect to.

--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -25,6 +25,7 @@
 
 #include <string>
 #include <vector>
+#include <functional>
 
 #include <memory>
 
@@ -131,6 +132,7 @@ class INDI::BaseClient : public INDI::BaseMediator
          *  will be created and handled.
          */
         void watchDevice(const char *deviceName);
+        void watchDevice(const char *deviceName, const std::function<void(INDI::BaseDevice *)> &callback);
 
         /** @brief Connect to INDI driver
          *  @param deviceName Name of the device to connect to.

--- a/libs/indibase/baseclient.h
+++ b/libs/indibase/baseclient.h
@@ -225,6 +225,7 @@ class INDI::BaseClient : public INDI::BaseMediator
         /** @brief Send opening tag for BLOB command to server */
         void startBlob(const char *devName, const char *propName, const char *timestamp);
         /** @brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
+        void sendOneBlob(IBLOB *bp);
         void sendOneBlob(INDI::WidgetView<IBLOB> *blob);
         /** @brief Send ONE blob content to server. The BLOB data in raw binary format and will be converted to base64 and sent to server */
         void sendOneBlob(const char *blobName, unsigned int blobSize, const char *blobFormat, void *blobBuffer);

--- a/libs/indibase/baseclient_p.h
+++ b/libs/indibase/baseclient_p.h
@@ -10,6 +10,7 @@
 #include <set>
 #include <thread>
 #include <cstdint>
+#include <functional>
 
 #include <lilxml.h>
 
@@ -108,6 +109,7 @@ class BaseClientPrivate
         std::list<BLOBMode> blobModes;
         std::map<std::string, std::set<std::string>> cWatchProperties;
         std::map<std::string, std::set<std::string>> directBlobAccess;
+        std::map<std::string, std::function<void(INDI::BaseDevice *)>> cDeviceNamesCallback;
 
         std::string cServer {"localhost"};
         uint32_t cPort      {7624};

--- a/libs/indibase/baseclient_p.h
+++ b/libs/indibase/baseclient_p.h
@@ -65,23 +65,23 @@ class BaseClientPrivate
 
     public:
         /** @brief Dispatch command received from INDI server to respective devices handled by the client */
-        int dispatchCommand(XMLEle *root, char *errmsg);
+        int dispatchCommand(const INDI::LilXmlElement &root, char *errmsg);
 
         /** @brief Remove device */
         int deleteDevice(const char *devName, char *errmsg);
 
         /** @brief Delete property command */
-        int delPropertyCmd(XMLEle *root, char *errmsg);
+        int delPropertyCmd(const INDI::LilXmlElement &root, char *errmsg);
 
         /** @brief Find and return a particular device */
-        INDI::BaseDevice *findDev(const char *devName, char *errmsg);
-        /** @brief Add a new device */
-        INDI::BaseDevice *addDevice(XMLEle *dep, char *errmsg);
+        INDI::BaseDevice *findDevice(const char *devName, char *errmsg);
         /** @brief Find a device, and if it doesn't exist, create it if create is set to 1 */
-        INDI::BaseDevice *findDev(XMLEle *root, int create, char *errmsg);
+        INDI::BaseDevice *findDevice(const INDI::LilXmlElement &root, bool create, char *errmsg);
+        /** @brief Add a new device */
+        INDI::BaseDevice *addDevice(const INDI::LilXmlElement &root, char *errmsg);
 
         /**  Process messages */
-        int messageCmd(XMLEle *root, char *errmsg);
+        int messageCmd(const INDI::LilXmlElement &root, char *errmsg);
 
     private:
         std::list<int> incomingSharedBuffers; /* During reception, fds accumulate here */
@@ -90,7 +90,7 @@ class BaseClientPrivate
         bool establish(const std::string &target);
 
         // Add an attribute for access to shared blobs
-        bool parseAttachedBlobs(XMLEle * root, std::vector<std::string> &blobs);
+        bool parseAttachedBlobs(const INDI::LilXmlElement &root, std::vector<std::string> &blobs);
 
     public:
         BaseClient *parent;

--- a/libs/indibase/baseclient_p.h
+++ b/libs/indibase/baseclient_p.h
@@ -21,6 +21,8 @@ typedef SSIZE_T ssize_t;
 #endif
 #endif
 
+#include "watchdeviceproperty.h"
+
 namespace INDI
 {
 
@@ -74,13 +76,6 @@ class BaseClientPrivate
         /** @brief Delete property command */
         int delPropertyCmd(const INDI::LilXmlElement &root, char *errmsg);
 
-        /** @brief Find and return a particular device */
-        INDI::BaseDevice *findDevice(const char *devName, char *errmsg);
-        /** @brief Find a device, and if it doesn't exist, create it if create is set to 1 */
-        INDI::BaseDevice *findDevice(const INDI::LilXmlElement &root, bool create, char *errmsg);
-        /** @brief Add a new device */
-        INDI::BaseDevice *addDevice(const INDI::LilXmlElement &root, char *errmsg);
-
         /**  Process messages */
         int messageCmd(const INDI::LilXmlElement &root, char *errmsg);
 
@@ -104,12 +99,10 @@ class BaseClientPrivate
         int sendFd {-1};
 #endif
 
-        std::vector<INDI::BaseDevice *> cDevices;
-        std::set<std::string> cDeviceNames;
+        WatchDeviceProperty watchDevice;
+
         std::list<BLOBMode> blobModes;
-        std::map<std::string, std::set<std::string>> cWatchProperties;
         std::map<std::string, std::set<std::string>> directBlobAccess;
-        std::map<std::string, std::function<void(INDI::BaseDevice *)>> cDeviceNamesCallback;
 
         std::string cServer {"localhost"};
         uint32_t cPort      {7624};

--- a/libs/indibase/baseclient_p.h
+++ b/libs/indibase/baseclient_p.h
@@ -109,18 +109,19 @@ class BaseClientPrivate
         std::map<std::string, std::set<std::string>> cWatchProperties;
         std::map<std::string, std::set<std::string>> directBlobAccess;
 
-        std::string cServer;
-        uint32_t cPort;
-        std::atomic_bool sConnected;
+        std::string cServer {"localhost"};
+        uint32_t cPort      {7624};
+
+        std::atomic_bool sConnected {false};
         std::atomic_bool sAboutToClose;
         std::mutex sSocketBusy;
         std::condition_variable sSocketChanged;
         int sExitCode;
-        bool verbose;
+        bool verbose {false};
 
         // Parse & FILE buffers for IO
 
-        uint32_t timeout_sec, timeout_us;
+        uint32_t timeout_sec {3}, timeout_us {0};
 };
 
 }

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -621,7 +621,7 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
 /* Set BLOB vector. Process incoming data stream
  * Return 0 if okay, -1 if error
 */
-int BaseDevicePrivate::setBLOB(const INDI::PropertyBlob &property, const LilXmlElement &root, char *errmsg)
+int BaseDevicePrivate::setBLOB(INDI::PropertyBlob &property, const LilXmlElement &root, char *errmsg)
 {
     for (const auto &element: root.getElementsByTagName("oneBLOB"))
     {
@@ -713,6 +713,7 @@ int BaseDevicePrivate::setBLOB(const INDI::PropertyBlob &property, const LilXmlE
             widget->setFormat(format);
         }
 
+        property.emitUpdate();
         if (mediator) mediator->newBLOB(widget);
     }
 

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -831,7 +831,7 @@ void BaseDevice::watchProperty(const std::string &name, const std::function<void
     d->watchPropertyMap[name] = callback;
 }
 
-void BaseDevice::registerProperty(INDI::Property &property)
+void BaseDevice::registerProperty(const INDI::Property &property)
 {
     D_PTR(BaseDevice);
 

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -827,6 +827,12 @@ void BaseDevice::registerProperty(void *p, INDI_PROPERTY_TYPE type)
         d->addProperty(INDI::Property(p, type));
 }
 
+void BaseDevice::watchProperty(const std::string &name, const std::function<void(INDI::Property)> &callback)
+{
+    D_PTR(BaseDevice);
+    d->watchPropertyMap[name] = callback;
+}
+
 void BaseDevice::registerProperty(INDI::Property &property)
 {
     D_PTR(BaseDevice);

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -809,22 +809,6 @@ const std::string &BaseDevice::lastMessage() const
     return d->messageLog.back();
 }
 
-void BaseDevice::registerProperty(void *p, INDI_PROPERTY_TYPE type)
-{
-    D_PTR(BaseDevice);
-    if (p == nullptr || type == INDI_UNKNOWN)
-        return;
-
-    const char *name = INDI::Property(p, type).getName();
-
-    auto pContainer = getProperty(name, type);
-
-    if (pContainer.isValid())
-        pContainer.setRegistered(true);
-    else
-        d->addProperty(INDI::Property(p, type));
-}
-
 void BaseDevice::watchProperty(const std::string &name, const std::function<void(INDI::Property)> &callback)
 {
     D_PTR(BaseDevice);
@@ -846,6 +830,12 @@ void BaseDevice::registerProperty(const INDI::Property &property)
         d->addProperty(property);
 }
 
+// #PS: TODO remove
+void BaseDevice::registerProperty(const INDI::Property &property, INDI_PROPERTY_TYPE)
+{
+    registerProperty(property);
+}
+
 const char *BaseDevice::getDriverName() const
 {
     auto driverInfo = getText("DRIVER_INFO");
@@ -856,57 +846,6 @@ const char *BaseDevice::getDriverName() const
     auto driverName = driverInfo->findWidgetByName("DRIVER_NAME");
 
     return driverName ? driverName->getText() : nullptr;
-}
-
-
-void BaseDevice::registerProperty(ITextVectorProperty *property)
-{
-    registerProperty(property, INDI_TEXT);
-}
-
-void BaseDevice::registerProperty(INumberVectorProperty *property)
-{
-    registerProperty(property, INDI_NUMBER);
-}
-
-void BaseDevice::registerProperty(ISwitchVectorProperty *property)
-{
-    registerProperty(property, INDI_SWITCH);
-}
-
-void BaseDevice::registerProperty(ILightVectorProperty *property)
-{
-    registerProperty(property, INDI_LIGHT);
-}
-
-void BaseDevice::registerProperty(IBLOBVectorProperty *property)
-{
-    registerProperty(property, INDI_BLOB);
-}
-
-void BaseDevice::registerProperty(PropertyView<IText> *property)
-{
-    registerProperty(static_cast<ITextVectorProperty*>(property));
-}
-
-void BaseDevice::registerProperty(PropertyView<INumber> *property)
-{
-    registerProperty(static_cast<INumberVectorProperty*>(property));
-}
-
-void BaseDevice::registerProperty(PropertyView<ISwitch> *property)
-{
-    registerProperty(static_cast<ISwitchVectorProperty*>(property));
-}
-
-void BaseDevice::registerProperty(PropertyView<ILight> *property)
-{
-    BaseDevice::registerProperty(static_cast<ILightVectorProperty*>(property));
-}
-
-void BaseDevice::registerProperty(PropertyView<IBLOB> *property)
-{
-    BaseDevice::registerProperty(static_cast<IBLOBVectorProperty*>(property));
 }
 
 const char *BaseDevice::getDriverExec() const

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -269,22 +269,20 @@ bool BaseDevice::buildSkeleton(const char *filename)
 
     for (const auto &element: document.root().getElements())
     {
-        buildProp(element.handle(), errmsg, true);
+        buildProp(element, errmsg, true);
     }
 
     return true;
 }
 
-int BaseDevice::buildProp(XMLEle *_root, char *errmsg, bool isDynamic)
+int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool isDynamic)
 {
     D_PTR(BaseDevice);
-
-    LilXmlElement root(_root);
 
     // only for check, #PS: remove
     {
         char *rname, *rdev;
-        if (crackDN(_root, &rdev, &rname, errmsg) < 0)
+        if (crackDN(root.handle(), &rdev, &rname, errmsg) < 0)
             return -1;
     }
 
@@ -501,11 +499,9 @@ static void for_property(
 /*
  * return 0 if ok else -1 with reason in errmsg
  */
-int BaseDevice::setValue(XMLEle *_root, char *errmsg)
+int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
 {
     D_PTR(BaseDevice);
-
-    LilXmlElement root = LilXmlElement(_root);
 
     if (!root.getAttribute("name").isValid())
     {

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -494,6 +494,8 @@ static void for_property(
         if (item)
             function(element, item);
     }
+
+    typedProperty.emitUpdate();
 }
 
 /*

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -810,7 +810,7 @@ const std::string &BaseDevice::lastMessage() const
     return d->messageLog.back();
 }
 
-void BaseDevice::watchProperty(const std::string &name, const std::function<void(INDI::Property)> &callback)
+void BaseDevice::watchProperty(const char *name, const std::function<void(INDI::Property)> &callback)
 {
     D_PTR(BaseDevice);
     d->watchPropertyMap[name] = callback;

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -79,29 +79,29 @@ BaseDevice::BaseDevice(BaseDevicePrivate &dd)
     : d_ptr(&dd)
 { }
 
-INDI::PropertyView<INumber> *BaseDevice::getNumber(const char *name) const
+INDI::PropertyNumber BaseDevice::getNumber(const char *name) const
 {
-    return static_cast<PropertyView<INumber> *>(getRawProperty(name, INDI_NUMBER));
+    return getProperty(name, INDI_NUMBER);
 }
 
-INDI::PropertyView<IText> *BaseDevice::getText(const char *name) const
+INDI::PropertyText BaseDevice::getText(const char *name) const
 {
-    return static_cast<PropertyView<IText> *>(getRawProperty(name, INDI_TEXT));
+    return getProperty(name, INDI_TEXT);
 }
 
-INDI::PropertyView<ISwitch> *BaseDevice::getSwitch(const char *name) const
+INDI::PropertySwitch BaseDevice::getSwitch(const char *name) const
 {
-    return static_cast<PropertyView<ISwitch> *>(getRawProperty(name, INDI_SWITCH));
+    return getProperty(name, INDI_SWITCH);
 }
 
-INDI::PropertyView<ILight> *BaseDevice::getLight(const char *name) const
+INDI::PropertyLight BaseDevice::getLight(const char *name) const
 {
-    return static_cast<PropertyView<ILight> *>(getRawProperty(name, INDI_LIGHT));
+    return getProperty(name, INDI_LIGHT);
 }
 
-INDI::PropertyView<IBLOB> *BaseDevice::getBLOB(const char *name) const
+INDI::PropertyBlob BaseDevice::getBLOB(const char *name) const
 {
-    return static_cast<PropertyView<IBLOB> *>(getRawProperty(name, INDI_BLOB));
+    return getProperty(name, INDI_BLOB);
 }
 
 IPState BaseDevice::getPropertyState(const char *name) const

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -326,7 +326,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             {
                 INDI::WidgetView<INumber> widget;
 
-                widget.setParent(typedProperty->getNumber());
+                widget.setParent(typedProperty.getNumber());
 
                 widget.setName   (element.getAttribute("name"));
                 widget.setLabel  (element.getAttribute("label"));
@@ -350,7 +350,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             {
                 INDI::WidgetView<ISwitch> widget;
 
-                widget.setParent(typedProperty->getSwitch());
+                widget.setParent(typedProperty.getSwitch());
 
                 widget.setName   (element.getAttribute("name"));
                 widget.setLabel  (element.getAttribute("label"));
@@ -370,7 +370,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             {
                 INDI::WidgetView<IText> widget;
 
-                widget.setParent(typedProperty->getText());
+                widget.setParent(typedProperty.getText());
 
                 widget.setName   (element.getAttribute("name"));
                 widget.setLabel  (element.getAttribute("label"));
@@ -390,7 +390,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             {
                 INDI::WidgetView<ILight> widget;
 
-                widget.setParent(typedProperty->getLight());
+                widget.setParent(typedProperty.getLight());
 
                 widget.setName   (element.getAttribute("name"));
                 widget.setLabel  (element.getAttribute("label"));
@@ -410,7 +410,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             {
                 INDI::WidgetView<IBLOB> widget;
 
-                widget.setParent(typedProperty->getBLOB());
+                widget.setParent(typedProperty.getBLOB());
 
                 widget.setName   (element.getAttribute("name"));
                 widget.setLabel  (element.getAttribute("label"));

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -27,6 +27,12 @@
 #include <vector>
 #include <cstdint>
 
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyswitch.h"
+#include "indipropertylight.h"
+#include "indipropertyblob.h"
+
 // #define MAXRBUF 2048 // #PS: defined in indibase.h
 
 /** @class INDI::BaseDevice
@@ -127,6 +133,7 @@ class BaseDevice
         void registerProperty(INDI::PropertyView<IBLOB> *property);
 
         void registerProperty(INDI::Property &property);
+        void watchProperty(const std::string &name, const std::function<void(INDI::Property)> &callback);
 
         /** @brief Remove a property
          *  @param name name of property to be removed. Pass NULL to remove the whole device.

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -244,9 +244,6 @@ class BaseDevice
         /** @brief handle SetXXX commands from client */
         int setValue(XMLEle *root, char *errmsg);
 
-        /** @brief Parse and store BLOB in the respective vector */
-        int setBLOB(IBLOBVectorProperty *pp, XMLEle *root, char *errmsg);
-
     protected:
         std::shared_ptr<BaseDevicePrivate> d_ptr;
         BaseDevice(BaseDevicePrivate &dd);

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -47,6 +47,7 @@
 namespace INDI
 {
 
+class LilXmlElement;
 class BaseDevicePrivate;
 class BaseDevice
 {
@@ -254,10 +255,10 @@ class BaseDevice
          *  @param isDynamic set to true if property is loaded from an XML file.
          *  @return 0 if parsing is successful, -1 otherwise and errmsg is set
          */
-        int buildProp(XMLEle *root, char *errmsg, bool isDynamic = false);
+        int buildProp(const INDI::LilXmlElement &root, char *errmsg, bool isDynamic = false);
 
         /** @brief handle SetXXX commands from client */
-        int setValue(XMLEle *root, char *errmsg);
+        int setValue(const INDI::LilXmlElement &root, char *errmsg);
 
     protected:
         std::shared_ptr<BaseDevicePrivate> d_ptr;

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -117,7 +117,7 @@ class BaseDevice
          *  @param name of property.
          *  @param callback as an argument of the function you can use INDI::PropertyNumber, INDI::PropertySwitch etc.
          */
-        void watchProperty(const std::string &name, const std::function<void(INDI::Property)> &callback);
+        void watchProperty(const char *name, const std::function<void (INDI::Property)> &callback);
 
         /** @brief Return a property and its type given its name.
          *  @param name of property to be found.

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -98,42 +98,11 @@ class BaseDevice
         BaseDevice();
         virtual ~BaseDevice();
 
-    public:
-        /** @return Return vector number property given its name */
-        INDI::PropertyView<INumber> *getNumber(const char *name) const;
-        /** @return Return vector text property given its name */
-        INDI::PropertyView<IText>   *getText(const char *name) const;
-        /** @return Return vector switch property given its name */
-        INDI::PropertyView<ISwitch> *getSwitch(const char *name) const;
-        /** @return Return vector light property given its name */
-        INDI::PropertyView<ILight>  *getLight(const char *name) const;
-        /** @return Return vector BLOB property given its name */
-        INDI::PropertyView<IBLOB>   *getBLOB(const char *name) const;
-
-    public:
-        /** @return Return property state */
-        IPState getPropertyState(const char *name) const;
-        /** @return Return property permission */
-        IPerm getPropertyPermission(const char *name) const;
-
-    public:
-        void registerProperty(void *p, INDI_PROPERTY_TYPE type);
-
-        // #PS: will be deprecated / backward compatibility
-        void registerProperty(ITextVectorProperty *property);
-        void registerProperty(INumberVectorProperty *property);
-        void registerProperty(ISwitchVectorProperty *property);
-        void registerProperty(ILightVectorProperty *property);
-        void registerProperty(IBLOBVectorProperty *property);
-
-        void registerProperty(INDI::PropertyView<IText> *property);
-        void registerProperty(INDI::PropertyView<INumber> *property);
-        void registerProperty(INDI::PropertyView<ISwitch> *property);
-        void registerProperty(INDI::PropertyView<ILight> *property);
-        void registerProperty(INDI::PropertyView<IBLOB> *property);
-
+    public: // property
+        /** @brief Register the property to be able to observe and update.
+         *  @param property any property from the INDI::PropertyXXX family.
+         */
         void registerProperty(INDI::Property &property);
-        void watchProperty(const std::string &name, const std::function<void(INDI::Property)> &callback);
 
         /** @brief Remove a property
          *  @param name name of property to be removed. Pass NULL to remove the whole device.
@@ -142,16 +111,11 @@ class BaseDevice
          */
         int removeProperty(const char *name, char *errmsg);
 
-        /** @brief Return a property and its type given its name.
-         *  @param name of property to be found.
-         *  @param type of property found.
-         *  @return If property is found, the raw void * pointer to the IXXXVectorProperty is returned. To be used you must use static_cast with given the type of property
-         *  returned. For example, INumberVectorProperty *num = static_cast<INumberVectorProperty> getRawProperty("FOO", INDI_NUMBER);
-         *
-         *  @note This is a low-level function and should not be called directly unless necessary. Use getXXX instead where XXX
-         *  is the property type (Number, Text, Switch..etc).
+        /** @brief Call the callback function if property is available.
+         *  @param name of property.
+         *  @param callback as an argument of the function you can use INDI::PropertyNumber, INDI::PropertySwitch etc.
          */
-        void *getRawProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
+        void watchProperty(const std::string &name, const std::function<void(INDI::Property)> &callback);
 
         /** @brief Return a property and its type given its name.
          *  @param name of property to be found.
@@ -164,6 +128,50 @@ class BaseDevice
         /** @brief Return a list of all properties in the device. */
         Properties getProperties();
         const Properties getProperties() const;
+
+    public: // deprecated
+        /** @return Return vector number property given its name */
+        INDI::PropertyView<INumber> *getNumber(const char *name) const;
+        /** @return Return vector text property given its name */
+        INDI::PropertyView<IText>   *getText(const char *name) const;
+        /** @return Return vector switch property given its name */
+        INDI::PropertyView<ISwitch> *getSwitch(const char *name) const;
+        /** @return Return vector light property given its name */
+        INDI::PropertyView<ILight>  *getLight(const char *name) const;
+        /** @return Return vector BLOB property given its name */
+        INDI::PropertyView<IBLOB>   *getBLOB(const char *name) const;
+
+    public: // deprecated
+        void registerProperty(void *p, INDI_PROPERTY_TYPE type);
+
+        void registerProperty(ITextVectorProperty *property);
+        void registerProperty(INumberVectorProperty *property);
+        void registerProperty(ISwitchVectorProperty *property);
+        void registerProperty(ILightVectorProperty *property);
+        void registerProperty(IBLOBVectorProperty *property);
+
+        void registerProperty(INDI::PropertyView<IText> *property);
+        void registerProperty(INDI::PropertyView<INumber> *property);
+        void registerProperty(INDI::PropertyView<ISwitch> *property);
+        void registerProperty(INDI::PropertyView<ILight> *property);
+        void registerProperty(INDI::PropertyView<IBLOB> *property);
+
+    public: // deprecated
+        /** @return Return property state */
+        IPState getPropertyState(const char *name) const;
+        /** @return Return property permission */
+        IPerm getPropertyPermission(const char *name) const;
+
+        /** @brief Return a property and its type given its name.
+         *  @param name of property to be found.
+         *  @param type of property found.
+         *  @return If property is found, the raw void * pointer to the IXXXVectorProperty is returned. To be used you must use static_cast with given the type of property
+         *  returned. For example, INumberVectorProperty *num = static_cast<INumberVectorProperty> getRawProperty("FOO", INDI_NUMBER);
+         *
+         *  @note This is a low-level function and should not be called directly unless necessary. Use getXXX instead where XXX
+         *  is the property type (Number, Text, Switch..etc).
+         */
+        void *getRawProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
 
     public:
         /** @brief Add message to the driver's message queue.

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -103,7 +103,7 @@ class BaseDevice
         /** @brief Register the property to be able to observe and update.
          *  @param property any property from the INDI::PropertyXXX family.
          */
-        void registerProperty(INDI::Property &property);
+        void registerProperty(const INDI::Property &property);
 
         /** @brief Remove a property
          *  @param name name of property to be removed. Pass NULL to remove the whole device.

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -104,6 +104,7 @@ class BaseDevice
          *  @param property any property from the INDI::PropertyXXX family.
          */
         void registerProperty(const INDI::Property &property);
+        void registerProperty(const INDI::Property &property, INDI_PROPERTY_TYPE type); // backward compatiblity (PentaxCCD, PkTriggerCordCCD)
 
         /** @brief Remove a property
          *  @param name name of property to be removed. Pass NULL to remove the whole device.
@@ -141,21 +142,6 @@ class BaseDevice
         INDI::PropertyView<ILight>  *getLight(const char *name) const;
         /** @return Return vector BLOB property given its name */
         INDI::PropertyView<IBLOB>   *getBLOB(const char *name) const;
-
-    public: // deprecated
-        void registerProperty(void *p, INDI_PROPERTY_TYPE type);
-
-        void registerProperty(ITextVectorProperty *property);
-        void registerProperty(INumberVectorProperty *property);
-        void registerProperty(ISwitchVectorProperty *property);
-        void registerProperty(ILightVectorProperty *property);
-        void registerProperty(IBLOBVectorProperty *property);
-
-        void registerProperty(INDI::PropertyView<IText> *property);
-        void registerProperty(INDI::PropertyView<INumber> *property);
-        void registerProperty(INDI::PropertyView<ISwitch> *property);
-        void registerProperty(INDI::PropertyView<ILight> *property);
-        void registerProperty(INDI::PropertyView<IBLOB> *property);
 
     public: // deprecated
         /** @return Return property state */

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -131,17 +131,17 @@ class BaseDevice
         Properties getProperties();
         const Properties getProperties() const;
 
-    public: // deprecated
+    public:
         /** @return Return vector number property given its name */
-        INDI::PropertyView<INumber> *getNumber(const char *name) const;
+        INDI::PropertyNumber getNumber(const char *name) const;
         /** @return Return vector text property given its name */
-        INDI::PropertyView<IText>   *getText(const char *name) const;
+        INDI::PropertyText getText(const char *name) const;
         /** @return Return vector switch property given its name */
-        INDI::PropertyView<ISwitch> *getSwitch(const char *name) const;
+        INDI::PropertySwitch getSwitch(const char *name) const;
         /** @return Return vector light property given its name */
-        INDI::PropertyView<ILight>  *getLight(const char *name) const;
+        INDI::PropertyLight getLight(const char *name) const;
         /** @return Return vector BLOB property given its name */
-        INDI::PropertyView<IBLOB>   *getBLOB(const char *name) const;
+        INDI::PropertyBlob getBLOB(const char *name) const;
 
     public: // deprecated
         /** @return Return property state */

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -26,6 +26,9 @@
 #include <string>
 #include <mutex>
 
+#include "indipropertyblob.h"
+#include "indililxml.h"
+
 namespace INDI
 {
 
@@ -35,10 +38,21 @@ class BaseDevicePrivate
         BaseDevicePrivate();
         virtual ~BaseDevicePrivate();
 
+        /** @brief Parse and store BLOB in the respective vector */
+        //int setBLOB(const INDI::PropertyBlob &propertyBlob, const LilXmlElement &element, char *errmsg);
+        int setBLOB(const INDI::PropertyBlob &propertyBlob, const INDI::LilXmlElement &root, char *errmsg);
+
+        void addProperty(const INDI::Property &property)
+        {
+            std::unique_lock<std::mutex> lock(m_Lock);
+            pAll.push_back(property);
+        }
+
     public:
         std::string deviceName;
         BaseDevice::Properties pAll;
-        LilXML *lp {nullptr};
+        LilXmlParser xmlParser;
+
         INDI::BaseMediator *mediator {nullptr};
         std::deque<std::string> messageLog;
         mutable std::mutex m_Lock;

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -41,8 +41,7 @@ class BaseDevicePrivate
         virtual ~BaseDevicePrivate();
 
         /** @brief Parse and store BLOB in the respective vector */
-        //int setBLOB(const INDI::PropertyBlob &propertyBlob, const LilXmlElement &element, char *errmsg);
-        int setBLOB(const INDI::PropertyBlob &propertyBlob, const INDI::LilXmlElement &root, char *errmsg);
+        int setBLOB(INDI::PropertyBlob &propertyBlob, const INDI::LilXmlElement &root, char *errmsg);
 
         void addProperty(const INDI::Property &property)
         {

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -524,8 +524,16 @@ bool DefaultDevice::ISNewBLOB(const char *dev, const char *name, int sizes[], in
 
 bool DefaultDevice::ISSnoopDevice(XMLEle *root)
 {
-    INDI_UNUSED(root);
-    return false;
+    D_PTR(DefaultDevice);
+    char errmsg[MAXRBUF];
+    return d->watchDevice.processXml(INDI::LilXmlElement(root), errmsg) < 0;
+}
+
+void DefaultDevice::watchDevice(const char *name, const std::function<void (BaseDevice)> &callback)
+{
+    D_PTR(DefaultDevice);
+    d->watchDevice[name].newDeviceCallback = callback;
+    IDSnoopDevice(name, nullptr);
 }
 
 void DefaultDevice::addDebugControl()

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -532,7 +532,7 @@ bool DefaultDevice::ISSnoopDevice(XMLEle *root)
 void DefaultDevice::watchDevice(const char *name, const std::function<void (BaseDevice)> &callback)
 {
     D_PTR(DefaultDevice);
-    d->watchDevice[name].newDeviceCallback = callback;
+    d->watchDevice.watchDevice(name, callback);
     IDSnoopDevice(name, nullptr);
 }
 

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -25,6 +25,11 @@
 #include "indistandardproperty.h"
 #include "connectionplugins/connectionserial.h"
 
+#include "indipropertyswitch.h"
+#include "indipropertytext.h"
+#include "indipropertynumber.h"
+#include "indipropertyblob.h"
+
 #include <cstdlib>
 #include <cstring>
 #include <assert.h>
@@ -422,175 +427,33 @@ bool DefaultDevice::ISNewSwitch(const char *dev, const char *name, ISState *stat
     if (strcmp(dev, getDeviceName()))
         return false;
 
-    auto svp = getSwitch(name);
+    INDI::PropertySwitch property = getProperty(name, INDI_SWITCH);
 
-    if (svp == nullptr)
+    if (!property.isValid())
         return false;
 
-    ////////////////////////////////////////////////////
-    // Connection
-    ////////////////////////////////////////////////////
-    if (svp->isNameMatch(d->ConnectionSP.getName()))
-    {
-        bool rc = false;
-
-        for (int i = 0; i < n; i++)
-        {
-            if (!strcmp(names[i], "CONNECT") && (states[i] == ISS_ON))
-            {
-                // If disconnected, try to connect.
-                if (isConnected() == false)
-                {
-                    rc = Connect();
-
-                    if (rc)
-                    {
-                        // Connection is successful, set it to OK and updateProperties.
-                        setConnected(true, IPS_OK);
-                        updateProperties();
-                    }
-                    else
-                        setConnected(false, IPS_ALERT);
-                }
-                else
-                    // Already connected, tell client we're connected already.
-                    setConnected(true);
-            }
-            else if (!strcmp(names[i], "DISCONNECT") && (states[i] == ISS_ON))
-            {
-                // If connected, try to disconnect.
-                if (isConnected() == true)
-                {
-                    rc = Disconnect();
-                    // Disconnection is successful, set it IDLE and updateProperties.
-                    if (rc)
-                    {
-                        setConnected(false, IPS_IDLE);
-                        updateProperties();
-                    }
-                    else
-                        setConnected(true, IPS_ALERT);
-                }
-                // Already disconnected, tell client we're disconnected already.
-                else
-                    setConnected(false, IPS_IDLE);
-            }
-        }
-
-        return true;
-    }
-
-    ////////////////////////////////////////////////////
-    // Connection Mode
-    ////////////////////////////////////////////////////
-    if (svp->isNameMatch(d->ConnectionModeSP.getName()))
-    {
-        d->ConnectionModeSP.update(states, names, n);
-
-        int activeConnectionMode = d->ConnectionModeSP.findOnSwitchIndex();
-
-        if (activeConnectionMode >= 0 && activeConnectionMode < static_cast<int>(d->connections.size()))
-        {
-            d->activeConnection = d->connections[activeConnectionMode];
-            d->activeConnection->Activated();
-
-            for (Connection::Interface *oneConnection : d->connections)
-            {
-                if (oneConnection == d->activeConnection)
-                    continue;
-
-                oneConnection->Deactivated();
-            }
-
-            d->ConnectionModeSP.setState(IPS_OK);
-        }
-        else
-            d->ConnectionModeSP.setState(IPS_ALERT);
-
-        d->ConnectionModeSP.apply();
-
-        return true;
-    }
-
-    ////////////////////////////////////////////////////
-    // Debug
-    ////////////////////////////////////////////////////
-    if (svp->isNameMatch("DEBUG"))
-    {
-        IUUpdateSwitch(svp, states, names, n);
-
-        auto sp = svp->findOnSwitch();
-        assert(sp != nullptr);
-
-        setDebug(sp->isNameMatch("ENABLE") ? true : false);
-
-        return true;
-    }
-
-    ////////////////////////////////////////////////////
-    // Simulation
-    ////////////////////////////////////////////////////
-    if (svp->isNameMatch("SIMULATION"))
-    {
-        IUUpdateSwitch(svp, states, names, n);
-
-        auto sp = svp->findOnSwitch();
-        assert(sp != nullptr);
-
-        setSimulation(sp->isNameMatch("ENABLE") ? true : false);
-
-        return true;
-    }
-
-    ////////////////////////////////////////////////////
-    // Configuration
-    ////////////////////////////////////////////////////
-    if (svp->isNameMatch("CONFIG_PROCESS"))
-    {
-        IUUpdateSwitch(svp, states, names, n);
-
-        auto sp = svp->findOnSwitch();
-        svp->reset();
-        bool pResult = false;
-
-        // Not suppose to happen (all switches off) but let's handle it anyway
-        if (sp == nullptr)
-        {
-            svp->setState(IPS_IDLE);
-            svp->apply();
-            return true;
-        }
-
-        if (sp->isNameMatch("CONFIG_LOAD"))
-            pResult = loadConfig();
-        else if (sp->isNameMatch("CONFIG_SAVE"))
-            pResult = saveConfig();
-        else if (sp->isNameMatch("CONFIG_DEFAULT"))
-            pResult = loadDefaultConfig();
-        else if (sp->isNameMatch("CONFIG_PURGE"))
-            pResult = purgeConfig();
-
-        svp->setState(pResult ? IPS_OK : IPS_ALERT);
-        svp->apply();
-        return true;
-    }
-
+    // #PS: TODO Remove
     ////////////////////////////////////////////////////
     // Debugging and Logging Levels
     ////////////////////////////////////////////////////
-    if (svp->isNameMatch("DEBUG_LEVEL") || svp->isNameMatch("LOGGING_LEVEL") || svp->isNameMatch("LOG_OUTPUT"))
+    if (
+        property.isNameMatch("DEBUG_LEVEL") ||
+        property.isNameMatch("LOGGING_LEVEL") ||
+        property.isNameMatch("LOG_OUTPUT"))
     {
         bool rc = Logger::ISNewSwitch(dev, name, states, names, n);
 
-        if (svp->isNameMatch("LOG_OUTPUT"))
+        if (property.isNameMatch("LOG_OUTPUT"))
         {
-            auto sw = svp->findWidgetByName("FILE_DEBUG");
+            auto sw = property.findWidgetByName("FILE_DEBUG");
             if (sw != nullptr && sw->getState() == ISS_ON)
                 DEBUGF(Logger::DBG_SESSION, "Session log file %s", Logger::getLogFile().c_str());
         }
 
         return rc;
     }
+
+    property.update(states, names, n);
 
     bool rc = false;
     for (Connection::Interface *oneConnection : d->connections)
@@ -602,17 +465,13 @@ bool DefaultDevice::ISNewSwitch(const char *dev, const char *name, ISState *stat
 bool DefaultDevice::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
 {
     D_PTR(DefaultDevice);
-    ////////////////////////////////////////////////////
-    // Polling Period
-    ////////////////////////////////////////////////////
-    if (d->PollPeriodNP.isNameMatch(name))
-    {
-        d->PollPeriodNP.update(values, names, n);
-        d->PollPeriodNP.setState(IPS_OK);
-        d->pollingPeriod = static_cast<uint32_t>(d->PollPeriodNP[0].getValue());
-        d->PollPeriodNP.apply();
-        return true;
-    }
+
+    INDI::PropertyNumber property = getProperty(name, INDI_NUMBER);
+
+    if (!property.isValid())
+        return false;
+
+    property.update(values, names, n);
 
     for (Connection::Interface *oneConnection : d->connections)
         oneConnection->ISNewNumber(dev, name, values, names, n);
@@ -623,6 +482,14 @@ bool DefaultDevice::ISNewNumber(const char *dev, const char *name, double values
 bool DefaultDevice::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
 {
     D_PTR(DefaultDevice);
+
+    INDI::PropertyText property = getProperty(name, INDI_TEXT);
+
+    if (!property.isValid())
+        return false;
+
+    property.update(texts, names, n);
+
     for (Connection::Interface *oneConnection : d->connections)
         oneConnection->ISNewText(dev, name, texts, names, n);
 
@@ -633,6 +500,14 @@ bool DefaultDevice::ISNewBLOB(const char *dev, const char *name, int sizes[], in
                               char *formats[], char *names[], int n)
 {
     D_PTR(DefaultDevice);
+
+    INDI::PropertyBlob property = getProperty(name, INDI_BLOB);
+
+    if (!property.isValid())
+        return false;
+
+    property.update(sizes, blobsizes, blobs, formats, names, n);
+
     for (Connection::Interface *oneConnection : d->connections)
         oneConnection->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);
 
@@ -932,9 +807,77 @@ bool DefaultDevice::initProperties()
     snprintf(versionStr, 16, "%d.%d", d->majorVersion, d->minorVersion);
     snprintf(interfaceStr, 16, "%d", d->interfaceDescriptor);
 
+    // Connection Mode
+    d->ConnectionModeSP.onUpdate([this, d](){
+        int activeConnectionMode = d->ConnectionModeSP.findOnSwitchIndex();
+
+        if (activeConnectionMode >= 0 && activeConnectionMode < static_cast<int>(d->connections.size()))
+        {
+            d->activeConnection = d->connections[activeConnectionMode];
+            d->activeConnection->Activated();
+
+            for (Connection::Interface *oneConnection : d->connections)
+            {
+                if (oneConnection == d->activeConnection)
+                    continue;
+
+                oneConnection->Deactivated();
+            }
+
+            d->ConnectionModeSP.setState(IPS_OK);
+        }
+        else
+            d->ConnectionModeSP.setState(IPS_ALERT);
+
+        d->ConnectionModeSP.apply();
+
+    });
+
+    // Connection
     d->ConnectionSP[INDI_ENABLED ].fill("CONNECT",    "Connect",    ISS_OFF);
     d->ConnectionSP[INDI_DISABLED].fill("DISCONNECT", "Disconnect", ISS_ON);
     d->ConnectionSP.fill(getDeviceName(), INDI::SP::CONNECTION, "Connection", "Main Control", IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    d->ConnectionSP.onNewValues([this](const INDI::PropertySwitch::NewValues &values)
+    {
+        if (values.contains("CONNECT", ISS_ON))
+        {
+            // If disconnected, try to connect.
+            if (isConnected() == false)
+            {
+                if (Connect())
+                {
+                    // Connection is successful, set it to OK and updateProperties.
+                    setConnected(true);
+                    updateProperties();
+                }
+                else
+                    setConnected(false, IPS_ALERT);
+            }
+            else
+                // Already connected, tell client we're connected already.
+                setConnected(true);
+        }
+
+        if (values.contains("DISCONNECT", ISS_ON))
+        {
+            // If connected, try to disconnect.
+            if (isConnected() == true)
+            {
+                // Disconnection is successful, set it IDLE and updateProperties.
+                if (Disconnect())
+                {
+                    setConnected(false, IPS_IDLE);
+                    updateProperties();
+                }
+                else
+                    setConnected(true, IPS_ALERT);
+            }
+            // Already disconnected, tell client we're disconnected already.
+            else
+                setConnected(false, IPS_IDLE);
+        }
+
+    });
     registerProperty(d->ConnectionSP);
 
     d->DriverInfoTP[0].fill("DRIVER_NAME", "Name", getDriverName());
@@ -944,22 +887,71 @@ bool DefaultDevice::initProperties()
     d->DriverInfoTP.fill(getDeviceName(), "DRIVER_INFO", "Driver Info", CONNECTION_TAB, IP_RO, 60, IPS_IDLE);
     registerProperty(d->DriverInfoTP);
 
+    // Debug
     d->DebugSP[INDI_ENABLED ].fill("ENABLE",  "Enable",  ISS_OFF);
     d->DebugSP[INDI_DISABLED].fill("DISABLE", "Disable", ISS_ON);
     d->DebugSP.fill(getDeviceName(), "DEBUG", "Debug", "Options", IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    d->DebugSP.onUpdate([this, d]()
+    {
+        auto sp = d->DebugSP.findOnSwitch();
+        assert(sp != nullptr);
+        setDebug(sp->isNameMatch("ENABLE") ? true : false);
+    });
 
+    // Simulation
     d->SimulationSP[INDI_ENABLED ].fill("ENABLE",  "Enable",  ISS_OFF);
     d->SimulationSP[INDI_DISABLED].fill("DISABLE", "Disable", ISS_ON);
     d->SimulationSP.fill(getDeviceName(), "SIMULATION", "Simulation", "Options", IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
+    d->SimulationSP.onUpdate([this, d]()
+    {
+        auto sp = d->SimulationSP.findOnSwitch();
+        assert(sp != nullptr);
+        setSimulation(sp->isNameMatch("ENABLE") ? true : false);
+    });
 
+    // Configuration
     d->ConfigProcessSP[0].fill("CONFIG_LOAD",    "Load",    ISS_OFF);
     d->ConfigProcessSP[1].fill("CONFIG_SAVE",    "Save",    ISS_OFF);
     d->ConfigProcessSP[2].fill("CONFIG_DEFAULT", "Default", ISS_OFF);
     d->ConfigProcessSP[3].fill("CONFIG_PURGE",   "Purge",   ISS_OFF);
     d->ConfigProcessSP.fill(getDeviceName(), "CONFIG_PROCESS", "Configuration", "Options", IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+    d->ConfigProcessSP.onUpdate([this, d]()
+    {
+        auto svp = d->ConfigProcessSP;
+        auto sp = svp.findOnSwitch();
+        svp.reset();
+        bool pResult = false;
 
+        // Not suppose to happen (all switches off) but let's handle it anyway
+        if (sp == nullptr)
+        {
+            svp.setState(IPS_IDLE);
+            svp.apply();
+            return;
+        }
+
+        if (sp->isNameMatch("CONFIG_LOAD"))
+            pResult = loadConfig();
+        else if (sp->isNameMatch("CONFIG_SAVE"))
+            pResult = saveConfig();
+        else if (sp->isNameMatch("CONFIG_DEFAULT"))
+            pResult = loadDefaultConfig();
+        else if (sp->isNameMatch("CONFIG_PURGE"))
+            pResult = purgeConfig();
+
+        svp.setState(pResult ? IPS_OK : IPS_ALERT);
+        svp.apply();
+    });
+
+    // Polling Period
     d->PollPeriodNP[0].fill("PERIOD_MS", "Period (ms)", "%.f", 10, 600000, 1000, d->pollingPeriod);
     d->PollPeriodNP.fill(getDeviceName(), "POLLING_PERIOD", "Polling", "Options", IP_RW, 0, IPS_IDLE);
+    d->PollPeriodNP.onUpdate([this, d]()
+    {
+        d->PollPeriodNP.setState(IPS_OK);
+        d->pollingPeriod = static_cast<uint32_t>(d->PollPeriodNP[0].getValue());
+        d->PollPeriodNP.apply();
+    });
 
     INDI::Logger::initProperties(this);
 

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -808,7 +808,7 @@ bool DefaultDevice::initProperties()
     snprintf(interfaceStr, 16, "%d", d->interfaceDescriptor);
 
     // Connection Mode
-    d->ConnectionModeSP.onUpdate([this, d](){
+    d->ConnectionModeSP.onUpdate([d](){
         int activeConnectionMode = d->ConnectionModeSP.findOnSwitchIndex();
 
         if (activeConnectionMode >= 0 && activeConnectionMode < static_cast<int>(d->connections.size()))
@@ -946,7 +946,7 @@ bool DefaultDevice::initProperties()
     // Polling Period
     d->PollPeriodNP[0].fill("PERIOD_MS", "Period (ms)", "%.f", 10, 600000, 1000, d->pollingPeriod);
     d->PollPeriodNP.fill(getDeviceName(), "POLLING_PERIOD", "Polling", "Options", IP_RW, 0, IPS_IDLE);
-    d->PollPeriodNP.onUpdate([this, d]()
+    d->PollPeriodNP.onUpdate([d]()
     {
         d->PollPeriodNP.setState(IPS_OK);
         d->pollingPeriod = static_cast<uint32_t>(d->PollPeriodNP[0].getValue());

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -1002,31 +1002,31 @@ bool DefaultDevice::deleteProperty(const char *propertyName)
 
 void DefaultDevice::defineProperty(INumberVectorProperty *property)
 {
-    registerProperty(property);
+    registerProperty(INDI::Property(property));
     static_cast<PropertyView<INumber>*>(property)->define();
 }
 
 void DefaultDevice::defineProperty(ITextVectorProperty *property)
 {
-    registerProperty(property);
+    registerProperty(INDI::Property(property));
     static_cast<PropertyView<IText>*>(property)->define();
 }
 
 void DefaultDevice::defineProperty(ISwitchVectorProperty *property)
 {
-    registerProperty(property);
+    registerProperty(INDI::Property(property));
     static_cast<PropertyView<ISwitch>*>(property)->define();
 }
 
 void DefaultDevice::defineProperty(ILightVectorProperty *property)
 {
-    registerProperty(property);
+    registerProperty(INDI::Property(property));
     static_cast<PropertyView<ILight>*>(property)->define();
 }
 
 void DefaultDevice::defineProperty(IBLOBVectorProperty *property)
 {
-    registerProperty(property);
+    registerProperty(INDI::Property(property));
     static_cast<PropertyView<IBLOB>*>(property)->define();
 }
 

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -453,7 +453,9 @@ bool DefaultDevice::ISNewSwitch(const char *dev, const char *name, ISState *stat
         return rc;
     }
 
-    property.update(states, names, n);
+    property.update(states, names, n); // update and callback
+    if (property.hasUpdateCallback())
+        return true;
 
     bool rc = false;
     for (Connection::Interface *oneConnection : d->connections)
@@ -471,7 +473,9 @@ bool DefaultDevice::ISNewNumber(const char *dev, const char *name, double values
     if (!property.isValid())
         return false;
 
-    property.update(values, names, n);
+    property.update(values, names, n); // update and callback
+    if (property.hasUpdateCallback())
+        return true;
 
     for (Connection::Interface *oneConnection : d->connections)
         oneConnection->ISNewNumber(dev, name, values, names, n);
@@ -488,7 +492,9 @@ bool DefaultDevice::ISNewText(const char *dev, const char *name, char *texts[], 
     if (!property.isValid())
         return false;
 
-    property.update(texts, names, n);
+    property.update(texts, names, n); // update and callback
+    if (property.hasUpdateCallback())
+        return true;
 
     for (Connection::Interface *oneConnection : d->connections)
         oneConnection->ISNewText(dev, name, texts, names, n);
@@ -506,7 +512,9 @@ bool DefaultDevice::ISNewBLOB(const char *dev, const char *name, int sizes[], in
     if (!property.isValid())
         return false;
 
-    property.update(sizes, blobsizes, blobs, formats, names, n);
+    property.update(sizes, blobsizes, blobs, formats, names, n); // update and callback
+    if (property.hasUpdateCallback())
+        return true;
 
     for (Connection::Interface *oneConnection : d->connections)
         oneConnection->ISNewBLOB(dev, name, sizes, blobsizes, blobs, formats, names, n);

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -320,7 +320,7 @@ class DefaultDevice : public BaseDevice
          *
          *  A driver may select to receive notifications of a specific other device.
          */
-        void watchDevice(const char *name, const std::function<void (INDI::BaseDevice)> &callback);
+        void watchDevice(const char *deviceName, const std::function<void (INDI::BaseDevice)> &callback);
 
     protected:
         /**

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -320,7 +320,7 @@ class DefaultDevice : public BaseDevice
          *
          *  A driver may select to receive notifications of a specific other device.
          */
-        void watchDevice(const char *name, const std::function<void (BaseDevice)> &callback);
+        void watchDevice(const char *name, const std::function<void (INDI::BaseDevice)> &callback);
 
     protected:
         /**

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -315,6 +315,13 @@ class DefaultDevice : public BaseDevice
          */
         void setDriverInterface(uint16_t value);
 
+    public:
+        /** @brief Add a device to the watch list.
+         *
+         *  A driver may select to receive notifications of a specific other device.
+         */
+        void watchDevice(const char *name, const std::function<void (BaseDevice)> &callback);
+
     protected:
         /**
          * @brief setDynamicPropertiesBehavior controls handling of dynamic properties. Dyanmic properties

--- a/libs/indibase/defaultdevice_p.h
+++ b/libs/indibase/defaultdevice_p.h
@@ -20,6 +20,7 @@
 
 #include "basedevice_p.h"
 #include "defaultdevice.h"
+#include "watchdeviceproperty.h"
 
 #include <cstring>
 #include <list>
@@ -76,6 +77,8 @@ class DefaultDevicePrivate: public BaseDevicePrivate
     public:
         static std::list<DefaultDevicePrivate*> devices;
         static std::recursive_mutex             devicesLock;
+
+        WatchDeviceProperty watchDevice;
 };
 
 }

--- a/libs/indibase/indiutility.h
+++ b/libs/indibase/indiutility.h
@@ -22,12 +22,44 @@
 */
 #pragma once
 
+
+#ifdef __cplusplus
 #include <string>
+#include <cstring>
 #include <sys/stat.h>
 #include <ctime>
 
 #include "indimacros.h"
+#else
+#include <string.h>
+#endif
 
+// C
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+/**
+ * @brief The strlcpy() function copy strings respectively.
+ * They are designed to be safer, more consistent, and less error prone replacements for strncpy.
+ */
+inline static size_t indi_strlcpy(char * dst, const char * src, size_t maxlen)
+{
+    const size_t srclen = strlen(src);
+    if (srclen + 1 < maxlen) {
+        memcpy(dst, src, srclen + 1);
+    } else if (maxlen != 0) {
+        memcpy(dst, src, maxlen - 1);
+        dst[maxlen-1] = '\0';
+    }
+    return srclen;
+}
+#ifdef __cplusplus
+}
+#endif
+
+// C++
+#ifdef __cplusplus
 namespace INDI
 {
 
@@ -48,4 +80,24 @@ std::string format_time(const std::tm &tm, const char *format);
  */
 void replace_all(std::string &subject, const std::string &search, const std::string &replace);
 
+/**
+ * @brief The strlcpy() function copy strings respectively.
+ * They are designed to be safer, more consistent, and less error prone replacements for strncpy.
+ */
+inline size_t strlcpy(char * dst, const char * src, size_t maxlen)
+{
+    return indi_strlcpy(dst, src, maxlen);
 }
+
+/**
+ * @brief The strlcpy() function copy strings respectively.
+ * They are designed to be safer, more consistent, and less error prone replacements for strncpy.
+ */
+template <size_t N>
+inline size_t strlcpy(char (&dst)[N], const char * src)
+{
+    return indi_strlcpy(dst, src, N);
+}
+
+}
+#endif

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -446,7 +446,7 @@ void Property::define(const char *format, ...) const
     va_end(ap);
 }
 
-void Property::onUpdate(std::function<void()> callback)
+void Property::onUpdate(const std::function<void()> &callback)
 {
     D_PTR(Property);
     d->onUpdateCallback = callback;

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -142,7 +142,7 @@ Property::Property(PropertyPrivate &dd)
     : d_ptr(&dd)
 { }
 
-Property::Property(std::shared_ptr<PropertyPrivate> dd)
+Property::Property(const std::shared_ptr<PropertyPrivate> &dd)
     : d_ptr(dd)
 { }
 

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright(c) 2011 Jasem Mutlaq. All rights reserved.
+               2022 Pawel Soja <kernel32.pl@gmail.com>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public
@@ -18,6 +19,12 @@
 
 #include "indiproperty.h"
 #include "indiproperty_p.h"
+
+#include "indipropertytext_p.h"
+#include "indipropertyswitch_p.h"
+#include "indipropertynumber_p.h"
+#include "indipropertylight_p.h"
+#include "indipropertyblob_p.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -111,29 +118,28 @@ Property::Property()
     : d_ptr(new PropertyPrivate(nullptr, INDI_UNKNOWN))
 { }
 
-Property::Property(void *property, INDI_PROPERTY_TYPE type)
-    : d_ptr(new PropertyPrivate(property, type))
-{ }
 
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
 Property::Property(INumberVectorProperty *property)
-    : d_ptr(new PropertyPrivate(property))
+    : d_ptr(new PropertyNumberPrivate(property))
 { }
 
 Property::Property(ITextVectorProperty   *property)
-    : d_ptr(new PropertyPrivate(property))
+    : d_ptr(new PropertyTextPrivate(property))
 { }
 
 Property::Property(ISwitchVectorProperty *property)
-    : d_ptr(new PropertyPrivate(property))
+    : d_ptr(new PropertySwitchPrivate(property))
 { }
 
 Property::Property(ILightVectorProperty  *property)
-    : d_ptr(new PropertyPrivate(property))
+    : d_ptr(new PropertyLightPrivate(property))
 { }
 
 Property::Property(IBLOBVectorProperty   *property)
-    : d_ptr(new PropertyPrivate(property))
+    : d_ptr(new PropertyBlobPrivate(property))
 { }
+#endif
 
 Property::~Property()
 { }

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -440,4 +440,17 @@ void Property::define(const char *format, ...) const
     va_end(ap);
 }
 
+void Property::onUpdate(std::function<void()> callback)
+{
+    D_PTR(Property);
+    d->onUpdateCallback = callback;
+}
+
+void Property::emitUpdate()
+{
+    D_PTR(Property);
+    if (d->onUpdateCallback)
+        d->onUpdateCallback();
+}
+
 }

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -459,4 +459,10 @@ void Property::emitUpdate()
         d->onUpdateCallback();
 }
 
+bool Property::hasUpdateCallback() const
+{
+    D_PTR(const Property);
+    return d->onUpdateCallback != nullptr;
+}
+
 }

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -103,7 +103,7 @@ class Property
         bool isLabelMatch(const std::string &otherLabel) const;
 
     public:
-        void onUpdate(std::function<void()> callback);
+        void onUpdate(const std::function<void()> &callback);
 
     public:
         void emitUpdate();

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -133,8 +133,13 @@ class Property
 
     protected:
         std::shared_ptr<PropertyPrivate> d_ptr;
-        Property(std::shared_ptr<PropertyPrivate> dd);
+        Property(const std::shared_ptr<PropertyPrivate> &dd);
         Property(PropertyPrivate &dd);
+        friend class PropertyNumber;
+        friend class PropertyText;
+        friend class PropertySwitch;
+        friend class PropertyLight;
+        friend class PropertyBlob;
 };
 
 } // namespace INDI

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -27,6 +27,7 @@
 
 #include <memory>
 #include <cstdarg>
+#include <functional>
 
 #define INDI_PROPERTY_BACKWARD_COMPATIBILE
 namespace INDI
@@ -98,6 +99,12 @@ class Property
 
         bool isLabelMatch(const char *otherLabel) const;
         bool isLabelMatch(const std::string &otherLabel) const;
+
+    public:
+        void onUpdate(std::function<void()> callback);
+
+    public:
+        void emitUpdate();
 
     public:
         void save(FILE *fp) const;

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -149,6 +149,7 @@ class Property
         operator INDI::PropertyView<IBLOB>   *() const { return getBLOB(); }
         bool operator != (std::nullptr_t) const        { return  isValid(); }
         bool operator == (std::nullptr_t) const        { return !isValid(); }
+        operator bool()                   const        { return  isValid(); }
 #endif
 
     protected:

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -107,6 +107,7 @@ class Property
 
     public:
         void emitUpdate();
+        bool hasUpdateCallback() const;
 
     public:
         void save(FILE *fp) const;

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright(c) 2011 Jasem Mutlaq. All rights reserved.
+               2022 Pawel Soja <kernel32.pl@gmail.com>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public
@@ -46,15 +47,16 @@ class Property
         DECLARE_PRIVATE(Property)
     public:
         Property();
-        Property(void *property, INDI_PROPERTY_TYPE type);
+        ~Property();
+
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+    public:
         Property(INumberVectorProperty *property);
         Property(ITextVectorProperty   *property);
         Property(ISwitchVectorProperty *property);
         Property(ILightVectorProperty  *property);
         Property(IBLOBVectorProperty   *property);
-
-        ~Property();
-
+#endif
     public:
         void setProperty(void *);
         void setType(INDI_PROPERTY_TYPE t);
@@ -123,11 +125,13 @@ class Property
         }
 
     public:
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
         INDI::PropertyView<INumber> *getNumber() const;
         INDI::PropertyView<IText>   *getText() const;
         INDI::PropertyView<ISwitch> *getSwitch() const;
         INDI::PropertyView<ILight>  *getLight() const;
         INDI::PropertyView<IBLOB>   *getBLOB() const;
+#endif
 
     public:
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
@@ -136,6 +140,14 @@ class Property
 
         operator INDI::Property *();
         operator const INDI::Property *() const;
+
+        operator INDI::PropertyView<INumber> *() const { return getNumber(); }
+        operator INDI::PropertyView<IText>   *() const { return getText(); }
+        operator INDI::PropertyView<ISwitch> *() const { return getSwitch(); }
+        operator INDI::PropertyView<ILight>  *() const { return getLight(); }
+        operator INDI::PropertyView<IBLOB>   *() const { return getBLOB(); }
+        bool operator != (std::nullptr_t) const        { return  isValid(); }
+        bool operator == (std::nullptr_t) const        { return !isValid(); }
 #endif
 
     protected:

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -1,5 +1,6 @@
 /*******************************************************************************
   Copyright(c) 2011 Jasem Mutlaq. All rights reserved.
+               2022 Pawel Soja <kernel32.pl@gmail.com>
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public
@@ -40,7 +41,7 @@ static inline std::shared_ptr<T> property_private_cast(const std::shared_ptr<U> 
     using S = std::remove_pointer_t<T>;
     static struct Invalid
     {
-        std::shared_ptr<T> instance {new S {0}};
+        std::shared_ptr<T> instance {new S {size_t(16)}};
         Invalid()
         {
             instance->type = INDI_UNKNOWN;

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -21,6 +21,8 @@
 #include "indibase.h"
 #include "indiproperty.h"
 #include <memory>
+#include <functional>
+
 namespace INDI
 {
 
@@ -57,6 +59,8 @@ class PropertyPrivate
         INDI_PROPERTY_TYPE type = INDI_UNKNOWN;
         bool registered = false;
         bool dynamic = false;
+
+        std::function<void()> onUpdateCallback;
 
         PropertyPrivate(void *property, INDI_PROPERTY_TYPE type);
         PropertyPrivate(ITextVectorProperty *property);

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -32,6 +32,22 @@ static inline std::shared_ptr<T> make_shared_weak(T *object)
 }
 #endif
 
+template <typename T, typename U>
+static inline std::shared_ptr<T> &property_private_cast(const std::shared_ptr<U> &r)
+{
+    using S = std::remove_pointer_t<T>;
+    static struct Invalid
+    {
+        std::shared_ptr<T> instance {new S {0}};
+        Invalid()
+        {
+            instance->type = INDI_UNKNOWN;
+        }
+    } invalid;
+    auto result = std::dynamic_pointer_cast<T>(r);
+    return result != nullptr ? result : invalid.instance;
+}
+
 class BaseDevice;
 class PropertyPrivate
 {

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -35,7 +35,7 @@ static inline std::shared_ptr<T> make_shared_weak(T *object)
 #endif
 
 template <typename T, typename U>
-static inline std::shared_ptr<T> &property_private_cast(const std::shared_ptr<U> &r)
+static inline std::shared_ptr<T> property_private_cast(const std::shared_ptr<U> &r)
 {
     using S = std::remove_pointer_t<T>;
     static struct Invalid

--- a/libs/indibase/property/indipropertybasic.cpp
+++ b/libs/indibase/property/indipropertybasic.cpp
@@ -44,6 +44,11 @@ PropertyBasic<T>::PropertyBasic(PropertyBasicPrivate &dd)
 { }
 
 template <typename T>
+PropertyBasic<T>::PropertyBasic(const std::shared_ptr<PropertyBasicPrivate> &dd)
+    : Property(std::static_pointer_cast<PropertyPrivate>(dd))
+{ }
+
+template <typename T>
 void PropertyBasic<T>::setName(const char *name)
 {
     D_PTR(PropertyBasic);

--- a/libs/indibase/property/indipropertybasic.cpp
+++ b/libs/indibase/property/indipropertybasic.cpp
@@ -425,6 +425,13 @@ PropertyView<T> *PropertyBasic<T>::operator ->()
     D_PTR(PropertyBasic);
     return static_cast<PropertyView<T> *>(static_cast<INDI::PropertyPrivate*>(d)->property);
 }
+
+template <typename T>
+INDI::PropertyView<T> PropertyBasic<T>::operator*()
+{
+    D_PTR(PropertyBasic);
+    return *static_cast<PropertyView<T> *>(static_cast<INDI::PropertyPrivate*>(d)->property);
+}
 #endif
 
 template class PropertyBasicPrivateTemplate<IText>;

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -136,6 +136,7 @@ class PropertyBasic : public INDI::Property
 
     protected:
         PropertyBasic(PropertyBasicPrivate &dd);
+        PropertyBasic(const std::shared_ptr<PropertyBasicPrivate> &dd);
 };
 
 }

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -144,6 +144,7 @@ class PropertyBasic : public INDI::Property
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
     public: // deprecated
         INDI::PropertyView<T> *operator->();
+        INDI::PropertyView<T>  operator*();
 #endif
 };
 

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -140,6 +140,11 @@ class PropertyBasic : public INDI::Property
     protected:
         PropertyBasic(PropertyBasicPrivate &dd);
         PropertyBasic(const std::shared_ptr<PropertyBasicPrivate> &dd);
+
+#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+    public: // deprecated
+        INDI::PropertyView<T> *operator->();
+#endif
 };
 
 }

--- a/libs/indibase/property/indipropertybasic.h
+++ b/libs/indibase/property/indipropertybasic.h
@@ -39,6 +39,9 @@ class PropertyBasic : public INDI::Property
         using PropertyBasicPrivate = PropertyBasicPrivateTemplate<T>;
         DECLARE_PRIVATE(PropertyBasic)
     public:
+        using ViewType = T;
+
+    public:
         ~PropertyBasic();
 
     public:

--- a/libs/indibase/property/indipropertybasic_p.h
+++ b/libs/indibase/property/indipropertybasic_p.h
@@ -22,6 +22,9 @@
 #include "indipropertyview.h"
 
 #include <vector>
+#include <functional>
+
+#define INDI_PROPERTY_RAW_CAST
 
 namespace INDI
 {
@@ -30,12 +33,24 @@ template <typename T>
 class PropertyBasicPrivateTemplate: public PropertyPrivate
 {
     public:
+        using RawPropertyType = typename WidgetTraits<T>::PropertyType;
+        using BasicPropertyType = PropertyBasicPrivateTemplate<T>;
+
+    public:
         PropertyBasicPrivateTemplate(size_t count);
+#ifdef INDI_PROPERTY_RAW_CAST
+        PropertyBasicPrivateTemplate(RawPropertyType *rawProperty);
+#endif
         virtual ~PropertyBasicPrivateTemplate();
 
     public:
         std::vector<WidgetView<T>>  widgets;
-        PropertyView<T>             property;
+#ifndef INDI_PROPERTY_RAW_CAST
+        PropertyView<T>            &property;
+#else
+        PropertyView<T>            &property;
+        bool raw {false};
+#endif
 };
 
 }

--- a/libs/indibase/property/indipropertyblob.cpp
+++ b/libs/indibase/property/indipropertyblob.cpp
@@ -33,6 +33,10 @@ PropertyBlob::PropertyBlob(size_t count)
     : PropertyBasic<IBLOB>(*new PropertyBlobPrivate(count))
 { }
 
+PropertyBlob::PropertyBlob(INDI::Property property)
+    : PropertyBasic<IBLOB>(property_private_cast<PropertyBlobPrivate>(property.d_ptr))
+{ }
+
 PropertyBlob::~PropertyBlob()
 { }
 

--- a/libs/indibase/property/indipropertyblob.cpp
+++ b/libs/indibase/property/indipropertyblob.cpp
@@ -46,7 +46,7 @@ bool PropertyBlob::update(
 )
 {
     D_PTR(PropertyBlob);
-    return d->property.update(sizes, blobsizes, blobs, formats, names, n);
+    return d->property.update(sizes, blobsizes, blobs, formats, names, n) && (emitUpdate(), true);
 }
 
 void PropertyBlob::fill(

--- a/libs/indibase/property/indipropertyblob.h
+++ b/libs/indibase/property/indipropertyblob.h
@@ -29,6 +29,7 @@ class PropertyBlob: public INDI::PropertyBasic<IBLOB>
         DECLARE_PRIVATE(PropertyBlob)
     public:
         PropertyBlob(size_t count);
+        PropertyBlob(INDI::Property property);
         ~PropertyBlob();
 
     public:

--- a/libs/indibase/property/indipropertyblob_p.h
+++ b/libs/indibase/property/indipropertyblob_p.h
@@ -28,6 +28,11 @@ class PropertyBlobPrivate: public PropertyBasicPrivateTemplate<IBLOB>
 {
     public:
         PropertyBlobPrivate(size_t count);
+#ifdef INDI_PROPERTY_RAW_CAST
+        PropertyBlobPrivate(RawPropertyType *p)
+            : BasicPropertyType(p)
+        { }
+#endif
         virtual ~PropertyBlobPrivate();
 
     public:

--- a/libs/indibase/property/indipropertylight.cpp
+++ b/libs/indibase/property/indipropertylight.cpp
@@ -33,6 +33,10 @@ PropertyLight::PropertyLight(size_t count)
     : PropertyBasic<ILight>(*new PropertyLightPrivate(count))
 { }
 
+PropertyLight::PropertyLight(INDI::Property property)
+    : PropertyBasic<ILight>(property_private_cast<PropertyLightPrivate>(property.d_ptr))
+{ }
+
 PropertyLight::~PropertyLight()
 { }
 

--- a/libs/indibase/property/indipropertylight.h
+++ b/libs/indibase/property/indipropertylight.h
@@ -29,6 +29,7 @@ class PropertyLight: public INDI::PropertyBasic<ILight>
         DECLARE_PRIVATE(PropertyLight)
     public:
         PropertyLight(size_t count);
+        PropertyLight(INDI::Property property);
         ~PropertyLight();
 
     public:

--- a/libs/indibase/property/indipropertylight_p.h
+++ b/libs/indibase/property/indipropertylight_p.h
@@ -28,6 +28,11 @@ class PropertyLightPrivate: public PropertyBasicPrivateTemplate<ILight>
 {
     public:
         PropertyLightPrivate(size_t count);
+#ifdef INDI_PROPERTY_RAW_CAST
+        PropertyLightPrivate(RawPropertyType *p)
+            : BasicPropertyType(p)
+        { }
+#endif
         virtual ~PropertyLightPrivate();
 
     public:

--- a/libs/indibase/property/indipropertynumber.cpp
+++ b/libs/indibase/property/indipropertynumber.cpp
@@ -43,7 +43,7 @@ PropertyNumber::~PropertyNumber()
 bool PropertyNumber::update(const double values[], const char * const names[], int n)
 {
     D_PTR(PropertyNumber);
-    return d->property.update(values, names, n);
+    return d->property.update(values, names, n) && (emitUpdate(), true);
 }
 
 void PropertyNumber::fill(

--- a/libs/indibase/property/indipropertynumber.cpp
+++ b/libs/indibase/property/indipropertynumber.cpp
@@ -33,6 +33,10 @@ PropertyNumber::PropertyNumber(size_t count)
     : PropertyBasic<INumber>(*new PropertyNumberPrivate(count))
 { }
 
+PropertyNumber::PropertyNumber(INDI::Property property)
+    : PropertyBasic<INumber>(property_private_cast<PropertyNumberPrivate>(property.d_ptr))
+{ }
+
 PropertyNumber::~PropertyNumber()
 { }
 

--- a/libs/indibase/property/indipropertynumber.h
+++ b/libs/indibase/property/indipropertynumber.h
@@ -29,6 +29,7 @@ class PropertyNumber: public INDI::PropertyBasic<INumber>
         DECLARE_PRIVATE(PropertyNumber)
     public:
         PropertyNumber(size_t count);
+        PropertyNumber(INDI::Property property);
         ~PropertyNumber();
 
     public:

--- a/libs/indibase/property/indipropertynumber_p.h
+++ b/libs/indibase/property/indipropertynumber_p.h
@@ -28,6 +28,11 @@ class PropertyNumberPrivate: public PropertyBasicPrivateTemplate<INumber>
 {
     public:
         PropertyNumberPrivate(size_t count);
+#ifdef INDI_PROPERTY_RAW_CAST
+        PropertyNumberPrivate(RawPropertyType *p)
+            : BasicPropertyType(p)
+        { }
+#endif
         virtual ~PropertyNumberPrivate();
 
     public:

--- a/libs/indibase/property/indipropertyswitch.cpp
+++ b/libs/indibase/property/indipropertyswitch.cpp
@@ -33,6 +33,10 @@ PropertySwitch::PropertySwitch(size_t count)
     : PropertyBasic<ISwitch>(*new PropertySwitchPrivate(count))
 { }
 
+PropertySwitch::PropertySwitch(INDI::Property property)
+    : PropertyBasic<ISwitch>(property_private_cast<PropertySwitchPrivate>(property.d_ptr))
+{ }
+
 PropertySwitch::~PropertySwitch()
 { }
 

--- a/libs/indibase/property/indipropertyswitch.cpp
+++ b/libs/indibase/property/indipropertyswitch.cpp
@@ -61,6 +61,17 @@ INDI::WidgetView<ISwitch> *PropertySwitch::findOnSwitch() const
 bool PropertySwitch::update(const ISState states[], const char * const names[], int n)
 {
     D_PTR(PropertySwitch);
+    if (d->onNewValuesCallback)
+    {
+        NewValues newValues;
+        for (int i=0; i<n; ++i)
+        {
+            newValues[names[i]] = states[i];
+        }
+
+        d->onNewValuesCallback(newValues);
+        return true;
+    }
     return d->property.update(states, names, n) && (emitUpdate(), true);
 }
 
@@ -90,6 +101,12 @@ const char * PropertySwitch::getRuleAsString() const
 {
     D_PTR(const PropertySwitch);
     return d->property.getRuleAsString();
+}
+
+void PropertySwitch::onNewValues(const std::function<void(const INDI::PropertySwitch::NewValues &)> &callback)
+{
+    D_PTR(PropertySwitch);
+    d->onNewValuesCallback = callback;
 }
 
 }

--- a/libs/indibase/property/indipropertyswitch.cpp
+++ b/libs/indibase/property/indipropertyswitch.cpp
@@ -75,6 +75,12 @@ bool PropertySwitch::update(const ISState states[], const char * const names[], 
     return d->property.update(states, names, n) && (emitUpdate(), true);
 }
 
+bool PropertySwitch::hasUpdateCallback() const
+{
+    D_PTR(const PropertySwitch);
+    return d->onNewValuesCallback != nullptr || d->onUpdateCallback != nullptr;
+}
+
 void PropertySwitch::fill(
     const char *device, const char *name, const char *label, const char *group,
     IPerm permission, ISRule rule, double timeout, IPState state

--- a/libs/indibase/property/indipropertyswitch.cpp
+++ b/libs/indibase/property/indipropertyswitch.cpp
@@ -61,7 +61,7 @@ INDI::WidgetView<ISwitch> *PropertySwitch::findOnSwitch() const
 bool PropertySwitch::update(const ISState states[], const char * const names[], int n)
 {
     D_PTR(PropertySwitch);
-    return d->property.update(states, names, n);
+    return d->property.update(states, names, n) && (emitUpdate(), true);
 }
 
 void PropertySwitch::fill(

--- a/libs/indibase/property/indipropertyswitch.h
+++ b/libs/indibase/property/indipropertyswitch.h
@@ -29,6 +29,7 @@ class PropertySwitch: public INDI::PropertyBasic<ISwitch>
         DECLARE_PRIVATE(PropertySwitch)
     public:
         PropertySwitch(size_t count);
+        PropertySwitch(INDI::Property property);
         ~PropertySwitch();
 
     public:

--- a/libs/indibase/property/indipropertyswitch.h
+++ b/libs/indibase/property/indipropertyswitch.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "indipropertybasic.h"
+#include <map>
 
 namespace INDI
 {
@@ -28,9 +29,22 @@ class PropertySwitch: public INDI::PropertyBasic<ISwitch>
 {
         DECLARE_PRIVATE(PropertySwitch)
     public:
+        struct NewValues: public std::map<std::string, ISState>
+        {
+            bool contains(const std::string &key, const ISState &state) const
+            {
+                auto it = this->find(key);
+                return it != this->cend() && it->second == state;
+            }
+        };
+
+    public:
         PropertySwitch(size_t count);
         PropertySwitch(INDI::Property property);
         ~PropertySwitch();
+
+    public:
+        void onNewValues(const std::function<void(const NewValues &)> &callback);
 
     public:
         bool update(const ISState states[], const char * const names[], int n);

--- a/libs/indibase/property/indipropertyswitch.h
+++ b/libs/indibase/property/indipropertyswitch.h
@@ -48,6 +48,7 @@ class PropertySwitch: public INDI::PropertyBasic<ISwitch>
 
     public:
         bool update(const ISState states[], const char * const names[], int n);
+        bool hasUpdateCallback() const;
 
         void fill(
             const char *device, const char *name, const char *label, const char *group,

--- a/libs/indibase/property/indipropertyswitch_p.h
+++ b/libs/indibase/property/indipropertyswitch_p.h
@@ -20,6 +20,9 @@
 
 #include "indipropertybasic_p.h"
 #include "indipropertyview.h"
+#include "indipropertyswitch.h"
+
+#include <functional>
 
 namespace INDI
 {
@@ -31,6 +34,7 @@ class PropertySwitchPrivate: public PropertyBasicPrivateTemplate<ISwitch>
         virtual ~PropertySwitchPrivate();
 
     public:
+        std::function<void(const INDI::PropertySwitch::NewValues &)> onNewValuesCallback;
 
 };
 

--- a/libs/indibase/property/indipropertyswitch_p.h
+++ b/libs/indibase/property/indipropertyswitch_p.h
@@ -31,6 +31,11 @@ class PropertySwitchPrivate: public PropertyBasicPrivateTemplate<ISwitch>
 {
     public:
         PropertySwitchPrivate(size_t count);
+#ifdef INDI_PROPERTY_RAW_CAST
+        PropertySwitchPrivate(RawPropertyType *p)
+            : BasicPropertyType(p)
+        { }
+#endif
         virtual ~PropertySwitchPrivate();
 
     public:

--- a/libs/indibase/property/indipropertytext.cpp
+++ b/libs/indibase/property/indipropertytext.cpp
@@ -33,6 +33,10 @@ PropertyText::PropertyText(size_t count)
     : PropertyBasic<IText>(*new PropertyTextPrivate(count))
 { }
 
+PropertyText::PropertyText(INDI::Property property)
+    : PropertyBasic<IText>(property_private_cast<PropertyTextPrivate>(property.d_ptr))
+{ }
+
 PropertyText::~PropertyText()
 { }
 

--- a/libs/indibase/property/indipropertytext.cpp
+++ b/libs/indibase/property/indipropertytext.cpp
@@ -43,7 +43,7 @@ PropertyText::~PropertyText()
 bool PropertyText::update(const char * const texts[], const char * const names[], int n)
 {
     D_PTR(PropertyText);
-    return d->property.update(texts, names, n);
+    return d->property.update(texts, names, n) && (emitUpdate(), true);
 }
 
 void PropertyText::fill(

--- a/libs/indibase/property/indipropertytext.h
+++ b/libs/indibase/property/indipropertytext.h
@@ -29,6 +29,7 @@ class PropertyText: public INDI::PropertyBasic<IText>
         DECLARE_PRIVATE(PropertyText)
     public:
         PropertyText(size_t count);
+        PropertyText(INDI::Property property);
         ~PropertyText();
 
     public:

--- a/libs/indibase/property/indipropertytext_p.h
+++ b/libs/indibase/property/indipropertytext_p.h
@@ -28,6 +28,11 @@ class PropertyTextPrivate: public PropertyBasicPrivateTemplate<IText>
 {
     public:
         PropertyTextPrivate(size_t count);
+#ifdef INDI_PROPERTY_RAW_CAST
+        PropertyTextPrivate(RawPropertyType *p)
+            : BasicPropertyType(p)
+        { }
+#endif
         virtual ~PropertyTextPrivate();
 
     public:

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -995,6 +995,10 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
         {
             return this->blob;
         }
+        std::string getBlobAsString() const
+        {
+            return std::string(static_cast<const char*>(this->blob), this->bloblen);
+        }
         int getBlobLen() const
         {
             return this->bloblen;

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -988,7 +988,10 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
         {
             return this->format;
         }
-
+        void *getBlob()
+        {
+            return this->blob;
+        }
         const void *getBlob()   const
         {
             return this->blob;

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -380,7 +380,7 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
 
         void setName(const char *name)
         {
-            strncpy(this->name, name, MAXINDINAME);
+            INDI::strlcpy(this->name, name);
         }
         void setName(const std::string &name)
         {
@@ -389,7 +389,7 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
 
         void setLabel(const char *label)
         {
-            strncpy(this->label, label, MAXINDILABEL);
+            INDI::strlcpy(this->label, label);
         }
         void setLabel(const std::string &label)
         {
@@ -399,8 +399,7 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
         //void setText(const char *text)                         { free(this->text); this->text = strndup(text, strlen(text)); }
         void setText(const char *text, size_t size)
         {
-            this->text = strncpy(static_cast<char*>(realloc(this->text, size + 1)), text, size);
-            this->text[size] = '\0';
+            INDI::strlcpy(this->text = static_cast<char*>(realloc(this->text, size + 1)), text, size);
         }
         void setText(const char *text)
         {
@@ -509,7 +508,7 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
 
         void setName(const char *name)
         {
-            strncpy(this->name, name, MAXINDINAME);
+            INDI::strlcpy(this->name, name);
         }
         void setName(const std::string &name)
         {
@@ -518,7 +517,7 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
 
         void setLabel(const char *label)
         {
-            strncpy(this->label, label, MAXINDILABEL);
+            INDI::strlcpy(this->label, label, MAXINDILABEL);
         }
         void setLabel(const std::string &label)
         {
@@ -527,7 +526,7 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
 
         void setFormat(const char *format)
         {
-            strncpy(this->format, format, MAXINDIFORMAT);
+            INDI::strlcpy(this->format, format, MAXINDIFORMAT);
         }
         void setFormat(const std::string &format)
         {
@@ -673,7 +672,7 @@ struct WidgetView<ISwitch>: PROPERTYVIEW_BASE_ACCESS ISwitch
 
         void setName(const char *name)
         {
-            strncpy(this->name, name, MAXINDINAME);
+            INDI::strlcpy(this->name, name);
         }
         void setName(const std::string &name)
         {
@@ -682,7 +681,7 @@ struct WidgetView<ISwitch>: PROPERTYVIEW_BASE_ACCESS ISwitch
 
         void setLabel(const char *label)
         {
-            strncpy(this->label, label, MAXINDILABEL);
+            INDI::strlcpy(this->label, label, MAXINDILABEL);
         }
         void setLabel(const std::string &label)
         {
@@ -802,7 +801,7 @@ struct WidgetView<ILight>: PROPERTYVIEW_BASE_ACCESS ILight
 
         void setName(const char *name)
         {
-            strncpy(this->name, name, MAXINDINAME);
+            INDI::strlcpy(this->name, name);
         }
         void setName(const std::string &name)
         {
@@ -811,7 +810,7 @@ struct WidgetView<ILight>: PROPERTYVIEW_BASE_ACCESS ILight
 
         void setLabel(const char *label)
         {
-            strncpy(this->label, label, MAXINDILABEL);
+            INDI::strlcpy(this->label, label, MAXINDILABEL);
         }
         void setLabel(const std::string &label)
         {
@@ -931,7 +930,7 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
 
         void setName(const char *name)
         {
-            strncpy(this->name, name, MAXINDINAME);
+            INDI::strlcpy(this->name, name);
         }
         void setName(const std::string &name)
         {
@@ -940,7 +939,7 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
 
         void setLabel(const char *label)
         {
-            strncpy(this->label, label, MAXINDILABEL);
+            INDI::strlcpy(this->label, label, MAXINDILABEL);
         }
         void setLabel(const std::string &label)
         {
@@ -949,7 +948,7 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
 
         void setFormat(const char *format)
         {
-            strncpy(this->format, format, MAXINDIBLOBFMT);
+            INDI::strlcpy(this->format, format, MAXINDIBLOBFMT);
         }
         void setFormat(const std::string &format)
         {
@@ -1052,7 +1051,7 @@ inline PropertyView<T>::PropertyView()
 template <typename T>
 inline void PropertyView<T>::setDeviceName(const char *name)
 {
-    strncpy(this->device, name, MAXINDIDEVICE);
+    INDI::strlcpy(this->device, name, MAXINDIDEVICE);
 }
 
 template <typename T>
@@ -1064,7 +1063,7 @@ inline void PropertyView<T>::setDeviceName(const std::string &name)
 template <typename T>
 inline void PropertyView<T>::setName(const char *name)
 {
-    strncpy(this->name, name, MAXINDINAME);
+    INDI::strlcpy(this->name, name);
 }
 
 template <typename T>
@@ -1076,7 +1075,7 @@ inline void PropertyView<T>::setName(const std::string &name)
 template <typename T>
 inline void PropertyView<T>::setLabel(const char *label)
 {
-    strncpy(this->label, label, MAXINDILABEL);
+    INDI::strlcpy(this->label, label, MAXINDILABEL);
 }
 
 template <typename T>
@@ -1088,7 +1087,7 @@ inline void PropertyView<T>::setLabel(const std::string &label)
 template <typename T>
 inline void PropertyView<T>::setGroupName(const char *name)
 {
-    strncpy(this->group, name, MAXINDIGROUP);
+    INDI::strlcpy(this->group, name, MAXINDIGROUP);
 }
 
 template <typename T>
@@ -1106,7 +1105,7 @@ inline void PropertyView<T>::setState(IPState state)
 template <typename T>
 inline void PropertyView<T>::setTimestamp(const char *timestamp)
 {
-    strncpy(this->timestamp, timestamp, MAXINDITSTAMP);
+    INDI::strlcpy(this->timestamp, timestamp, MAXINDITSTAMP);
 }
 
 template <typename T>

--- a/libs/indibase/property/indiwidgettraits.h
+++ b/libs/indibase/property/indiwidgettraits.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "indiapi.h"
+#include "indiutility.h"
 
 namespace INDI
 {

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -1,0 +1,124 @@
+/*
+    Copyright (C) 2022 Pawel Soja <kernel32.pl@gmail.com>
+    Copyright (C) 2011 Jasem Mutlaq. All rights reserved.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#include "watchdeviceproperty.h"
+
+namespace INDI
+{
+
+std::vector<BaseDevice *> WatchDeviceProperty::getDevices() const
+{
+    std::vector<BaseDevice *> result;
+    for (const auto &it : data)
+    {
+        result.push_back(it.second.device.get());
+    }
+    return result;
+}
+
+BaseDevice *WatchDeviceProperty::getDeviceByName(const char *name) const
+{
+    auto it = data.find(name);
+    return it != data.end() ? it->second.device.get() : nullptr;
+}
+
+WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const char *name, const std::function<BaseDevice*()> &constructor)
+{
+    auto &it = data[name];
+    if (it.device == nullptr)
+    {
+        it.device.reset(constructor());
+        it.device->setDeviceName(name);
+        it.emitWatchDevice();
+    }
+    return it;
+}
+
+bool WatchDeviceProperty::isEmpty() const
+{
+    return data.empty();
+}
+
+bool WatchDeviceProperty::isDeviceWatched(const char *name) const
+{
+    return data.size() == 0 || data.find(name) != data.end();
+}
+
+void WatchDeviceProperty::clear()
+{
+    data.clear();
+}
+
+bool WatchDeviceProperty::deleteDevice(const BaseDevice *device)
+{
+    for (auto it = data.begin(); it != data.end();)
+    {
+        if (it->second.device.get() == device)
+        {
+            it = data.erase(it);
+            return true;
+        }
+        else
+            ++it;
+    }
+    return false;
+}
+
+int WatchDeviceProperty::processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice*()> &constructor)
+{
+    auto deviceName = root.getAttribute("device");
+    if (!deviceName.isValid() || deviceName.toString() == "" || !isDeviceWatched(deviceName))
+    {
+        return 0;
+    }
+
+    // Get the device information, if not available, create it
+    auto &deviceInfo = ensureDeviceByName(deviceName, constructor);
+
+    // If we are asked to watch for specific properties only, we ignore everything else
+    if (deviceInfo.properties.size() != 0)
+    {
+        const auto it = deviceInfo.properties.find(root.getAttribute("name").toString());
+        if (it == deviceInfo.properties.end())
+            return 0;
+    }
+
+    static const std::set<std::string> defVectors{
+        "defTextVector",  "defNumberVector", "defSwitchVector",
+        "defLightVector", "defBLOBVector"
+    };
+
+    if (defVectors.find(root.tagName()) != defVectors.end())
+    {
+        return deviceInfo.device->buildProp(root, errmsg);
+    }
+
+    static const std::set<std::string> setVectors{
+        "setTextVector",  "setNumberVector", "setSwitchVector",
+        "setLightVector", "setBLOBVector"
+    };
+
+    if (setVectors.find(root.tagName()) != setVectors.end())
+    {
+        return deviceInfo.device->setValue(root, errmsg);
+    }
+
+    return INDI_DISPATCH_ERROR;
+}
+
+}

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -44,6 +44,8 @@ WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const c
     {
         it.device.reset(constructor());
         it.device->setDeviceName(name);
+        if (auto mediator = it.device->getMediator())
+            mediator->newDevice(it.device.get());
         it.emitWatchDevice();
     }
     return it;

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -58,7 +58,29 @@ bool WatchDeviceProperty::isEmpty() const
 
 bool WatchDeviceProperty::isDeviceWatched(const char *name) const
 {
-    return data.size() == 0 || data.find(name) != data.end();
+    return watchedDevice.size() == 0 || watchedDevice.find(name) != watchedDevice.end();
+}
+
+void WatchDeviceProperty::unwatchDevices()
+{
+    watchedDevice.clear();
+}
+
+void WatchDeviceProperty::watchDevice(const std::string &deviceName)
+{
+    watchedDevice.insert(deviceName);
+}
+
+void WatchDeviceProperty::watchDevice(const std::string &deviceName, const std::function<void (BaseDevice)> &callback)
+{
+    watchedDevice.insert(deviceName);
+    data[deviceName].newDeviceCallback = callback;
+}
+
+void WatchDeviceProperty::watchProperty(const std::string &deviceName, const std::string &propertyName)
+{
+    watchedDevice.insert(deviceName);
+    data[deviceName].properties.insert(propertyName);
 }
 
 void WatchDeviceProperty::clear()

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -66,6 +66,14 @@ void WatchDeviceProperty::clear()
     data.clear();
 }
 
+void WatchDeviceProperty::clearDevices()
+{
+    for (auto &deviceInfo : data)
+    {
+        deviceInfo.second.device.reset(nullptr);
+    }
+}
+
 bool WatchDeviceProperty::deleteDevice(const BaseDevice *device)
 {
     for (auto it = data.begin(); it != data.end();)

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -69,6 +69,7 @@ class WatchDeviceProperty
 
     public:
         void clear();
+        void clearDevices();
         bool deleteDevice(const BaseDevice *device);
 
     public:

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -68,6 +68,13 @@ class WatchDeviceProperty
         bool isDeviceWatched(const char *deviceName) const;
 
     public:
+        void unwatchDevices();
+
+        void watchDevice(const std::string &deviceName);
+        void watchDevice(const std::string &deviceName, const std::function<void (BaseDevice)> &callback);
+
+        void watchProperty(const std::string &deviceName, const std::string &propertyName);
+
         void clear();
         void clearDevices();
         bool deleteDevice(const BaseDevice *device);
@@ -76,11 +83,6 @@ class WatchDeviceProperty
         int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice*()> &constructor = [](){ return new BaseDevice(); } );
 
     public:
-        DeviceInfo &operator[](const char *name)
-        {
-            return data[name];
-        }
-
         std::map<std::string, DeviceInfo>::iterator begin()
         {
             return data.begin();
@@ -92,6 +94,7 @@ class WatchDeviceProperty
         }
 
     protected:
+        std::set<std::string> watchedDevice;
         std::map<std::string, DeviceInfo> data;
 };
 

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -1,0 +1,97 @@
+/*
+    Copyright (C) 2022 Pawel Soja <kernel32.pl@gmail.com>
+    Copyright (C) 2011 Jasem Mutlaq. All rights reserved.
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include "basedevice.h"
+#include "indililxml.h"
+
+#include <functional>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace INDI
+{
+// Internal use only - Common implementatnion for client and driver side
+class WatchDeviceProperty
+{
+    public:
+        struct DeviceInfo
+        {
+            std::unique_ptr<BaseDevice> device;
+            std::function<void (BaseDevice)> newDeviceCallback; // call if device available
+            std::set<std::string> properties; // watch only specific properties only
+
+            void emitWatchDevice()
+            {
+                if (newDeviceCallback)
+                    newDeviceCallback(*device.get());
+            }
+        };
+
+    public:
+        static BaseDevice *baseDeviceConstructor()
+        {
+            return new BaseDevice;
+        }
+
+    public:
+        std::vector<BaseDevice *> getDevices() const;
+        BaseDevice *getDeviceByName(const char *name) const;
+        DeviceInfo &ensureDeviceByName(const char *name, const std::function<BaseDevice*()> &constructor);
+
+    public:
+        bool isEmpty() const;
+
+        /**
+         * @brief checks if the device is being watched by something
+         * 
+         * @param deviceName name of the searched device on the list
+         * @return true if the device is in the list or the list is empty 
+         */
+        bool isDeviceWatched(const char *deviceName) const;
+
+    public:
+        void clear();
+        bool deleteDevice(const BaseDevice *device);
+
+    public:
+        int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice*()> &constructor = [](){ return new BaseDevice(); } );
+
+    public:
+        DeviceInfo &operator[](const char *name)
+        {
+            return data[name];
+        }
+
+        std::map<std::string, DeviceInfo>::iterator begin()
+        {
+            return data.begin();
+        }
+
+        std::map<std::string, DeviceInfo>::iterator end()
+        {
+            return data.end();
+        }
+
+    protected:
+        std::map<std::string, DeviceInfo> data;
+};
+
+}

--- a/libs/indililxml.h
+++ b/libs/indililxml.h
@@ -1,0 +1,443 @@
+/*
+    Copyright (C) 2022 by Pawel Soja <kernel32.pl@gmail.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#pragma once
+
+#include "lilxml.h"
+#include "indiapi.h"
+#include "indicom.h"
+#include "indidevapi.h"
+
+#include <string>
+#include <functional>
+#include <list>
+#include <stdexcept>
+
+#include <cstring>
+
+namespace INDI
+{
+
+// helper
+template <typename T>
+class safe_ptr
+{
+    T fake, *ptr;
+
+public:
+    safe_ptr(T *ptr = nullptr): ptr(ptr ? ptr : &fake)
+    { }
+
+    T& operator *() { return *ptr; }
+    operator bool() const { return true; }
+};
+
+class LilXmlValue
+{
+public:
+    explicit LilXmlValue(const char *value);
+    explicit LilXmlValue(const char *value, size_t size);
+
+public:
+    bool isValid() const;
+    const void *data()  const;
+    size_t size() const;
+
+public:
+    int         toInt(safe_ptr<bool> ok = nullptr) const;
+    double      toDoubleSexa(safe_ptr<bool> ok = nullptr) const;
+    double      toDouble(safe_ptr<bool> ok = nullptr) const;
+    const char *toCString() const;
+    std::string toString() const;
+    ISState     toISState(safe_ptr<bool> ok = nullptr) const;
+    IPState     toIPState(safe_ptr<bool> ok = nullptr) const;
+    IPerm       toIPerm(safe_ptr<bool> ok = nullptr) const;
+
+public:
+    std::size_t indexOf(const char *needle, size_t from = 0) const;
+    std::size_t indexOf(const std::string &needle, size_t from = 0) const;
+
+    std::size_t lastIndexOf(const char *needle, size_t from = 0) const;
+    std::size_t lastIndexOf(const std::string &needle, size_t from = 0) const;
+
+    bool startsWith(const char *needle) const;
+    bool startsWith(const std::string &needle) const;
+
+    bool endsWith(const char *needle) const;
+    bool endsWith(const std::string &needle) const;
+
+public:
+    operator const char *() const { return toCString(); }
+    operator double  () const { return toDouble();  }
+    operator int     () const { return toInt();     }
+    operator ISState () const { return toISState(); }
+    operator IPState () const { return toIPState(); }
+    operator IPerm   () const { return toIPerm();   }
+    operator size_t  () const { return toInt();     }
+
+protected:
+    const char *mValue; 
+    size_t      mSize;
+};
+
+class LilXmlAttribute: public LilXmlValue
+{
+public:
+    explicit LilXmlAttribute(XMLAtt *a);
+
+public:
+    bool isValid() const;
+
+public:
+    std::string name() const;
+    const LilXmlValue &value() const { return *this; }
+
+public:
+    operator bool() const { return isValid(); }
+
+public:
+    XMLAtt *handle() const;
+
+protected:
+    XMLAtt *mHandle;
+};
+
+class LilXmlElement
+{
+public:
+    using Elements = std::list<LilXmlElement>; // or implement custom container/iterators
+
+public:
+    explicit LilXmlElement(XMLEle *e);
+
+public:
+    bool isValid() const;
+    std::string tagName() const;
+
+public:
+    Elements getElements() const;
+    Elements getElementsByTagName(const char *tagName) const;
+    LilXmlAttribute getAttribute(const char *name) const;
+    LilXmlValue context() const;
+
+public:
+    XMLEle *handle() const;
+
+protected:
+    XMLEle *mHandle;
+    char errmsg[128];
+};
+
+class LilXmlDocument
+{
+    LilXmlDocument(const LilXmlDocument &) = delete;
+    LilXmlDocument &operator=(const LilXmlDocument&) = delete;
+
+public:
+    explicit LilXmlDocument(XMLEle *root);
+    LilXmlDocument(LilXmlDocument &&other);
+    ~LilXmlDocument() = default;
+
+public:
+    bool isValid() const;
+    LilXmlElement root() const;
+
+protected:
+    std::unique_ptr<XMLEle, void(*)(XMLEle*)> mRoot;
+};
+
+class LilXmlParser
+{
+    LilXmlParser(const LilXmlDocument &) = delete;
+    LilXmlParser &operator=(const LilXmlDocument&) = delete;
+    LilXmlParser(LilXmlDocument &&) = delete;
+    LilXmlParser &operator=(LilXmlDocument &&) = delete;
+
+public:
+    LilXmlParser();
+    ~LilXmlParser() = default;
+
+public:
+    LilXmlDocument readFromFile(FILE *file);
+    LilXmlDocument readFromFile(const char *fileName);
+    LilXmlDocument readFromFile(const std::string &fileName);
+
+public:
+    const char *errorMessage() const;
+
+protected:
+    std::unique_ptr<LilXML, void(*)(LilXML *)> mHandle;
+    char mErrorMessage[MAXRBUF] = {0, };
+};
+
+
+
+// LilXmlValue Implementation
+inline LilXmlValue::LilXmlValue(const char *value)
+    : mValue(value)
+    , mSize(value ? strlen(value) : 0)
+{ }
+
+inline LilXmlValue::LilXmlValue(const char *value, size_t size)
+    : mValue(value)
+    , mSize(size)
+{ }
+
+inline bool LilXmlValue::isValid() const
+{
+    return mValue != nullptr;
+}
+
+inline const void *LilXmlValue::data() const
+{
+    return mValue;
+}
+
+inline size_t LilXmlValue::size() const
+{
+    return mSize;
+}
+
+inline int LilXmlValue::toInt(safe_ptr<bool> ok) const
+{
+    int result = 0;
+    try {
+        result = std::stoi(mValue);
+        *ok = true;
+    } catch (std::invalid_argument) {
+        *ok = false;
+    }
+    return result;
+}
+
+inline double LilXmlValue::toDoubleSexa(safe_ptr<bool> ok) const
+{
+    double result = 0;
+    *ok = (isValid() && f_scansexa(mValue, &result) >= 0);
+    return result;
+}
+
+inline double LilXmlValue::toDouble(safe_ptr<bool> ok) const
+{
+    double result = 0;
+    try {
+        result = std::stod(mValue);
+        *ok = true;
+    } catch (std::invalid_argument) {
+        *ok = false;
+    }
+    return result;
+}
+
+inline const char *LilXmlValue::toCString() const
+{
+    return isValid() ? mValue : "";
+}
+
+inline std::string LilXmlValue::toString() const
+{
+    return isValid() ? mValue : "";
+}
+
+inline ISState LilXmlValue::toISState(safe_ptr<bool> ok) const
+{
+    ISState state = ISS_OFF;
+    *ok = (isValid() && crackISState(mValue, &state) >= 0);
+    return state;
+}
+
+inline IPState LilXmlValue::toIPState(safe_ptr<bool> ok) const
+{
+    IPState state = IPS_OK;
+    *ok = (isValid() && crackIPState(mValue, &state) >= 0);
+    return state;
+}
+
+inline IPerm LilXmlValue::toIPerm(safe_ptr<bool> ok) const
+{
+    IPerm result = IP_RO;
+    *ok = (isValid() && crackIPerm(mValue, &result) >= 0);
+    return result;
+}
+
+inline std::size_t LilXmlValue::indexOf(const char *needle, size_t from) const
+{
+    return toString().find_first_of(needle, from);
+}
+
+inline std::size_t LilXmlValue::indexOf(const std::string &needle, size_t from) const
+{
+    return toString().find_first_of(needle, from);
+}
+
+inline std::size_t LilXmlValue::lastIndexOf(const char *needle, size_t from) const
+{
+    return toString().find_last_of(needle, from);
+}
+
+inline std::size_t LilXmlValue::lastIndexOf(const std::string &needle, size_t from) const
+{
+    return toString().find_last_of(needle, from);
+}
+
+inline bool LilXmlValue::startsWith(const char *needle) const
+{
+    return indexOf(needle) == 0;
+}
+
+inline bool LilXmlValue::startsWith(const std::string &needle) const
+{
+    return indexOf(needle) == 0;
+}
+
+inline bool LilXmlValue::endsWith(const char *needle) const
+{
+    return lastIndexOf(needle) == (size() - strlen(needle));
+}
+
+inline bool LilXmlValue::endsWith(const std::string &needle) const
+{
+    return lastIndexOf(needle) == (size() - needle.size());
+}
+
+// LilXmlAttribute Implementation
+
+inline LilXmlAttribute::LilXmlAttribute(XMLAtt *a)
+    : LilXmlValue(a ? valuXMLAtt(a) : nullptr)
+    , mHandle(a)
+{ }
+
+inline XMLAtt *LilXmlAttribute::handle() const
+{
+    return mHandle;
+}
+
+inline bool LilXmlAttribute::isValid() const
+{
+    return mHandle != nullptr;
+}
+
+
+inline std::string LilXmlAttribute::name() const
+{
+    return isValid() ? nameXMLAtt(mHandle) : "";
+}
+
+// LilXmlElement Implementation
+
+inline LilXmlElement::LilXmlElement(XMLEle *e)
+    : mHandle(e)
+{ }
+
+inline XMLEle *LilXmlElement::handle() const
+{
+    return mHandle;
+}
+
+inline std::string LilXmlElement::tagName() const
+{
+    return tagXMLEle(mHandle);
+}
+
+inline LilXmlElement::Elements LilXmlElement::getElements() const
+{
+    Elements result;
+    for (XMLEle *ep = nextXMLEle(mHandle, 1); ep != nullptr; ep = nextXMLEle(mHandle, 0))
+        result.push_back(LilXmlElement(ep));
+    return result;
+}
+
+inline LilXmlElement::Elements LilXmlElement::getElementsByTagName(const char *tagName) const
+{
+    LilXmlElement::Elements result;
+    for (XMLEle *ep = nextXMLEle(mHandle, 1); ep != nullptr; ep = nextXMLEle(mHandle, 0))
+    {
+        LilXmlElement element(ep);
+        if (element.tagName() == tagName)
+        {
+            result.push_back(element);
+        }
+    }
+    return result;
+}
+
+inline LilXmlAttribute LilXmlElement::getAttribute(const char *name) const
+{
+    return LilXmlAttribute(findXMLAtt(mHandle, name));
+}
+
+inline LilXmlValue LilXmlElement::context() const
+{
+    return LilXmlValue(pcdataXMLEle(mHandle), pcdatalenXMLEle(mHandle));
+}
+
+// LilXmlDocument Implementation
+
+inline LilXmlDocument::LilXmlDocument(XMLEle *root)
+    : mRoot(root, [](XMLEle* root) { if (root) delXMLEle(root); })
+{ }
+
+inline LilXmlDocument::LilXmlDocument(LilXmlDocument &&other)
+    : mRoot(std::exchange(other.mRoot, nullptr))
+{ }
+
+inline bool LilXmlDocument::isValid() const
+{
+    return mRoot != nullptr;
+}
+
+inline LilXmlElement LilXmlDocument::root() const
+{
+    return LilXmlElement(mRoot.get());
+}
+
+// LilXmlParser Implementation
+
+inline LilXmlParser::LilXmlParser()
+    : mHandle(newLilXML(), [](LilXML *handle) { delLilXML(handle); })
+{ }
+
+inline LilXmlDocument LilXmlParser::readFromFile(FILE *file)
+{
+    return LilXmlDocument(readXMLFile(file, mHandle.get(), mErrorMessage));
+}
+
+inline LilXmlDocument LilXmlParser::readFromFile(const char *fileName)
+{
+    FILE *fp = fopen(fileName, "r");
+    if (fp == nullptr)
+    {
+        snprintf(mErrorMessage, sizeof(mErrorMessage), "Error loading file %s", fileName);
+        return LilXmlDocument(nullptr);
+    }
+
+    LilXmlDocument result = readFromFile(fp);
+    fclose(fp);
+    return result;
+}
+
+inline LilXmlDocument LilXmlParser::readFromFile(const std::string &fileName)
+{
+    return readFromFile(fileName.c_str());
+}
+
+inline const char *LilXmlParser::errorMessage() const
+{
+    return mErrorMessage;
+}
+
+}

--- a/libs/indililxml.h
+++ b/libs/indililxml.h
@@ -36,152 +36,152 @@ namespace INDI
 template <typename T>
 class safe_ptr
 {
-    T fake, *ptr;
+        T fake, *ptr;
 
-public:
-    safe_ptr(T *ptr = nullptr): ptr(ptr ? ptr : &fake)
-    { }
+    public:
+        safe_ptr(T *ptr = nullptr): ptr(ptr ? ptr : &fake)
+        { }
 
-    T& operator *() { return *ptr; }
-    operator bool() const { return true; }
+        T& operator *() { return *ptr; }
+        operator bool() const { return true; }
 };
 
 class LilXmlValue
 {
-public:
-    explicit LilXmlValue(const char *value);
-    explicit LilXmlValue(const char *value, size_t size);
+    public:
+        explicit LilXmlValue(const char *value);
+        explicit LilXmlValue(const char *value, size_t size);
 
-public:
-    bool isValid() const;
-    const void *data()  const;
-    size_t size() const;
+    public:
+        bool isValid() const;
+        const void *data()  const;
+        size_t size() const;
 
-public:
-    int         toInt(safe_ptr<bool> ok = nullptr) const;
-    double      toDoubleSexa(safe_ptr<bool> ok = nullptr) const;
-    double      toDouble(safe_ptr<bool> ok = nullptr) const;
-    const char *toCString() const;
-    std::string toString() const;
-    ISState     toISState(safe_ptr<bool> ok = nullptr) const;
-    IPState     toIPState(safe_ptr<bool> ok = nullptr) const;
-    IPerm       toIPerm(safe_ptr<bool> ok = nullptr) const;
+    public:
+        int         toInt(safe_ptr<bool> ok = nullptr) const;
+        double      toDoubleSexa(safe_ptr<bool> ok = nullptr) const;
+        double      toDouble(safe_ptr<bool> ok = nullptr) const;
+        const char *toCString() const;
+        std::string toString() const;
+        ISState     toISState(safe_ptr<bool> ok = nullptr) const;
+        IPState     toIPState(safe_ptr<bool> ok = nullptr) const;
+        IPerm       toIPerm(safe_ptr<bool> ok = nullptr) const;
 
-public:
-    std::size_t indexOf(const char *needle, size_t from = 0) const;
-    std::size_t indexOf(const std::string &needle, size_t from = 0) const;
+    public:
+        std::size_t indexOf(const char *needle, size_t from = 0) const;
+        std::size_t indexOf(const std::string &needle, size_t from = 0) const;
 
-    std::size_t lastIndexOf(const char *needle, size_t from = 0) const;
-    std::size_t lastIndexOf(const std::string &needle, size_t from = 0) const;
+        std::size_t lastIndexOf(const char *needle, size_t from = 0) const;
+        std::size_t lastIndexOf(const std::string &needle, size_t from = 0) const;
 
-    bool startsWith(const char *needle) const;
-    bool startsWith(const std::string &needle) const;
+        bool startsWith(const char *needle) const;
+        bool startsWith(const std::string &needle) const;
 
-    bool endsWith(const char *needle) const;
-    bool endsWith(const std::string &needle) const;
+        bool endsWith(const char *needle) const;
+        bool endsWith(const std::string &needle) const;
 
-public:
-    operator const char *() const { return toCString(); }
-    operator double  () const { return toDouble();  }
-    operator int     () const { return toInt();     }
-    operator ISState () const { return toISState(); }
-    operator IPState () const { return toIPState(); }
-    operator IPerm   () const { return toIPerm();   }
-    operator size_t  () const { return toInt();     }
+    public:
+        operator const char *() const { return toCString(); }
+        operator double  () const { return toDouble();  }
+        operator int     () const { return toInt();     }
+        operator ISState () const { return toISState(); }
+        operator IPState () const { return toIPState(); }
+        operator IPerm   () const { return toIPerm();   }
+        operator size_t  () const { return toInt();     }
 
-protected:
-    const char *mValue; 
-    size_t      mSize;
+    protected:
+        const char *mValue; 
+        size_t      mSize;
 };
 
 class LilXmlAttribute: public LilXmlValue
 {
-public:
-    explicit LilXmlAttribute(XMLAtt *a);
+    public:
+        explicit LilXmlAttribute(XMLAtt *a);
 
-public:
-    bool isValid() const;
+    public:
+        bool isValid() const;
 
-public:
-    std::string name() const;
-    const LilXmlValue &value() const { return *this; }
+    public:
+        std::string name() const;
+        const LilXmlValue &value() const { return *this; }
 
-public:
-    operator bool() const { return isValid(); }
+    public:
+        operator bool() const { return isValid(); }
 
-public:
-    XMLAtt *handle() const;
+    public:
+        XMLAtt *handle() const;
 
-protected:
-    XMLAtt *mHandle;
+    protected:
+        XMLAtt *mHandle;
 };
 
 class LilXmlElement
 {
-public:
-    using Elements = std::list<LilXmlElement>; // or implement custom container/iterators
+    public:
+        using Elements = std::list<LilXmlElement>; // or implement custom container/iterators
 
-public:
-    explicit LilXmlElement(XMLEle *e);
+    public:
+        explicit LilXmlElement(XMLEle *e);
 
-public:
-    bool isValid() const;
-    std::string tagName() const;
+    public:
+        bool isValid() const;
+        std::string tagName() const;
 
-public:
-    Elements getElements() const;
-    Elements getElementsByTagName(const char *tagName) const;
-    LilXmlAttribute getAttribute(const char *name) const;
-    LilXmlValue context() const;
+    public:
+        Elements getElements() const;
+        Elements getElementsByTagName(const char *tagName) const;
+        LilXmlAttribute getAttribute(const char *name) const;
+        LilXmlValue context() const;
 
-public:
-    XMLEle *handle() const;
+    public:
+        XMLEle *handle() const;
 
-protected:
-    XMLEle *mHandle;
-    char errmsg[128];
+    protected:
+        XMLEle *mHandle;
+        char errmsg[128];
 };
 
 class LilXmlDocument
 {
-    LilXmlDocument(const LilXmlDocument &) = delete;
-    LilXmlDocument &operator=(const LilXmlDocument&) = delete;
+        LilXmlDocument(const LilXmlDocument &) = delete;
+        LilXmlDocument &operator=(const LilXmlDocument&) = delete;
 
-public:
-    explicit LilXmlDocument(XMLEle *root);
-    LilXmlDocument(LilXmlDocument &&other);
-    ~LilXmlDocument() = default;
+    public:
+        explicit LilXmlDocument(XMLEle *root);
+        LilXmlDocument(LilXmlDocument &&other);
+        ~LilXmlDocument() = default;
 
-public:
-    bool isValid() const;
-    LilXmlElement root() const;
+    public:
+        bool isValid() const;
+        LilXmlElement root() const;
 
-protected:
-    std::unique_ptr<XMLEle, void(*)(XMLEle*)> mRoot;
+    protected:
+        std::unique_ptr<XMLEle, void(*)(XMLEle*)> mRoot;
 };
 
 class LilXmlParser
 {
-    LilXmlParser(const LilXmlDocument &) = delete;
-    LilXmlParser &operator=(const LilXmlDocument&) = delete;
-    LilXmlParser(LilXmlDocument &&) = delete;
-    LilXmlParser &operator=(LilXmlDocument &&) = delete;
+        LilXmlParser(const LilXmlDocument &) = delete;
+        LilXmlParser &operator=(const LilXmlDocument&) = delete;
+        LilXmlParser(LilXmlDocument &&) = delete;
+        LilXmlParser &operator=(LilXmlDocument &&) = delete;
 
-public:
-    LilXmlParser();
-    ~LilXmlParser() = default;
+    public:
+        LilXmlParser();
+        ~LilXmlParser() = default;
 
-public:
-    LilXmlDocument readFromFile(FILE *file);
-    LilXmlDocument readFromFile(const char *fileName);
-    LilXmlDocument readFromFile(const std::string &fileName);
+    public:
+        LilXmlDocument readFromFile(FILE *file);
+        LilXmlDocument readFromFile(const char *fileName);
+        LilXmlDocument readFromFile(const std::string &fileName);
 
-public:
-    const char *errorMessage() const;
+    public:
+        const char *errorMessage() const;
 
-protected:
-    std::unique_ptr<LilXML, void(*)(LilXML *)> mHandle;
-    char mErrorMessage[MAXRBUF] = {0, };
+    protected:
+        std::unique_ptr<LilXML, void(*)(LilXML *)> mHandle;
+        char mErrorMessage[MAXRBUF] = {0, };
 };
 
 

--- a/libs/indililxml.h
+++ b/libs/indililxml.h
@@ -247,7 +247,7 @@ inline double LilXmlValue::toDouble(safe_ptr<bool> ok) const
     try {
         result = std::stod(mValue);
         *ok = true;
-    } catch (const std::invalid_argument &) {
+    } catch (...) {
         *ok = false;
     }
     return result;

--- a/libs/indililxml.h
+++ b/libs/indililxml.h
@@ -136,6 +136,7 @@ class LilXmlElement
         void removeAttribute(const char *name);
 
         LilXmlValue context() const;
+        void setContext(const char *data);
 
         void print(FILE *f, int level = 0) const;
 
@@ -365,6 +366,9 @@ inline std::string LilXmlElement::tagName() const
 inline LilXmlElement::Elements LilXmlElement::getElements() const
 {
     Elements result;
+    if (handle() == nullptr)
+        return result;
+
     for (XMLEle *ep = nextXMLEle(mHandle, 1); ep != nullptr; ep = nextXMLEle(mHandle, 0))
         result.push_back(LilXmlElement(ep));
     return result;
@@ -373,6 +377,9 @@ inline LilXmlElement::Elements LilXmlElement::getElements() const
 inline LilXmlElement::Elements LilXmlElement::getElementsByTagName(const char *tagName) const
 {
     LilXmlElement::Elements result;
+    if (handle() == nullptr)
+        return result;
+
     for (XMLEle *ep = nextXMLEle(mHandle, 1); ep != nullptr; ep = nextXMLEle(mHandle, 0))
     {
         LilXmlElement element(ep);
@@ -402,6 +409,11 @@ inline void LilXmlElement::removeAttribute(const char *name)
 inline LilXmlValue LilXmlElement::context() const
 {
     return LilXmlValue(pcdataXMLEle(mHandle), pcdatalenXMLEle(mHandle));
+}
+
+inline void LilXmlElement::setContext(const char *data)
+{
+    editXMLEle(mHandle, data);
 }
 
 inline void LilXmlElement::print(FILE *f, int level) const

--- a/libs/indililxml.h
+++ b/libs/indililxml.h
@@ -218,7 +218,7 @@ inline int LilXmlValue::toInt(safe_ptr<bool> ok) const
     try {
         result = std::stoi(mValue);
         *ok = true;
-    } catch (std::invalid_argument) {
+    } catch (const std::invalid_argument &) {
         *ok = false;
     }
     return result;
@@ -237,7 +237,7 @@ inline double LilXmlValue::toDouble(safe_ptr<bool> ok) const
     try {
         result = std::stod(mValue);
         *ok = true;
-    } catch (std::invalid_argument) {
+    } catch (const std::invalid_argument &) {
         *ok = false;
     }
     return result;


### PR DESCRIPTION
Hi!

Event service for INDI::Property
Example:
```cpp
mRainSwitch[0].fill("On", "");
mRainSwitch[1].fill("Off", "");
mRainSwitch.fill(getDeviceName(), "Control Rain", "", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);

mRainSwitch.onUpdate([this]() // new method
{
    if (mRainSwitch[0].getState() == ISS_ON)
    {
        mRainLight[0].setState(IPS_ALERT);
        mRainLight.setState(IPS_ALERT);
        mRainLight.apply("Alert! Alert! Rain detected!");
    }
    else
    {
        mRainLight[0].setState(IPS_IDLE);
        mRainLight.setState(IPS_OK);
        mRainLight.apply("Rain threat passed. The skies are clear.");
    }
    mRainSwitch.setState(IPS_OK);
    mRainSwitch.apply();
});
```
There are 2 events to choose from:
- onUpdate - updates values appropriate for the type (Switch / Number / Text / Blob) and then performs the function
- onNewValues - turns off the automatic updating of values and performs the function passing new values in the form of a map - currently implemented only for Switch

The changes are backwards compatible.
This will allow you to get rid of completely in the future:
- DefaultDevice :: ISNewSwitch
- DefaultDevice :: ISNewNumber
- DefaultDevice :: ISNewText
- DefaultDevice :: ISNewBLOB

I updated the "tutorial_five" example, which now shows how to use onUpdate.
If the feature is approved, I'd like to use it to simplify indi and indi-3rdparty.
Of course, the new indi-3rdparty will lose compatibility with the older indi libraries.
