### PR TITLE
Simplification of virtual functions - watchProperty with the ability to choose the behavior

### DIFF
--- a/examples/tutorial_five/dome.cpp
+++ b/examples/tutorial_five/dome.cpp
@@ -89,26 +89,23 @@ bool Dome::initProperties()
             mRainLight = rain; // we have real rainLight property, override mRainLight
             static IPState oldRainState = rain[0].getState();
 
-            rain.onUpdate([this, rain]()
+            IPState newRainState = rain[0].getState();
+            if (newRainState == IPS_ALERT)
             {
-                IPState newRainState = rain[0].getState();
-                if (newRainState == IPS_ALERT)
-                {
-                    // If dome is open, then close it */
-                    if (mShutterSwitch[0].getState() == ISS_ON)
-                        closeShutter();
-                    else
-                        IDMessage(getDeviceName(), "Rain Alert Detected! Dome is already closed.");
-                }
-                
-                if (newRainState != IPS_ALERT && oldRainState == IPS_ALERT)
-                {
-                    IDMessage(getDeviceName(), "Rain threat passed. Opening the dome is now safe.");
-                }
+                // If dome is open, then close it */
+                if (mShutterSwitch[0].getState() == ISS_ON)
+                    closeShutter();
+                else
+                    IDMessage(getDeviceName(), "Rain Alert Detected! Dome is already closed.");
+            }
+            
+            if (newRainState != IPS_ALERT && oldRainState == IPS_ALERT)
+            {
+                IDMessage(getDeviceName(), "Rain threat passed. Opening the dome is now safe.");
+            }
 
-                oldRainState = newRainState;
-            });
-        });
+            oldRainState = newRainState;
+        }, BaseDevice::WATCH_NEW_OR_UPDATE);
     });
 
     return true;

--- a/examples/tutorial_six/tutorial_client.cpp
+++ b/examples/tutorial_six/tutorial_client.cpp
@@ -77,7 +77,7 @@ MyClient::MyClient()
         {
             IDLog("Connecting to INDI Driver...\n");
             connectDevice("Simple CCD");
-        });
+        }, INDI::BaseDevice::WATCH_NEW);
 
         // wait for the availability of the "CCD_TEMPERATURE" property
         device.watchProperty("CCD_TEMPERATURE", [this](INDI::PropertyNumber property)
@@ -98,24 +98,20 @@ MyClient::MyClient()
                     takeExposure(1);
                 }
             });
-        });
+        }, INDI::BaseDevice::WATCH_NEW);
 
-        // wait for the availability of the "CCD1" property
+        // call if updated of the "CCD1" property - simplified way
         device.watchProperty("CCD1", [](INDI::PropertyBlob property)
         {
-            // call lambda function if property changed
-            property.onUpdate([property]()
-            {
-                // Save FITS file to disk
-                std::ofstream myfile;
+            // Save FITS file to disk
+            std::ofstream myfile;
 
-                myfile.open("ccd_simulator.fits", std::ios::out | std::ios::binary);
-                myfile.write(static_cast<char *>(property[0].getBlob()), property[0].getBlobLen());
-                myfile.close();
+            myfile.open("ccd_simulator.fits", std::ios::out | std::ios::binary);
+            myfile.write(static_cast<char *>(property[0].getBlob()), property[0].getBlobLen());
+            myfile.close();
 
-                IDLog("Received image, saved as ccd_simulator.fits\n");
-            });
-        });
+            IDLog("Received image, saved as ccd_simulator.fits\n");
+        }, INDI::BaseDevice::WATCH_UPDATE);
     });
 }
 

--- a/libs/indidevice/basedevice.cpp
+++ b/libs/indidevice/basedevice.cpp
@@ -907,10 +907,18 @@ bool BaseDevice::isValid() const
     return d->valid;
 }
 
-void BaseDevice::watchProperty(const char *name, const std::function<void(INDI::Property)> &callback)
+void BaseDevice::watchProperty(const char *name, const std::function<void(INDI::Property)> &callback, WATCH watch)
 {
     D_PTR(BaseDevice);
-    d->watchPropertyMap[name] = callback;
+    d->watchPropertyMap[name].callback = callback;
+    d->watchPropertyMap[name].watch = watch;
+
+    // call callback function if property already exists
+    INDI::Property property = getProperty(name);
+    if (property.isValid())
+    {
+        callback(property);
+    }
 }
 
 void BaseDevice::registerProperty(const INDI::Property &property)

--- a/libs/indidevice/basedevice.h
+++ b/libs/indidevice/basedevice.h
@@ -71,6 +71,14 @@ class BaseDevice
             INDI_DISABLED
         };
 
+        /*! Used for watchProperty callback method. */
+        enum WATCH
+        {
+            WATCH_NEW = 0,        /*!< Applies to discovered properties only. */
+            WATCH_UPDATE,         /*!< Applies to updated properties only. */
+            WATCH_NEW_OR_UPDATE   /*!< Applies when a property appears or is updated, i.e. both of the above. */
+        };
+
         /** @brief The DRIVER_INTERFACE enum defines the class of devices the driver implements. A driver may implement one or more interfaces. */
         enum DRIVER_INTERFACE
         {
@@ -116,8 +124,11 @@ class BaseDevice
         /** @brief Call the callback function if property is available.
          *  @param name of property.
          *  @param callback as an argument of the function you can use INDI::PropertyNumber, INDI::PropertySwitch etc.
+         *  @param watch you can decide whether the callback should be executed only once (WATCH_NEW) on discovery of the property or
+         *  also on every change of the value (WATCH_UPDATE) or both (WATCH_NEW_OR_UPDATE)
+         *  @note the behavior is analogous to BaseMediator::newProperty/updateProperty
          */
-        void watchProperty(const char *name, const std::function<void (INDI::Property)> &callback);
+        void watchProperty(const char *name, const std::function<void (INDI::Property)> &callback, WATCH watch = WATCH_NEW);
 
         /** @brief Return a property and its type given its name.
          *  @param name of property to be found.

--- a/libs/indidevice/basedevice_p.h
+++ b/libs/indidevice/basedevice_p.h
@@ -45,6 +45,20 @@ class BaseDevicePrivate
         /** @brief Parse and store BLOB in the respective vector */
         int setBLOB(INDI::PropertyBlob propertyBlob, const INDI::LilXmlElement &root, char *errmsg);
 
+        void emitWatchProperty(const INDI::Property &property, bool isNew)
+        {
+            auto it = watchPropertyMap.find(property.getName());
+            if (it != watchPropertyMap.end())
+            {
+                if (
+                    (it->second.watch == BaseDevice::WATCH_NEW_OR_UPDATE) ||
+                    (it->second.watch == BaseDevice::WATCH_NEW && isNew) ||
+                    (it->second.watch == BaseDevice::WATCH_UPDATE && !isNew)
+                )
+                    it->second.callback(property);
+            } 
+        }
+
         void addProperty(const INDI::Property &property)
         {
             {
@@ -52,11 +66,7 @@ class BaseDevicePrivate
                 pAll.push_back(property);
             }
 
-            auto it = watchPropertyMap.find(property.getName());
-            if (it != watchPropertyMap.end())
-            {
-                it->second(property);
-            }
+            emitWatchProperty(property, true);
         }
 
     public: // mediator
@@ -95,6 +105,7 @@ class BaseDevicePrivate
 
         void mediateUpdateProperty(Property property)
         {
+            emitWatchProperty(property, false);
             if (mediator)
             {
                 mediator->updateProperty(property);
@@ -158,10 +169,17 @@ class BaseDevicePrivate
         }
 
     public:
+        struct WatchDetails
+        {
+            std::function<void(INDI::Property)> callback;
+            BaseDevice::WATCH watch {BaseDevice::WATCH_NEW};
+        };
+
+    public:
         BaseDevice self {make_shared_weak(this)}; // backward compatibile (for operators as pointer)
         std::string deviceName;
         BaseDevice::Properties pAll;
-        std::map<std::string, std::function<void(INDI::Property)>> watchPropertyMap;
+        std::map<std::string, WatchDetails> watchPropertyMap;
         LilXmlParser xmlParser;
 
         INDI::BaseMediator *mediator {nullptr};

--- a/libs/indidevice/property/indiproperty.cpp
+++ b/libs/indidevice/property/indiproperty.cpp
@@ -437,6 +437,21 @@ bool Property::isLabelMatch(const std::string &otherLabel) const
     return false;
 }
 
+bool Property::isDeviceNameMatch(const char *otherDeviceName) const
+{
+    return isDeviceNameMatch(std::string(otherDeviceName));
+}
+
+bool Property::isDeviceNameMatch(const std::string &otherDeviceName) const
+{
+    return getDeviceName() == otherDeviceName;
+}
+
+bool Property::isTypeMatch(INDI_PROPERTY_TYPE otherType) const
+{
+    return getType() == otherType;
+}
+
 PropertyViewNumber *Property::getNumber() const
 {
     D_PTR(const Property);

--- a/libs/indidevice/property/indiproperty.h
+++ b/libs/indidevice/property/indiproperty.h
@@ -123,6 +123,11 @@ class Property
         bool isLabelMatch(const char *otherLabel) const;
         bool isLabelMatch(const std::string &otherLabel) const;
 
+        bool isDeviceNameMatch(const char *otherDeviceName) const;
+        bool isDeviceNameMatch(const std::string &otherDeviceName) const;
+
+        bool isTypeMatch(INDI_PROPERTY_TYPE otherType) const;
+
     public:
         void onUpdate(const std::function<void()> &callback);
 


### PR DESCRIPTION
New features have been added, completely backwards compatible.

### New additional argument for INDI::BaseDevice::watchProperty
A function useful for writing clients (`BaseClient`), is an alternative to implementing virtual functions `newProperty`/`updateProperty` and creating a series of conditions to get to a specific property.

Of course, this does not mean that you should not use the implementation of virtual functions. It all depends on the implementation and purpose of the client program. If you want to easily read new values or react to their changes, the watchProperty function gives you such a possibility.

Now you can specify when the function is to be executed, you can choose:
- `WATCH_NEW` - when the property appears in the device - equivalent to `newProperty`
- `WATCH_UPDATE` - when the property changes its value - equivalent to `updateProperty`
- `WATCH_NEW_OR_UPDATE` - any of the above events, combination of `newProperty` and `updateProperty`

By default, the behavior is specified as `WATCH_NEW` and is compatible with the previous implementation behavior.

```cpp
class BaseDevice
{
/* ... */
        /*! Used for watchProperty callback method. */
        enum WATCH
        {
            WATCH_NEW = 0,        /*!< Applies to discovered properties only. */
            WATCH_UPDATE,         /*!< Applies to updated properties only. */
            WATCH_NEW_OR_UPDATE   /*!< Applies when a property appears or is updated, i.e. both of the above. */
        };

        /** @brief Call the callback function if property is available.
         *  @param name of property.
         *  @param callback as an argument of the function you can use INDI::PropertyNumber, INDI::PropertySwitch etc.
         *  @param watch you can decide whether the callback should be executed only once (WATCH_NEW) on discovery of the property or
         *  also on every change of the value (WATCH_UPDATE) or both (WATCH_NEW_OR_UPDATE)
         *  @note the behavior is analogous to BaseMediator::newProperty/updateProperty
         */
        void watchProperty(const char *name, const std::function<void (INDI::Property)> &callback, WATCH watch = WATCH_NEW);
/* ... */
```

### Example of usage `watchProperty`
The example below displays the temperature and saves the photo if it has been taken.
Note that with this type of implementation, **you don't have to** explicitly **check the** property **name, type**, and you don't have to check if the received property is from a given device. Additionally, when passing a function with a property argument of a given type, the conversion from the generic type is performed automatically.

```cpp
INDI::BaseClient indiClient;

/* ... */

indiClient.watchDevice("CCD Simulator", [](INDI::BaseDevice device)
{
    // display ccd temperature
    device.watchProperty("CCD_TEMPERATURE", [](INDI::PropertyNumber property)
    {
        IDLog("Receving new CCD Temperature: %g C\n", property[0].getValue());
    }, INDI::BaseDevice::WATCH_NEW_OR_UPDATE);

    // call if updated of the "CCD1" property - simplified way
    device.watchProperty("CCD1", [](INDI::PropertyBlob property)
    {
        // Save FITS file to disk
        std::ofstream myfile;
        myfile.open("ccd_simulator.fits", std::ios::out | std::ios::binary);
        myfile.write(static_cast<char *>(property[0].getBlob()), property[0].getBlobLen());
        myfile.close();

        IDLog("Received image, saved as ccd_simulator.fits\n");
    }, INDI::BaseDevice::WATCH_UPDATE);
});
```

### INDI::Property::isDeviceNameMatch / INDI::Property::isTypeMatch
First function, returns a comparison of the device name with the given one, this is useful to simplify currently used comparisons.
The second works analogously, but compares types.

For example, a deprecated comparison.
```cpp
// ignore if not ours //
if (strcmp(device.getDeviceName(), deviceName))
    return false;
```
New way:
```cpp
// ignore if not ours //
if (!device.isNameMatch(deviceName))
    return false;
```

Function prototypes
```cpp
class Property
{
/* ... */
        bool isDeviceNameMatch(const char *otherDeviceName) const;
        bool isDeviceNameMatch(const std::string &otherDeviceName) const;
        bool isTypeMatch(INDI_PROPERTY_TYPE otherType) const;
/* ... */
```
