### PR TITLE
Shared pointers for INDI::BaseDevice

### DIFF
--- a/libs/indibase/abstractbaseclient.h
+++ b/libs/indibase/abstractbaseclient.h
@@ -125,10 +125,20 @@ class AbstractBaseClient : public INDI::BaseMediator
         /** @param deviceName Name of device to search for in the list of devices owned by INDI server,
          *  @returns If \e deviceName exists, it returns an instance of the device. Otherwise, it returns NULL.
          */
+        [[deprecated("Use getSharedDevice(const char *, std::shared_ptr<INDI::BaseDevice> &).")]]
         INDI::BaseDevice *getDevice(const char *deviceName);
 
+        /** @param deviceName Name of device to search for in the list of devices owned by INDI server,
+         *  @param dp shared pointer to device, if found.
+         *  @returns If \e deviceName exists, it returns true, otherwise false.
+         */
+        bool getSharedDevice(const char *deviceName, std::shared_ptr<BaseDevice> &dp);
+
         /** @returns Returns a vector of all devices created in the client. */
+        [[deprecated("Use getSharedDevices().")]]
         std::vector<INDI::BaseDevice *> getDevices() const;
+
+        std::vector<std::shared_ptr<INDI::BaseDevice>> getSharedDevices() const;
 
         /** @brief getDevices Returns list of devices that belong to a particular @ref INDI::BaseDevice::DRIVER_INTERFACE "DRIVER_INTERFACE" class.
          *
@@ -223,15 +233,29 @@ class AbstractBaseClient : public INDI::BaseMediator
         virtual void newUniversalMessage(std::string message);
 
     protected: // override INDI::BaseMediator methods, when they are not needed
+
+        [[deprecated]]
         virtual void newDevice(INDI::BaseDevice *dp) override;
+        virtual void newDevice(const std::shared_ptr<INDI::BaseDevice> &dp) override;
+
+        [[deprecated]]
         virtual void removeDevice(INDI::BaseDevice *dp) override;
+        virtual void removeDevice(const std::shared_ptr<INDI::BaseDevice> &dp) override;
+
+        [[deprecated]]
         virtual void newProperty(INDI::Property *property) override;
+        virtual void newProperty(INDI::Property property) override;
+
+        [[deprecated]]
         virtual void removeProperty(INDI::Property *property) override;
+        virtual void removeProperty(INDI::Property property) override;
+
         virtual void newBLOB(IBLOB *bp) override;
         virtual void newSwitch(ISwitchVectorProperty *svp) override;
         virtual void newNumber(INumberVectorProperty *nvp) override;
         virtual void newText(ITextVectorProperty *tvp) override;
         virtual void newLight(ILightVectorProperty *lvp) override;
+
         virtual void newMessage(INDI::BaseDevice *dp, int messageID) override;
         virtual void serverConnected() override;
 

--- a/libs/indibase/indibase.h
+++ b/libs/indibase/indibase.h
@@ -4,6 +4,7 @@
 #include "indiapi.h"
 #include "indidevapi.h"
 #include "indibasetypes.h"
+#include <memory>
 
 #define MAXRBUF 2048
 
@@ -85,22 +86,46 @@ class INDI::BaseMediator
         /** @brief Emmited when a new device is created from INDI server.
          *  @param dp Pointer to the base device instance
          */
+        [[deprecated("Use newDevice(INDI::BaseDevice).")]]
         virtual void newDevice(INDI::BaseDevice *dp) = 0;
+
+        /** @brief Emmited when a new device is created from INDI server.
+         *  @param dp Shared Pointer to the base device instance
+         */
+        virtual void newDevice(const std::shared_ptr<INDI::BaseDevice> &dp) = 0;
 
         /** @brief Emmited when a device is deleted from INDI server.
          *  @param dp Pointer to the base device instance.
          */
+        [[deprecated("Use removeDevice(INDI::BaseDevice).")]]
         virtual void removeDevice(INDI::BaseDevice *dp) = 0;
+
+        /** @brief Emmited when a device is deleted from INDI server.
+         *  @param dp Shared Pointer to the base device instance.
+         */
+        virtual void removeDevice(const std::shared_ptr<INDI::BaseDevice> &dp) = 0;
 
         /** @brief Emmited when a new property is created for an INDI driver.
          *  @param property Pointer to the Property Container
          */
+        [[deprecated("Use newProperty(INDI::Property).")]]
         virtual void newProperty(INDI::Property *property) = 0;
+
+        /** @brief Emmited when a new property is created for an INDI driver.
+         *  @param property Shared Pointer to the Property Container
+         */
+        virtual void newProperty(INDI::Property property) = 0;
 
         /** @brief Emmited when a property is deleted for an INDI driver.
          *  @param property Pointer to the Property Container to remove.
          */
+        [[deprecated("Use removeProperty(INDI::Property).")]]
         virtual void removeProperty(INDI::Property *property) = 0;
+
+        /** @brief Emmited when a property is deleted for an INDI driver.
+         *  @param property Shared Pointer to the Property Container to remove.
+         */
+        virtual void removeProperty(INDI::Property property) = 0;
 
         /** @brief Emmited when a new BLOB value arrives from INDI server.
          *  @param bp Pointer to filled and process BLOB.

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -34,7 +34,7 @@ class WatchDeviceProperty
     public:
         struct DeviceInfo
         {
-            std::unique_ptr<BaseDevice> device;
+            std::shared_ptr<BaseDevice> device;
             std::function<void (BaseDevice)> newDeviceCallback; // call if device available
             std::set<std::string> properties; // watch only specific properties only
 
@@ -52,8 +52,11 @@ class WatchDeviceProperty
         }
 
     public:
+        [[deprecated]]
         std::vector<BaseDevice *> getDevices() const;
-        BaseDevice *getDeviceByName(const char *name) const;
+        std::vector<std::shared_ptr<BaseDevice>> getSharedDevices() const;
+
+        bool getDeviceByName(const char *name, std::shared_ptr<BaseDevice> &device) const;
         DeviceInfo &ensureDeviceByName(const char *name, const std::function<BaseDevice*()> &constructor);
 
     public:
@@ -77,7 +80,7 @@ class WatchDeviceProperty
 
         void clear();
         void clearDevices();
-        bool deleteDevice(const BaseDevice *device);
+        bool deleteDevice(const std::shared_ptr<BaseDevice> &device);
 
     public:
         int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice*()> &constructor = [](){ return new BaseDevice(); } );


### PR DESCRIPTION
This would ensure that references to INDi::BaseDevice are safe in memory when shared among clients.