### PR TITLE
Fix - no exception for std::string construct with nullptr.

### DIFF
--- a/libs/indicore/indililxml.h
+++ b/libs/indicore/indililxml.h
@@ -230,7 +230,7 @@ inline int LilXmlValue::toInt(safe_ptr<bool> ok) const
 {
     int result = 0;
     try {
-        result = std::stoi(mValue);
+        result = std::stoi(toString());
         *ok = true;
     } catch (...) {
         *ok = false;
@@ -249,7 +249,7 @@ inline double LilXmlValue::toDouble(safe_ptr<bool> ok) const
 {
     double result = 0;
     try {
-        result = std::stod(mValue);
+        result = std::stod(toString());
         *ok = true;
     } catch (...) {
         *ok = false;


### PR DESCRIPTION
This behavior for macos does not throw an exception.
```cpp
    const char *p = nullptr;
    
    try
    {
        std::cout << std::stod(p) << std::endl;
    }
    catch(...)
    {
        std::cout << "error" << std::endl;
    }
```