### PR TITLE
Fix PMC8 tracking rate

### DIFF
--- a/drivers/telescope/pmc8driver.cpp
+++ b/drivers/telescope/pmc8driver.cpp
@@ -76,10 +76,10 @@ double PMC8_AXIS1_SCALE = PMC8_EXOS2_AXIS1_SCALE;
 #define PMC8_RETRY_DELAY 30000 /* how long to wait before retrying i/o */
 #define PMC8_MAX_IO_ERROR_THRESHOLD 2 /* how many consecutive read timeouts before trying to reset the connection */
 
-#define PMC8_RATE_SIDEREAL 15.041
-#define PMC8_RATE_LUNAR 14.685
-#define PMC8_RATE_SOLAR 15.0
-#define PMC8_RATE_KING 15.0369
+#define PMC8_RATE_SIDEREAL 15.000
+#define PMC8_RATE_LUNAR 14.451
+#define PMC8_RATE_SOLAR 14.959
+#define PMC8_RATE_KING 14.996
 
 PMC8_CONNECTION_TYPE pmc8_connection         = PMC8_SERIAL_AUTO;
 bool pmc8_debug                 = false;


### PR DESCRIPTION
Simple fix for PMC8 resuming tracking at Solar rather than previous (usually Sidereal rate) after a slew. This issue was reported also here: https://indilib.org/forum/mounts/12752-tracking-rates-changing-in-indi.html.

The tracking rates were in solar arc seconds, but according to the docs (https://02d3287.netsolhost.com/pmc-eight/PMC_Eight_ProgrammersReferenceManual_Release2_2019_February_01.pdf), PMC8 responds to the get precision tracking rate ("ESGx!") command with sidereal arc seconds.

I have tested this on the iExos-100 and confirm that it now reports the correct tracking rate. I am not sure if there are any (negative) knock-on effects in any INDI internal calculations for guiding pulse duration etc .