### PR TITLE
Disable PEC training for Gemini firmware 6 and above.

### DIFF
--- a/drivers/telescope/lx200gemini.cpp
+++ b/drivers/telescope/lx200gemini.cpp
@@ -405,6 +405,7 @@ bool LX200Gemini::updateProperties()
         if (gemini_software_level_ >= 5.0 && gemini_software_level_ < 6.0)
         {
 	    defineProperty(&PECControlSP);
+	    PECControlSP.s = IPS_OK;
 	}
         if (gemini_software_level_ >= 5.0 && getGeminiProperty(PEC_COUNTER_ID, value))
         {
@@ -413,7 +414,6 @@ bool LX200Gemini::updateProperties()
 	    sscanf(value, "%u", &pec_counter);
 	    snprintf(valueString, 32, "%i", pec_counter);
 
-	    PECControlSP.s = IPS_OK;
 	    IUSaveText(&PECCounterT[0], valueString);
 	    defineProperty(&PECCounterTP);
 	}

--- a/drivers/telescope/lx200gemini.cpp
+++ b/drivers/telescope/lx200gemini.cpp
@@ -402,9 +402,12 @@ bool LX200Gemini::updateProperties()
             PECGuidingSpeedN[0].value = guiding_speed_value;
             defineProperty(&PECGuidingSpeedNP);
         }
-        if (gemini_software_level_ >= 5.0 && getGeminiProperty(PEC_COUNTER_ID, value))
+        if (gemini_software_level_ >= 5.0 && gemini_software_level_ < 6.0)
         {
 	    defineProperty(&PECControlSP);
+	}
+        if (gemini_software_level_ >= 5.0 && getGeminiProperty(PEC_COUNTER_ID, value))
+        {
 	    char valueString[32] = {0};
 	    uint32_t pec_counter = 0;
 	    sscanf(value, "%u", &pec_counter);
@@ -575,7 +578,6 @@ bool LX200Gemini::updateProperties()
         deleteProperty(GuidingSpeedNP.name);
         deleteProperty(GuidingSpeedBothNP.name);
         deleteProperty(CenteringSpeedNP.name);
-	deleteProperty(PECControlSP.name);
 	deleteProperty(PECStateTP.name);
 	deleteProperty(PECCounterTP.name);
         deleteProperty(PECMaxStepsNP.name);
@@ -585,6 +587,10 @@ bool LX200Gemini::updateProperties()
         deleteProperty(PECGuidingSpeedNP.name);
         deleteProperty(VersionTP.name);
 	deleteProperty(FlipPositionNP.name);
+        if (gemini_software_level_ >= 5.0 && gemini_software_level_ < 6.0)
+        {
+	  deleteProperty(PECControlSP.name);
+	}
     }
 
     return true;
@@ -688,7 +694,7 @@ bool LX200Gemini::ISNewSwitch(const char *dev, const char *name, ISState *states
 	  setGeminiProperty(FLIP_POINTS_ENABLED_ID, valueString);
 	}
 	
-        if (gemini_software_level_ >= 5.0 && !strcmp(name, PECControlSP.name))
+        if (gemini_software_level_ >= 5.0 && gemini_software_level_ < 6.0 && !strcmp(name, PECControlSP.name))
         {
 	    for(int i = 0; i<n; ++i){
 	        if (!strcmp(names[i], PECControlS[PEC_START_TRAINING].name))


### PR DESCRIPTION
This is no longer supported and could cause sdcard corruption.