### PR TITLE
Improved star brightness handling for higher gain

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -523,8 +523,7 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
     else
         exposure_time = ExposureRequest;
 
-    auto gain = std::max(10.0, GainN[0].value);
-    exposure_time *= sqrt(gain) / 10.0;
+    exposure_time *= (1 + sqrt(GainN[0].value));
 
     auto targetFocalLength = ScopeInfoNP[FocalLength].getValue() > 0 ? ScopeInfoNP[FocalLength].getValue() : snoopedFocalLength;
 

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -800,7 +800,7 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
         if (ftype == INDI::CCDChip::LIGHT_FRAME || ftype == INDI::CCDChip::FLAT_FRAME)
         {
             //  calculate flux from our zero point and gain values
-            float glow = m_SkyGlow;
+            float glow = m_SkyGlow * 1.3;
 
             if (ftype == INDI::CCDChip::FLAT_FRAME)
             {

--- a/drivers/ccd/guide_simulator.cpp
+++ b/drivers/ccd/guide_simulator.cpp
@@ -392,8 +392,7 @@ int GuideSim::DrawCcdFrame(INDI::CCDChip * targetChip)
     else
         exposure_time = ExposureRequest;
 
-    auto gain = std::max(10.0, GainN[0].value);
-    exposure_time *= sqrt(gain) / 10.0;
+    exposure_time *= (1 + sqrt(GainN[0].value));
 
     auto targetFocalLength = ScopeInfoNP[FocalLength].getValue() > 0 ? ScopeInfoNP[FocalLength].getValue() : snoopedFocalLength;
 


### PR DESCRIPTION
To enhance star brightness for higher gains, the exposure time is multiplied by (1+sqrt(gain)) when using star creation with GSC. This improves star detection in the simulators for focusing, alignment and guiding.