### PR TITLE
Swig fix: add conversion constructors

### DIFF
--- a/libs/indidevice/property/indiproperty.cpp
+++ b/libs/indidevice/property/indiproperty.cpp
@@ -22,6 +22,12 @@
 
 #include "basedevice.h"
 
+#include "indipropertytext.h"
+#include "indipropertyswitch.h"
+#include "indipropertynumber.h"
+#include "indipropertylight.h"
+#include "indipropertyblob.h"
+
 #include "indipropertytext_p.h"
 #include "indipropertyswitch_p.h"
 #include "indipropertynumber_p.h"
@@ -120,8 +126,48 @@ Property::Property()
     : d_ptr(new PropertyPrivate(nullptr, INDI_UNKNOWN))
 { }
 
+Property::Property(INDI::PropertyNumber property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertyText   property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertySwitch property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertyLight  property)
+    : d_ptr(property.d_ptr)
+{ }
+
+Property::Property(INDI::PropertyBlob   property)
+    : d_ptr(property.d_ptr)
+{ }
 
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+
+Property::Property(INDI::PropertyView<INumber> *property)
+    : d_ptr(new PropertyNumberPrivate(property))
+{ }
+
+Property::Property(INDI::PropertyView<IText>   *property)
+    : d_ptr(new PropertyTextPrivate(property))
+{ }
+
+Property::Property(INDI::PropertyView<ISwitch> *property)
+    : d_ptr(new PropertySwitchPrivate(property))
+{ }
+
+Property::Property(INDI::PropertyView<ILight>  *property)
+    : d_ptr(new PropertyLightPrivate(property))
+{ }
+
+Property::Property(INDI::PropertyView<IBLOB>   *property)
+    : d_ptr(new PropertyBlobPrivate(property))
+{ }
+
 Property::Property(INumberVectorProperty *property)
     : d_ptr(new PropertyNumberPrivate(property))
 { }

--- a/libs/indidevice/property/indiproperty.h
+++ b/libs/indidevice/property/indiproperty.h
@@ -32,7 +32,11 @@
 namespace INDI
 {
 class BaseDevice;
-
+class PropertyNumber;
+class PropertyText;
+class PropertySwitch;
+class PropertyLight;
+class PropertyBlob;
 /**
  * \class INDI::Property
    \brief Provides generic container for INDI properties
@@ -47,6 +51,13 @@ class Property
         Property();
         ~Property();
 
+    public:
+        Property(INDI::PropertyNumber property);
+        Property(INDI::PropertyText   property);
+        Property(INDI::PropertySwitch property);
+        Property(INDI::PropertyLight  property);
+        Property(INDI::PropertyBlob   property);
+
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
     public:
         Property(INumberVectorProperty *property);
@@ -54,6 +65,14 @@ class Property
         Property(ISwitchVectorProperty *property);
         Property(ILightVectorProperty  *property);
         Property(IBLOBVectorProperty   *property);
+
+    public:
+        Property(INDI::PropertyView<INumber> *property);
+        Property(INDI::PropertyView<IText>   *property);
+        Property(INDI::PropertyView<ISwitch> *property);
+        Property(INDI::PropertyView<ILight>  *property);
+        Property(INDI::PropertyView<IBLOB>   *property);
+
 #endif
     public:
         void setProperty(void *);


### PR DESCRIPTION
Adding constructors will enable type conversion for Python.
This conversion happened in C++ because classes inherit from each other.
Unfortunately for Python this was not enough.