### PR TITLE
Downgrade to base64 for snooped blobs

### DIFF
--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -587,7 +587,7 @@ class MsgQueue: public Collectable
 
         void setFds(int rFd, int wFd);
 
-        bool acceptSharedBuffers() const
+        virtual bool acceptSharedBuffers() const
         {
             return useSharedBuffer;
         }
@@ -747,6 +747,12 @@ class DvrInfo: public MsgQueue
 
         /* Reference to all active drivers */
         static ConcurrentSet<DvrInfo> drivers;
+
+        // decoding of attached blobs from driver is not supported ATM. Be conservative here
+        virtual bool acceptSharedBuffers() const
+        {
+            return false;
+        }
 };
 
 class LocalDvrInfo: public DvrInfo

--- a/integs/DriverMock.h
+++ b/integs/DriverMock.h
@@ -31,8 +31,6 @@
  */
 class DriverMock
 {
-        std::string abstractPath;
-        int serverConnection;
         int driverConnection;
 
         int driverFds[2];
@@ -42,7 +40,6 @@ class DriverMock
 
         // Start the listening socket that will receive driver upon their starts
         void setup();
-        void unsetup();
 
         void waitEstablish();
 

--- a/integs/IndiServerController.cpp
+++ b/integs/IndiServerController.cpp
@@ -18,6 +18,9 @@
 
 #include <system_error>
 #include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 
 #include "utils.h"
 #include "IndiServerController.h"
@@ -25,8 +28,24 @@
 
 #define TEST_TCP_PORT 17624
 #define TEST_UNIX_SOCKET "/tmp/indi-test-server"
+#define TEST_INDI_FIFO "/tmp/indi-test-fifo"
 #define STRINGIFY_TOK(x) #x
 #define TO_STRING(x) STRINGIFY_TOK(x)
+
+IndiServerController::IndiServerController() {
+    fifo = false;
+}
+
+IndiServerController::~IndiServerController() {
+    // Abort any pending indi server
+    kill();
+    join();
+}
+
+
+void IndiServerController::setFifo(bool fifo) {
+    this->fifo = fifo;
+}
 
 void IndiServerController::start(const std::vector<std::string> & args) {
     ProcessController::start("../indiserver/indiserver", args);
@@ -38,9 +57,39 @@ void IndiServerController::startDriver(const std::string & path) {
     args.push_back("-u");
     args.push_back(TEST_UNIX_SOCKET);
 #endif
+
+    if (fifo) {
+        unlink(TEST_INDI_FIFO);
+        if (mkfifo(TEST_INDI_FIFO, 0600) == -1) {
+            throw std::system_error(errno, std::generic_category(), "mkfifo");
+        }
+        args.push_back("-f");
+        args.push_back(TEST_INDI_FIFO);
+    }
     args.push_back(path);
 
     start(args);
+}
+
+void IndiServerController::addDriver(const std::string & driver) {
+    if (!fifo) {
+        throw new std::runtime_error("Fifo is not enabled - cannot add driver");
+    }
+
+    int fifoFd = open(TEST_INDI_FIFO, O_WRONLY);
+    if (fifoFd == -1) {
+        throw std::system_error(errno, std::generic_category(), "opening fifo");
+    }
+
+    std::string cmd = "start " + driver +"\n";
+    int wr = write(fifoFd, cmd.data(), cmd.length());
+    if (wr == -1) {
+        auto e = errno;
+        close(fifoFd);
+        throw std::system_error(e, std::generic_category(), "write to fifo");
+    }
+
+    close(fifoFd);
 }
 
 std::string IndiServerController::getUnixSocketPath() const {

--- a/integs/IndiServerController.h
+++ b/integs/IndiServerController.h
@@ -31,11 +31,16 @@
  */
 class IndiServerController : public ProcessController
 {
-
+        bool fifo;
     public:
+        IndiServerController();
+        ~IndiServerController();
+        void setFifo(bool enable);
         void start(const std::vector<std::string> & args);
 
         void startDriver(const std::string & driver);
+
+        void addDriver(const std::string & path);
 
         std::string getUnixSocketPath() const;
         int getTcpPort() const;

--- a/integs/ProcessController.cpp
+++ b/integs/ProcessController.cpp
@@ -89,7 +89,7 @@ void ProcessController::start(const std::string & path, const std::vector<std::s
     }
     if (pid == 0) {
         std::string error = "exec " + path;
-
+        // TODO : Close all file descriptor
         execv(fullArgs[0], (char * const *) fullArgs);
 
         // Child goes here....
@@ -101,6 +101,13 @@ void ProcessController::start(const std::string & path, const std::vector<std::s
 void ProcessController::waitProcessEnd(int exitCode) {
     join();
     expectExitCode(exitCode);
+}
+
+void ProcessController::kill() {
+    if (pid == -1) {
+        return;
+    }
+    ::kill(pid, SIGKILL);
 }
 
 void ProcessController::join() {

--- a/integs/ProcessController.h
+++ b/integs/ProcessController.h
@@ -43,6 +43,7 @@ public:
     void expectAlive();
     void expectExitCode(int e);
     void join();
+    void kill();
 
     void waitProcessEnd(int expectedExitCode);
 

--- a/integs/TestIndiserverSingleDriver.cpp
+++ b/integs/TestIndiserverSingleDriver.cpp
@@ -529,6 +529,8 @@ TEST(IndiserverSingleDriver, ForwardAttachedBlobToDriver)
     ssize_t size = 32;
     driverSendAttachedBlob(fakeDriver, size);
 
+#if 0
+    // Until proper support by drivers, indiserver converts to base64 for that path
     snoopDriver.cnx.allowBufferReceive(true);
     snoopDriver.cnx.expectXml("<setBLOBVector device='fakedev1' name='testblob' timestamp='2018-01-01T00:01:00'>");
     snoopDriver.cnx.expectXml("<oneBLOB name='content' size='32' format='.fits' attached='true'/>\n");
@@ -537,8 +539,14 @@ TEST(IndiserverSingleDriver, ForwardAttachedBlobToDriver)
     SharedBuffer receivedFd;
     snoopDriver.cnx.expectBuffer(receivedFd);
     snoopDriver.cnx.allowBufferReceive(false);
-
     EXPECT_GE( receivedFd.getSize(), 32);
+#else
+    snoopDriver.cnx.expectXml("<setBLOBVector device='fakedev1' name='testblob' timestamp='2018-01-01T00:01:00'>");
+    snoopDriver.cnx.expectXml("<oneBLOB name='content' size='32' format='.fits'>\n");
+    snoopDriver.cnx.expect("\nMDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNDU2Nzg5MDE=");
+    snoopDriver.cnx.expectXml("</oneBLOB>\n");
+    snoopDriver.cnx.expectXml("</setBLOBVector>");
+#endif
 
     fakeDriver.terminateDriver();
     snoopDriver.terminateDriver();

--- a/integs/utils.cpp
+++ b/integs/utils.cpp
@@ -79,6 +79,10 @@ int unixSocketListen(const std::string &unixAddr)
         throw std::system_error(errno, std::generic_category(), "Socket");
     }
 
+#ifndef __linux__
+    fcntl(sockfd, F_SETFD, FD_CLOEXEC);
+#endif
+
     int reuse = 1;
     if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse)) < 0)
     {


### PR DESCRIPTION
Force the blob sent to driver to be sent as base64 until proper support is implemented on driver side. (fix [#1822](https://github.com/indilib/indi/issues/1822) )