### PR TITLE
DRIVER_INFO also present for F2 focuser so that the device is detected

### DIFF
--- a/drivers/focuser/focuslynx.cpp
+++ b/drivers/focuser/focuslynx.cpp
@@ -770,7 +770,6 @@ bool FocusLynxF2::initProperties()
 {
     FocusLynxBase::initProperties();
     // Remove from F2 to avoid confusion, already present on F1
-    deleteProperty("DRIVER_INFO");
     deleteProperty("SIMULATION");
     // deleteProperty("POLLING_PERIOD");
     return true;


### PR DESCRIPTION
EKOS uses the DRIVER_INFO to detect INDI devices, therefore also the second focuser needs to provide this info.