### PR TITLE
Built-in shared pointers for INDI::BaseDevice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,6 +206,7 @@ SET(indiclient_C_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/base64.c)
 
 SET(indiclient_CXX_SRC
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/parentdevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclient.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indibase.cpp
@@ -241,7 +242,7 @@ SET(indiclient_C_SRC ${indiclient_C_SRC}
 add_library(indiclient STATIC ${indiclient_C_SRC} ${indiclient_CXX_SRC})
 
 add_subdirectory(libs/sockets)
-target_link_libraries(indiclient sockets)
+target_link_libraries(indiclient sockets ${ZLIB_LIBRARY})
 
 if (NOT CYGWIN AND NOT WIN32)
 set_target_properties(indiclient PROPERTIES COMPILE_FLAGS "-fPIC")
@@ -299,6 +300,7 @@ SET(indiclientqt_C_SRC
     
 SET(indiclientqt_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/parentdevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclientqt.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indibase.cpp
@@ -495,6 +497,7 @@ SET(indidriver_C_SRC
 
 SET(indidriver_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/parentdevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/defaultdevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/watchdeviceproperty.cpp
@@ -2198,6 +2201,7 @@ if (INDI_BUILD_DRIVERS OR INDI_BUILD_CLIENT OR INDI_BUILD_QT5_CLIENT)
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indibase.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indibasetypes.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/parentdevice.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/defaultdevice.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indiccd.h
         ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indiccdchip.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ SET(indiclient_C_SRC
 SET(indiclient_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclient.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indibase.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/abstractbaseclient.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/watchdeviceproperty.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
@@ -300,6 +301,7 @@ SET(indiclientqt_CXX_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/libastro.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/basedevice.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/baseclientqt.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/indibase.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/abstractbaseclient.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperty.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/libs/indibase/property/indiproperties.cpp

--- a/drivers/agent/agent_imager.h
+++ b/drivers/agent/agent_imager.h
@@ -45,16 +45,12 @@ class Imager : public virtual INDI::DefaultDevice, public virtual INDI::BaseClie
 
         // BaseClient
 
-        virtual void newDevice(INDI::BaseDevice *dp) override;
-        virtual void newProperty(INDI::Property *property) override;
-        virtual void removeProperty(INDI::Property *property) override;
-        virtual void removeDevice(INDI::BaseDevice *dp) override;
+        virtual void newDevice(INDI::BaseDevice baseDevice) override;
+        virtual void newProperty(INDI::Property property) override;
         virtual void newBLOB(IBLOB *bp) override;
-        virtual void newSwitch(ISwitchVectorProperty *svp) override;
-        virtual void newNumber(INumberVectorProperty *nvp) override;
-        virtual void newText(ITextVectorProperty *tvp) override;
-        virtual void newLight(ILightVectorProperty *lvp) override;
-        virtual void newMessage(INDI::BaseDevice *dp, int messageID) override;
+        virtual void newSwitch(INDI::PropertySwitch property) override;
+        virtual void newNumber(INDI::PropertyNumber property) override;
+        virtual void newText(INDI::PropertyText property) override;
         virtual void serverConnected() override;
         virtual void serverDisconnected(int exit_code) override;
 

--- a/drivers/agent/agent_imager.h
+++ b/drivers/agent/agent_imager.h
@@ -47,10 +47,8 @@ class Imager : public virtual INDI::DefaultDevice, public virtual INDI::BaseClie
 
         virtual void newDevice(INDI::BaseDevice baseDevice) override;
         virtual void newProperty(INDI::Property property) override;
-        virtual void newBLOB(IBLOB *bp) override;
-        virtual void newSwitch(INDI::PropertySwitch property) override;
-        virtual void newNumber(INDI::PropertyNumber property) override;
-        virtual void newText(INDI::PropertyText property) override;
+        virtual void updateProperty(INDI::Property property) override;
+
         virtual void serverConnected() override;
         virtual void serverDisconnected(int exit_code) override;
 

--- a/examples/tutorial_six/tutorial_client.cpp
+++ b/examples/tutorial_six/tutorial_client.cpp
@@ -159,12 +159,12 @@ void MyClient::takeExposure(double seconds)
 /**************************************************************************************
 **
 ***************************************************************************************/
-void MyClient::newMessage(INDI::BaseDevice *dp, int messageID)
+void MyClient::newMessage(INDI::BaseDevice baseDevice, int messageID)
 {
-    if (!dp->isDeviceNameMatch("Simple CCD"))
+    if (!baseDevice.isDeviceNameMatch("Simple CCD"))
         return;
 
     IDLog("Recveing message from Server:\n"
           "    %s\n\n", 
-          dp->messageQueue(messageID).c_str());
+          baseDevice.messageQueue(messageID).c_str());
 }

--- a/examples/tutorial_six/tutorial_client.h
+++ b/examples/tutorial_six/tutorial_client.h
@@ -48,7 +48,7 @@ class MyClient : public INDI::BaseClient
         void takeExposure(double seconds);
 
     protected:
-        void newMessage(INDI::BaseDevice *dp, int messageID) override;
+        void newMessage(INDI::BaseDevice baseDevice, int messageID) override;
 
     private:
         INDI::BaseDevice mSimpleCCD;

--- a/libs/indibase/abstractbaseclient.cpp
+++ b/libs/indibase/abstractbaseclient.cpp
@@ -72,7 +72,7 @@ int AbstractBaseClientPrivate::dispatchCommand(const LilXmlElement &root, char *
     // Ignore echoed newXXX
     if (root.tagName().find("new") == 0)
     {
-        return 0;       
+        return 0;
     }
 
     if (root.tagName() == "pingRequest")
@@ -114,7 +114,8 @@ int AbstractBaseClientPrivate::dispatchCommand(const LilXmlElement &root, char *
         return 0;
     }
 
-    return watchDevice.processXml(root, errmsg, [this]() { // create new device if nessesery
+    return watchDevice.processXml(root, errmsg, [this]  // create new device if nessesery
+    {
         BaseDevice *device = new BaseDevice();
         device->setMediator(parent);
         return device;
@@ -405,7 +406,7 @@ std::vector<BaseDevice> AbstractBaseClient::getDevices() const
 bool AbstractBaseClient::getDevices(std::vector<BaseDevice> &deviceList, uint16_t driverInterface )
 {
     D_PTR(AbstractBaseClient);
-    for (auto &it: d->watchDevice)
+    for (auto &it : d->watchDevice)
     {
         if (it.second.device.getDriverInterface() & driverInterface)
             deviceList.push_back(it.second.device);

--- a/libs/indibase/abstractbaseclient.cpp
+++ b/libs/indibase/abstractbaseclient.cpp
@@ -22,6 +22,9 @@
 #include "abstractbaseclient.h"
 #include "abstractbaseclient_p.h"
 
+#include "basedevice.h"
+#include "basedevice_p.h"
+
 #include "indiuserio.h"
 #include "locale_compat.h"
 #include "indistandardproperty.h"
@@ -122,7 +125,7 @@ int AbstractBaseClientPrivate::deleteDevice(const char *devName, char *errmsg)
 {
     if (auto device = watchDevice.getDeviceByName(devName))
     {
-        parent->removeDevice(device);
+        device.d_ptr->mediateRemoveDevice();
         watchDevice.deleteDevice(device);
         return 0;
     }
@@ -157,7 +160,9 @@ int AbstractBaseClientPrivate::delPropertyCmd(const LilXmlElement &root, char *e
     if (auto property = dp.getProperty(propertyName))
     {
         if (sConnected)
-            parent->removeProperty(property);
+        {
+            dp.d_ptr->mediateRemoveProperty(property);
+        }
         return dp.removeProperty(propertyName, errmsg);
     }
 

--- a/libs/indibase/abstractbaseclient.cpp
+++ b/libs/indibase/abstractbaseclient.cpp
@@ -116,7 +116,7 @@ int AbstractBaseClientPrivate::dispatchCommand(const LilXmlElement &root, char *
 
     return watchDevice.processXml(root, errmsg, [this]  // create new device if nessesery
     {
-        BaseDevice device;
+        ParentDevice device(ParentDevice::Valid);
         device.setMediator(parent);
         return device;
     });

--- a/libs/indibase/abstractbaseclient.cpp
+++ b/libs/indibase/abstractbaseclient.cpp
@@ -614,45 +614,6 @@ void AbstractBaseClient::newUniversalMessage(std::string message)
     IDLog("%s\n", message.c_str());
 }
 
-void AbstractBaseClient::newDevice(INDI::BaseDevice *)
-{ }
-
-void AbstractBaseClient::removeDevice(INDI::BaseDevice *)
-{ }
-
-void AbstractBaseClient::newProperty(INDI::Property *)
-{ }
-
-void AbstractBaseClient::removeProperty(INDI::Property *)
-{ }
-
-void AbstractBaseClient::newBLOB(IBLOB *)
-{ }
-
-void AbstractBaseClient::newSwitch(ISwitchVectorProperty *)
-{ }
-
-void AbstractBaseClient::newNumber(INumberVectorProperty *)
-{ }
-
-void AbstractBaseClient::newText(ITextVectorProperty *)
-{ }
-
-void AbstractBaseClient::newLight(ILightVectorProperty *)
-{ }
-
-void AbstractBaseClient::newMessage(INDI::BaseDevice *, int)
-{ }
-
-void AbstractBaseClient::serverConnected()
-{ }
-
-// avoid calling pure virtual method from destructor
-void AbstractBaseClient::serverDisconnected(int exit_code)
-{
-    INDI_UNUSED(exit_code);
-}
-
 }
 
 #if defined(_MSC_VER)

--- a/libs/indibase/abstractbaseclient.cpp
+++ b/libs/indibase/abstractbaseclient.cpp
@@ -126,7 +126,7 @@ int AbstractBaseClientPrivate::deleteDevice(const char *devName, char *errmsg)
 {
     if (auto device = watchDevice.getDeviceByName(devName))
     {
-        device.d_ptr->mediateRemoveDevice(device);
+        device.detach();
         watchDevice.deleteDevice(device);
         return 0;
     }

--- a/libs/indibase/abstractbaseclient.cpp
+++ b/libs/indibase/abstractbaseclient.cpp
@@ -126,7 +126,7 @@ int AbstractBaseClientPrivate::deleteDevice(const char *devName, char *errmsg)
 {
     if (auto device = watchDevice.getDeviceByName(devName))
     {
-        device.d_ptr->mediateRemoveDevice();
+        device.d_ptr->mediateRemoveDevice(device);
         watchDevice.deleteDevice(device);
         return 0;
     }

--- a/libs/indibase/abstractbaseclient.cpp
+++ b/libs/indibase/abstractbaseclient.cpp
@@ -116,8 +116,8 @@ int AbstractBaseClientPrivate::dispatchCommand(const LilXmlElement &root, char *
 
     return watchDevice.processXml(root, errmsg, [this]  // create new device if nessesery
     {
-        BaseDevice *device = new BaseDevice();
-        device->setMediator(parent);
+        BaseDevice device;
+        device.setMediator(parent);
         return device;
     });
 }

--- a/libs/indibase/abstractbaseclient.h
+++ b/libs/indibase/abstractbaseclient.h
@@ -222,24 +222,9 @@ class AbstractBaseClient : public INDI::BaseMediator
          */
         virtual void newUniversalMessage(std::string message);
 
-    protected: // override INDI::BaseMediator methods, when they are not needed
-        virtual void newDevice(INDI::BaseDevice *dp) override;
-        virtual void removeDevice(INDI::BaseDevice *dp) override;
-        virtual void newProperty(INDI::Property *property) override;
-        virtual void removeProperty(INDI::Property *property) override;
-        virtual void newBLOB(IBLOB *bp) override;
-        virtual void newSwitch(ISwitchVectorProperty *svp) override;
-        virtual void newNumber(INumberVectorProperty *nvp) override;
-        virtual void newText(ITextVectorProperty *tvp) override;
-        virtual void newLight(ILightVectorProperty *lvp) override;
-        virtual void newMessage(INDI::BaseDevice *dp, int messageID) override;
-        virtual void serverConnected() override;
-
     protected:
         friend class BaseClientPrivate;
         friend class BaseClientQtPrivate;
-        // avoid calling pure virtual method from destructor
-        void serverDisconnected(int exit_code) override;
 
     protected:
         AbstractBaseClient(std::unique_ptr<AbstractBaseClientPrivate> &&dd);

--- a/libs/indibase/abstractbaseclient.h
+++ b/libs/indibase/abstractbaseclient.h
@@ -249,3 +249,7 @@ class AbstractBaseClient : public INDI::BaseMediator
 };
 
 }
+
+#ifdef SWIG
+%template(BaseDeviceVectorShared) std::vector<INDI::BaseDevice>;
+#endif

--- a/libs/indibase/abstractbaseclient.h
+++ b/libs/indibase/abstractbaseclient.h
@@ -125,10 +125,10 @@ class AbstractBaseClient : public INDI::BaseMediator
         /** @param deviceName Name of device to search for in the list of devices owned by INDI server,
          *  @returns If \e deviceName exists, it returns an instance of the device. Otherwise, it returns NULL.
          */
-        INDI::BaseDevice *getDevice(const char *deviceName);
+        INDI::BaseDevice getDevice(const char *deviceName);
 
         /** @returns Returns a vector of all devices created in the client. */
-        std::vector<INDI::BaseDevice *> getDevices() const;
+        std::vector<INDI::BaseDevice> getDevices() const;
 
         /** @brief getDevices Returns list of devices that belong to a particular @ref INDI::BaseDevice::DRIVER_INTERFACE "DRIVER_INTERFACE" class.
          *
@@ -143,7 +143,7 @@ class AbstractBaseClient : public INDI::BaseMediator
          *  @param driverInterface ORed DRIVER_INTERFACE values to select the desired class of devices.
          *  @return True if one or more devices are found for the supplied driverInterface, false if no matching devices found.
          */
-        bool getDevices(std::vector<INDI::BaseDevice *> &deviceList, uint16_t driverInterface);
+        bool getDevices(std::vector<INDI::BaseDevice> &deviceList, uint16_t driverInterface);
 
     public:
         /** @brief Set Binary Large Object policy mode

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -489,6 +489,18 @@ bool BaseDevice::isConnected() const
     return sp && sp->getState() == ISS_ON && svp->getState() == IPS_OK;
 }
 
+void BaseDevice::attach()
+{
+    D_PTR(BaseDevice);
+    d->mediateNewDevice(*this);
+}
+
+void BaseDevice::detach()
+{
+    D_PTR(BaseDevice);
+    d->mediateRemoveDevice(*this);
+}
+
 // helper for BaseDevice::setValue
 template <typename TypedProperty>
 static void for_property(

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -463,8 +463,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
     d->addProperty(property);
 
     // IDLog("Adding number property %s to list.\n", property.getName());
-    if (d->mediator)
-        d->mediator->newProperty(property);
+    d->mediateProperty(property);
 
     return (0);
 }
@@ -583,7 +582,7 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
                 if (auto max = element.getAttribute("max")) item->setMax(max);
             });
             locale.Restore();
-            if (d->mediator) d->mediator->newNumber(property.getNumber());
+            d->mediate(INDI::PropertyNumber(property));
             break;
         }
 
@@ -591,7 +590,7 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
             for_property<INDI::PropertySwitch>(root, property, [](const LilXmlElement &element, auto *item) {
                 item->setState(element.context());
             });
-            if (d->mediator) d->mediator->newSwitch(property.getSwitch());
+            d->mediate(INDI::PropertySwitch(property));
             break;
         }
 
@@ -599,7 +598,7 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
             for_property<INDI::PropertyText>(root, property, [](const LilXmlElement &element, auto *item) {
                 item->setText(element.context());
             });
-            if (d->mediator) d->mediator->newText(property.getText());
+            d->mediate(INDI::PropertyText(property));
             break;
         }
 
@@ -607,7 +606,7 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
             for_property<INDI::PropertyLight>(root, property, [](const LilXmlElement &element, auto *item) {
                 item->setState(element.context());
             });
-            if (d->mediator) d->mediator->newLight(property.getLight());
+            d->mediate(INDI::PropertyLight(property));
             break;
         }
 
@@ -685,7 +684,7 @@ int BaseDevicePrivate::setBLOB(INDI::PropertyBlob &property, const LilXmlElement
 
         if (size.toInt() == 0)
         {
-            if (mediator) mediator->newBLOB(widget);
+            mediate(widget);
             continue;
         }
 
@@ -737,7 +736,7 @@ int BaseDevicePrivate::setBLOB(INDI::PropertyBlob &property, const LilXmlElement
         }
 
         property.emitUpdate();
-        if (mediator) mediator->newBLOB(widget);
+        mediate(widget);
     }
 
     return 0;
@@ -813,8 +812,7 @@ void BaseDevice::addMessage(const std::string &msg)
     d->messageLog.push_back(msg);
     guard.unlock();
 
-    if (d->mediator)
-        d->mediator->newMessage(this, d->messageLog.size() - 1);
+    d->mediateMessage(d->messageLog.size() - 1);
 }
 
 const std::string &BaseDevice::messageQueue(size_t index) const

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -55,7 +55,8 @@
 namespace INDI
 {
 
-BaseDevicePrivate::BaseDevicePrivate()
+BaseDevicePrivate::BaseDevicePrivate(BaseDevice *parent)
+    : parent(parent)
 {
     static char indidev[] = "INDIDEV=";
 
@@ -72,7 +73,7 @@ BaseDevicePrivate::~BaseDevicePrivate()
 }
 
 BaseDevice::BaseDevice()
-    : d_ptr(new BaseDevicePrivate)
+    : d_ptr(new BaseDevicePrivate(this))
 { }
 
 BaseDevice::~BaseDevice()
@@ -832,6 +833,19 @@ const std::string &BaseDevice::lastMessage() const
     return d->messageLog.back();
 }
 
+BaseDevice BaseDevice::invalid()
+{
+    static BaseDevice device;
+    device.d_ptr->valid = false;
+    return device;
+}
+
+bool BaseDevice::isValid() const
+{
+    D_PTR(const BaseDevice);
+    return d->valid;
+}
+
 void BaseDevice::watchProperty(const char *name, const std::function<void(INDI::Property)> &callback)
 {
     D_PTR(BaseDevice);
@@ -917,6 +931,18 @@ INDI::BaseMediator *BaseDevice::getMediator() const
 {
     D_PTR(const BaseDevice);
     return d->mediator;
+}
+
+BaseDevice *BaseDevice::operator->()
+{
+    D_PTR(BaseDevice);
+    return d->parent;
+}
+
+BaseDevice::operator BaseDevice*()
+{
+    D_PTR(BaseDevice);
+    return d->parent;
 }
 
 }

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -933,14 +933,8 @@ const char *BaseDevice::getDriverVersion() const
 
 uint16_t BaseDevice::getDriverInterface() const
 {
-    D_PTR(const BaseDevice);
-    return d->interfaceDescriptor;
-}
-
-void BaseDevice::setDriverInterface(uint16_t value)
-{
-    D_PTR(BaseDevice);
-    d->interfaceDescriptor = value;
+    auto driverInterface = getText("DRIVER_INFO").findWidgetByName("DRIVER_INTERFACE");
+    return driverInterface ? atoi(driverInterface->getText()) : 0;
 }
 
 void BaseDevice::setMediator(INDI::BaseMediator *mediator)

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -909,16 +909,16 @@ const char *BaseDevice::getDriverVersion() const
     return driverVersion ? driverVersion->getText() : nullptr;
 }
 
-uint16_t BaseDevice::getDriverInterface()
+uint16_t BaseDevice::getDriverInterface() const
 {
-    auto driverInfo = getText("DRIVER_INFO");
+    D_PTR(const BaseDevice);
+    return d->interfaceDescriptor;
+}
 
-    if (!driverInfo)
-        return 0;
-
-    auto driverInterface = driverInfo->findWidgetByName("DRIVER_INTERFACE");
-
-    return driverInterface ? atoi(driverInterface->getText()) : 0;
+void BaseDevice::setDriverInterface(uint16_t value)
+{
+    D_PTR(BaseDevice);
+    d->interfaceDescriptor = value;
 }
 
 void BaseDevice::setMediator(INDI::BaseMediator *mediator)

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -223,7 +223,7 @@ static std::string sGetSheletonFilePath(std::string fileName)
         return pathName;
     }
 
-    // absolute file path 
+    // absolute file path
     if (stat(fileName.c_str(), &st) == 0)
     {
         pathName = fileName;
@@ -262,7 +262,7 @@ bool BaseDevice::buildSkeleton(const char *filename)
     D_PTR(BaseDevice);
 
     LilXmlDocument document = d->xmlParser.readFromFile(sGetSheletonFilePath(filename));
-    
+
     if(!document.isValid())
     {
         IDLog("Unable to parse skeleton XML: %s", d->xmlParser.errorMessage());
@@ -271,7 +271,7 @@ bool BaseDevice::buildSkeleton(const char *filename)
 
     char errmsg[MAXRBUF];
 
-    for (const auto &element: document.root().getElements())
+    for (const auto &element : document.root().getElements())
     {
         buildProp(element, errmsg, true);
     }
@@ -291,16 +291,18 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
     }
 
     // find type of tag
-    static const std::map<INDI_PROPERTY_TYPE, std::string> tagTypeName = {
+    static const std::map<INDI_PROPERTY_TYPE, std::string> tagTypeName =
+    {
         {INDI_NUMBER, "defNumberVector"},
         {INDI_SWITCH, "defSwitchVector"},
         {INDI_TEXT,   "defTextVector"},
         {INDI_LIGHT,  "defLightVector"},
-        {INDI_BLOB,   "defBLOBVector"}        
+        {INDI_BLOB,   "defBLOBVector"}
     };
 
     const auto rootTagName = root.tagName();
-    const auto rootTagType = std::find_if(tagTypeName.begin(), tagTypeName.end(), [&rootTagName](const auto &it) {
+    const auto rootTagType = std::find_if(tagTypeName.begin(), tagTypeName.end(), [&rootTagName](const auto & it)
+    {
         return rootTagName == it.second;
     });
 
@@ -324,9 +326,10 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
     INDI::Property property;
     switch (rootTagType->first)
     {
-        case INDI_NUMBER: {
+        case INDI_NUMBER:
+        {
             INDI::PropertyNumber typedProperty {0};
-            for (const auto &element: root.getElementsByTagName("defNumber"))
+            for (const auto &element : root.getElementsByTagName("defNumber"))
             {
                 INDI::WidgetView<INumber> widget;
 
@@ -348,10 +351,11 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             property = typedProperty;
             break;
         }
-        case INDI_SWITCH: {
+        case INDI_SWITCH:
+        {
             INDI::PropertySwitch typedProperty {0};
             typedProperty.setRule(root.getAttribute("rule"));
-            for (const auto &element: root.getElementsByTagName("defSwitch"))
+            for (const auto &element : root.getElementsByTagName("defSwitch"))
             {
                 INDI::WidgetView<ISwitch> widget;
 
@@ -369,9 +373,10 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             break;
         }
 
-        case INDI_TEXT: {
+        case INDI_TEXT:
+        {
             INDI::PropertyText typedProperty {0};
-            for (const auto &element: root.getElementsByTagName("defText"))
+            for (const auto &element : root.getElementsByTagName("defText"))
             {
                 INDI::WidgetView<IText> widget;
 
@@ -388,10 +393,11 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             property = typedProperty;
             break;
         }
-        
-        case INDI_LIGHT: {
+
+        case INDI_LIGHT:
+        {
             INDI::PropertyLight typedProperty {0};
-            for (const auto &element: root.getElementsByTagName("defLight"))
+            for (const auto &element : root.getElementsByTagName("defLight"))
             {
                 INDI::WidgetView<ILight> widget;
 
@@ -409,9 +415,10 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             break;
         }
 
-        case INDI_BLOB: {
+        case INDI_BLOB:
+        {
             INDI::PropertyBlob typedProperty {0};
-            for (const auto &element: root.getElementsByTagName("defBLOB"))
+            for (const auto &element : root.getElementsByTagName("defBLOB"))
             {
                 INDI::WidgetView<IBLOB> widget;
 
@@ -429,7 +436,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
             break;
         }
 
-        case INDI_UNKNOWN: // it will never happen 
+        case INDI_UNKNOWN: // it will never happen
             return -1;
     }
 
@@ -490,7 +497,7 @@ static void for_property(
 {
     TypedProperty typedProperty = property;
 
-    for (const auto &element: root.getElements())
+    for (const auto &element : root.getElements())
     {
         auto * item = typedProperty.findWidgetByName(element.getAttribute("name"));
         if (item)
@@ -517,16 +524,18 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
     checkMessage(root.handle());
 
     // find type of tag
-    static const std::map<INDI_PROPERTY_TYPE, std::string> tagTypeName = {
+    static const std::map<INDI_PROPERTY_TYPE, std::string> tagTypeName =
+    {
         {INDI_NUMBER, "setNumberVector"},
         {INDI_SWITCH, "setSwitchVector"},
         {INDI_TEXT,   "setTextVector"},
         {INDI_LIGHT,  "setLightVector"},
-        {INDI_BLOB,   "setBLOBVector"}        
+        {INDI_BLOB,   "setBLOBVector"}
     };
 
     const auto rootTagName = root.tagName();
-    const auto rootTagType = std::find_if(tagTypeName.begin(), tagTypeName.end(), [&rootTagName](const auto &it) {
+    const auto rootTagType = std::find_if(tagTypeName.begin(), tagTypeName.end(), [&rootTagName](const auto & it)
+    {
         return rootTagName == it.second;
     });
 
@@ -554,7 +563,8 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
 
         if (!ok)
         {
-            snprintf(errmsg, MAXRBUF, "INDI: <%s> bogus state %s for %s", rootTagName.c_str(), root.getAttribute("state").toCString(), propertyName);
+            snprintf(errmsg, MAXRBUF, "INDI: <%s> bogus state %s for %s", rootTagName.c_str(), root.getAttribute("state").toCString(),
+                     propertyName);
             return -1;
         }
     }
@@ -572,9 +582,11 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
     // update specific values
     switch (rootTagType->first)
     {
-        case INDI_NUMBER: {
+        case INDI_NUMBER:
+        {
             AutoCNumeric locale;
-            for_property<INDI::PropertyNumber>(root, property, [](const LilXmlElement &element, auto *item) {
+            for_property<INDI::PropertyNumber>(root, property, [](const LilXmlElement & element, auto * item)
+            {
                 item->setValue(element.context());
 
                 // Permit changing of min/max
@@ -586,36 +598,43 @@ int BaseDevice::setValue(const INDI::LilXmlElement &root, char *errmsg)
             break;
         }
 
-        case INDI_SWITCH: {
-            for_property<INDI::PropertySwitch>(root, property, [](const LilXmlElement &element, auto *item) {
+        case INDI_SWITCH:
+        {
+            for_property<INDI::PropertySwitch>(root, property, [](const LilXmlElement & element, auto * item)
+            {
                 item->setState(element.context());
             });
             d->mediate(INDI::PropertySwitch(property));
             break;
         }
 
-        case INDI_TEXT: {
-            for_property<INDI::PropertyText>(root, property, [](const LilXmlElement &element, auto *item) {
+        case INDI_TEXT:
+        {
+            for_property<INDI::PropertyText>(root, property, [](const LilXmlElement & element, auto * item)
+            {
                 item->setText(element.context());
             });
             d->mediate(INDI::PropertyText(property));
             break;
         }
 
-        case INDI_LIGHT: {
-            for_property<INDI::PropertyLight>(root, property, [](const LilXmlElement &element, auto *item) {
+        case INDI_LIGHT:
+        {
+            for_property<INDI::PropertyLight>(root, property, [](const LilXmlElement & element, auto * item)
+            {
                 item->setState(element.context());
             });
             d->mediate(INDI::PropertyLight(property));
             break;
         }
 
-        case INDI_BLOB: {
+        case INDI_BLOB:
+        {
             INDI::PropertyBlob typedProperty = property;
             return d->setBLOB(typedProperty, root, errmsg);
         }
 
-        case INDI_UNKNOWN: // it will never happen 
+        case INDI_UNKNOWN: // it will never happen
             return -1;
     }
 
@@ -666,7 +685,7 @@ static bool sSharedToBlob(const INDI::LilXmlElement &element, INDI::WidgetView<I
 */
 int BaseDevicePrivate::setBLOB(INDI::PropertyBlob &property, const LilXmlElement &root, char *errmsg)
 {
-    for (const auto &element: root.getElementsByTagName("oneBLOB"))
+    for (const auto &element : root.getElementsByTagName("oneBLOB"))
     {
         auto name   = element.getAttribute("name");
         auto format = element.getAttribute("format");
@@ -677,8 +696,8 @@ int BaseDevicePrivate::setBLOB(INDI::PropertyBlob &property, const LilXmlElement
         if (!name || !format || !size)
         {
             snprintf(errmsg, MAXRBUF, "INDI: %s.%s.%s No valid members.",
-                property.getDeviceName(), property.getName(), name.toCString()
-            );
+                     property.getDeviceName(), property.getName(), name.toCString()
+                    );
             return -1;
         }
 

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -72,7 +72,7 @@ BaseDevicePrivate::~BaseDevicePrivate()
 }
 
 BaseDevice::BaseDevice()
-    : d_ptr(new BaseDevicePrivate)
+    : d_ptr(BaseDevicePrivate::invalid())
 { }
 
 BaseDevice::~BaseDevice()
@@ -455,7 +455,7 @@ int BaseDevice::buildProp(const INDI::LilXmlElement &root, char *errmsg, bool is
         return 0;
     }
 
-    property.setBaseDevice (this);
+    property.setBaseDevice (*this);
     property.setName       (propertyName);
     property.setDynamic    (isDynamic);
     property.setDeviceName (getDeviceName());
@@ -860,19 +860,6 @@ const std::string &BaseDevice::lastMessage() const
     std::lock_guard<std::mutex> lock(d->m_Lock);
     assert(d->messageLog.size() != 0);
     return d->messageLog.back();
-}
-
-BaseDevice &BaseDevice::invalid()
-{
-    static class BaseDeviceInvalid: public BaseDevice
-    {
-        public:
-            BaseDeviceInvalid()
-            {
-                d_ptr->valid = false;
-            }
-    } device;
-    return device;
 }
 
 bool BaseDevice::isValid() const

--- a/libs/indibase/basedevice.cpp
+++ b/libs/indibase/basedevice.cpp
@@ -942,7 +942,7 @@ BaseDevice *BaseDevice::operator->()
 BaseDevice::operator BaseDevice*()
 {
     D_PTR(BaseDevice);
-    return d->parent;
+    return isValid() ? d->parent : nullptr;
 }
 
 }

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -231,20 +231,11 @@ class BaseDevice
          *  @return driver device interface descriptor.
          *  @note For example, to know if the driver supports CCD interface, check the retruned value:
          *  @code{.cpp}
-         *  if (device->getDriverInterface() & CCD_INTERFACE)
+         *  if (device.getDriverInterface() & CCD_INTERFACE)
          *       cout << "We received a camera!" << endl;
          *  @endcode
          */
         uint16_t getDriverInterface() const;
-
-    protected:
-        /**
-         * @brief setInterface Set driver interface.
-         * @param value ORed list of DeviceInterface values.
-         * @warning This only updates the internal driver interface property and does not send it to the
-         * client. To synchronize the client, use DefaultDevice::syncDriverInfo funciton.
-         */
-        virtual void setDriverInterface(uint16_t value);
 
     public:
         /** @brief Build driver properties from a skeleton file.

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -186,6 +186,16 @@ class BaseDevice
         /** @return True if the device is connected (CONNECT=ON), False otherwise */
         bool isConnected() const;
 
+        /** @brief indicates that the device is ready
+         *  @note the BaseMediator::newDevice method will be called
+         */
+        void attach();
+
+        /** @brief indicates that the device is being removed
+         *  @note the BaseMediator::removeDevice method will be called
+         */
+        void detach();
+
         /** @brief Set the driver's mediator to receive notification of news devices and updated property values. */
         void setMediator(INDI::BaseMediator *mediator);
 
@@ -281,7 +291,6 @@ class BaseDevice
         }
 
     protected:
-        friend class WatchDeviceProperty;
         friend class AbstractBaseClientPrivate;
         std::shared_ptr<BaseDevicePrivate> d_ptr;
         BaseDevice(BaseDevicePrivate &dd);

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -176,10 +176,6 @@ class BaseDevice
         const std::string &lastMessage() const;
 
     public:
-        /** @return return device where isValid() == false */
-        static BaseDevice &invalid();
-
-    public:
         /** @return True if the device exists */
         bool isValid() const;
 
@@ -291,6 +287,11 @@ class BaseDevice
         }
 
     protected:
+        BaseDevice *operator&()
+        {
+            return this;
+        }
+
         friend class AbstractBaseClientPrivate;
         std::shared_ptr<BaseDevicePrivate> d_ptr;
         BaseDevice(BaseDevicePrivate &dd);

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -279,6 +279,8 @@ class BaseDevice
         }
 
     protected:
+        friend class WatchDeviceProperty;
+        friend class AbstractBaseClientPrivate;
         std::shared_ptr<BaseDevicePrivate> d_ptr;
         BaseDevice(BaseDevicePrivate &dd);
 };

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -176,9 +176,11 @@ class BaseDevice
         const std::string &lastMessage() const;
 
     public:
-        static BaseDevice invalid();
+        /** @return return device where isValid() == false */
+        static BaseDevice &invalid();
 
     public:
+        /** @return True if the device exists */
         bool isValid() const;
 
         /** @return True if the device is connected (CONNECT=ON), False otherwise */
@@ -283,6 +285,7 @@ class BaseDevice
         friend class AbstractBaseClientPrivate;
         std::shared_ptr<BaseDevicePrivate> d_ptr;
         BaseDevice(BaseDevicePrivate &dd);
+        BaseDevice(const std::shared_ptr<BaseDevicePrivate> &dd);
 };
 
 }

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -226,7 +226,7 @@ class BaseDevice
          *       cout << "We received a camera!" << endl;
          *  @endcode
          */
-        virtual uint16_t getDriverInterface();
+        uint16_t getDriverInterface();
 
     public:
         /** @brief Build driver properties from a skeleton file.

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -175,6 +175,11 @@ class BaseDevice
         const std::string &lastMessage() const;
 
     public:
+        static BaseDevice invalid();
+
+    public:
+        bool isValid() const;
+
         /** @return True if the device is connected (CONNECT=ON), False otherwise */
         bool isConnected() const;
 
@@ -245,6 +250,14 @@ class BaseDevice
 
         /** @brief handle SetXXX commands from client */
         int setValue(const INDI::LilXmlElement &root, char *errmsg);
+
+    public:
+        operator BaseDevice*();
+        BaseDevice* operator->();
+
+        bool operator != (std::nullptr_t) const        { return  isValid(); }
+        bool operator == (std::nullptr_t) const        { return !isValid(); }
+        operator bool()                   const        { return  isValid(); }
 
     protected:
         std::shared_ptr<BaseDevicePrivate> d_ptr;

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -104,7 +104,8 @@ class BaseDevice
          *  @param property any property from the INDI::PropertyXXX family.
          */
         void registerProperty(const INDI::Property &property);
-        void registerProperty(const INDI::Property &property, INDI_PROPERTY_TYPE type); // backward compatiblity (PentaxCCD, PkTriggerCordCCD)
+        void registerProperty(const INDI::Property &property,
+                              INDI_PROPERTY_TYPE type); // backward compatiblity (PentaxCCD, PkTriggerCordCCD)
 
         /** @brief Remove a property
          *  @param name name of property to be removed. Pass NULL to remove the whole device.
@@ -264,9 +265,18 @@ class BaseDevice
         operator BaseDevice*();
         BaseDevice* operator->();
 
-        bool operator != (std::nullptr_t) const        { return  isValid(); }
-        bool operator == (std::nullptr_t) const        { return !isValid(); }
-        operator bool()                   const        { return  isValid(); }
+        bool operator != (std::nullptr_t) const
+        {
+            return  isValid();
+        }
+        bool operator == (std::nullptr_t) const
+        {
+            return !isValid();
+        }
+        operator bool()                   const
+        {
+            return  isValid();
+        }
 
     protected:
         std::shared_ptr<BaseDevicePrivate> d_ptr;

--- a/libs/indibase/basedevice.h
+++ b/libs/indibase/basedevice.h
@@ -226,7 +226,16 @@ class BaseDevice
          *       cout << "We received a camera!" << endl;
          *  @endcode
          */
-        uint16_t getDriverInterface();
+        uint16_t getDriverInterface() const;
+
+    protected:
+        /**
+         * @brief setInterface Set driver interface.
+         * @param value ORed list of DeviceInterface values.
+         * @warning This only updates the internal driver interface property and does not send it to the
+         * client. To synchronize the client, use DefaultDevice::syncDriverInfo funciton.
+         */
+        virtual void setDriverInterface(uint16_t value);
 
     public:
         /** @brief Build driver properties from a skeleton file.

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -63,7 +63,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->newDevice(parent);
+#endif
                 mediator->newDevice(*parent);
             }
         }
@@ -72,7 +74,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->removeDevice(parent);
+#endif
                 mediator->removeDevice(*parent);
             }
         }
@@ -81,7 +85,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->newNumber(property.getNumber());
+#endif
                 mediator->newNumber(property);
             }
         }
@@ -90,7 +96,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->newSwitch(property.getSwitch());
+#endif
                 mediator->newSwitch(property);
             }
         }
@@ -99,7 +107,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->newText(property.getText());
+#endif
                 mediator->newText(property);
             }
         }
@@ -108,7 +118,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->newLight(property.getLight());
+#endif
                 mediator->newLight(property);
             }
         }
@@ -127,7 +139,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->newMessage(parent, messageID);
+#endif
                 mediator->newMessage(*parent, messageID);
             }
         }
@@ -136,7 +150,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->newProperty((Property *)property);
+#endif
                 mediator->newProperty(property);
             }
         }
@@ -145,7 +161,9 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+#if INDI_VERSION_MAJOR < 2
                 mediator->removeProperty((Property *)property);
+#endif
                 mediator->removeProperty(property);
             }
         }

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -70,6 +70,7 @@ class BaseDevicePrivate
         mutable std::mutex m_Lock;
 
         bool valid = true;
+        uint16_t interfaceDescriptor {0};
 };
 
 }

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -169,7 +169,6 @@ class BaseDevicePrivate
         mutable std::mutex m_Lock;
 
         bool valid {true};
-        uint16_t interfaceDescriptor {0};
 };
 
 }

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -86,12 +86,12 @@ class BaseDevicePrivate
             }
         }
 
-        void mediate(PropertyLight light)
+        void mediate(PropertyLight property)
         {
             if (mediator)
             {
-                mediator->newLight(light.getLight());
-                mediator->newLight(light);
+                mediator->newLight(property.getLight());
+                mediator->newLight(property);
             }
         }
 

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -59,6 +59,24 @@ class BaseDevicePrivate
         }
 
     public: // mediator
+        void mediateNewDevice()
+        {
+            if (mediator)
+            {
+                mediator->newDevice(parent);
+                mediator->newDevice(*parent);
+            }
+        }
+
+        void mediateRemoveDevice()
+        {
+            if (mediator)
+            {
+                mediator->removeDevice(parent);
+                mediator->removeDevice(*parent);
+            }
+        }
+
         void mediate(PropertyNumber property)
         {
             if (mediator)
@@ -120,6 +138,15 @@ class BaseDevicePrivate
             {
                 mediator->newProperty((Property *)property);
                 mediator->newProperty(property);
+            }
+        }
+
+        void mediateRemoveProperty(Property property)
+        {
+            if (mediator)
+            {
+                mediator->removeProperty((Property *)property);
+                mediator->removeProperty(property);
             }
         }
 

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "indimacros.h"
 #include "basedevice.h"
 #include "lilxml.h"
 #include "indibase.h"
@@ -38,7 +39,7 @@ class BaseDevice;
 class BaseDevicePrivate
 {
     public:
-        BaseDevicePrivate(BaseDevice *parent);
+        BaseDevicePrivate();
         virtual ~BaseDevicePrivate();
 
         /** @brief Parse and store BLOB in the respective vector */
@@ -59,29 +60,29 @@ class BaseDevicePrivate
         }
 
     public: // mediator
-        void mediateNewDevice()
+        void mediateNewDevice(BaseDevice &baseDevice)
         {
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->newDevice(parent);
+                mediator->newDevice(&baseDevice);
 #endif
-                mediator->newDevice(*parent);
+                mediator->newDevice(baseDevice);
             }
         }
 
-        void mediateRemoveDevice()
+        void mediateRemoveDevice(BaseDevice &baseDevice)
         {
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->removeDevice(parent);
+                mediator->removeDevice(&baseDevice);
 #endif
-                mediator->removeDevice(*parent);
+                mediator->removeDevice(baseDevice);
             }
         }
 
-        void mediate(PropertyNumber property)
+        void mediateNewNumber(PropertyNumber property)
         {
             if (mediator)
             {
@@ -92,7 +93,7 @@ class BaseDevicePrivate
             }
         }
 
-        void mediate(PropertySwitch property)
+        void mediateNewSwitch(PropertySwitch property)
         {
             if (mediator)
             {
@@ -103,7 +104,7 @@ class BaseDevicePrivate
             }
         }
 
-        void mediate(PropertyText property)
+        void mediateNewText(PropertyText property)
         {
             if (mediator)
             {
@@ -114,7 +115,7 @@ class BaseDevicePrivate
             }
         }
 
-        void mediate(PropertyLight property)
+        void mediateNewLight(PropertyLight property)
         {
             if (mediator)
             {
@@ -125,7 +126,7 @@ class BaseDevicePrivate
             }
         }
 
-        void mediate(IBLOB *blob)
+        void mediateNewBlob(IBLOB *blob)
         {
             if (mediator)
             {
@@ -135,18 +136,18 @@ class BaseDevicePrivate
             }
         }
 
-        void mediateMessage(int messageID)
+        void mediateNewMessage(BaseDevice &baseDevice, int messageID)
         {
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->newMessage(parent, messageID);
+                mediator->newMessage(&baseDevice, messageID);
 #endif
-                mediator->newMessage(*parent, messageID);
+                mediator->newMessage(baseDevice, messageID);
             }
         }
 
-        void mediateProperty(Property property)
+        void mediateNewProperty(Property &property)
         {
             if (mediator)
             {
@@ -157,7 +158,7 @@ class BaseDevicePrivate
             }
         }
 
-        void mediateRemoveProperty(Property property)
+        void mediateRemoveProperty(Property &property)
         {
             if (mediator)
             {
@@ -169,7 +170,7 @@ class BaseDevicePrivate
         }
 
     public:
-        BaseDevice *parent;
+        BaseDevice self {make_shared_weak(this)}; // backward compatibile (for operators as pointer)
         std::string deviceName;
         BaseDevice::Properties pAll;
         std::map<std::string, std::function<void(INDI::Property)>> watchPropertyMap;

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -64,6 +64,7 @@ class BaseDevicePrivate
             if (mediator)
             {
                 mediator->newNumber(property.getNumber());
+                mediator->newNumber(property);
             }
         }
 
@@ -72,6 +73,7 @@ class BaseDevicePrivate
             if (mediator)
             {
                 mediator->newSwitch(property.getSwitch());
+                mediator->newSwitch(property);
             }
         }
 
@@ -80,6 +82,7 @@ class BaseDevicePrivate
             if (mediator)
             {
                 mediator->newText(property.getText());
+                mediator->newText(property);
             }
         }
 
@@ -88,6 +91,7 @@ class BaseDevicePrivate
             if (mediator)
             {
                 mediator->newLight(light.getLight());
+                mediator->newLight(light);
             }
         }
 
@@ -96,6 +100,8 @@ class BaseDevicePrivate
             if (mediator)
             {
                 mediator->newBLOB(blob);
+                // #PS: TODO - Blob requires complete refactoring,
+                //             there is no certainty how long the data is kept.
             }
         }
 
@@ -104,6 +110,7 @@ class BaseDevicePrivate
             if (mediator)
             {
                 mediator->newMessage(parent, messageID);
+                mediator->newMessage(*parent, messageID);
             }
         }
 
@@ -111,6 +118,7 @@ class BaseDevicePrivate
         {
             if (mediator)
             {
+                mediator->newProperty((Property *)property);
                 mediator->newProperty(property);
             }
         }

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -114,7 +114,7 @@ class BaseDevicePrivate
                         mediator->newLight(property.getLight());
                         break;
                     case INDI_BLOB:
-                        for (auto &it : PropertySwitch(property))
+                        for (auto &it : PropertyBlob(property))
                         {
                             mediator->newBLOB(&it);
                         }

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -50,11 +50,68 @@ class BaseDevicePrivate
                 std::unique_lock<std::mutex> lock(m_Lock);
                 pAll.push_back(property);
             }
-            
+
             auto it = watchPropertyMap.find(property.getName());
             if (it != watchPropertyMap.end())
             {
                 it->second(property);
+            }
+        }
+
+    public: // mediator
+        void mediate(PropertyNumber property)
+        {
+            if (mediator)
+            {
+                mediator->newNumber(property.getNumber());
+            }
+        }
+
+        void mediate(PropertySwitch property)
+        {
+            if (mediator)
+            {
+                mediator->newSwitch(property.getSwitch());
+            }
+        }
+
+        void mediate(PropertyText property)
+        {
+            if (mediator)
+            {
+                mediator->newText(property.getText());
+            }
+        }
+
+        void mediate(PropertyLight light)
+        {
+            if (mediator)
+            {
+                mediator->newLight(light.getLight());
+            }
+        }
+
+        void mediate(IBLOB *blob)
+        {
+            if (mediator)
+            {
+                mediator->newBLOB(blob);
+            }
+        }
+
+        void mediateMessage(int messageID)
+        {
+            if (mediator)
+            {
+                mediator->newMessage(parent, messageID);
+            }
+        }
+
+        void mediateProperty(Property property)
+        {
+            if (mediator)
+            {
+                mediator->newProperty(property);
             }
         }
 

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -150,16 +150,11 @@ class BaseDevicePrivate
     public:
         static std::shared_ptr<BaseDevicePrivate> invalid()
         {
-            class InvalidBaseDevicePrivate : public BaseDevicePrivate
+            static struct Invalid : public BaseDevicePrivate
             {
-                public:
-                    InvalidBaseDevicePrivate()
-                    {
-                        valid = false;
-                    }
-            };
-            static std::shared_ptr<BaseDevicePrivate> priv(new InvalidBaseDevicePrivate);
-            return priv;
+                Invalid() { valid = false; }
+            } invalid;
+            return make_shared_weak(&invalid);
         }
 
     public:

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -43,7 +43,7 @@ class BaseDevicePrivate
         virtual ~BaseDevicePrivate();
 
         /** @brief Parse and store BLOB in the respective vector */
-        int setBLOB(INDI::PropertyBlob &propertyBlob, const INDI::LilXmlElement &root, char *errmsg);
+        int setBLOB(INDI::PropertyBlob propertyBlob, const INDI::LilXmlElement &root, char *errmsg);
 
         void addProperty(const INDI::Property &property)
         {
@@ -82,71 +82,6 @@ class BaseDevicePrivate
             }
         }
 
-        void mediateNewNumber(PropertyNumber property)
-        {
-            if (mediator)
-            {
-#if INDI_VERSION_MAJOR < 2
-                mediator->newNumber(property.getNumber());
-#endif
-                mediator->newNumber(property);
-            }
-        }
-
-        void mediateNewSwitch(PropertySwitch property)
-        {
-            if (mediator)
-            {
-#if INDI_VERSION_MAJOR < 2
-                mediator->newSwitch(property.getSwitch());
-#endif
-                mediator->newSwitch(property);
-            }
-        }
-
-        void mediateNewText(PropertyText property)
-        {
-            if (mediator)
-            {
-#if INDI_VERSION_MAJOR < 2
-                mediator->newText(property.getText());
-#endif
-                mediator->newText(property);
-            }
-        }
-
-        void mediateNewLight(PropertyLight property)
-        {
-            if (mediator)
-            {
-#if INDI_VERSION_MAJOR < 2
-                mediator->newLight(property.getLight());
-#endif
-                mediator->newLight(property);
-            }
-        }
-
-        void mediateNewBlob(IBLOB *blob)
-        {
-            if (mediator)
-            {
-                mediator->newBLOB(blob);
-                // #PS: TODO - Blob requires complete refactoring,
-                //             there is no certainty how long the data is kept.
-            }
-        }
-
-        void mediateNewMessage(BaseDevice &baseDevice, int messageID)
-        {
-            if (mediator)
-            {
-#if INDI_VERSION_MAJOR < 2
-                mediator->newMessage(&baseDevice, messageID);
-#endif
-                mediator->newMessage(baseDevice, messageID);
-            }
-        }
-
         void mediateNewProperty(Property &property)
         {
             if (mediator)
@@ -158,6 +93,39 @@ class BaseDevicePrivate
             }
         }
 
+        void mediateUpdateProperty(Property property)
+        {
+            if (mediator)
+            {
+                mediator->updateProperty(property);
+#if INDI_VERSION_MAJOR < 2
+                switch (property.getType())
+                {
+                    case INDI_NUMBER:
+                        mediator->newNumber(property.getNumber());
+                        break;
+                    case INDI_SWITCH:
+                        mediator->newSwitch(property.getSwitch());
+                        break;
+                    case INDI_TEXT:
+                        mediator->newText(property.getText());
+                        break;
+                    case INDI_LIGHT:
+                        mediator->newLight(property.getLight());
+                        break;
+                    case INDI_BLOB:
+                        for (auto &it : PropertySwitch(property))
+                        {
+                            mediator->newBLOB(&it);
+                        }
+                        break;
+                    case INDI_UNKNOWN:
+                        ;
+                }
+#endif
+            }
+        }
+
         void mediateRemoveProperty(Property &property)
         {
             if (mediator)
@@ -166,6 +134,17 @@ class BaseDevicePrivate
                 mediator->removeProperty((Property *)property);
 #endif
                 mediator->removeProperty(property);
+            }
+        }
+
+        void mediateNewMessage(BaseDevice &baseDevice, int messageID)
+        {
+            if (mediator)
+            {
+#if INDI_VERSION_MAJOR < 2
+                mediator->newMessage(&baseDevice, messageID);
+#endif
+                mediator->newMessage(baseDevice, messageID);
             }
         }
 

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -60,29 +60,29 @@ class BaseDevicePrivate
         }
 
     public: // mediator
-        void mediateNewDevice(BaseDevice &baseDevice)
+        void mediateNewDevice(BaseDevice baseDevice)
         {
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->newDevice(&baseDevice);
+                mediator->newDevice((BaseDevice *)baseDevice);
 #endif
                 mediator->newDevice(baseDevice);
             }
         }
 
-        void mediateRemoveDevice(BaseDevice &baseDevice)
+        void mediateRemoveDevice(BaseDevice baseDevice)
         {
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->removeDevice(&baseDevice);
+                mediator->removeDevice((BaseDevice *)baseDevice);
 #endif
                 mediator->removeDevice(baseDevice);
             }
         }
 
-        void mediateNewProperty(Property &property)
+        void mediateNewProperty(Property property)
         {
             if (mediator)
             {
@@ -126,7 +126,7 @@ class BaseDevicePrivate
             }
         }
 
-        void mediateRemoveProperty(Property &property)
+        void mediateRemoveProperty(Property property)
         {
             if (mediator)
             {
@@ -137,15 +137,29 @@ class BaseDevicePrivate
             }
         }
 
-        void mediateNewMessage(BaseDevice &baseDevice, int messageID)
+        void mediateNewMessage(BaseDevice baseDevice, int messageID)
         {
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->newMessage(&baseDevice, messageID);
+                mediator->newMessage((BaseDevice *)baseDevice, messageID);
 #endif
                 mediator->newMessage(baseDevice, messageID);
             }
+        }
+    public:
+        static std::shared_ptr<BaseDevicePrivate> invalid()
+        {
+            class InvalidBaseDevicePrivate : public BaseDevicePrivate
+            {
+                public:
+                    InvalidBaseDevicePrivate()
+                    {
+                        valid = false;
+                    }
+            };
+            static std::shared_ptr<BaseDevicePrivate> priv(new InvalidBaseDevicePrivate);
+            return priv;
         }
 
     public:
@@ -159,7 +173,7 @@ class BaseDevicePrivate
         std::deque<std::string> messageLog;
         mutable std::mutex m_Lock;
 
-        bool valid = true;
+        bool valid {true};
         uint16_t interfaceDescriptor {0};
 };
 

--- a/libs/indibase/basedevice_p.h
+++ b/libs/indibase/basedevice_p.h
@@ -34,10 +34,11 @@
 namespace INDI
 {
 
+class BaseDevice;
 class BaseDevicePrivate
 {
     public:
-        BaseDevicePrivate();
+        BaseDevicePrivate(BaseDevice *parent);
         virtual ~BaseDevicePrivate();
 
         /** @brief Parse and store BLOB in the respective vector */
@@ -58,6 +59,7 @@ class BaseDevicePrivate
         }
 
     public:
+        BaseDevice *parent;
         std::string deviceName;
         BaseDevice::Properties pAll;
         std::map<std::string, std::function<void(INDI::Property)>> watchPropertyMap;
@@ -66,6 +68,8 @@ class BaseDevicePrivate
         INDI::BaseMediator *mediator {nullptr};
         std::deque<std::string> messageLog;
         mutable std::mutex m_Lock;
+
+        bool valid = true;
 };
 
 }

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -793,12 +793,6 @@ bool DefaultDevice::updateProperties()
     return true;
 }
 
-uint16_t DefaultDevice::getDriverInterface()
-{
-    D_PTR(DefaultDevice);
-    return d->interfaceDescriptor;
-}
-
 void DefaultDevice::setDriverInterface(uint16_t value)
 {
     D_PTR(DefaultDevice);

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -136,17 +136,13 @@ DefaultDevicePrivate::~DefaultDevicePrivate()
 }
 
 DefaultDevice::DefaultDevice()
-    : BaseDevice(*new DefaultDevicePrivate(this))
+    : ParentDevice(std::shared_ptr<ParentDevicePrivate>(new DefaultDevicePrivate(this)))
 {
     D_PTR(DefaultDevice);
     d->m_MainLoopTimer.setSingleShot(true);
     d->m_MainLoopTimer.setInterval(getPollingPeriod());
     d->m_MainLoopTimer.callOnTimeout(std::bind(&DefaultDevice::TimerHit, this));
 }
-
-DefaultDevice::DefaultDevice(DefaultDevicePrivate &dd)
-    : BaseDevice(dd)
-{ }
 
 bool DefaultDevice::loadConfig(INDI::Property &property)
 {

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -793,7 +793,7 @@ void DefaultDevice::setDriverInterface(uint16_t value)
 {
     D_PTR(DefaultDevice);
     char interfaceStr[16];
-    snprintf(interfaceStr, 16, "%d", d->interfaceDescriptor);
+    snprintf(interfaceStr, 16, "%d", value);
     d->DriverInfoTP[3].setText(interfaceStr);
     BaseDevice::setDriverInterface(value);
 }

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -789,13 +789,23 @@ bool DefaultDevice::updateProperties()
     return true;
 }
 
+// Early access to properties.
+// The `BaseDevice::getDriverInterface()` function will return a false value of 0
+// when the `DriverInfoTP` property has not yet been registered.
+//
+// The situation occurs in the case of drivers where the class that inherits from `DefaultDevice`
+// will call the `setDriverInterface` function in the constructor
+
+uint16_t DefaultDevice::getDriverInterface() const
+{
+    D_PTR(const DefaultDevice);
+    return atoi(d->DriverInfoTP[3 /* DRIVER_INTERFACE */].getText());
+}
+
 void DefaultDevice::setDriverInterface(uint16_t value)
 {
     D_PTR(DefaultDevice);
-    char interfaceStr[16];
-    snprintf(interfaceStr, 16, "%d", value);
-    d->DriverInfoTP[3].setText(interfaceStr);
-    BaseDevice::setDriverInterface(value);
+    d->DriverInfoTP[3 /* DRIVER_INTERFACE */].setText(std::to_string(value));
 }
 
 void DefaultDevice::syncDriverInfo()

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -123,8 +123,7 @@ namespace INDI
 {
 
 DefaultDevicePrivate::DefaultDevicePrivate(DefaultDevice *defaultDevice)
-    : BaseDevicePrivate(defaultDevice)
-    , defaultDevice(defaultDevice)
+    : defaultDevice(defaultDevice)
 {
     const std::unique_lock<std::recursive_mutex> lock(DefaultDevicePrivate::devicesLock);
     devices.push_back(this);

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -798,9 +798,9 @@ void DefaultDevice::setDriverInterface(uint16_t value)
 {
     D_PTR(DefaultDevice);
     char interfaceStr[16];
-    d->interfaceDescriptor = value;
     snprintf(interfaceStr, 16, "%d", d->interfaceDescriptor);
     d->DriverInfoTP[3].setText(interfaceStr);
+    BaseDevice::setDriverInterface(value);
 }
 
 void DefaultDevice::syncDriverInfo()
@@ -816,7 +816,7 @@ bool DefaultDevice::initProperties()
     char interfaceStr[16];
 
     snprintf(versionStr, 16, "%d.%d", d->majorVersion, d->minorVersion);
-    snprintf(interfaceStr, 16, "%d", d->interfaceDescriptor);
+    snprintf(interfaceStr, 16, "%d", getDriverInterface());
 
     // Connection Mode
     d->ConnectionModeSP.onUpdate([d](){

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -123,7 +123,8 @@ namespace INDI
 {
 
 DefaultDevicePrivate::DefaultDevicePrivate(DefaultDevice *defaultDevice)
-    : defaultDevice(defaultDevice)
+    : BaseDevicePrivate(defaultDevice)
+    , defaultDevice(defaultDevice)
 {
     const std::unique_lock<std::recursive_mutex> lock(DefaultDevicePrivate::devicesLock);
     devices.push_back(this);

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -302,11 +302,6 @@ class DefaultDevice : public BaseDevice
         virtual bool ISSnoopDevice(XMLEle *root);
 
         /**
-         * @return getInterface Return the interface declared by the driver.
-         */
-        virtual uint16_t getDriverInterface() override;
-
-        /**
          * @brief setInterface Set driver interface. By default the driver interface is set to GENERAL_DEVICE.
          * You may send an ORed list of DeviceInterface values.
          * @param value ORed list of DeviceInterface values.

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -302,13 +302,18 @@ class DefaultDevice : public ParentDevice
         virtual bool ISSnoopDevice(XMLEle *root);
 
         /**
+         * @return getInterface Return the interface declared by the driver.
+         */
+        uint16_t getDriverInterface() const;
+
+        /**
          * @brief setInterface Set driver interface. By default the driver interface is set to GENERAL_DEVICE.
          * You may send an ORed list of DeviceInterface values.
          * @param value ORed list of DeviceInterface values.
          * @warning This only updates the internal driver interface property and does not send it to the
          * client. To synchronize the client, use syncDriverInfo funciton.
          */
-        void setDriverInterface(uint16_t value) override;
+        void setDriverInterface(uint16_t value);
 
     public:
         /** @brief Add a device to the watch list.

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "basedevice.h"
+#include "parentdevice.h"
 #include "indidriver.h"
 #include "indilogger.h"
 
@@ -115,7 +115,7 @@ namespace INDI
 {
 
 class DefaultDevicePrivate;
-class DefaultDevice : public BaseDevice
+class DefaultDevice : public ParentDevice
 {
         DECLARE_PRIVATE(DefaultDevice)
 
@@ -561,7 +561,7 @@ class DefaultDevice : public BaseDevice
         friend class FocuserInterface;
 
     protected:
-        DefaultDevice(DefaultDevicePrivate &dd);
+        DefaultDevice(const std::shared_ptr<DefaultDevicePrivate> &dd);
 };
 
 }

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -308,7 +308,7 @@ class DefaultDevice : public BaseDevice
          * @warning This only updates the internal driver interface property and does not send it to the
          * client. To synchronize the client, use syncDriverInfo funciton.
          */
-        void setDriverInterface(uint16_t value);
+        void setDriverInterface(uint16_t value) override;
 
     public:
         /** @brief Add a device to the watch list.

--- a/libs/indibase/defaultdevice_p.h
+++ b/libs/indibase/defaultdevice_p.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "basedevice_p.h"
+#include "parentdevice_p.h"
 #include "defaultdevice.h"
 #include "watchdeviceproperty.h"
 
@@ -33,7 +33,7 @@
 
 namespace INDI
 {
-class DefaultDevicePrivate: public BaseDevicePrivate
+class DefaultDevicePrivate: public ParentDevicePrivate
 {
     public:
         DefaultDevicePrivate(DefaultDevice *defaultDevice);

--- a/libs/indibase/defaultdevice_p.h
+++ b/libs/indibase/defaultdevice_p.h
@@ -49,7 +49,6 @@ class DefaultDevicePrivate: public BaseDevicePrivate
 
         uint16_t majorVersion { 1 };
         uint16_t minorVersion { 0 };
-        uint16_t interfaceDescriptor { 0 };
         int m_ConfigConnectionMode {-1};
 
         PropertySwitch SimulationSP     { 2 };

--- a/libs/indibase/indibase.cpp
+++ b/libs/indibase/indibase.cpp
@@ -41,6 +41,7 @@ void BaseMediator::serverDisconnected(int)
 { }
 
 // deprecated
+#if INDI_VERSION_MAJOR < 2
 void BaseMediator::newDevice(INDI::BaseDevice *)
 { }
 
@@ -67,5 +68,6 @@ void BaseMediator::newLight(ILightVectorProperty *)
 
 void BaseMediator::newMessage(INDI::BaseDevice *, int)
 { }
+#endif
 
 }

--- a/libs/indibase/indibase.cpp
+++ b/libs/indibase/indibase.cpp
@@ -1,4 +1,5 @@
 #include "indibase.h"
+#include "basedevice.h"
 
 namespace INDI
 {
@@ -6,13 +7,25 @@ namespace INDI
 void BaseMediator::newDevice(INDI::BaseDevice *)
 { }
 
+void BaseMediator::newDevice(INDI::BaseDevice)
+{ }
+
 void BaseMediator::removeDevice(INDI::BaseDevice *)
+{ }
+
+void BaseMediator::removeDevice(INDI::BaseDevice)
 { }
 
 void BaseMediator::newProperty(INDI::Property *)
 { }
 
+void BaseMediator::newProperty(INDI::Property)
+{ }
+
 void BaseMediator::removeProperty(INDI::Property *)
+{ }
+
+void BaseMediator::removeProperty(INDI::Property)
 { }
 
 void BaseMediator::newBLOB(IBLOB *)
@@ -21,16 +34,31 @@ void BaseMediator::newBLOB(IBLOB *)
 void BaseMediator::newSwitch(ISwitchVectorProperty *)
 { }
 
+void BaseMediator::newSwitch(INDI::PropertySwitch)
+{ }
+
 void BaseMediator::newNumber(INumberVectorProperty *)
+{ }
+
+void BaseMediator::newNumber(INDI::PropertyNumber)
 { }
 
 void BaseMediator::newText(ITextVectorProperty *)
 { }
 
+void BaseMediator::newText(INDI::PropertyText)
+{ }
+
 void BaseMediator::newLight(ILightVectorProperty *)
 { }
 
+void BaseMediator::newLight(INDI::PropertyLight)
+{ }
+
 void BaseMediator::newMessage(INDI::BaseDevice *, int)
+{ }
+
+void BaseMediator::newMessage(INDI::BaseDevice, int)
 { }
 
 void BaseMediator::serverConnected()

--- a/libs/indibase/indibase.cpp
+++ b/libs/indibase/indibase.cpp
@@ -4,25 +4,13 @@
 namespace INDI
 {
 
-void BaseMediator::newDevice(INDI::BaseDevice *)
-{ }
-
 void BaseMediator::newDevice(INDI::BaseDevice)
-{ }
-
-void BaseMediator::removeDevice(INDI::BaseDevice *)
 { }
 
 void BaseMediator::removeDevice(INDI::BaseDevice)
 { }
 
-void BaseMediator::newProperty(INDI::Property *)
-{ }
-
 void BaseMediator::newProperty(INDI::Property)
-{ }
-
-void BaseMediator::removeProperty(INDI::Property *)
 { }
 
 void BaseMediator::removeProperty(INDI::Property)
@@ -31,31 +19,16 @@ void BaseMediator::removeProperty(INDI::Property)
 void BaseMediator::newBLOB(IBLOB *)
 { }
 
-void BaseMediator::newSwitch(ISwitchVectorProperty *)
-{ }
-
 void BaseMediator::newSwitch(INDI::PropertySwitch)
-{ }
-
-void BaseMediator::newNumber(INumberVectorProperty *)
 { }
 
 void BaseMediator::newNumber(INDI::PropertyNumber)
 { }
 
-void BaseMediator::newText(ITextVectorProperty *)
-{ }
-
 void BaseMediator::newText(INDI::PropertyText)
 { }
 
-void BaseMediator::newLight(ILightVectorProperty *)
-{ }
-
 void BaseMediator::newLight(INDI::PropertyLight)
-{ }
-
-void BaseMediator::newMessage(INDI::BaseDevice *, int)
 { }
 
 void BaseMediator::newMessage(INDI::BaseDevice, int)
@@ -65,6 +38,34 @@ void BaseMediator::serverConnected()
 { }
 
 void BaseMediator::serverDisconnected(int)
+{ }
+
+// deprecated
+void BaseMediator::newDevice(INDI::BaseDevice *)
+{ }
+
+void BaseMediator::removeDevice(INDI::BaseDevice *)
+{ }
+
+void BaseMediator::newProperty(INDI::Property *)
+{ }
+
+void BaseMediator::removeProperty(INDI::Property *)
+{ }
+
+void BaseMediator::newSwitch(ISwitchVectorProperty *)
+{ }
+
+void BaseMediator::newNumber(INumberVectorProperty *)
+{ }
+
+void BaseMediator::newText(ITextVectorProperty *)
+{ }
+
+void BaseMediator::newLight(ILightVectorProperty *)
+{ }
+
+void BaseMediator::newMessage(INDI::BaseDevice *, int)
 { }
 
 }

--- a/libs/indibase/indibase.cpp
+++ b/libs/indibase/indibase.cpp
@@ -1,0 +1,42 @@
+#include "indibase.h"
+
+namespace INDI
+{
+
+void BaseMediator::newDevice(INDI::BaseDevice *)
+{ }
+
+void BaseMediator::removeDevice(INDI::BaseDevice *)
+{ }
+
+void BaseMediator::newProperty(INDI::Property *)
+{ }
+
+void BaseMediator::removeProperty(INDI::Property *)
+{ }
+
+void BaseMediator::newBLOB(IBLOB *)
+{ }
+
+void BaseMediator::newSwitch(ISwitchVectorProperty *)
+{ }
+
+void BaseMediator::newNumber(INumberVectorProperty *)
+{ }
+
+void BaseMediator::newText(ITextVectorProperty *)
+{ }
+
+void BaseMediator::newLight(ILightVectorProperty *)
+{ }
+
+void BaseMediator::newMessage(INDI::BaseDevice *, int)
+{ }
+
+void BaseMediator::serverConnected()
+{ }
+
+void BaseMediator::serverDisconnected(int)
+{ }
+
+}

--- a/libs/indibase/indibase.cpp
+++ b/libs/indibase/indibase.cpp
@@ -4,35 +4,31 @@
 namespace INDI
 {
 
+// device
+
 void BaseMediator::newDevice(INDI::BaseDevice)
 { }
 
 void BaseMediator::removeDevice(INDI::BaseDevice)
 { }
 
+// property
+
 void BaseMediator::newProperty(INDI::Property)
+{ }
+
+void BaseMediator::updateProperty(INDI::Property)
 { }
 
 void BaseMediator::removeProperty(INDI::Property)
 { }
 
-void BaseMediator::newBLOB(IBLOB *)
-{ }
-
-void BaseMediator::newSwitch(INDI::PropertySwitch)
-{ }
-
-void BaseMediator::newNumber(INDI::PropertyNumber)
-{ }
-
-void BaseMediator::newText(INDI::PropertyText)
-{ }
-
-void BaseMediator::newLight(INDI::PropertyLight)
-{ }
+// message
 
 void BaseMediator::newMessage(INDI::BaseDevice, int)
 { }
+
+// server
 
 void BaseMediator::serverConnected()
 { }
@@ -64,6 +60,9 @@ void BaseMediator::newText(ITextVectorProperty *)
 { }
 
 void BaseMediator::newLight(ILightVectorProperty *)
+{ }
+
+void BaseMediator::newBLOB(IBLOB *)
 { }
 
 void BaseMediator::newMessage(INDI::BaseDevice *, int)

--- a/libs/indibase/indibase.h
+++ b/libs/indibase/indibase.h
@@ -5,6 +5,11 @@
 #include "indidevapi.h"
 #include "indibasetypes.h"
 
+#ifdef SWIG
+// api version for swig
+%include "indiapi.h"
+#endif
+
 #define MAXRBUF 2048
 
 /** @namespace INDI
@@ -146,6 +151,7 @@ class INDI::BaseMediator
         virtual void serverDisconnected(int exit_code);
 
     public: // deprecated interface
+#if INDI_VERSION_MAJOR < 2
         /** @brief Emmited when a new device is created from INDI server.
          *  @param dp Pointer to the base device instance
          */
@@ -191,4 +197,5 @@ class INDI::BaseMediator
          *  @param messageID ID of the message that can be used to retrieve the message from the device's messageQueue() function.
          */
         virtual void newMessage(INDI::BaseDevice *dp, int messageID); // deprecated
+#endif
 };

--- a/libs/indibase/indibase.h
+++ b/libs/indibase/indibase.h
@@ -85,59 +85,59 @@ class INDI::BaseMediator
         /** @brief Emmited when a new device is created from INDI server.
          *  @param dp Pointer to the base device instance
          */
-        virtual void newDevice(INDI::BaseDevice *dp) = 0;
+        virtual void newDevice(INDI::BaseDevice *dp);
 
         /** @brief Emmited when a device is deleted from INDI server.
          *  @param dp Pointer to the base device instance.
          */
-        virtual void removeDevice(INDI::BaseDevice *dp) = 0;
+        virtual void removeDevice(INDI::BaseDevice *dp);
 
         /** @brief Emmited when a new property is created for an INDI driver.
          *  @param property Pointer to the Property Container
          */
-        virtual void newProperty(INDI::Property *property) = 0;
+        virtual void newProperty(INDI::Property *property);
 
         /** @brief Emmited when a property is deleted for an INDI driver.
          *  @param property Pointer to the Property Container to remove.
          */
-        virtual void removeProperty(INDI::Property *property) = 0;
+        virtual void removeProperty(INDI::Property *property);
 
         /** @brief Emmited when a new BLOB value arrives from INDI server.
          *  @param bp Pointer to filled and process BLOB.
          */
-        virtual void newBLOB(IBLOB *bp) = 0;
+        virtual void newBLOB(IBLOB *bp);
 
         /** @brief Emmited when a new switch value arrives from INDI server.
          *  @param svp Pointer to a switch vector property.
          */
-        virtual void newSwitch(ISwitchVectorProperty *svp) = 0;
+        virtual void newSwitch(ISwitchVectorProperty *svp);
 
         /** @brief Emmited when a new number value arrives from INDI server.
          *  @param nvp Pointer to a number vector property.
          */
-        virtual void newNumber(INumberVectorProperty *nvp) = 0;
+        virtual void newNumber(INumberVectorProperty *nvp);
 
         /** @brief Emmited when a new text value arrives from INDI server.
          *  @param tvp Pointer to a text vector property.
          */
-        virtual void newText(ITextVectorProperty *tvp) = 0;
+        virtual void newText(ITextVectorProperty *tvp);
 
         /** @brief Emmited when a new light value arrives from INDI server.
          *  @param lvp Pointer to a light vector property.
          */
-        virtual void newLight(ILightVectorProperty *lvp) = 0;
+        virtual void newLight(ILightVectorProperty *lvp);
 
         /** @brief Emmited when a new message arrives from INDI server.
          *  @param dp pointer to the INDI device the message is sent to.
          *  @param messageID ID of the message that can be used to retrieve the message from the device's messageQueue() function.
          */
-        virtual void newMessage(INDI::BaseDevice *dp, int messageID) = 0;
+        virtual void newMessage(INDI::BaseDevice *dp, int messageID);
 
         /** @brief Emmited when the server is connected. */
-        virtual void serverConnected() = 0;
+        virtual void serverConnected();
 
         /** @brief Emmited when the server gets disconnected.
          *  @param exit_code 0 if client was requested to disconnect from server. -1 if connection to server is terminated due to remote server disconnection.
          */
-        virtual void serverDisconnected(int exit_code) = 0;
+        virtual void serverDisconnected(int exit_code);
 };

--- a/libs/indibase/indibase.h
+++ b/libs/indibase/indibase.h
@@ -70,6 +70,10 @@ class GPS;
 class Weather;
 class USBDevice;
 class Property;
+class PropertySwitch;
+class PropertyNumber;
+class PropertyText;
+class PropertyLight;
 class Controller;
 class Logger;
 }
@@ -85,22 +89,27 @@ class INDI::BaseMediator
         /** @brief Emmited when a new device is created from INDI server.
          *  @param dp Pointer to the base device instance
          */
-        virtual void newDevice(INDI::BaseDevice *dp);
+        virtual void newDevice(INDI::BaseDevice *dp); // deprecated
+        virtual void newDevice(INDI::BaseDevice dp);
 
         /** @brief Emmited when a device is deleted from INDI server.
          *  @param dp Pointer to the base device instance.
          */
-        virtual void removeDevice(INDI::BaseDevice *dp);
+        virtual void removeDevice(INDI::BaseDevice *dp); // deprecated
+        virtual void removeDevice(INDI::BaseDevice dp);
+        
 
         /** @brief Emmited when a new property is created for an INDI driver.
          *  @param property Pointer to the Property Container
          */
-        virtual void newProperty(INDI::Property *property);
+        virtual void newProperty(INDI::Property *property); // deprecated
+        virtual void newProperty(INDI::Property property);
 
         /** @brief Emmited when a property is deleted for an INDI driver.
          *  @param property Pointer to the Property Container to remove.
          */
-        virtual void removeProperty(INDI::Property *property);
+        virtual void removeProperty(INDI::Property *property); // deprecated
+        virtual void removeProperty(INDI::Property property);
 
         /** @brief Emmited when a new BLOB value arrives from INDI server.
          *  @param bp Pointer to filled and process BLOB.
@@ -110,28 +119,33 @@ class INDI::BaseMediator
         /** @brief Emmited when a new switch value arrives from INDI server.
          *  @param svp Pointer to a switch vector property.
          */
-        virtual void newSwitch(ISwitchVectorProperty *svp);
+        virtual void newSwitch(ISwitchVectorProperty *svp); // deprecated
+        virtual void newSwitch(INDI::PropertySwitch property);
 
         /** @brief Emmited when a new number value arrives from INDI server.
          *  @param nvp Pointer to a number vector property.
          */
-        virtual void newNumber(INumberVectorProperty *nvp);
+        virtual void newNumber(INumberVectorProperty *nvp); // deprecated
+        virtual void newNumber(INDI::PropertyNumber property);
 
         /** @brief Emmited when a new text value arrives from INDI server.
          *  @param tvp Pointer to a text vector property.
          */
-        virtual void newText(ITextVectorProperty *tvp);
+        virtual void newText(ITextVectorProperty *tvp); // deprecated
+        virtual void newText(INDI::PropertyText property);
 
         /** @brief Emmited when a new light value arrives from INDI server.
          *  @param lvp Pointer to a light vector property.
          */
-        virtual void newLight(ILightVectorProperty *lvp);
+        virtual void newLight(ILightVectorProperty *lvp); // deprecated
+        virtual void newLight(INDI::PropertyLight property);
 
         /** @brief Emmited when a new message arrives from INDI server.
          *  @param dp pointer to the INDI device the message is sent to.
          *  @param messageID ID of the message that can be used to retrieve the message from the device's messageQueue() function.
          */
-        virtual void newMessage(INDI::BaseDevice *dp, int messageID);
+        virtual void newMessage(INDI::BaseDevice *dp, int messageID); // deprecated
+        virtual void newMessage(INDI::BaseDevice dp, int messageID);
 
         /** @brief Emmited when the server is connected. */
         virtual void serverConnected();

--- a/libs/indibase/indibase.h
+++ b/libs/indibase/indibase.h
@@ -87,28 +87,23 @@ class INDI::BaseMediator
         virtual ~BaseMediator() = default;
 
         /** @brief Emmited when a new device is created from INDI server.
-         *  @param dp Pointer to the base device instance
+         *  @param baseDevice BaseDevice instance.
          */
-        virtual void newDevice(INDI::BaseDevice *dp); // deprecated
-        virtual void newDevice(INDI::BaseDevice dp);
+        virtual void newDevice(INDI::BaseDevice baseDevice);
 
         /** @brief Emmited when a device is deleted from INDI server.
-         *  @param dp Pointer to the base device instance.
+         *  @param baseDevice BaseDevice instance.
          */
-        virtual void removeDevice(INDI::BaseDevice *dp); // deprecated
-        virtual void removeDevice(INDI::BaseDevice dp);
-        
+        virtual void removeDevice(INDI::BaseDevice baseDevice);        
 
         /** @brief Emmited when a new property is created for an INDI driver.
-         *  @param property Pointer to the Property Container
+         *  @param property Property container.
          */
-        virtual void newProperty(INDI::Property *property); // deprecated
         virtual void newProperty(INDI::Property property);
 
         /** @brief Emmited when a property is deleted for an INDI driver.
-         *  @param property Pointer to the Property Container to remove.
+         *  @param property Property container.
          */
-        virtual void removeProperty(INDI::Property *property); // deprecated
         virtual void removeProperty(INDI::Property property);
 
         /** @brief Emmited when a new BLOB value arrives from INDI server.
@@ -117,35 +112,30 @@ class INDI::BaseMediator
         virtual void newBLOB(IBLOB *bp);
 
         /** @brief Emmited when a new switch value arrives from INDI server.
-         *  @param svp Pointer to a switch vector property.
+         *  @param property PropertySwitch container.
          */
-        virtual void newSwitch(ISwitchVectorProperty *svp); // deprecated
         virtual void newSwitch(INDI::PropertySwitch property);
 
         /** @brief Emmited when a new number value arrives from INDI server.
-         *  @param nvp Pointer to a number vector property.
+         *  @param property PropertyNumber container.
          */
-        virtual void newNumber(INumberVectorProperty *nvp); // deprecated
         virtual void newNumber(INDI::PropertyNumber property);
 
         /** @brief Emmited when a new text value arrives from INDI server.
-         *  @param tvp Pointer to a text vector property.
+         *  @param property PropertyText container.
          */
-        virtual void newText(ITextVectorProperty *tvp); // deprecated
         virtual void newText(INDI::PropertyText property);
 
         /** @brief Emmited when a new light value arrives from INDI server.
-         *  @param lvp Pointer to a light vector property.
+         *  @param property PropertyLight container.
          */
-        virtual void newLight(ILightVectorProperty *lvp); // deprecated
         virtual void newLight(INDI::PropertyLight property);
 
         /** @brief Emmited when a new message arrives from INDI server.
-         *  @param dp pointer to the INDI device the message is sent to.
+         *  @param baseDevice BaseDevice instance the message is sent to.
          *  @param messageID ID of the message that can be used to retrieve the message from the device's messageQueue() function.
          */
-        virtual void newMessage(INDI::BaseDevice *dp, int messageID); // deprecated
-        virtual void newMessage(INDI::BaseDevice dp, int messageID);
+        virtual void newMessage(INDI::BaseDevice baseDevice, int messageID);
 
         /** @brief Emmited when the server is connected. */
         virtual void serverConnected();
@@ -154,4 +144,51 @@ class INDI::BaseMediator
          *  @param exit_code 0 if client was requested to disconnect from server. -1 if connection to server is terminated due to remote server disconnection.
          */
         virtual void serverDisconnected(int exit_code);
+
+    public: // deprecated interface
+        /** @brief Emmited when a new device is created from INDI server.
+         *  @param dp Pointer to the base device instance
+         */
+        virtual void newDevice(INDI::BaseDevice *dp); // deprecated
+
+        /** @brief Emmited when a device is deleted from INDI server.
+         *  @param dp Pointer to the base device instance.
+         */
+        virtual void removeDevice(INDI::BaseDevice *dp); // deprecated
+
+        /** @brief Emmited when a new property is created for an INDI driver.
+         *  @param property Pointer to the Property Container
+         */
+        virtual void newProperty(INDI::Property *property); // deprecated
+
+        /** @brief Emmited when a property is deleted for an INDI driver.
+         *  @param property Pointer to the Property Container to remove.
+         */
+        virtual void removeProperty(INDI::Property *property); // deprecated
+
+        /** @brief Emmited when a new switch value arrives from INDI server.
+         *  @param svp Pointer to a switch vector property.
+         */
+        virtual void newSwitch(ISwitchVectorProperty *svp); // deprecated
+
+        /** @brief Emmited when a new number value arrives from INDI server.
+         *  @param nvp Pointer to a number vector property.
+         */
+        virtual void newNumber(INumberVectorProperty *nvp); // deprecated
+
+        /** @brief Emmited when a new text value arrives from INDI server.
+         *  @param tvp Pointer to a text vector property.
+         */
+        virtual void newText(ITextVectorProperty *tvp); // deprecated
+
+        /** @brief Emmited when a new light value arrives from INDI server.
+         *  @param lvp Pointer to a light vector property.
+         */
+        virtual void newLight(ILightVectorProperty *lvp); // deprecated
+
+        /** @brief Emmited when a new message arrives from INDI server.
+         *  @param dp pointer to the INDI device the message is sent to.
+         *  @param messageID ID of the message that can be used to retrieve the message from the device's messageQueue() function.
+         */
+        virtual void newMessage(INDI::BaseDevice *dp, int messageID); // deprecated
 };

--- a/libs/indibase/indibase.h
+++ b/libs/indibase/indibase.h
@@ -91,6 +91,7 @@ class INDI::BaseMediator
     public:
         virtual ~BaseMediator() = default;
 
+    public:
         /** @brief Emmited when a new device is created from INDI server.
          *  @param baseDevice BaseDevice instance.
          */
@@ -101,47 +102,30 @@ class INDI::BaseMediator
          */
         virtual void removeDevice(INDI::BaseDevice baseDevice);        
 
+    public:
         /** @brief Emmited when a new property is created for an INDI driver.
          *  @param property Property container.
          */
         virtual void newProperty(INDI::Property property);
+
+        /** @brief Emmited when a new property value arrives from INDI server.
+         *  @param property Property container.
+         */
+        virtual void updateProperty(INDI::Property property);
 
         /** @brief Emmited when a property is deleted for an INDI driver.
          *  @param property Property container.
          */
         virtual void removeProperty(INDI::Property property);
 
-        /** @brief Emmited when a new BLOB value arrives from INDI server.
-         *  @param bp Pointer to filled and process BLOB.
-         */
-        virtual void newBLOB(IBLOB *bp);
-
-        /** @brief Emmited when a new switch value arrives from INDI server.
-         *  @param property PropertySwitch container.
-         */
-        virtual void newSwitch(INDI::PropertySwitch property);
-
-        /** @brief Emmited when a new number value arrives from INDI server.
-         *  @param property PropertyNumber container.
-         */
-        virtual void newNumber(INDI::PropertyNumber property);
-
-        /** @brief Emmited when a new text value arrives from INDI server.
-         *  @param property PropertyText container.
-         */
-        virtual void newText(INDI::PropertyText property);
-
-        /** @brief Emmited when a new light value arrives from INDI server.
-         *  @param property PropertyLight container.
-         */
-        virtual void newLight(INDI::PropertyLight property);
-
+    public:
         /** @brief Emmited when a new message arrives from INDI server.
          *  @param baseDevice BaseDevice instance the message is sent to.
          *  @param messageID ID of the message that can be used to retrieve the message from the device's messageQueue() function.
          */
         virtual void newMessage(INDI::BaseDevice baseDevice, int messageID);
 
+    public:
         /** @brief Emmited when the server is connected. */
         virtual void serverConnected();
 
@@ -191,6 +175,11 @@ class INDI::BaseMediator
          *  @param lvp Pointer to a light vector property.
          */
         virtual void newLight(ILightVectorProperty *lvp); // deprecated
+
+        /** @brief Emmited when a new property value arrives from INDI server.
+         *  @param bp Pointer to filled and process BLOB.
+         */
+        virtual void newBLOB(IBLOB *bp); // deprecated
 
         /** @brief Emmited when a new message arrives from INDI server.
          *  @param dp pointer to the INDI device the message is sent to.

--- a/libs/indibase/indimacros.h
+++ b/libs/indibase/indimacros.h
@@ -143,3 +143,10 @@ static inline typename Wrapper::element_type *getPtrHelper(const Wrapper &p)
 # endif
 #endif
 
+#ifdef SWIG
+# define INDI_DEPRECATED(message)
+#elif __cplusplus
+# define INDI_DEPRECATED(message) [[deprecated(message)]]
+#else
+# define INDI_DEPRECATED(message) __attribute__ ((deprecated))
+#endif

--- a/libs/indibase/indimacros.h
+++ b/libs/indibase/indimacros.h
@@ -100,6 +100,14 @@
  */
 #if defined(__cplusplus)
 
+#include <memory>
+
+template <typename T>
+static inline std::shared_ptr<T> make_shared_weak(T *object)
+{
+    return std::shared_ptr<T>(object, [](T*) {});
+}
+
 template <typename T>
 static inline T *getPtrHelper(T *ptr)
 {

--- a/libs/indibase/parentdevice.cpp
+++ b/libs/indibase/parentdevice.cpp
@@ -1,0 +1,60 @@
+#include "parentdevice.h"
+#include "parentdevice_p.h"
+
+#include "basedevice.h"
+#include "basedevice_p.h"
+
+#include <atomic>
+
+namespace INDI
+{
+
+static std::shared_ptr<ParentDevicePrivate> create(bool valid)
+{
+    class InvalidParentDevicePrivate: public ParentDevicePrivate
+    {
+        public:
+            InvalidParentDevicePrivate()
+            {
+                this->valid = false;
+            }
+    };
+
+    if (valid == false)
+    {
+        static std::shared_ptr<ParentDevicePrivate> invalidDevice(new InvalidParentDevicePrivate);
+        return invalidDevice;
+    }
+    else
+    {
+        std::shared_ptr<ParentDevicePrivate> validDevice(new ParentDevicePrivate);
+        return validDevice;
+    }
+}
+
+
+ParentDevice::ParentDevice(ParentDevice::Type type)
+    : BaseDevice(std::shared_ptr<BaseDevicePrivate>(create(type == Valid)))
+{
+    D_PTR(ParentDevice);
+    ++d->ref;
+}
+
+ParentDevice::ParentDevice(const std::shared_ptr<ParentDevicePrivate> &dd)
+    : BaseDevice(std::shared_ptr<BaseDevicePrivate>(dd))
+{
+    D_PTR(ParentDevice);
+    ++d->ref;
+}
+
+ParentDevice::~ParentDevice()
+{
+    D_PTR(ParentDevice);
+    if (--d->ref == 0)
+    {
+        // prevent circular reference
+        d->pAll.clear();
+    }
+}
+
+}

--- a/libs/indibase/parentdevice.h
+++ b/libs/indibase/parentdevice.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "basedevice.h"
+
+/**
+ * @class INDI::ParentDevice
+ * @brief The class is used to create device instances.
+ * Class copying is not allowed. When an object is destroyed,
+ * the property list (INDI::Property) is cleared to prevent a circular reference along with the properties.
+ * The base INDI::BaseDevice class and its INDI::Properties exist as long as they are used by other objects.
+ */
+
+namespace INDI
+{
+
+class ParentDevicePrivate;
+class ParentDevice: public BaseDevice
+{
+        DECLARE_PRIVATE(ParentDevice)
+
+        ParentDevice(const ParentDevice &) = delete;
+        ParentDevice &operator=(const ParentDevice &) = delete;
+
+    public:
+        enum Type
+        {
+            Valid,
+            Invalid
+        };
+
+    public:
+        explicit ParentDevice(Type type);
+        ~ParentDevice();
+
+    public:
+        ParentDevice(ParentDevice &&other) = default;
+        ParentDevice &operator=(ParentDevice &&other) = default;
+
+    protected:
+        ParentDevice(const std::shared_ptr<ParentDevicePrivate> &dd);
+};
+
+}

--- a/libs/indibase/parentdevice_p.h
+++ b/libs/indibase/parentdevice_p.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "basedevice_p.h"
+#include <atomic>
+
+namespace INDI
+{
+
+class ParentDevicePrivate: public BaseDevicePrivate
+{
+    public:
+        std::atomic_int ref {0};
+};
+
+}

--- a/libs/indibase/property/indiproperty.cpp
+++ b/libs/indibase/property/indiproperty.cpp
@@ -20,6 +20,8 @@
 #include "indiproperty.h"
 #include "indiproperty_p.h"
 
+#include "basedevice.h"
+
 #include "indipropertytext_p.h"
 #include "indipropertyswitch_p.h"
 #include "indipropertynumber_p.h"
@@ -181,7 +183,13 @@ void Property::setDynamic(bool dyn)
 void Property::setBaseDevice(BaseDevice *idp)
 {
     D_PTR(Property);
-    d->baseDevice = idp;
+    d->baseDevice = (idp == nullptr ? BaseDevice() : *idp);
+}
+
+void Property::setBaseDevice(BaseDevice baseDevice)
+{
+    D_PTR(Property);
+    d->baseDevice = baseDevice;
 }
 
 void *Property::getProperty() const
@@ -228,7 +236,7 @@ bool Property::isDynamic() const
     return d->dynamic;
 }
 
-BaseDevice *Property::getBaseDevice() const
+BaseDevice Property::getBaseDevice() const
 {
     D_PTR(const Property);
     return d->baseDevice;

--- a/libs/indibase/property/indiproperty.h
+++ b/libs/indibase/property/indiproperty.h
@@ -62,7 +62,11 @@ class Property
         void setType(INDI_PROPERTY_TYPE t);
         void setRegistered(bool r);
         void setDynamic(bool d);
+
+        INDI_DEPRECATED("Use setBaseDevice(BaseDevice).")
         void setBaseDevice(BaseDevice *idp);
+
+        void setBaseDevice(BaseDevice device);
 
     public:
         void *getProperty() const;
@@ -70,7 +74,7 @@ class Property
         const char *getTypeAsString() const;
         bool getRegistered() const;
         bool isDynamic() const;
-        BaseDevice *getBaseDevice() const;
+        BaseDevice getBaseDevice() const;
 
     public: // Convenience Functions
         void setName(const char *name);

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -32,17 +32,12 @@ namespace INDI
 template <typename T, typename U>
 static inline std::shared_ptr<T> property_private_cast(const std::shared_ptr<U> &r)
 {
-    using S = std::remove_pointer_t<T>;
-    static struct Invalid
+    static struct Invalid : public T
     {
-        std::shared_ptr<T> instance {new S {size_t(16)}};
-        Invalid()
-        {
-            instance->type = INDI_UNKNOWN;
-        }
+        Invalid() : T(16) { this->type = INDI_UNKNOWN; }
     } invalid;
     auto result = std::dynamic_pointer_cast<T>(r);
-    return result != nullptr ? result : invalid.instance;
+    return result != nullptr ? result : make_shared_weak(&invalid);
 }
 
 class BaseDevice;

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include "indimacros.h"
 #include "indibase.h"
 #include "indiproperty.h"
 #include <memory>
@@ -26,14 +27,6 @@
 
 namespace INDI
 {
-
-#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
-template <typename T>
-static inline std::shared_ptr<T> make_shared_weak(T *object)
-{
-    return std::shared_ptr<T>(object, [](T*) {});
-}
-#endif
 
 template <typename T, typename U>
 static inline std::shared_ptr<T> property_private_cast(const std::shared_ptr<U> &r)

--- a/libs/indibase/property/indiproperty_p.h
+++ b/libs/indibase/property/indiproperty_p.h
@@ -22,6 +22,7 @@
 #include "indimacros.h"
 #include "indibase.h"
 #include "indiproperty.h"
+#include "basedevice.h"
 #include <memory>
 #include <functional>
 
@@ -49,7 +50,7 @@ class PropertyPrivate
 {
     public:
         void *property = nullptr;
-        BaseDevice *baseDevice = nullptr;
+        BaseDevice baseDevice;
         INDI_PROPERTY_TYPE type = INDI_UNKNOWN;
         bool registered = false;
         bool dynamic = false;

--- a/libs/indibase/property/indipropertyview.h
+++ b/libs/indibase/property/indipropertyview.h
@@ -427,7 +427,7 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
         }
         const char *getText()  const
         {
-            return this->text;
+            return this->text ? this->text : "";
         }
 
         void *getAux() const

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -33,7 +33,7 @@ std::vector<BaseDevice> WatchDeviceProperty::getDevices() const
     return result;
 }
 
-BaseDevice WatchDeviceProperty::getDeviceByName(const char *name) const
+BaseDevice &WatchDeviceProperty::getDeviceByName(const char *name)
 {
     auto it = data.find(name);
     return it != data.end() ? it->second.device : BaseDevice::invalid();
@@ -46,7 +46,7 @@ WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const c
     {
         it.device = constructor();
         it.device.setDeviceName(name);
-        it.device.d_ptr->mediateNewDevice();
+        it.device.d_ptr->mediateNewDevice(it.device);
         it.emitWatchDevice();
     }
     return it;

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -33,13 +33,13 @@ std::vector<BaseDevice> WatchDeviceProperty::getDevices() const
     return result;
 }
 
-BaseDevice &WatchDeviceProperty::getDeviceByName(const char *name)
+BaseDevice WatchDeviceProperty::getDeviceByName(const char *name)
 {
     auto it = data.find(name);
-    return it != data.end() ? it->second.device : BaseDevice::invalid();
+    return it != data.end() ? it->second.device : BaseDevice();
 }
 
-WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const char *name, const std::function<BaseDevice()> &constructor)
+WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const char *name, const std::function<ParentDevice()> &constructor)
 {
     auto &it = data[name];
     if (!it.device.isValid())
@@ -93,7 +93,7 @@ void WatchDeviceProperty::clearDevices()
 {
     for (auto &deviceInfo : data)
     {
-        deviceInfo.second.device = BaseDevice::invalid();
+        deviceInfo.second.device = ParentDevice(ParentDevice::Invalid);
     }
 }
 
@@ -112,7 +112,7 @@ bool WatchDeviceProperty::deleteDevice(const BaseDevice &device)
     return false;
 }
 
-int WatchDeviceProperty::processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice()> &constructor)
+int WatchDeviceProperty::processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<ParentDevice()> &constructor)
 {
     auto deviceName = root.getAttribute("device");
     if (!deviceName.isValid() || deviceName.toString() == "" || !isDeviceWatched(deviceName))

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -17,6 +17,8 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "watchdeviceproperty.h"
+#include "basedevice.h"
+#include "basedevice_p.h"
 
 namespace INDI
 {
@@ -44,8 +46,7 @@ WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const c
     {
         it.device = *constructor();
         it.device.setDeviceName(name);
-        if (auto mediator = it.device.getMediator())
-            mediator->newDevice(it.device);
+        it.device.d_ptr->mediateNewDevice();
         it.emitWatchDevice();
     }
     return it;

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -39,12 +39,12 @@ BaseDevice WatchDeviceProperty::getDeviceByName(const char *name) const
     return it != data.end() ? it->second.device : BaseDevice::invalid();
 }
 
-WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const char *name, const std::function<BaseDevice*()> &constructor)
+WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const char *name, const std::function<BaseDevice()> &constructor)
 {
     auto &it = data[name];
     if (!it.device.isValid())
     {
-        it.device = *constructor();
+        it.device = constructor();
         it.device.setDeviceName(name);
         it.device.d_ptr->mediateNewDevice();
         it.emitWatchDevice();
@@ -112,7 +112,7 @@ bool WatchDeviceProperty::deleteDevice(const BaseDevice &device)
     return false;
 }
 
-int WatchDeviceProperty::processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice*()> &constructor)
+int WatchDeviceProperty::processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice()> &constructor)
 {
     auto deviceName = root.getAttribute("device");
     if (!deviceName.isValid() || deviceName.toString() == "" || !isDeviceWatched(deviceName))

--- a/libs/indibase/watchdeviceproperty.cpp
+++ b/libs/indibase/watchdeviceproperty.cpp
@@ -46,7 +46,7 @@ WatchDeviceProperty::DeviceInfo &WatchDeviceProperty::ensureDeviceByName(const c
     {
         it.device = constructor();
         it.device.setDeviceName(name);
-        it.device.d_ptr->mediateNewDevice(it.device);
+        it.device.attach();
         it.emitWatchDevice();
     }
     return it;

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -34,7 +34,7 @@ class WatchDeviceProperty
     public:
         struct DeviceInfo
         {
-            BaseDevice device;
+            BaseDevice device {BaseDevice::invalid()};
             std::function<void (BaseDevice)> newDeviceCallback; // call if device available
             std::set<std::string> properties; // watch only specific properties only
 
@@ -47,7 +47,7 @@ class WatchDeviceProperty
 
     public:
         std::vector<BaseDevice> getDevices() const;
-        BaseDevice getDeviceByName(const char *name) const;
+        BaseDevice &getDeviceByName(const char *name);
         DeviceInfo &ensureDeviceByName(const char *name, const std::function<BaseDevice()> &constructor);
 
     public:

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -34,14 +34,14 @@ class WatchDeviceProperty
     public:
         struct DeviceInfo
         {
-            std::unique_ptr<BaseDevice> device;
+            BaseDevice device;
             std::function<void (BaseDevice)> newDeviceCallback; // call if device available
             std::set<std::string> properties; // watch only specific properties only
 
             void emitWatchDevice()
             {
                 if (newDeviceCallback)
-                    newDeviceCallback(*device.get());
+                    newDeviceCallback(device);
             }
         };
 
@@ -52,8 +52,8 @@ class WatchDeviceProperty
         }
 
     public:
-        std::vector<BaseDevice *> getDevices() const;
-        BaseDevice *getDeviceByName(const char *name) const;
+        std::vector<BaseDevice> getDevices() const;
+        BaseDevice getDeviceByName(const char *name) const;
         DeviceInfo &ensureDeviceByName(const char *name, const std::function<BaseDevice*()> &constructor);
 
     public:
@@ -77,7 +77,7 @@ class WatchDeviceProperty
 
         void clear();
         void clearDevices();
-        bool deleteDevice(const BaseDevice *device);
+        bool deleteDevice(const BaseDevice &device);
 
     public:
         int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice*()> &constructor = [](){ return new BaseDevice(); } );

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -46,15 +46,9 @@ class WatchDeviceProperty
         };
 
     public:
-        static BaseDevice *baseDeviceConstructor()
-        {
-            return new BaseDevice;
-        }
-
-    public:
         std::vector<BaseDevice> getDevices() const;
         BaseDevice getDeviceByName(const char *name) const;
-        DeviceInfo &ensureDeviceByName(const char *name, const std::function<BaseDevice*()> &constructor);
+        DeviceInfo &ensureDeviceByName(const char *name, const std::function<BaseDevice()> &constructor);
 
     public:
         bool isEmpty() const;
@@ -80,7 +74,7 @@ class WatchDeviceProperty
         bool deleteDevice(const BaseDevice &device);
 
     public:
-        int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice*()> &constructor = [](){ return new BaseDevice(); } );
+        int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice()> &constructor = [] { return BaseDevice(); } );
 
     public:
         std::map<std::string, DeviceInfo>::iterator begin()

--- a/libs/indibase/watchdeviceproperty.h
+++ b/libs/indibase/watchdeviceproperty.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "basedevice.h"
+#include "parentdevice.h"
 #include "indililxml.h"
 
 #include <functional>
@@ -34,7 +35,7 @@ class WatchDeviceProperty
     public:
         struct DeviceInfo
         {
-            BaseDevice device {BaseDevice::invalid()};
+            ParentDevice device{ParentDevice::Invalid};
             std::function<void (BaseDevice)> newDeviceCallback; // call if device available
             std::set<std::string> properties; // watch only specific properties only
 
@@ -47,8 +48,8 @@ class WatchDeviceProperty
 
     public:
         std::vector<BaseDevice> getDevices() const;
-        BaseDevice &getDeviceByName(const char *name);
-        DeviceInfo &ensureDeviceByName(const char *name, const std::function<BaseDevice()> &constructor);
+        BaseDevice getDeviceByName(const char *name);
+        DeviceInfo &ensureDeviceByName(const char *name, const std::function<ParentDevice()> &constructor);
 
     public:
         bool isEmpty() const;
@@ -74,7 +75,7 @@ class WatchDeviceProperty
         bool deleteDevice(const BaseDevice &device);
 
     public:
-        int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<BaseDevice()> &constructor = [] { return BaseDevice(); } );
+        int processXml(const INDI::LilXmlElement &root, char *errmsg, const std::function<ParentDevice()> &constructor = [] { return ParentDevice(ParentDevice::Valid); } );
 
     public:
         std::map<std::string, DeviceInfo>::iterator begin()

--- a/test/core/test_property_class.cpp
+++ b/test/core/test_property_class.cpp
@@ -24,6 +24,8 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "basedevice.h"
+
 #include "indiproperty.h"
 #include "indipropertynumber.h"
 #include "indipropertytext.h"
@@ -155,7 +157,8 @@ TEST(CORE_PROPERTY_CLASS, DISABLED_Test_Integrity)
     INDI::Property p;
 
     INumberVectorProperty * corrupted_property = (INumberVectorProperty*) (void*) 0x12345678;
-    INDI::BaseDevice * corrupted_device = (INDI::BaseDevice*) (void*) 0x87654321;
+    //INDI::BaseDevice * corrupted_device = (INDI::BaseDevice*) (void*) 0x87654321;
+    INDI::BaseDevice corrupted_device;
 
     p.setProperty(corrupted_property);
 


### PR DESCRIPTION
Referring to https://github.com/indilib/indi/pull/1761. This pull request aims to get rid of the use of raw pointers and use the `shared_ptr` which is in the `INDI::BaseDevice` class to store the data.

### BaseClient
Previously:
https://github.com/indilib/indi/blob/6b5ac8408ef021eb832479d4392aa97b66687c78/libs/indibase/abstractbaseclient.h#L128-L131

Now:
https://github.com/indilib/indi/blob/a53ae5bd45aa4c37361e5d50a28cb73b724f54c5/libs/indibase/abstractbaseclient.h#L128-L131

### BaseMediator
The virtual methods in `INDI::BaseMediator` require a bit of talking.
https://github.com/indilib/indi/blob/6b5ac8408ef021eb832479d4392aa97b66687c78/libs/indibase/indibase.h#L88-L103

This class is no longer needed after the introduction of `watchDevice` and `watchProperty`  https://github.com/indilib/indi/pull/1738
There is also passing `BaseDevice` by the pointer, but it will not be a problem to convert it to a value (built-in shared_ptr).