### PR TITLE
Save XISF as planar

### DIFF
--- a/libs/indixisf/indixisf.cpp
+++ b/libs/indixisf/indixisf.cpp
@@ -54,7 +54,6 @@ bool writeImage(const XISFImageParam &params, const std::vector<FITSRecord> &fit
 
         if (params.channelCount == 3)
         {
-            image.setPixelStorage(LibXISF::Image::Normal);
             image.setColorSpace(LibXISF::Image::RGB);
         }
 


### PR DESCRIPTION
RGB images are stored in planar format not normal.