### PR TITLE
Deprecated use of Property/BaseDevice as pointer.

### DIFF
--- a/drivers/filter_wheel/pegasus_indigo.cpp
+++ b/drivers/filter_wheel/pegasus_indigo.cpp
@@ -71,7 +71,7 @@ bool PegasusINDIGO::updateProperties()
     {
         // Main Control
         getFirmware();
-        defineProperty(&FirmwareTP);
+        defineProperty(FirmwareTP);
     }
     else
     {

--- a/drivers/focuser/esatto.cpp
+++ b/drivers/focuser/esatto.cpp
@@ -46,7 +46,7 @@ Esatto::Esatto()
         auto lastValue = TemperatureNP[0].value;
         auto rc = updateTemperature();
         if (rc && std::abs(lastValue - TemperatureNP[0].value) >= 0.1)
-            IDSetNumber(&TemperatureNP, nullptr);
+            TemperatureNP.apply();
     });
     m_TemperatureTimer.setInterval(10000);
 }
@@ -128,7 +128,7 @@ bool Esatto::updateProperties()
     }
     else
     {
-        if (TemperatureNP->getState() == IPS_OK)
+        if (TemperatureNP.getState() == IPS_OK)
             deleteProperty(TemperatureNP);
         deleteProperty(FirmwareTP);
     }
@@ -225,10 +225,10 @@ bool Esatto::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Fast motion
-        if (FastMoveSP->isNameMatch(name))
+        if (FastMoveSP.isNameMatch(name))
         {
             FastMoveSP.update(states, names, n);
-            auto current_switch = IUFindOnSwitchIndex(&FastMoveSP);
+            auto current_switch = FastMoveSP.findOnSwitchIndex();
 
             switch (current_switch)
             {
@@ -246,7 +246,7 @@ bool Esatto::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
             }
 
             FastMoveSP.setState(IPS_BUSY);
-            FastMoveSP->apply();
+            FastMoveSP.apply();
             return true;
         }
     }

--- a/drivers/focuser/sestosenso2.h
+++ b/drivers/focuser/sestosenso2.h
@@ -137,7 +137,6 @@ class SestoSenso2 : public INDI::Focuser
         };
 
         INDI::PropertySwitch MotorHoldSP {2};
-        ISwitch MotorHoldS[2];
         enum
         {
             MOTOR_HOLD_ON,

--- a/drivers/focuser/tcfs.cpp
+++ b/drivers/focuser/tcfs.cpp
@@ -512,7 +512,7 @@ bool TCFS::ISNewSwitch(const char *dev, const char *name, ISState *states, char 
             {
                 svp.setState(IPS_IDLE);
                 LOG_WARN("Focuser is still in sleep mode. Wake up in order to issue commands.");
-                svp->apply();
+                svp.apply();
             }
             return true;
         }

--- a/drivers/telescope/astrotrac.cpp
+++ b/drivers/telescope/astrotrac.cpp
@@ -170,12 +170,12 @@ bool AstroTrac::updateProperties()
     }
     else
     {
-        deleteProperty(FirmwareTP.getName());
-        deleteProperty(AccelerationNP.getName());
-        deleteProperty(EncoderNP.getName());
+        deleteProperty(FirmwareTP);
+        deleteProperty(AccelerationNP);
+        deleteProperty(EncoderNP);
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
-        deleteProperty(GuideRateNP->getName());
+        deleteProperty(GuideRateNP);
     }
 
     return true;

--- a/drivers/video/lx/Lx.cpp
+++ b/drivers/video/lx/Lx.cpp
@@ -97,8 +97,8 @@ bool Lx::initProperties(INDI::DefaultDevice *device)
     IUFillSwitch(&LxSerialAddeolS[3], "CR+LF", "", ISS_OFF);
     IUFillSwitchVector(&LxSerialAddeolSP, LxSerialAddeolS, NARRAY(LxSerialAddeolS), device_name, "Add EOL", "", LX_TAB,
                        IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
-    FlashStrobeSP     = nullptr;
-    FlashStrobeStopSP = nullptr;
+    FlashStrobeSP     = INDI::Property();
+    FlashStrobeStopSP = INDI::Property();
     ledmethod         = PWCIOCTL;
     return true;
 }
@@ -107,7 +107,6 @@ bool Lx::updateProperties()
 {
     if (dev->isConnected())
     {
-        INDI::Property *pfound;
         dev->defineProperty(&LxEnableSP);
         dev->defineProperty(&LxModeSP);
         dev->defineProperty(&LxPortTP);
@@ -120,12 +119,13 @@ bool Lx::updateProperties()
         dev->defineProperty(&LxSerialParitySP);
         dev->defineProperty(&LxSerialStopSP);
         dev->defineProperty(&LxSerialAddeolSP);
-        pfound = findbyLabel(dev, (char *)"Strobe");
+
+        INDI::Property pfound = findByLabel(dev, "Strobe");
         if (pfound)
         {
-            FlashStrobeSP     = dev->getSwitch(pfound->getName());
-            pfound            = findbyLabel(dev, (char *)"Stop Strobe");
-            FlashStrobeStopSP = dev->getSwitch(pfound->getName());
+            FlashStrobeSP     = dev->getSwitch(pfound.getName());
+            pfound            = findByLabel(dev, "Stop Strobe");
+            FlashStrobeStopSP = dev->getSwitch(pfound.getName());
         }
     }
     else
@@ -142,8 +142,8 @@ bool Lx::updateProperties()
         dev->deleteProperty(LxSerialParitySP.name);
         dev->deleteProperty(LxSerialStopSP.name);
         dev->deleteProperty(LxSerialAddeolSP.name);
-        FlashStrobeSP     = nullptr;
-        FlashStrobeStopSP = nullptr;
+        FlashStrobeSP     = INDI::Property();
+        FlashStrobeStopSP = INDI::Property();
     }
     return true;
 }
@@ -560,12 +560,12 @@ int Lx::stopLxSerial()
     return 0;
 }
 
-INDI::Property *Lx::findbyLabel(INDI::DefaultDevice *dev, char *label)
+INDI::Property Lx::findByLabel(INDI::DefaultDevice *dev, const char *label)
 {
-    for(auto &oneProperty : *dev->getProperties())
-        if (oneProperty->isLabelMatch(label))
+    for(auto &oneProperty : dev->getProperties())
+        if (oneProperty.isLabelMatch(label))
             return oneProperty;
-    return nullptr;
+    return INDI::Property();
 }
 
 // PWC Stuff
@@ -605,26 +605,26 @@ void Lx::pwcsetLed(int on, int off)
 void Lx::pwcsetflashon()
 {
     ISState states[2]    = { ISS_ON, ISS_OFF };
-    const char *names[2] = { FlashStrobeSP->at(0)->getName(), FlashStrobeStopSP->at(0)->getName() };
-    dev->ISNewSwitch(device_name, FlashStrobeSP->getName(), &(states[0]), (char **)names, 1);
-    //dev->ISNewSwitch(device_name, FlashStrobeStopSP->name, &(states[1]), (char **)(names + 1), 1);
-    FlashStrobeSP->setState(IPS_OK);
-    FlashStrobeSP->apply();
-    FlashStrobeStopSP->setState(IPS_IDLE);
-    FlashStrobeStopSP->apply();
+    const char *names[2] = { FlashStrobeSP[0].getName(), FlashStrobeStopSP[0].getName() };
+    dev->ISNewSwitch(device_name, FlashStrobeSP.getName(), &(states[0]), (char **)names, 1);
+    //dev->ISNewSwitch(device_name, FlashStrobeStopSP.name, &(states[1]), (char **)(names + 1), 1);
+    FlashStrobeSP.setState(IPS_OK);
+    FlashStrobeSP.apply();
+    FlashStrobeStopSP.setState(IPS_IDLE);
+    FlashStrobeStopSP.apply();
 }
 
 void Lx::pwcsetflashoff()
 {
     ISState states[2]    = { ISS_OFF, ISS_ON };
-    const char *names[2] = { FlashStrobeSP->at(0)->getName(), FlashStrobeStopSP->at(0)->getName()};
-    //dev->ISNewSwitch(device_name, FlashStrobeSP->name, &(states[0]), (char **)names, 1);
-    dev->ISNewSwitch(device_name, FlashStrobeStopSP->getName(), &(states[1]), (char **)(names + 1), 1);
-    FlashStrobeStopSP->setState(IPS_OK);
-    FlashStrobeStopSP->apply();
+    const char *names[2] = { FlashStrobeSP[0].getName(), FlashStrobeStopSP[0].getName()};
+    //dev->ISNewSwitch(device_name, FlashStrobeSP.name, &(states[0]), (char **)names, 1);
+    dev->ISNewSwitch(device_name, FlashStrobeStopSP.getName(), &(states[1]), (char **)(names + 1), 1);
+    FlashStrobeStopSP.setState(IPS_OK);
+    FlashStrobeStopSP.apply();
 
-    FlashStrobeSP->setState(IPS_IDLE);
-    FlashStrobeSP->apply();
+    FlashStrobeSP.setState(IPS_IDLE);
+    FlashStrobeSP.apply();
 }
 
 bool Lx::startLxPWC()

--- a/drivers/video/lx/Lx.h
+++ b/drivers/video/lx/Lx.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include "defaultdevice.h"
+#include "indiproperty.h"
+#include "indipropertyswitch.h"
 
 //For SPC900 Led control
 #include "webcam/pwc-ioctl.h"
@@ -72,10 +74,12 @@ class Lx
         int stopLxSerial();
         void getSerialOptions(unsigned int *speed, unsigned int *wordsize, unsigned int *parity, unsigned int *stops);
         const char *getSerialEOL();
-        INDI::Property *findbyLabel(INDI::DefaultDevice *dev, char *label);
+        INDI::Property findByLabel(INDI::DefaultDevice *dev, const char *label);
+        
         // PWC Cameras
-        INDI::PropertyViewSwitch *FlashStrobeSP;
-        INDI::PropertyViewSwitch *FlashStrobeStopSP;
+        INDI::PropertySwitch FlashStrobeSP     {INDI::Property()};
+        INDI::PropertySwitch FlashStrobeStopSP {INDI::Property()};
+
         enum pwcledmethod
         {
             PWCIOCTL,

--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -1504,7 +1504,7 @@ void V4L2_Driver::newFrame()
 
         struct timeval const current_exposure = getElapsedExposure();
 
-        if (EncodeFormatSP->findOnSwitchIndex() ==  FORMAT_NATIVE && v4l_base->getFormat() == V4L2_PIX_FMT_MJPEG)
+        if (EncodeFormatSP.findOnSwitchIndex() ==  FORMAT_NATIVE && v4l_base->getFormat() == V4L2_PIX_FMT_MJPEG)
         {
             std::unique_lock<std::mutex> guard(ccdBufferLock);
             int totalBytes = 0;

--- a/drivers/weather/uranusmeteo.cpp
+++ b/drivers/weather/uranusmeteo.cpp
@@ -56,8 +56,8 @@ bool UranusMeteo::initProperties()
     WI::initProperties(MAIN_CONTROL_TAB, ENVIRONMENT_TAB);
 
     // To distinguish them from GPS properties.
-    WI::UpdatePeriodNP->setLabel("Weather Update");
-    WI::RefreshSP->setLabel("Weahter Refresh");
+    WI::UpdatePeriodNP.setLabel("Weather Update");
+    WI::RefreshSP.setLabel("Weahter Refresh");
 
     addAuxControls();
 
@@ -232,8 +232,8 @@ IPState UranusMeteo::updateGPS()
             GPSNP[GPSSpeed].setValue(std::stod(result[GPSSpeed]));
             GPSNP[GPSBearing].setValue(std::stod(result[GPSBearing]));
 
-            GPSNP->setState(IPS_OK);
-            GPSNP->apply();
+            GPSNP.setState(IPS_OK);
+            GPSNP.apply();
 
             if (GPSNP[GPSFix].getValue() < 3)
                 return IPS_BUSY;
@@ -320,21 +320,21 @@ bool UranusMeteo::ISNewNumber(const char * dev, const char * name, double values
     if (dev && !strcmp(dev, getDeviceName()))
     {
         // Sky Quality Update
-        if (SkyQualityUpdateNP->isNameMatch(name))
+        if (SkyQualityUpdateNP.isNameMatch(name))
         {
             SkyQualityUpdateNP.update(values, names, n);
             auto value = SkyQualityUpdateNP[0].getValue();
             if (value > 0)
             {
                 m_SkyQualityUpdateTimer.start(value * 1000);
-                SkyQualityUpdateNP->setState(IPS_OK);
+                SkyQualityUpdateNP.setState(IPS_OK);
             }
             else
             {
                 LOG_INFO("Sky Quality Update is disabled.");
-                SkyQualityUpdateNP->setState(IPS_IDLE);
+                SkyQualityUpdateNP.setState(IPS_IDLE);
             }
-            SkyQualityUpdateNP->apply();
+            SkyQualityUpdateNP.apply();
             return true;
         }
 
@@ -401,8 +401,8 @@ bool UranusMeteo::readSensors()
             SensorNP[BatteryUsage].setValue(std::stod(result[BatteryUsage]));
             SensorNP[BatteryVoltage].setValue(std::stod(result[BatteryVoltage]));
 
-            SensorNP->setState(IPS_OK);
-            SensorNP->apply();
+            SensorNP.setState(IPS_OK);
+            SensorNP.apply();
             return true;
         }
         catch(...)
@@ -439,8 +439,8 @@ bool UranusMeteo::readSkyQuality()
             SkyQualityNP[VisualSpectrum].setValue(std::stod(result[VisualSpectrum]));
             SkyQualityNP[InfraredSpectrum].setValue(std::stod(result[InfraredSpectrum]));
 
-            SkyQualityNP->setState(IPS_OK);
-            SkyQualityNP->apply();
+            SkyQualityNP.setState(IPS_OK);
+            SkyQualityNP.apply();
             return true;
         }
         catch(...)
@@ -477,8 +477,8 @@ bool UranusMeteo::readClouds()
             CloudsNP[CloudAmbientTemperature].setValue(std::stod(result[CloudAmbientTemperature]));
             CloudsNP[InfraredEmissivity].setValue(std::stod(result[InfraredEmissivity]));
 
-            CloudsNP->setState(IPS_OK);
-            CloudsNP->apply();
+            CloudsNP.setState(IPS_OK);
+            CloudsNP.apply();
             return true;
         }
         catch(...)

--- a/examples/tutorial_four/simpleskeleton.cpp
+++ b/examples/tutorial_four/simpleskeleton.cpp
@@ -79,8 +79,8 @@ bool SimpleSkeleton::initProperties()
 
     // Let's print a list of all device properties
     int i = 0;
-    for(const auto &oneProperty : *getProperties())
-        IDLog("Property #%d: %s\n", i++, oneProperty->getName());
+    for(const auto &oneProperty : getProperties())
+        IDLog("Property #%d: %s\n", i++, oneProperty.getName());
 
     // Set the green light (IPS_OK) for a "Number Property" if changed
     INDI::PropertyNumber number = getNumber("Number Property");

--- a/libs/indiabstractclient/abstractbaseclient.cpp
+++ b/libs/indiabstractclient/abstractbaseclient.cpp
@@ -502,7 +502,7 @@ void AbstractBaseClient::sendNewText(const char *deviceName, const char *propert
     if (!tvp.isValid())
         return;
 
-    auto tp = tvp->findWidgetByName(elementName);
+    auto tp = tvp.findWidgetByName(elementName);
 
     if (!tp)
         return;
@@ -528,7 +528,7 @@ void AbstractBaseClient::sendNewNumber(const char *deviceName, const char *prope
     if (!nvp.isValid())
         return;
 
-    auto np = nvp->findWidgetByName(elementName);
+    auto np = nvp.findWidgetByName(elementName);
 
     if (!np)
         return;
@@ -552,7 +552,7 @@ void AbstractBaseClient::sendNewSwitch(const char *deviceName, const char *prope
     if (!svp.isValid())
         return;
 
-    auto sp = svp->findWidgetByName(elementName);
+    auto sp = svp.findWidgetByName(elementName);
 
     if (!sp)
         return;

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -186,7 +186,7 @@ DefaultDevice::DefaultDevice()
 
 bool DefaultDevice::loadConfig(INDI::Property &property)
 {
-    return loadConfig(true, property->getName());
+    return loadConfig(true, property.getName());
 }
 
 bool DefaultDevice::loadConfig(bool silent, const char *property)
@@ -233,11 +233,11 @@ bool DefaultDevice::saveConfigItems(FILE *fp)
 
 bool DefaultDevice::saveAllConfigItems(FILE *fp)
 {
-    for (const auto &oneProperty : *getProperties())
+    for (const auto &oneProperty : getProperties())
     {
-        if (oneProperty->getType() == INDI_SWITCH)
+        if (oneProperty.getType() == INDI_SWITCH)
         {
-            const auto &svp = oneProperty->getSwitch();
+            const auto &svp = oneProperty.getSwitch();
             /* Never save CONNECTION property. Don't save switches with no switches on if the rule is one of many */
             if (
                 (svp->isNameMatch(INDI::SP::CONNECTION)) ||
@@ -245,7 +245,7 @@ bool DefaultDevice::saveAllConfigItems(FILE *fp)
             )
                 continue;
         }
-        oneProperty->save(fp);
+        oneProperty.save(fp);
     }
     return true;
 }
@@ -265,7 +265,7 @@ bool DefaultDevice::purgeConfig()
 
 bool DefaultDevice::saveConfig(INDI::Property &property)
 {
-    return saveConfig(true, property->getName());
+    return saveConfig(true, property.getName());
 }
 
 bool DefaultDevice::saveConfig(bool silent, const char *property)
@@ -339,7 +339,7 @@ bool DefaultDevice::saveConfig(bool silent, const char *property)
             if (!strcmp(tagName, "newSwitchVector"))
             {
                 auto svp = getSwitch(elemName);
-                if (svp == nullptr)
+                if (!svp)
                 {
                     delXMLEle(root);
                     return false;
@@ -348,8 +348,8 @@ bool DefaultDevice::saveConfig(bool silent, const char *property)
                 XMLEle *sw = nullptr;
                 for (sw = nextXMLEle(ep, 1); sw != nullptr; sw = nextXMLEle(ep, 0))
                 {
-                    auto oneSwitch = svp->findWidgetByName(findXMLAttValu(sw, "name"));
-                    if (oneSwitch == nullptr)
+                    auto oneSwitch = svp.findWidgetByName(findXMLAttValu(sw, "name"));
+                    if (!oneSwitch)
                     {
                         delXMLEle(root);
                         return false;
@@ -365,7 +365,7 @@ bool DefaultDevice::saveConfig(bool silent, const char *property)
             else if (!strcmp(tagName, "newNumberVector"))
             {
                 auto nvp = getNumber(elemName);
-                if (nvp == nullptr)
+                if (!nvp)
                 {
                     delXMLEle(root);
                     return false;
@@ -374,8 +374,8 @@ bool DefaultDevice::saveConfig(bool silent, const char *property)
                 XMLEle *np = nullptr;
                 for (np = nextXMLEle(ep, 1); np != nullptr; np = nextXMLEle(ep, 0))
                 {
-                    auto oneNumber = nvp->findWidgetByName(findXMLAttValu(np, "name"));
-                    if (oneNumber == nullptr)
+                    auto oneNumber = nvp.findWidgetByName(findXMLAttValu(np, "name"));
+                    if (!oneNumber)
                         return false;
 
                     char formatString[MAXRBUF];
@@ -389,7 +389,7 @@ bool DefaultDevice::saveConfig(bool silent, const char *property)
             else if (!strcmp(tagName, "newTextVector"))
             {
                 auto tvp = getText(elemName);
-                if (tvp == nullptr)
+                if (!tvp)
                 {
                     delXMLEle(root);
                     return false;
@@ -398,8 +398,8 @@ bool DefaultDevice::saveConfig(bool silent, const char *property)
                 XMLEle *tp = nullptr;
                 for (tp = nextXMLEle(ep, 1); tp != nullptr; tp = nextXMLEle(ep, 0))
                 {
-                    auto oneText = tvp->findWidgetByName(findXMLAttValu(tp, "name"));
-                    if (oneText == nullptr)
+                    auto oneText = tvp.findWidgetByName(findXMLAttValu(tp, "name"));
+                    if (!oneText)
                         return false;
 
                     char formatString[MAXRBUF];
@@ -710,10 +710,10 @@ void DefaultDevice::ISGetProperties(const char *dev)
 
     for (const auto &oneProperty : *getProperties())
     {
-        if (d->defineDynamicProperties == false && oneProperty->isDynamic())
+        if (d->defineDynamicProperties == false && oneProperty.isDynamic())
             continue;
 
-        oneProperty->define();
+        oneProperty.define();
     }
 
     // Remember debug & logging settings
@@ -773,10 +773,10 @@ void DefaultDevice::ISGetProperties(const char *dev)
 
 void DefaultDevice::resetProperties()
 {
-    for (auto &oneProperty : *getProperties())
+    for (auto &oneProperty : getProperties())
     {
-        oneProperty->setState(IPS_IDLE);
-        oneProperty->apply();
+        oneProperty.setState(IPS_IDLE);
+        oneProperty.apply();
     }
 }
 
@@ -786,14 +786,14 @@ void DefaultDevice::setConnected(bool status, IPState state, const char *msg)
     if (!svp)
         return;
 
-    svp->at(INDI_ENABLED)->setState(status ? ISS_ON : ISS_OFF);
-    svp->at(INDI_DISABLED)->setState(status ? ISS_OFF : ISS_ON);
-    svp->setState(state);
+    svp[INDI_ENABLED].setState(status ? ISS_ON : ISS_OFF);
+    svp[INDI_DISABLED].setState(status ? ISS_OFF : ISS_ON);
+    svp.setState(state);
 
     if (msg == nullptr)
-        svp->apply();
+        svp.apply();
     else
-        svp->apply("%s", msg);
+        svp.apply("%s", msg);
 }
 
 // Set the timeout for the TimerHit function.
@@ -1039,8 +1039,8 @@ bool DefaultDevice::deleteProperty(const char *propertyName)
     // Keep dynamic properties in existing property list so they can be reused
     if (d->deleteDynamicProperties == false)
     {
-        INDI::Property *prop = getProperty(propertyName);
-        if (prop && prop->isDynamic())
+        INDI::Property prop = getProperty(propertyName);
+        if (prop && prop.isDynamic())
         {
             IDDelete(getDeviceName(), propertyName, nullptr);
             return true;
@@ -1260,8 +1260,8 @@ void DefaultDevice::setActiveConnection(Connection::Interface *existingConnectio
                 d->ConnectionModeSP[index].setState(ISS_ON);
                 d->ConnectionModeSP.setState(IPS_OK);
                 // If property is registerned then send back response to client
-                INDI::Property *connectionProperty = getProperty(d->ConnectionModeSP.getName(), INDI_SWITCH);
-                if (connectionProperty && connectionProperty->getRegistered())
+                INDI::Property connectionProperty = getProperty(d->ConnectionModeSP.getName(), INDI_SWITCH);
+                if (connectionProperty && connectionProperty.getRegistered())
                     d->ConnectionModeSP.apply();
             }
         }

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -149,7 +149,8 @@ class DefaultDevice : public ParentDevice
          * save configuration files.
          * \param nvp The number vector property to be defined
          */
-        void defineNumber(INumberVectorProperty *nvp) __attribute__((deprecated));
+        INDI_DEPRECATED("Use defineProperty(INDI::Property &).")
+        void defineNumber(INumberVectorProperty *nvp);
         void defineProperty(INumberVectorProperty *property);
 
         /**
@@ -158,7 +159,8 @@ class DefaultDevice : public ParentDevice
          * configuration files.
          * \param tvp The text vector property to be defined
          */
-        void defineText(ITextVectorProperty *tvp) __attribute__((deprecated));
+        INDI_DEPRECATED("Use defineProperty(INDI::Property &).")
+        void defineText(ITextVectorProperty *tvp);
         void defineProperty(ITextVectorProperty *property);
 
         /**
@@ -167,7 +169,8 @@ class DefaultDevice : public ParentDevice
          * configuration files.
          * \param svp The switch vector property to be defined
          */
-        void defineSwitch(ISwitchVectorProperty *svp) __attribute__((deprecated));
+        INDI_DEPRECATED("Use defineProperty(INDI::Property &).")
+        void defineSwitch(ISwitchVectorProperty *svp);
         void defineProperty(ISwitchVectorProperty *property);
 
         /**
@@ -176,7 +179,8 @@ class DefaultDevice : public ParentDevice
          * configuration files.
          * \param lvp The light vector property to be defined
          */
-        void defineLight(ILightVectorProperty *lvp) __attribute__((deprecated));
+        INDI_DEPRECATED("Use defineProperty(INDI::Property &).")
+        void defineLight(ILightVectorProperty *lvp);
         void defineProperty(ILightVectorProperty *property);
 
         /**
@@ -185,7 +189,8 @@ class DefaultDevice : public ParentDevice
          * save configuration files.
          * \param bvp The BLOB vector property to be defined
          */
-        void defineBLOB(IBLOBVectorProperty *bvp) __attribute__((deprecated));
+        INDI_DEPRECATED("Use defineProperty(INDI::Property &).")
+        void defineBLOB(IBLOBVectorProperty *bvp);
         void defineProperty(IBLOBVectorProperty *property);
 
         void defineProperty(INDI::Property &property);

--- a/libs/indibase/dsp/dspinterface.cpp
+++ b/libs/indibase/dsp/dspinterface.cpp
@@ -284,7 +284,7 @@ void Interface::addFITSKeywords(fitsfile *fptr)
     }
 
     nv = m_Device->getNumber("EQUATORIAL_EOD_COORDS");
-    if(nv != nullptr)
+    if(nv)
     {
         double RA = nv[0].getValue();
         double Dec = nv[1].getValue();

--- a/libs/indibase/indiweatherinterface.cpp
+++ b/libs/indibase/indiweatherinterface.cpp
@@ -171,18 +171,18 @@ bool WeatherInterface::processSwitch(const char *dev, const char *name, ISState 
     INDI_UNUSED(dev);
 
     // Refresh
-    if (RefreshSP->isNameMatch(name))
+    if (RefreshSP.isNameMatch(name))
     {
         RefreshSP[0].setState(ISS_OFF);
         RefreshSP.setState(IPS_OK);
-        RefreshSP->apply();
+        RefreshSP.apply();
 
         checkWeatherUpdate();
         return true;
     }
 
     // Override
-    if (OverrideSP->isNameMatch(name))
+    if (OverrideSP.isNameMatch(name))
     {
         OverrideSP.update(states, names, n);
         if (OverrideSP[0].getState() == ISS_ON)
@@ -202,7 +202,7 @@ bool WeatherInterface::processSwitch(const char *dev, const char *name, ISState 
             IDSetLight(&critialParametersLP, nullptr);
         }
 
-        OverrideSP->apply();
+        OverrideSP.apply();
         return true;
     }
 
@@ -214,11 +214,11 @@ bool WeatherInterface::processNumber(const char *dev, const char *name, double v
     INDI_UNUSED(dev);
 
     // Update period
-    if (UpdatePeriodNP->isNameMatch(name))
+    if (UpdatePeriodNP.isNameMatch(name))
     {
         UpdatePeriodNP.update(values, names, n);
-        UpdatePeriodNP->setState(IPS_OK);
-        UpdatePeriodNP->apply();
+        UpdatePeriodNP.setState(IPS_OK);
+        UpdatePeriodNP.apply();
 
         if (UpdatePeriodNP[0].getValue() == 0)
             DEBUGDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_SESSION, "Periodic updates are disabled.");

--- a/libs/indibase/stream/streammanager.cpp
+++ b/libs/indibase/stream/streammanager.cpp
@@ -1190,12 +1190,12 @@ bool StreamManagerPrivate::uploadStream(const uint8_t * buffer, uint32_t nbytes)
             return true;
         }
 #endif
-        imageBP->at(0)->setBlob(const_cast<uint8_t *>(buffer));
-        imageBP->at(0)->setBlobLen(nbytes);
-        imageBP->at(0)->setSize(nbytes);
-        imageBP->at(0)->setFormat(".stream_jpg");
-        imageBP->setState(IPS_OK);
-        imageBP->apply();
+        imageBP[0].setBlob(const_cast<uint8_t *>(buffer));
+        imageBP[0].setBlobLen(nbytes);
+        imageBP[0].setSize(nbytes);
+        imageBP[0].setFormat(".stream_jpg");
+        imageBP.setState(IPS_OK);
+        imageBP.apply();
         return true;
     }
 
@@ -1211,7 +1211,7 @@ bool StreamManagerPrivate::uploadStream(const uint8_t * buffer, uint32_t nbytes)
 
     if(currentDevice->getDriverInterface() & INDI::DefaultDevice::CCD_INTERFACE)
     {
-        if (encoder->upload(imageBP->at(0), buffer, nbytes, dynamic_cast<INDI::CCD*>(currentDevice)->PrimaryCCD.isCompressed()))
+        if (encoder->upload(&imageBP[0], buffer, nbytes, dynamic_cast<INDI::CCD*>(currentDevice)->PrimaryCCD.isCompressed()))
         {
 #ifdef HAVE_WEBSOCKET
             if (dynamic_cast<INDI::CCD*>(currentDevice)->HasWebSocket()
@@ -1228,19 +1228,19 @@ bool StreamManagerPrivate::uploadStream(const uint8_t * buffer, uint32_t nbytes)
             }
 #endif
             // Upload to client now
-            imageBP->setState(IPS_OK);
-            imageBP->apply();
+            imageBP.setState(IPS_OK);
+            imageBP.apply();
             return true;
         }
     }
     else if(currentDevice->getDriverInterface() & INDI::DefaultDevice::SENSOR_INTERFACE)
     {
-        if (encoder->upload(imageBP->at(0), buffer, nbytes,
+        if (encoder->upload(&imageBP[0], buffer, nbytes,
                             false))//dynamic_cast<INDI::SensorInterface*>(currentDevice)->isCompressed()))
         {
             // Upload to client now
-            imageBP->setState(IPS_OK);
-            imageBP->apply();
+            imageBP.setState(IPS_OK);
+            imageBP.apply();
             return true;
         }
     }

--- a/libs/indibase/stream/streammanager_p.h
+++ b/libs/indibase/stream/streammanager_p.h
@@ -42,6 +42,7 @@
 #include "indipropertytext.h"
 #include "indipropertynumber.h"
 #include "indipropertyswitch.h"
+#include "indipropertyblob.h"
 namespace INDI
 {
 
@@ -201,7 +202,7 @@ class StreamManagerPrivate
         INDI::PropertyNumber StreamFrameNP {4};
 
         /* BLOBs */
-        INDI::PropertyViewBlob *imageBP {nullptr};
+        INDI::PropertyBlob imageBP{INDI::Property()};
 
         // Encoder Selector. It's static now but should this implemented as plugin interface?
         INDI::PropertySwitch EncoderSP {2};

--- a/libs/indidevice/basedevice.cpp
+++ b/libs/indidevice/basedevice.cpp
@@ -131,8 +131,8 @@ IPerm BaseDevice::getPropertyPermission(const char *name) const
 
 void *BaseDevice::getRawProperty(const char *name, INDI_PROPERTY_TYPE type) const
 {
-    INDI::Property *prop = getProperty(name, type);
-    return prop != nullptr ? prop->getProperty() : nullptr;
+    INDI::Property prop = getProperty(name, type);
+    return prop ? prop.getProperty() : nullptr;
 }
 
 INDI::Property BaseDevice::getProperty(const char *name, INDI_PROPERTY_TYPE type) const
@@ -523,9 +523,9 @@ bool BaseDevice::isConnected() const
     if (!svp)
         return false;
 
-    auto sp = svp->findWidgetByName("CONNECT");
+    auto sp = svp.findWidgetByName("CONNECT");
 
-    return sp && sp->getState() == ISS_ON && svp->getState() == IPS_OK;
+    return sp && sp->getState() == ISS_ON && svp.getState() == IPS_OK;
 }
 
 void BaseDevice::attach()
@@ -936,37 +936,20 @@ void BaseDevice::registerProperty(const INDI::Property &property, INDI_PROPERTY_
 
 const char *BaseDevice::getDriverName() const
 {
-    auto driverInfo = getText("DRIVER_INFO");
-
-    if (!driverInfo)
-        return nullptr;
-
-    auto driverName = driverInfo->findWidgetByName("DRIVER_NAME");
+    auto driverName = getText("DRIVER_INFO").findWidgetByName("DRIVER_NAME");
 
     return driverName ? driverName->getText() : nullptr;
 }
 
 const char *BaseDevice::getDriverExec() const
 {
-    auto driverInfo = getText("DRIVER_INFO");
-
-    if (!driverInfo)
-        return nullptr;
-
-    auto driverExec = driverInfo->findWidgetByName("DRIVER_EXEC");
-
+    auto driverExec = getText("DRIVER_INFO").findWidgetByName("DRIVER_EXEC");
     return driverExec ? driverExec->getText() : nullptr;
 }
 
 const char *BaseDevice::getDriverVersion() const
 {
-    auto driverInfo = getText("DRIVER_INFO");
-
-    if (!driverInfo)
-        return nullptr;
-
-    auto driverVersion = driverInfo->findWidgetByName("DRIVER_VERSION");
-
+    auto driverVersion = getText("DRIVER_INFO").findWidgetByName("DRIVER_VERSION");
     return driverVersion ? driverVersion->getText() : nullptr;
 }
 

--- a/libs/indidevice/basedevice.h
+++ b/libs/indidevice/basedevice.h
@@ -266,18 +266,29 @@ class BaseDevice
         static std::string getSharedFilePath(std::string fileName);
 
     public:
+        INDI_DEPRECATED("Do not use BaseDevice as pointer.")
         operator BaseDevice*();
+
+        INDI_DEPRECATED("Do not use BaseDevice as pointer.")
         BaseDevice* operator->();
 
+        INDI_DEPRECATED("Use comparison to true.")
         bool operator != (std::nullptr_t) const
         {
             return  isValid();
         }
+
+        INDI_DEPRECATED("Use comparison to false.")
         bool operator == (std::nullptr_t) const
         {
             return !isValid();
         }
+
         operator bool()                   const
+        {
+            return  isValid();
+        }
+        operator bool()
         {
             return  isValid();
         }

--- a/libs/indidevice/basedevice_p.h
+++ b/libs/indidevice/basedevice_p.h
@@ -65,7 +65,7 @@ class BaseDevicePrivate
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->newDevice((BaseDevice *)baseDevice);
+                mediator->newDevice(&self);
 #endif
                 mediator->newDevice(baseDevice);
             }
@@ -76,7 +76,7 @@ class BaseDevicePrivate
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->removeDevice((BaseDevice *)baseDevice);
+                mediator->removeDevice(&self);
 #endif
                 mediator->removeDevice(baseDevice);
             }
@@ -87,7 +87,7 @@ class BaseDevicePrivate
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->newProperty((Property *)property);
+                mediator->newProperty(property.self());
 #endif
                 mediator->newProperty(property);
             }
@@ -131,7 +131,7 @@ class BaseDevicePrivate
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->removeProperty((Property *)property);
+                mediator->removeProperty(property.self());
 #endif
                 mediator->removeProperty(property);
             }
@@ -142,7 +142,7 @@ class BaseDevicePrivate
             if (mediator)
             {
 #if INDI_VERSION_MAJOR < 2
-                mediator->newMessage((BaseDevice *)baseDevice, messageID);
+                mediator->newMessage(&self, messageID);
 #endif
                 mediator->newMessage(baseDevice, messageID);
             }

--- a/libs/indidevice/property/indiproperty.cpp
+++ b/libs/indidevice/property/indiproperty.cpp
@@ -100,6 +100,12 @@ Property::operator const INDI::Property *() const
 }
 #endif
 
+INDI::Property *Property::self()
+{
+    D_PTR(Property);
+    return isValid() ? &d->self : nullptr;
+}
+
 #define PROPERTY_CASE(CODE) \
     switch (d->property != nullptr ? d->type : INDI_UNKNOWN) \
     { \

--- a/libs/indidevice/property/indiproperty.h
+++ b/libs/indidevice/property/indiproperty.h
@@ -157,20 +157,41 @@ class Property
 
     public:
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         INDI::Property* operator->();
+
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         const INDI::Property* operator->() const;
 
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         operator INDI::Property *();
+
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         operator const INDI::Property *() const;
 
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         operator INDI::PropertyViewNumber *() const { return getNumber(); }
+
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         operator INDI::PropertyViewText   *() const { return getText(); }
+
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         operator INDI::PropertyViewSwitch *() const { return getSwitch(); }
+
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         operator INDI::PropertyViewLight  *() const { return getLight(); }
+
+        INDI_DEPRECATED("Do not use INDI::Property as pointer.")
         operator INDI::PropertyViewBlob   *() const { return getBLOB(); }
+
+        INDI_DEPRECATED("Use comparison to true.")
         bool operator != (std::nullptr_t) const     { return  isValid(); }
+
+        INDI_DEPRECATED("Use comparison to false.")
         bool operator == (std::nullptr_t) const     { return !isValid(); }
+
         operator bool()                   const     { return  isValid(); }
+        operator bool()                             { return  isValid(); }
 #endif
 
     protected:
@@ -182,6 +203,10 @@ class Property
         friend class PropertySwitch;
         friend class PropertyLight;
         friend class PropertyBlob;
+
+    protected:
+        friend class BaseDevicePrivate;
+        INDI::Property *self();
 };
 
 } // namespace INDI

--- a/libs/indidevice/property/indipropertybasic.h
+++ b/libs/indidevice/property/indipropertybasic.h
@@ -102,6 +102,7 @@ class PropertyBasic : public INDI::Property
 
     public:
         size_t size() const;
+        size_t count() const { return size(); }
 
     public:
         void reserve(size_t size);

--- a/libs/indidevice/property/indipropertybasic.h
+++ b/libs/indidevice/property/indipropertybasic.h
@@ -97,7 +97,7 @@ class PropertyBasic : public INDI::Property
         void apply() const;
         void define() const;
 
-    public:
+    protected:
         PropertyView<T> * operator &();
 
     public:
@@ -145,7 +145,10 @@ class PropertyBasic : public INDI::Property
 
 #ifdef INDI_PROPERTY_BACKWARD_COMPATIBILE
     public: // deprecated
+        INDI_DEPRECATED("Do not use INDI::PropertyXXX as pointer.")
         INDI::PropertyView<T> *operator->();
+
+        INDI_DEPRECATED("Do not use INDI::PropertyXXX as pointer.")
         INDI::PropertyView<T>  operator*();
 #endif
 };


### PR DESCRIPTION
Changes are backwards compatible.

It is recommended to refer directly to `INDI::PropertyXXX` and `INDI:BaseDevice` without dereferencing.
The project source codes have been corrected to use the correct form of object reference.