### PR TITLE
Use modern INDI::PropertyXXX in INDI::Property

### DIFF
--- a/libs/indidevice/basedevice.cpp
+++ b/libs/indidevice/basedevice.cpp
@@ -129,12 +129,6 @@ IPerm BaseDevice::getPropertyPermission(const char *name) const
     return IP_RO;
 }
 
-void *BaseDevice::getRawProperty(const char *name, INDI_PROPERTY_TYPE type) const
-{
-    INDI::Property *prop = getProperty(name, type);
-    return prop != nullptr ? prop->getProperty() : nullptr;
-}
-
 INDI::Property BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE type) const
 {
     D_PTR(const BaseDevice);

--- a/libs/indidevice/basedevice.cpp
+++ b/libs/indidevice/basedevice.cpp
@@ -478,9 +478,9 @@ bool BaseDevice::isConnected() const
     if (!svp)
         return false;
 
-    auto sp = svp->findWidgetByName("CONNECT");
+    auto sp = svp.findWidgetByName("CONNECT");
 
-    return sp && sp->getState() == ISS_ON && svp->getState() == IPS_OK;
+    return sp && sp->getState() == ISS_ON && svp.getState() == IPS_OK;
 }
 
 void BaseDevice::attach()
@@ -891,37 +891,19 @@ void BaseDevice::registerProperty(const INDI::Property &property, INDI_PROPERTY_
 
 const char *BaseDevice::getDriverName() const
 {
-    auto driverInfo = getText("DRIVER_INFO");
-
-    if (!driverInfo)
-        return nullptr;
-
-    auto driverName = driverInfo->findWidgetByName("DRIVER_NAME");
-
+    auto driverName = getText("DRIVER_INFO").findWidgetByName("DRIVER_NAME");
     return driverName ? driverName->getText() : nullptr;
 }
 
 const char *BaseDevice::getDriverExec() const
 {
-    auto driverInfo = getText("DRIVER_INFO");
-
-    if (!driverInfo)
-        return nullptr;
-
-    auto driverExec = driverInfo->findWidgetByName("DRIVER_EXEC");
-
+    auto driverExec = getText("DRIVER_INFO").findWidgetByName("DRIVER_EXEC");
     return driverExec ? driverExec->getText() : nullptr;
 }
 
 const char *BaseDevice::getDriverVersion() const
 {
-    auto driverInfo = getText("DRIVER_INFO");
-
-    if (!driverInfo)
-        return nullptr;
-
-    auto driverVersion = driverInfo->findWidgetByName("DRIVER_VERSION");
-
+    auto driverVersion = getText("DRIVER_INFO").findWidgetByName("DRIVER_VERSION");
     return driverVersion ? driverVersion->getText() : nullptr;
 }
 

--- a/libs/indidevice/basedevice.h
+++ b/libs/indidevice/basedevice.h
@@ -150,17 +150,6 @@ class BaseDevice
         /** @return Return property permission */
         IPerm getPropertyPermission(const char *name) const;
 
-        /** @brief Return a property and its type given its name.
-         *  @param name of property to be found.
-         *  @param type of property found.
-         *  @return If property is found, the raw void * pointer to the IXXXVectorProperty is returned. To be used you must use static_cast with given the type of property
-         *  returned. For example, INumberVectorProperty *num = static_cast<INumberVectorProperty> getRawProperty("FOO", INDI_NUMBER);
-         *
-         *  @note This is a low-level function and should not be called directly unless necessary. Use getXXX instead where XXX
-         *  is the property type (Number, Text, Switch..etc).
-         */
-        void *getRawProperty(const char *name, INDI_PROPERTY_TYPE type = INDI_UNKNOWN) const;
-
     public:
         /** @brief Add message to the driver's message queue.
          *  @param msg Message to add.

--- a/libs/indidevice/property/indiproperties.h
+++ b/libs/indidevice/property/indiproperties.h
@@ -84,6 +84,7 @@ class Properties
         iterator erase_if(Predicate predicate);
 
     public:
+#ifndef SWIG
 #ifdef INDI_PROPERTIES_BACKWARD_COMPATIBILE
         INDI::Properties operator *();
         const INDI::Properties operator *() const;
@@ -96,6 +97,7 @@ class Properties
 
         operator Properties *();
         operator const Properties *() const;
+#endif
 #endif
 
     protected:

--- a/libs/indidevice/property/indiproperty.cpp
+++ b/libs/indidevice/property/indiproperty.cpp
@@ -210,14 +210,6 @@ void Property::setBaseDevice(BaseDevice baseDevice)
     d->baseDevice = baseDevice;
 }
 
-#if 0
-void *Property::getProperty() const
-{
-    D_PTR(const Property);
-    return d->property;
-}
-#endif
-
 INDI_PROPERTY_TYPE Property::getType() const
 {
     D_PTR(const Property);

--- a/libs/indidevice/property/indiproperty.cpp
+++ b/libs/indidevice/property/indiproperty.cpp
@@ -28,6 +28,12 @@
 #include "indipropertylight_p.h"
 #include "indipropertyblob_p.h"
 
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+#include "indipropertynumber.h"
+#include "indipropertylight.h"
+#include "indipropertyblob.h"
+
 #include <cstdlib>
 #include <cstring>
 
@@ -92,6 +98,13 @@ Property::operator const INDI::Property *() const
     D_PTR(const Property);
     return isValid() ? &d->self : nullptr;
 }
+
+Property::operator INDI::PropertyView<INumber> *() const { return this->getNumber(); }
+Property::operator INDI::PropertyView<IText>   *() const { return this->getText(); }
+Property::operator INDI::PropertyView<ISwitch> *() const { return this->getSwitch(); }
+Property::operator INDI::PropertyView<ILight>  *() const { return this->getLight(); }
+Property::operator INDI::PropertyView<IBLOB>   *() const { return this->getBLOB(); }
+
 #endif
 
 #define PROPERTY_CASE(CODE) \
@@ -120,6 +133,25 @@ Property::Property()
     : d_ptr(new PropertyPrivate(nullptr, INDI_UNKNOWN))
 { }
 
+Property::Property(INDI::PropertyNumber property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertyText   property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertySwitch property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertyLight  property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertyBlob   property)
+    : d_ptr(property.d_ptr)
+{ }
 
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
 Property::Property(INumberVectorProperty *property)
@@ -154,20 +186,6 @@ Property::Property(const std::shared_ptr<PropertyPrivate> &dd)
     : d_ptr(dd)
 { }
 
-void Property::setProperty(void *p)
-{
-    D_PTR(Property);
-    d->type       = p ? d->type : INDI_UNKNOWN;
-    d->registered = p != nullptr;
-    d->property   = p;
-}
-
-void Property::setType(INDI_PROPERTY_TYPE t)
-{
-    D_PTR(Property);
-    d->type = t;
-}
-
 void Property::setRegistered(bool r)
 {
     D_PTR(Property);
@@ -192,11 +210,13 @@ void Property::setBaseDevice(BaseDevice baseDevice)
     d->baseDevice = baseDevice;
 }
 
+#if 0
 void *Property::getProperty() const
 {
     D_PTR(const Property);
     return d->property;
 }
+#endif
 
 INDI_PROPERTY_TYPE Property::getType() const
 {
@@ -385,49 +405,29 @@ bool Property::isLabelMatch(const std::string &otherLabel) const
     return false;
 }
 
-PropertyView<INumber> *Property::getNumber() const
+INDI::PropertyNumber Property::getNumber() const
 {
-    D_PTR(const Property);
-    if (d->type == INDI_NUMBER)
-        return static_cast<PropertyView<INumber>*>(d->property);
-
-    return nullptr;
+    return *this;
 }
 
-PropertyView<IText> *Property::getText() const
+INDI::PropertyText Property::getText() const
 {
-    D_PTR(const Property);
-    if (d->type == INDI_TEXT)
-        return static_cast<PropertyView<IText>*>(d->property);
-
-    return nullptr;
+    return *this;
 }
 
-PropertyView<ILight> *Property::getLight() const
+INDI::PropertyLight Property::getLight() const
 {
-    D_PTR(const Property);
-    if (d->type == INDI_LIGHT)
-        return static_cast<PropertyView<ILight>*>(d->property);
-
-    return nullptr;
+    return *this;
 }
 
-PropertyView<ISwitch> *Property::getSwitch() const
+INDI::PropertySwitch Property::getSwitch() const
 {
-    D_PTR(const Property);
-    if (d->type == INDI_SWITCH)
-        return static_cast<PropertyView<ISwitch>*>(d->property);
-
-    return nullptr;
+    return *this;
 }
 
-PropertyView<IBLOB> *Property::getBLOB() const
+INDI::PropertyBlob Property::getBLOB() const
 {
-    D_PTR(const Property);
-    if (d->type == INDI_BLOB)
-        return static_cast<PropertyView<IBLOB>*>(d->property);
-
-    return nullptr;
+    return *this;
 }
 
 void Property::save(FILE *fp) const

--- a/libs/indidevice/property/indiproperty.h
+++ b/libs/indidevice/property/indiproperty.h
@@ -32,7 +32,11 @@
 namespace INDI
 {
 class BaseDevice;
-
+class PropertyNumber;
+class PropertyText;
+class PropertySwitch;
+class PropertyLight;
+class PropertyBlob;
 /**
  * \class INDI::Property
    \brief Provides generic container for INDI properties
@@ -47,6 +51,13 @@ class Property
         Property();
         ~Property();
 
+    public:
+        Property(INDI::PropertyNumber property);
+        Property(INDI::PropertyText   property);
+        Property(INDI::PropertySwitch property);
+        Property(INDI::PropertyLight  property);
+        Property(INDI::PropertyBlob   property);
+
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
     public:
         Property(INumberVectorProperty *property);
@@ -56,8 +67,6 @@ class Property
         Property(IBLOBVectorProperty   *property);
 #endif
     public:
-        void setProperty(void *);
-        void setType(INDI_PROPERTY_TYPE t);
         void setRegistered(bool r);
         void setDynamic(bool d);
 
@@ -67,7 +76,6 @@ class Property
         void setBaseDevice(BaseDevice device);
 
     public:
-        void *getProperty() const;
         INDI_PROPERTY_TYPE getType() const;
         const char *getTypeAsString() const;
         bool getRegistered() const;
@@ -115,6 +123,7 @@ class Property
         void save(FILE *fp) const;
 
     public:
+#ifndef SWIG
         void apply(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
         void define(const char *format, ...) const ATTRIBUTE_FORMAT_PRINTF(2, 3);
 
@@ -126,17 +135,17 @@ class Property
         {
             define(nullptr);
         }
-
-    public:
-#ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
-        INDI::PropertyView<INumber> *getNumber() const;
-        INDI::PropertyView<IText>   *getText() const;
-        INDI::PropertyView<ISwitch> *getSwitch() const;
-        INDI::PropertyView<ILight>  *getLight() const;
-        INDI::PropertyView<IBLOB>   *getBLOB() const;
 #endif
 
     public:
+        INDI::PropertyNumber getNumber() const;
+        INDI::PropertyText   getText() const;
+        INDI::PropertySwitch getSwitch() const;
+        INDI::PropertyLight  getLight() const;
+        INDI::PropertyBlob   getBLOB() const;
+
+    public:
+#ifndef SWIG
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
         INDI::Property* operator->();
         const INDI::Property* operator->() const;
@@ -144,15 +153,16 @@ class Property
         operator INDI::Property *();
         operator const INDI::Property *() const;
 
-        operator INDI::PropertyView<INumber> *() const { return getNumber(); }
-        operator INDI::PropertyView<IText>   *() const { return getText(); }
-        operator INDI::PropertyView<ISwitch> *() const { return getSwitch(); }
-        operator INDI::PropertyView<ILight>  *() const { return getLight(); }
-        operator INDI::PropertyView<IBLOB>   *() const { return getBLOB(); }
+        operator INDI::PropertyView<INumber> *() const;
+        operator INDI::PropertyView<IText>   *() const;
+        operator INDI::PropertyView<ISwitch> *() const;
+        operator INDI::PropertyView<ILight>  *() const;
+        operator INDI::PropertyView<IBLOB>   *() const;
         bool operator != (std::nullptr_t) const        { return  isValid(); }
         bool operator == (std::nullptr_t) const        { return !isValid(); }
-        operator bool()                   const        { return  isValid(); }
 #endif
+#endif
+        operator bool()                   const        { return  isValid(); }
 
     protected:
         std::shared_ptr<PropertyPrivate> d_ptr;

--- a/libs/indidevice/property/indipropertybasic.cpp
+++ b/libs/indidevice/property/indipropertybasic.cpp
@@ -439,7 +439,7 @@ template <typename T>
 PropertyBasic<T>::operator INDI::PropertyView<T> *() const
 {
     D_PTR(const Property);
-    return static_cast<PropertyView<T> *>(d->property);
+    return isValid() ? static_cast<PropertyView<T> *>(d->property) : nullptr;
 }
 
 #endif

--- a/libs/indidevice/property/indipropertybasic.cpp
+++ b/libs/indidevice/property/indipropertybasic.cpp
@@ -422,19 +422,33 @@ PropertyView<T> * PropertyBasic<T>::operator &()
 
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
 template <typename T>
-PropertyView<T> *PropertyBasic<T>::operator ->()
+PropertyView<T> *PropertyBasic<T>::operator ->() const
 {
-    D_PTR(PropertyBasic);
-    return static_cast<PropertyView<T> *>(static_cast<INDI::PropertyPrivate*>(d)->property);
+    D_PTR(const Property);
+    return static_cast<PropertyView<T> *>(d->property);
 }
 
 template <typename T>
-INDI::PropertyView<T> PropertyBasic<T>::operator*()
+INDI::PropertyView<T> PropertyBasic<T>::operator*() const
 {
-    D_PTR(PropertyBasic);
-    return *static_cast<PropertyView<T> *>(static_cast<INDI::PropertyPrivate*>(d)->property);
+    D_PTR(const Property);
+    return *static_cast<PropertyView<T> *>(d->property);
 }
+
+template <typename T>
+PropertyBasic<T>::operator INDI::PropertyView<T> *() const
+{
+    D_PTR(const Property);
+    return static_cast<PropertyView<T> *>(d->property);
+}
+
 #endif
+
+template <typename T>
+PropertyBasic<T>::operator bool() const
+{
+    return isValid();
+}
 
 template class PropertyBasicPrivateTemplate<IText>;
 template class PropertyBasicPrivateTemplate<INumber>;

--- a/libs/indidevice/property/indipropertybasic.h
+++ b/libs/indidevice/property/indipropertybasic.h
@@ -86,7 +86,7 @@ class PropertyBasic : public INDI::Property
 
     public:
         void save(FILE *f) const;
-
+#ifndef SWIG
         void vapply(const char *format, va_list args) const;
         void vdefine(const char *format, va_list args) const;
 
@@ -95,7 +95,7 @@ class PropertyBasic : public INDI::Property
 
         void apply() const;
         void define() const;
-
+#endif
     public:
         PropertyView<T> * operator &();
 
@@ -141,11 +141,16 @@ class PropertyBasic : public INDI::Property
         PropertyBasic(PropertyBasicPrivate &dd);
         PropertyBasic(const std::shared_ptr<PropertyBasicPrivate> &dd);
 
+#ifndef SWIG
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
     public: // deprecated
-        INDI::PropertyView<T> *operator->();
-        INDI::PropertyView<T>  operator*();
+        INDI::PropertyView<T> *operator->() const;
+        INDI::PropertyView<T>  operator*() const;
+        operator INDI::PropertyView<T> *() const;
 #endif
+#endif
+    public:
+        operator bool() const;
 };
 
 }

--- a/libs/indidevice/property/indipropertyview.h
+++ b/libs/indidevice/property/indipropertyview.h
@@ -220,7 +220,7 @@ struct PropertyView: PROPERTYVIEW_BASE_ACCESS WidgetTraits<T>::PropertyType
 
     public: // only driver side
         void save(FILE *f) const;                              /* outside implementation */
-
+#ifndef SWIG
         void vapply(const char *format, va_list args)
         const;   /* outside implementation - only driver side, see indipropertyview_driver.cpp */
         void vdefine(const char *format, va_list args)
@@ -239,7 +239,7 @@ struct PropertyView: PROPERTYVIEW_BASE_ACCESS WidgetTraits<T>::PropertyType
         {
             define(nullptr);
         }
-
+#endif
     public:
         template <typename X = T, enable_if_is_same_t<X, IText> = true>
         void fill(

--- a/test/core/test_property_class.cpp
+++ b/test/core/test_property_class.cpp
@@ -37,8 +37,10 @@ TEST(CORE_PROPERTY_CLASS, Test_EmptyProperty)
 {
     INDI::Property p;
 
-    ASSERT_EQ(p.getProperty(), nullptr);
-    ASSERT_EQ(p.getBaseDevice(), nullptr);
+    ASSERT_FALSE(p.getBaseDevice());
+    ASSERT_FALSE(p.getBaseDevice().isValid());
+    ASSERT_EQ(p.getBaseDevice(), nullptr); // deprecated
+
     ASSERT_EQ(p.getType(), INDI_UNKNOWN);
     ASSERT_EQ(p.getRegistered(), false);
     ASSERT_EQ(p.isDynamic(), false);
@@ -52,17 +54,29 @@ TEST(CORE_PROPERTY_CLASS, Test_EmptyProperty)
     ASSERT_EQ(p.getState(), IPS_ALERT);
     ASSERT_EQ(p.getPermission(), IP_RO);
 
-    ASSERT_EQ(p.getNumber(), nullptr);
-    ASSERT_EQ(p.getText(), nullptr);
-    ASSERT_EQ(p.getSwitch(), nullptr);
-    ASSERT_EQ(p.getLight(), nullptr);
-    ASSERT_EQ(p.getBLOB(), nullptr);
+    ASSERT_FALSE(p.getNumber());
+    ASSERT_FALSE(p.getNumber().isValid());
+    ASSERT_EQ(p.getNumber(), nullptr); // deprecated
+
+    ASSERT_FALSE(p.getText());
+    ASSERT_FALSE(p.getText().isValid());
+    ASSERT_EQ(p.getText(), nullptr); // deprecated
+
+    ASSERT_FALSE(p.getSwitch());
+    ASSERT_FALSE(p.getSwitch().isValid());
+    ASSERT_EQ(p.getSwitch(), nullptr); // deprecated
+
+    ASSERT_FALSE(p.getLight());
+    ASSERT_FALSE(p.getLight().isValid());
+    ASSERT_EQ(p.getLight(), nullptr); // deprecated
+
+    ASSERT_FALSE(p.getBLOB());
+    ASSERT_FALSE(p.getBLOB().isValid());
+    ASSERT_EQ(p.getBLOB(), nullptr); // deprecated
 }
 
 TEST(CORE_PROPERTY_CLASS, Test_PropertySetters)
 {
-    INDI::Property p;
-
     INumberVectorProperty nvp
     {
         "device field",
@@ -72,62 +86,37 @@ TEST(CORE_PROPERTY_CLASS, Test_PropertySetters)
         IP_RW, 42, IPS_BUSY,
         nullptr, 0,
         "timestamp field",
-        nullptr };
+        nullptr
+    };
 
-    // Setting a property makes it registered but NOT meaningful
-    p.setProperty(&nvp);
-    ASSERT_EQ(p.getProperty(), &nvp);
-    ASSERT_EQ(p.getType(), INDI_UNKNOWN);
-    ASSERT_EQ(p.getNumber(), nullptr);
-
-    // Property fields remain unpropagated
-    ASSERT_EQ(p.getName(), nullptr);
-    ASSERT_EQ(p.getLabel(), nullptr);
-    ASSERT_EQ(p.getGroupName(), nullptr);
-    ASSERT_EQ(p.getDeviceName(), nullptr);
-    ASSERT_EQ(p.getTimestamp(), nullptr);
-
-    // Other fields remain unchanged
-    ASSERT_EQ(p.getRegistered(), true);
-    ASSERT_EQ(p.isDynamic(), false);
-    ASSERT_EQ(p.getBaseDevice(), nullptr);
-    ASSERT_EQ(p.getState(), IPS_ALERT);
-    ASSERT_EQ(p.getPermission(), IP_RO);
-
-    // Other specific conversions return nothing
-    ASSERT_EQ(p.getText(), nullptr);
-    ASSERT_EQ(p.getSwitch(), nullptr);
-    ASSERT_EQ(p.getLight(), nullptr);
-    ASSERT_EQ(p.getBLOB(), nullptr);
-
-    // Setting a property type gives a meaning to the property
-    // Note the possible desync between property value and type
-    p.setType(INDI_NUMBER);
-    ASSERT_EQ(p.getProperty(), &nvp);
-    ASSERT_EQ(p.getNumber(), &nvp);
+    // Setting a property
+    INDI::Property p(&nvp);
     ASSERT_EQ(p.getType(), INDI_NUMBER);
 
-    // Property fields are propagated
+    // Property fields remain unpropagated
     ASSERT_STREQ(p.getName(), "name field");
     ASSERT_STREQ(p.getLabel(), "label field");
     ASSERT_STREQ(p.getGroupName(), "group field");
     ASSERT_STREQ(p.getDeviceName(), "device field");
     ASSERT_STREQ(p.getTimestamp(), "timestamp field");
 
-    // And previously set fields remain unchanged
+    // Other fields remain unchanged
     ASSERT_EQ(p.getRegistered(), true);
     ASSERT_EQ(p.isDynamic(), false);
-    ASSERT_EQ(p.getBaseDevice(), nullptr);
+    ASSERT_EQ(p.getState(), IPS_BUSY);
+    ASSERT_EQ(p.getPermission(), IP_RW);
+    ASSERT_FALSE(p.getBaseDevice());
 
-    // Other specific conversions still return nothing
-    ASSERT_EQ(p.getText(), nullptr);
-    ASSERT_EQ(p.getSwitch(), nullptr);
-    ASSERT_EQ(p.getLight(), nullptr);
-    ASSERT_EQ(p.getBLOB(), nullptr);
+    ASSERT_TRUE(p.getNumber());
+
+    // Other specific conversions return invalid property
+    ASSERT_FALSE(p.getText());
+    ASSERT_FALSE(p.getSwitch());
+    ASSERT_FALSE(p.getLight());
+    ASSERT_FALSE(p.getBLOB());
 
     // Clearing a property brings it back to the unregistered state
-    p.setProperty(nullptr);
-    ASSERT_EQ(p.getProperty(), nullptr);
+    p = INDI::Property();
     ASSERT_EQ(p.getType(), INDI_UNKNOWN);
     ASSERT_EQ(p.getRegistered(), false);
 
@@ -140,57 +129,17 @@ TEST(CORE_PROPERTY_CLASS, Test_PropertySetters)
 
     // And other fields are reset
     ASSERT_EQ(p.isDynamic(), false);
-    ASSERT_EQ(p.getBaseDevice(), nullptr);
     ASSERT_EQ(p.getState(), IPS_ALERT);
     ASSERT_EQ(p.getPermission(), IP_RO);
+    ASSERT_FALSE(p.getBaseDevice());
 
     // Again, conversions return nothing
-    ASSERT_EQ(p.getNumber(), nullptr);
-    ASSERT_EQ(p.getText(), nullptr);
-    ASSERT_EQ(p.getSwitch(), nullptr);
-    ASSERT_EQ(p.getLight(), nullptr);
-    ASSERT_EQ(p.getBLOB(), nullptr);
+    ASSERT_FALSE(p.getNumber());
+    ASSERT_FALSE(p.getText());
+    ASSERT_FALSE(p.getSwitch());
+    ASSERT_FALSE(p.getLight());
+    ASSERT_FALSE(p.getBLOB());
 }
-
-TEST(CORE_PROPERTY_CLASS, DISABLED_Test_Integrity)
-{
-    INDI::Property p;
-
-    INumberVectorProperty * corrupted_property = (INumberVectorProperty*) (void*) 0x12345678;
-    //INDI::BaseDevice * corrupted_device = (INDI::BaseDevice*) (void*) 0x87654321;
-    INDI::BaseDevice corrupted_device;
-
-    p.setProperty(corrupted_property);
-
-    // A magic header should protect the property from returning garbage
-    EXPECT_EQ(p.getProperty(), nullptr);
-    EXPECT_EQ(p.getRegistered(), false);
-
-    // A verification mechanism should protect the property from getting an incorrect type
-    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
-    p.setType(INDI_NUMBER);
-    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
-    p.setType(INDI_TEXT);
-    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
-    p.setType(INDI_SWITCH);
-    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
-    p.setType(INDI_LIGHT);
-    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
-    p.setType(INDI_BLOB);
-    EXPECT_EQ(p.getType(), INDI_UNKNOWN);
-
-    // A verification mechanism should protect the property from being converted to an incorrect type
-    EXPECT_EQ(p.getNumber(), nullptr);
-    EXPECT_EQ(p.getText(), nullptr);
-    EXPECT_EQ(p.getSwitch(), nullptr);
-    EXPECT_EQ(p.getLight(), nullptr);
-    EXPECT_EQ(p.getBLOB(), nullptr);
-
-    // A verification mechanism should protect the property from being associated to an invalid device
-    p.setBaseDevice(corrupted_device);
-    EXPECT_EQ(p.getBaseDevice(), nullptr);
-}
-
 
 TEST(CORE_PROPERTY_CLASS, Test_PropertyNumber)
 {


### PR DESCRIPTION
The most important changes:
- Deleted `void *BaseDevice::getRawProperty(const char *name, INDI_PROPERTY_TYPE type) const`
- Deleted `void Property::setProperty(void *p)` and `void *Property::getProperty() const`
- Deleted `void Property::setType(INDI_PROPERTY_TYPE t)`
- Different type returned by `INDI::Property::getXXX()` - `INDI::PropertyXXX` instead of `INDI::PropertyView<XXX>`
