### PR TITLE
Check pull request with astyle for proper code style

### DIFF
--- a/.github/workflows/linux-codestyle.yml
+++ b/.github/workflows/linux-codestyle.yml
@@ -1,0 +1,34 @@
+name: Check Codestyle
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get INDI Sources
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v35
+
+      - name: Check codestyle of all changed files with suffix cpp,cxx,c,h
+        run: |
+          sudo apt-get update
+          sudo apt-get -qq -y install astyle
+          for file in ${{ steps.changed-files.outputs.all_changed_files }}; do
+            echo "changed file $file";
+            scripts/check-codestyle.sh "$file";
+          done
+        shell: bash

--- a/scripts/check-codestyle.sh
+++ b/scripts/check-codestyle.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+FILE_TO_CHECK=${1}
+RC=0
+
+if [[ ! -f "${FILE_TO_CHECK}" ]] || [[ ! "${FILE_TO_CHECK}" =~ (.*?)\.(cxx|cpp|c|h)$ ]]; then
+    exit ${RC}
+fi
+
+TMP_FILE_DIFF=$(mktemp /tmp/indi.diff.XXXXXXXXX)
+TMP_FILE_ASTYLE=$(mktemp /tmp/indi.astyle.XXXXXXXXX)
+TMP_FILE_WARNINGS=$(mktemp /tmp/indi.warning.XXXXXXXXX)
+ASTYLE_OPTIONS="--style=allman --align-reference=name --indent-switches --indent-modifiers --indent-classes --pad-oper --indent-col1-comments --lineend=linux --max-code-length=124"
+
+git diff --function-context --unified=1 HEAD ${FILE_TO_CHECK} | sed -e '/diff --git/,+3d;/^@@/d;/^-/d;s/^+/ /' | cut -d' ' -f2- > ${TMP_FILE_DIFF}
+astyle ${ASTYLE_OPTIONS} -n < ${TMP_FILE_DIFF} > ${TMP_FILE_ASTYLE}
+diff -u ${TMP_FILE_DIFF} ${TMP_FILE_ASTYLE} | tail -n +3 | sed -e '/^-/d;/^@@/d;s/^+/[STYLE WARNING] /' > ${TMP_FILE_WARNINGS}
+
+if [[ -s ${TMP_FILE_WARNINGS} ]]; then
+    cat ${TMP_FILE_WARNINGS}
+    RC=1
+fi
+
+if [[ ${RC} -eq 1 ]]; then
+    echo -e "File ${FILE_TO_CHECK} has style warning(s), see" \
+	 "https://github.com/indilib/indi/blob/master/README.md"
+fi
+
+rm -f ${TMP_FILE_DIFF} ${TMP_FILE_ASTYLE} ${TMP_FILE_WARNINGS}
+
+exit ${RC}


### PR DESCRIPTION
Leverage astyle source code indenter and formatter for pre-checking pull request code style by means of github CI's workflow.
If code style is not in agreement with astyle settings listed in script scripts/check-codestyle.sh, prepend string "[STYLE WARNING]" to each line with inproper code style and list the filename as well as message with link to https://github.com/indilib/indi/blob/master/README.md.