### PR TITLE
DeepSkyDad AF3: Mark as OK after backlash compensation

### DIFF
--- a/drivers/focuser/deepskydad_af3.cpp
+++ b/drivers/focuser/deepskydad_af3.cpp
@@ -804,8 +804,10 @@ void DeepSkyDadAF3::TimerHit()
     {
         if (!isMoving())
         {
-            FocusAbsPosNP.s = IPS_OK;
-            FocusRelPosNP.s = IPS_OK;
+            if( backlashComp == 0 ) {
+                FocusAbsPosNP.s = IPS_OK;
+                FocusRelPosNP.s = IPS_OK;
+            }
             IDSetNumber(&FocusAbsPosNP, nullptr);
             IDSetNumber(&FocusRelPosNP, nullptr);
             lastPos = FocusAbsPosN[0].value;


### PR DESCRIPTION
Otherwise the restart of focus procedure may start to early: 

https://invent.kde.org/education/kstars/-/issues/224