### PR TITLE
Refactor indiapi structures

### DIFF
--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -839,7 +839,7 @@ bool V4L2_Driver::ISNewNumber(const char * dev, const char * name, double values
 
         for (int i = 0; i < ImageAdjustNP.nnp; i++)
         {
-            unsigned int const ctrl_id = *((unsigned int *)ImageAdjustNP.np[i].aux0);
+            unsigned int const ctrl_id = *((unsigned int *)ImageAdjustNP.np[i].aux);
             double const value = ImageAdjustNP.np[i].value;
 
             LOGF_DEBUG("  Setting %s (%s) to %f, ctrl_id = 0x%X", ImageAdjustNP.np[i].name,
@@ -1107,7 +1107,7 @@ bool V4L2_Driver::setManualExposure(double duration)
         LOGF_DEBUG("%.3f-second exposure translates to %ld 1/10,000th-second device ticks.",
                    duration, ticks);
 
-        unsigned int const ctrl_id = *((unsigned int *)AbsExposureN->aux0);
+        unsigned int const ctrl_id = *((unsigned int *)AbsExposureN->aux);
 
         char errmsg[MAXRBUF];
         if (v4l_base->setINTControl(ctrl_id, AbsExposureN->value, errmsg) < 0)

--- a/libs/indibase/indicontroller.cpp
+++ b/libs/indibase/indicontroller.cpp
@@ -37,7 +37,7 @@ Controller::Controller(DefaultDevice *cdevice)
 Controller::~Controller()
 {
     for (int i = 0; i < JoystickSettingTP.ntp; i++)
-        free(JoystickSettingT[i].aux0);
+        free(JoystickSettingT[i].aux);
 
     free(JoystickSettingT);
 }
@@ -71,7 +71,7 @@ void Controller::mapController(const char *propertyName, const char *propertyLab
     memset(JoystickSettingT + JoystickSettingTP.ntp, 0, sizeof(IText));
     IUFillText(&JoystickSettingT[JoystickSettingTP.ntp], propertyName, propertyLabel, initialValue);
 
-    JoystickSettingT[JoystickSettingTP.ntp++].aux0 = ctype;
+    JoystickSettingT[JoystickSettingTP.ntp++].aux = ctype;
 
     IUFillTextVector(&JoystickSettingTP, JoystickSettingT, JoystickSettingTP.ntp, device->getDeviceName(),
                      "JOYSTICKSETTINGS", "Settings", "Joystick", IP_RW, 0, IPS_IDLE);
@@ -81,7 +81,7 @@ void Controller::clearMap()
 {
     for (int i = 0; i < JoystickSettingTP.ntp; i++)
     {
-        free(JoystickSettingT[i].aux0);
+        free(JoystickSettingT[i].aux);
         free(JoystickSettingT[i].text);
     }
 
@@ -192,7 +192,7 @@ bool Controller::ISNewText(const char *dev, const char *name, char *texts[], cha
                 if (tp)
                 {
                     ControllerType cType  = getControllerType(texts[i]);
-                    ControllerType myType = *(static_cast<ControllerType *>(JoystickSettingT[i].aux0));
+                    ControllerType myType = *(static_cast<ControllerType *>(JoystickSettingT[i].aux));
                     if (cType != myType)
                     {
                         JoystickSettingTP.s = IPS_ALERT;

--- a/libs/indibase/indiweatherinterface.cpp
+++ b/libs/indibase/indiweatherinterface.cpp
@@ -39,7 +39,6 @@ WeatherInterface::~WeatherInterface()
     for (int i = 0; i < ParametersNP.nnp; i++)
     {
         free(ParametersN[i].aux0);
-        free(ParametersN[i].aux1);
         free(ParametersRangeNP[i].np);
     }
 

--- a/libs/indibase/indiweatherinterface.cpp
+++ b/libs/indibase/indiweatherinterface.cpp
@@ -38,7 +38,7 @@ WeatherInterface::~WeatherInterface()
 {
     for (int i = 0; i < ParametersNP.nnp; i++)
     {
-        free(ParametersN[i].aux0);
+        free(ParametersN[i].aux);
         free(ParametersRangeNP[i].np);
     }
 
@@ -239,7 +239,7 @@ bool WeatherInterface::processNumber(const char *dev, const char *name, double v
 
                 ParametersN[i].min               = ParametersRangeNP[i].np[0].value;
                 ParametersN[i].max               = ParametersRangeNP[i].np[1].value;
-                *(static_cast<double *>(ParametersN[i].aux0)) = ParametersRangeNP[i].np[2].value;
+                *(static_cast<double *>(ParametersN[i].aux)) = ParametersRangeNP[i].np[2].value;
 
                 if (syncCriticalParameters())
                     IDSetLight(&critialParametersLP, nullptr);
@@ -278,7 +278,7 @@ void WeatherInterface::addParameter(std::string name, std::string label, double 
 
     IUFillNumber(&ParametersN[ParametersNP.nnp], name.c_str(), label.c_str(), "%4.2f", numMinOk, numMaxOk, 0, 0);
 
-    ParametersN[ParametersNP.nnp].aux0 = warn;
+    ParametersN[ParametersNP.nnp].aux = warn;
 
     ParametersNP.np = ParametersN;
     ParametersNP.nnp++;
@@ -326,7 +326,7 @@ bool WeatherInterface::setCriticalParameter(std::string param)
 
 IPState WeatherInterface::checkParameterState(const INumber &parameter) const
 {
-    double warn = *(static_cast<double *>(parameter.aux0));
+    double warn = *(static_cast<double *>(parameter.aux));
     double rangeWarn = (parameter.max - parameter.min) * (warn / 100);
 
     if ((parameter.value < parameter.min) || (parameter.value > parameter.max))
@@ -429,7 +429,7 @@ void WeatherInterface::createParameterRange(std::string name, std::string label)
     IUFillNumber(&rangesN[0], "MIN_OK", "OK range min", "%4.2f", -1e6, 1e6, 0, ParametersN[nRanges].min);
     IUFillNumber(&rangesN[1], "MAX_OK", "OK range max", "%4.2f", -1e6, 1e6, 0, ParametersN[nRanges].max);
     IUFillNumber(&rangesN[2], "PERC_WARN", "% for Warning", "%g", 0, 100, 1,
-                 *(static_cast<double *>(ParametersN[nRanges].aux0)));
+                 *(static_cast<double *>(ParametersN[nRanges].aux)));
 
     char propName[MAXINDINAME];
     char propLabel[MAXINDILABEL];

--- a/libs/indibase/webcam/v4l2_base.cpp
+++ b/libs/indibase/webcam/v4l2_base.cpp
@@ -2229,7 +2229,7 @@ void V4L2_Base::queryControls(INumberVectorProperty * nvp, unsigned int * nnumbe
                 if (0 == XIOCTL(fd, VIDIOC_G_CTRL, &control))
                     numbers[nnum].value = control.value;
 
-                /* Store ID info in INumber. This is the first time ever I make use of aux0!! */
+                /* Store ID info in INumber. This is the first time ever I make use of aux!! */
                 num_ctrls[nnum] = queryctrl.id;
 
                 cerr << "Adding " << queryctrl.name << " -- min: " << queryctrl.minimum << " max: " << queryctrl.maximum
@@ -2383,7 +2383,7 @@ void V4L2_Base::queryControls(INumberVectorProperty * nvp, unsigned int * nnumbe
                 if (0 == XIOCTL(fd, VIDIOC_G_CTRL, &control))
                     numbers[nnum].value = control.value;
 
-                /* Store ID info in INumber. This is the first time ever I make use of aux0!! */
+                /* Store ID info in INumber. This is the first time ever I make use of aux!! */
                 num_ctrls[nnum] = queryctrl.id;
                 cerr << "Adding ext. " << queryctrl.name << " -- min: " << queryctrl.minimum
                      << " max: " << queryctrl.maximum << " step: " << queryctrl.step
@@ -2496,9 +2496,9 @@ void V4L2_Base::queryControls(INumberVectorProperty * nvp, unsigned int * nnumbe
             break;
     }
 
-    /* Store numbers in aux0 */
+    /* Store numbers in aux */
     for (int i = 0; i < nnum; i++)
-        numbers[i].aux0 = &num_ctrls[i];
+        numbers[i].aux = &num_ctrls[i];
 
     nvp->np  = numbers;
     nvp->nnp = nnum;
@@ -2550,7 +2550,7 @@ int V4L2_Base::queryINTControls(INumberVectorProperty * nvp)
                 if (0 == XIOCTL(fd, VIDIOC_G_CTRL, &control))
                     numbers[nnum].value = control.value;
 
-                /* Store ID info in INumber. This is the first time ever I make use of aux0!! */
+                /* Store ID info in INumber. This is the first time ever I make use of aux!! */
                 num_ctrls[nnum] = queryctrl.id;
 
                 DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG, "%.*s -- min: %d max: %d step: %d value: %d",
@@ -2601,7 +2601,7 @@ int V4L2_Base::queryINTControls(INumberVectorProperty * nvp)
                 if (0 == XIOCTL(fd, VIDIOC_G_CTRL, &control))
                     numbers[nnum].value = control.value;
 
-                /* Store ID info in INumber. This is the first time ever I make use of aux0!! */
+                /* Store ID info in INumber. This is the first time ever I make use of aux!! */
                 num_ctrls[nnum] = queryctrl.id;
 
                 nnum++;
@@ -2611,9 +2611,9 @@ int V4L2_Base::queryINTControls(INumberVectorProperty * nvp)
             break;
     }
 
-    /* Store numbers in aux0 */
+    /* Store numbers in aux */
     for (int i = 0; i < nnum; i++)
-        numbers[i].aux0 = &num_ctrls[i];
+        numbers[i].aux = &num_ctrls[i];
 
     nvp->np  = numbers;
     nvp->nnp = nnum;
@@ -2822,7 +2822,7 @@ bool V4L2_Base::queryExtControls(INumberVectorProperty * nvp, unsigned int * nnu
             if (0 == XIOCTL(fd, VIDIOC_G_CTRL, &control))
                 numbers[nnum].value = control.value;
 
-            /* Store ID info in INumber. This is the first time ever I make use of aux0!! */
+            /* Store ID info in INumber. This is the first time ever I make use of aux!! */
             num_ctrls[nnum] = queryctrl.id;
 
             DEBUGFDEVICE(deviceName, INDI::Logger::DBG_DEBUG, "Adding %.*s -- min: %d max: %d step: %d value: %d",
@@ -2961,9 +2961,9 @@ bool V4L2_Base::queryExtControls(INumberVectorProperty * nvp, unsigned int * nnu
         queryctrl.id |= V4L2_CTRL_FLAG_NEXT_CTRL;
     }
 
-    /* Store numbers in aux0 */
+    /* Store numbers in aux */
     for (int i = 0; i < nnum; i++)
-        numbers[i].aux0 = &num_ctrls[i];
+        numbers[i].aux = &num_ctrls[i];
 
     nvp->np  = numbers;
     nvp->nnp = nnum;

--- a/libs/indicore/indiapi.h.in
+++ b/libs/indicore/indiapi.h.in
@@ -125,7 +125,9 @@ For a full list of contributors, please check <a href="https://github.com/indili
     \brief Constants and Data structure definitions for the interface to the reference INDI C API implementation.
     \author Elwood C. Downey
 */
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 /*******************************************************************************
  * INDI wire protocol version implemented by this API.
  * N.B. this is indepedent of the API itself.
@@ -224,16 +226,16 @@ IP_RW  /*!< Read & Write */
  */
 typedef struct _IText
 {
-/** Index name */
-char name[MAXINDINAME];
+    /** Helper info */
+    void *aux;
+    /** Pointer to parent */
+    struct _ITextVectorProperty *tvp;
+    /** Index name */
+    char name[MAXINDINAME];
     /** Short description */
     char label[MAXINDILABEL];
     /** Allocated text string */
     char *text;
-    /** Pointer to parent */
-    struct _ITextVectorProperty *tvp;
-    /** Helper info */
-    void *aux;
 } IText;
 
 /**
@@ -242,6 +244,8 @@ char name[MAXINDINAME];
  */
 typedef struct _ITextVectorProperty
 {
+    /** Helper info */
+    void *aux;
     /** Device name */
     char device[MAXINDIDEVICE];
     /** Property name */
@@ -250,10 +254,6 @@ typedef struct _ITextVectorProperty
     char label[MAXINDILABEL];
     /** GUI grouping hint */
     char group[MAXINDIGROUP];
-    /** Client accessibility hint */
-    IPerm p;
-    /** Current max time to change, secs */
-    double timeout;
     /** Current property state */
     IPState s;
     /** Texts comprising this vector */
@@ -262,8 +262,10 @@ typedef struct _ITextVectorProperty
     int ntp;
     /** ISO 8601 timestamp of this event */
     char timestamp[MAXINDITSTAMP];
-    /** Helper info */
-    void *aux;
+    /** Current max time to change, secs */
+    double timeout;
+    /** Client accessibility hint */
+    IPerm p;
 } ITextVectorProperty;
 
 /**
@@ -272,6 +274,10 @@ typedef struct _ITextVectorProperty
  */
 typedef struct _INumber
 {
+    /** Helper info */
+    void *aux;
+    /** Pointer to parent */
+    struct _INumberVectorProperty *nvp;
     /** Index name */
     char name[MAXINDINAME];
     /** Short description */
@@ -286,10 +292,6 @@ typedef struct _INumber
     double step;
     /** Current value */
     double value;
-    /** Pointer to parent */
-    struct _INumberVectorProperty *nvp;
-    /** Helper info */
-    void *aux;
 } INumber;
 
 /**
@@ -313,6 +315,8 @@ typedef struct _INumber
  */
 typedef struct _INumberVectorProperty
 {
+    /** Helper info */
+    void *aux;
     /** Device name */
     char device[MAXINDIDEVICE];
     /** Property name */
@@ -321,11 +325,7 @@ typedef struct _INumberVectorProperty
     char label[MAXINDILABEL];
     /** GUI grouping hint */
     char group[MAXINDIGROUP];
-    /** Client accessibility hint */
-    IPerm p;
-    /** Current max time to change, secs */
-    double timeout;
-    /** current property state */
+    /** Current property state */
     IPState s;
     /** Numbers comprising this vector */
     INumber *np;
@@ -333,8 +333,10 @@ typedef struct _INumberVectorProperty
     int nnp;
     /** ISO 8601 timestamp of this event */
     char timestamp[MAXINDITSTAMP];
-    /** Helper info */
-    void *aux;
+    /** Current max time to change, secs */
+    double timeout;
+    /** Client accessibility hint */
+    IPerm p;
 } INumberVectorProperty;
 
 /**
@@ -343,16 +345,16 @@ typedef struct _INumberVectorProperty
  */
 typedef struct _ISwitch
 {
+    /** Helper info */
+    void *aux;
+    /** Pointer to parent */
+    struct _ISwitchVectorProperty *svp;
     /** Index name */
     char name[MAXINDINAME];
     /** Switch label */
     char label[MAXINDILABEL];
     /** Switch state */
     ISState s;
-    /** Pointer to parent */
-    struct _ISwitchVectorProperty *svp;
-    /** Helper info */
-    void *aux;
 } ISwitch;
 
 /**
@@ -361,6 +363,8 @@ typedef struct _ISwitch
  */
 typedef struct _ISwitchVectorProperty
 {
+    /** Helper info */
+    void *aux;
     /** Device name */
     char device[MAXINDIDEVICE];
     /** Property name */
@@ -369,12 +373,6 @@ typedef struct _ISwitchVectorProperty
     char label[MAXINDILABEL];
     /** GUI grouping hint */
     char group[MAXINDIGROUP];
-    /** Client accessibility hint */
-    IPerm p;
-    /** Switch behavior hint */
-    ISRule r;
-    /** Current max time to change, secs */
-    double timeout;
     /** Current property state */
     IPState s;
     /** Switches comprising this vector */
@@ -383,8 +381,12 @@ typedef struct _ISwitchVectorProperty
     int nsp;
     /** ISO 8601 timestamp of this event */
     char timestamp[MAXINDITSTAMP];
-    /** Helper info */
-    void *aux;
+    /** Current max time to change, secs */
+    double timeout;
+    /** Client accessibility hint */
+    IPerm p;
+   /** Switch behavior hint */
+    ISRule r;
 } ISwitchVectorProperty;
 
 /**
@@ -393,16 +395,16 @@ typedef struct _ISwitchVectorProperty
  */
 typedef struct _ILight
 {
+    /** Helper info */
+    void *aux;
+    /** Pointer to parent */
+    struct _ILightVectorProperty *lvp;
     /** Index name */
     char name[MAXINDINAME];
     /** Light labels */
     char label[MAXINDILABEL];
     /** Light state */
     IPState s;
-    /** Pointer to parent */
-    struct _ILightVectorProperty *lvp;
-    /** Helper info */
-    void *aux;
 } ILight;
 
 /**
@@ -411,6 +413,8 @@ typedef struct _ILight
  */
 typedef struct _ILightVectorProperty
 {
+    /** Helper info */
+    void *aux;
     /** Device name */
     char device[MAXINDIDEVICE];
     /** Property name */
@@ -427,16 +431,22 @@ typedef struct _ILightVectorProperty
     int nlp;
     /** ISO 8601 timestamp of this event */
     char timestamp[MAXINDITSTAMP];
-    /** Helper info */
-    void *aux;
+    /** Reserved **/
+    double unused2;
+    /** Reserved **/
+    IPerm unused1;
 } ILightVectorProperty;
 
 /**
  * @struct IBLOB
  * @brief One Blob (Binary Large Object) descriptor.
  */
-typedef struct _IBLOB/* one BLOB descriptor */
+typedef struct _IBLOB
 {
+    /** Helper info */
+    void *aux;
+    /** Pointer to parent */
+    struct _IBLOBVectorProperty *bvp;
     /** Index name */
     char name[MAXINDINAME];
     /** Blob label */
@@ -449,18 +459,16 @@ typedef struct _IBLOB/* one BLOB descriptor */
     int bloblen;
     /** N uncompressed bytes */
     int size;
-    /** Pointer to parent */
-    struct _IBLOBVectorProperty *bvp;
-    /** Helper info */
-    void *aux;
 } IBLOB;
 
 /**
  * @struct _IBLOBVectorProperty
  * @brief BLOB (Binary Large Object) vector property descriptor.
  */
-typedef struct _IBLOBVectorProperty /* BLOB vector property descriptor */
+typedef struct _IBLOBVectorProperty
 {
+    /** Helper info */
+    void *aux;
     /** Device name */
     char device[MAXINDIDEVICE];
     /** Property name */
@@ -469,10 +477,6 @@ typedef struct _IBLOBVectorProperty /* BLOB vector property descriptor */
     char label[MAXINDILABEL];
     /** GUI grouping hint */
     char group[MAXINDIGROUP];
-    /** Client accessibility hint */
-    IPerm p;
-    /** Current max time to change, secs */
-    double timeout;
     /** Current property state */
     IPState s;
     /** BLOBs comprising this vector */
@@ -481,8 +485,10 @@ typedef struct _IBLOBVectorProperty /* BLOB vector property descriptor */
     int nbp;
     /** ISO 8601 timestamp of this event */
     char timestamp[MAXINDITSTAMP];
-    /** Helper info */
-    void *aux;
+    /** Current max time to change, secs */
+    double timeout;
+    /** Client accessibility hint */
+    IPerm p;
 } IBLOBVectorProperty;
 
 /**
@@ -495,11 +501,6 @@ typedef struct _IBLOBVectorProperty /* BLOB vector property descriptor */
  * @brief Bails out if memory pointer is 0. Prints file and function.
  */
 #define assert_mem(p) if((p) == 0) { fprintf(stderr, "%s(%s): Failed to allocate memory\n", __FILE__, __func__); exit(1); }
-
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 // FIXME: duplicated from indidevapi.h. Can we share ?
 

--- a/libs/indicore/indiapi.h.in
+++ b/libs/indicore/indiapi.h.in
@@ -459,8 +459,6 @@ typedef struct _IBLOB/* one BLOB descriptor */
     void *aux0;
     /** Helper info */
     void *aux1;
-    /** Helper info */
-    void *aux2;
 } IBLOB;
 
 /**

--- a/libs/indicore/indiapi.h.in
+++ b/libs/indicore/indiapi.h.in
@@ -233,7 +233,7 @@ char name[MAXINDINAME];
     /** Pointer to parent */
     struct _ITextVectorProperty *tvp;
     /** Helper info */
-    void *aux0;
+    void *aux;
 } IText;
 
 /**
@@ -289,7 +289,7 @@ typedef struct _INumber
     /** Pointer to parent */
     struct _INumberVectorProperty *nvp;
     /** Helper info */
-    void *aux0;
+    void *aux;
 } INumber;
 
 /**
@@ -452,7 +452,7 @@ typedef struct _IBLOB/* one BLOB descriptor */
     /** Pointer to parent */
     struct _IBLOBVectorProperty *bvp;
     /** Helper info */
-    void *aux0;
+    void *aux;
 } IBLOB;
 
 /**

--- a/libs/indicore/indiapi.h.in
+++ b/libs/indicore/indiapi.h.in
@@ -234,8 +234,6 @@ char name[MAXINDINAME];
     struct _ITextVectorProperty *tvp;
     /** Helper info */
     void *aux0;
-    /** Helper info */
-    void *aux1;
 } IText;
 
 /**
@@ -292,8 +290,6 @@ typedef struct _INumber
     struct _INumberVectorProperty *nvp;
     /** Helper info */
     void *aux0;
-    /** Helper info */
-    void *aux1;
 } INumber;
 
 /**
@@ -457,8 +453,6 @@ typedef struct _IBLOB/* one BLOB descriptor */
     struct _IBLOBVectorProperty *bvp;
     /** Helper info */
     void *aux0;
-    /** Helper info */
-    void *aux1;
 } IBLOB;
 
 /**

--- a/libs/indicore/indidevapi.c
+++ b/libs/indicore/indidevapi.c
@@ -241,7 +241,6 @@ void IUFillBLOB(IBLOB *bp, const char *name, const char *label, const char *form
     bp->bvp     = 0;
     bp->aux0    = 0;
     bp->aux1    = 0;
-    bp->aux2    = 0;
 }
 
 void IUFillSwitchVector(ISwitchVectorProperty *svp, ISwitch *sp, int nsp, const char *dev, const char *name,

--- a/libs/indicore/indidevapi.c
+++ b/libs/indicore/indidevapi.c
@@ -198,7 +198,6 @@ void IUFillNumber(INumber *np, const char *name, const char *label, const char *
     np->value = value;
     np->nvp   = NULL;
     np->aux0  = NULL;
-    np->aux1  = NULL;
 }
 
 void IUFillText(IText *tp, const char *name, const char *label, const char *initialText)
@@ -216,7 +215,6 @@ void IUFillText(IText *tp, const char *name, const char *label, const char *init
 
     tp->tvp  = NULL;
     tp->aux0 = NULL;
-    tp->aux1 = NULL;
 
     if (initialText && initialText[0])
         IUSaveText(tp, initialText);
@@ -240,7 +238,6 @@ void IUFillBLOB(IBLOB *bp, const char *name, const char *label, const char *form
     bp->size    = 0;
     bp->bvp     = 0;
     bp->aux0    = 0;
-    bp->aux1    = 0;
 }
 
 void IUFillSwitchVector(ISwitchVectorProperty *svp, ISwitch *sp, int nsp, const char *dev, const char *name,

--- a/libs/indicore/indidevapi.c
+++ b/libs/indicore/indidevapi.c
@@ -197,7 +197,7 @@ void IUFillNumber(INumber *np, const char *name, const char *label, const char *
     np->step  = step;
     np->value = value;
     np->nvp   = NULL;
-    np->aux0  = NULL;
+    np->aux  = NULL;
 }
 
 void IUFillText(IText *tp, const char *name, const char *label, const char *initialText)
@@ -214,7 +214,7 @@ void IUFillText(IText *tp, const char *name, const char *label, const char *init
     tp->text = NULL;
 
     tp->tvp  = NULL;
-    tp->aux0 = NULL;
+    tp->aux = NULL;
 
     if (initialText && initialText[0])
         IUSaveText(tp, initialText);
@@ -237,7 +237,7 @@ void IUFillBLOB(IBLOB *bp, const char *name, const char *label, const char *form
     bp->bloblen = 0;
     bp->size    = 0;
     bp->bvp     = 0;
-    bp->aux0    = 0;
+    bp->aux    = 0;
 }
 
 void IUFillSwitchVector(ISwitchVectorProperty *svp, ISwitch *sp, int nsp, const char *dev, const char *name,

--- a/libs/indidevice/property/indipropertyview.h
+++ b/libs/indidevice/property/indipropertyview.h
@@ -409,7 +409,7 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
 
         void setAux(void *user)
         {
-            this->aux0 = user;
+            this->aux = user;
         }
         // don't use any other aux!
 
@@ -429,7 +429,7 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
 
         void *getAux() const
         {
-            return this->aux0;
+            return this->aux;
         }
 
     public: //tests
@@ -554,7 +554,7 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
 
         void setAux(void *user)
         {
-            this->aux0 = user;
+            this->aux = user;
         }
         // don't use any other aux!
 
@@ -591,7 +591,7 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
 
         void *getAux() const
         {
-            return this->aux0;
+            return this->aux;
         }
 
     public: //tests
@@ -967,7 +967,7 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
 
         void setAux(void *user)
         {
-            this->aux0 = user;
+            this->aux = user;
         }
         // don't use any other aux!
 
@@ -1007,7 +1007,7 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
 
         void *getAux() const
         {
-            return this->aux0;
+            return this->aux;
         }
 
     public: //tests

--- a/test/core/test_property_class.cpp
+++ b/test/core/test_property_class.cpp
@@ -79,14 +79,17 @@ TEST(CORE_PROPERTY_CLASS, Test_PropertySetters)
 {
     INumberVectorProperty nvp
     {
-        "device field",
-        "name field",
-        "label field",
-        "group field",
-        IP_RW, 42, IPS_BUSY,
-        nullptr, 0,
-        "timestamp field",
-        nullptr
+        nullptr,           // aux
+        "device field",    // group
+        "name field",      // name
+        "label field",     // label
+        "group field",     // group
+        IPS_BUSY,          // s
+        nullptr,           // nvp
+        0,                 // nnp
+        "timestamp field", // timestamp
+        42,                // timeout
+        IP_RW              // p
     };
 
     // Setting a property


### PR DESCRIPTION
It comes back like a boomerang.

The goal is to arrange the fields in the structures so that they are close to each other.
This will help with the property work to ultimately manage memory (which is a nuisance in blobs).

With this organization, I can introduce a more generic structure to the library and simplify some implementations.
```cpp
/* this is just an example */

typedef struct _IGeneric
{
    /** Helper info */
    void *aux;
    /** Pointer to parent */
    void *parent;
    /** Index name */
    char name[MAXINDINAME];
    /** Short description */
    char label[MAXINDILABEL];

    union
    {
        struct
        {
            /** Allocated text string */
            char *text;
        } itext;

        struct
        {
            /** GUI display format, see above */
            char format[MAXINDIFORMAT];
            /** Range min, ignored if min == max */
            double min;
            /** Range max, ignored if min == max */
            double max;
            /** Step size, ignored if step == 0 */
            double step;
            /** Current value */
            double value;
        } inumber;

        struct
        {
            /** Switch state */
            ISState s;
        } iswitch;

        struct
        {
            /** Light state */
            IPState s;
        } ilight;

        struct
        {
            /** Format attr */
            char format[MAXINDIBLOBFMT];
            /** Allocated binary large object bytes - maybe a shared buffer: use IDSharedBlobFree to free*/
            void *blob;
            /** Blob size in bytes */
            int bloblen;
            /** N uncompressed bytes */
            int size;
        } iblob;
    };
} IGeneric;

typedef struct _IGenericVectorProperty
{
    /** Helper info */
    void *aux;
    /** Device name */
    char device[MAXINDIDEVICE];
    /** Property name */
    char name[MAXINDINAME];
    /** Short description */
    char label[MAXINDILABEL];
    /** GUI grouping hint */
    char group[MAXINDIGROUP];
    /** Current property state */
    IPState s;
    /** Widgets comprising this vector */
    void *widgets;
    /** Dimension of widgets[] */
    int count;
    /** ISO 8601 timestamp of this event */
    char timestamp[MAXINDITSTAMP];
    /** Current max time to change, secs */
    double timeout;
    /** Client accessibility hint */
    IPerm p;

    union
    {
        struct
        {
            /** Switch behavior hint */
            ISRule r;
        } iswitch;
    };
} IGenericVectorProperty;
```

Apart from changing the location of the field data, the most significant change is the removal of `aux0, aux1, aux2` and leaving only `aux`.
This is not a problem with `INDI Core` and `INDI 3-rdparty`.
**A small problem arises with the `KStars` implementation** where `aux2` is used, among other things.

I leave the topic as a draft open for discussion.