### PR TITLE
Automatically take the version from the main CMakeLists.txt

### DIFF
--- a/libs/indicore/CMakeLists.txt
+++ b/libs/indicore/CMakeLists.txt
@@ -13,7 +13,7 @@ configure_file(indiapi.h.in indiapi.h @ONLY)
 
 # Headers
 list(APPEND ${PROJECT_NAME}_HEADERS
-    indiapi.h
+    ${CMAKE_CURRENT_BINARY_DIR}/indiapi.h
     indidevapi.h
     lilxml.h
     base64.h

--- a/libs/indicore/CMakeLists.txt
+++ b/libs/indicore/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(${PROJECT_NAME} OBJECT "")
 
 CHECK_FUNCTION_EXISTS(mremap HAVE_MREMAP)
 
+configure_file(indiapi.h.in indiapi.h @ONLY)
+
 # Headers
 list(APPEND ${PROJECT_NAME}_HEADERS
     indiapi.h
@@ -70,7 +72,10 @@ target_sources(${PROJECT_NAME}
 )
 
 target_include_directories(${PROJECT_NAME}
-    PUBLIC . ${CMAKE_CURRENT_BINARY_DIR}/../..
+    PUBLIC
+    .
+    ${CMAKE_CURRENT_BINARY_DIR}/../.. # config.h
+    ${CMAKE_CURRENT_BINARY_DIR}       # indiapi.h
 )
 
 install(FILES

--- a/libs/indicore/indiapi.h.in
+++ b/libs/indicore/indiapi.h.in
@@ -134,9 +134,9 @@ For a full list of contributors, please check <a href="https://github.com/indili
 #define INDIV 1.7
 
 /* INDI Library version */
-#define INDI_VERSION_MAJOR   1
-#define INDI_VERSION_MINOR   9
-#define INDI_VERSION_RELEASE 9
+#define INDI_VERSION_MAJOR   @CMAKE_INDI_VERSION_MAJOR@
+#define INDI_VERSION_MINOR   @CMAKE_INDI_VERSION_MINOR@
+#define INDI_VERSION_RELEASE @CMAKE_INDI_VERSION_RELEASE@
 
 /*******************************************************************************
  * Manifest constants


### PR DESCRIPTION
A small improvement suggestion to make the header file automatically update based on the version from the main CMakeLists.txt