### PR TITLE
Re-do Gemini SetTrackMode and SetTrackEnabled

### DIFF
--- a/drivers/telescope/lx200gemini.cpp
+++ b/drivers/telescope/lx200gemini.cpp
@@ -2098,41 +2098,13 @@ bool LX200Gemini::setGeminiProperty(uint32_t propertyNumber, char* value)
 
 bool LX200Gemini::SetTrackMode(uint8_t mode)
 {
-    int rc = TTY_OK, nbytes_written = 0;
-    char prefix[16] = {0};
-    char cmd[16] = {0};
-
-    snprintf(prefix, 16, ">130:%d", mode + 131);
-
-    uint8_t checksum = calculateChecksum(prefix);
-
-    snprintf(cmd, 16, "%s%c#", prefix, checksum);
-
-    LOGF_DEBUG("CMD: <%s>", cmd);
-
-    if ((rc = tty_write_string(PortFD, cmd, &nbytes_written)) != TTY_OK)
-    {
-        char errmsg[256];
-        tty_error_msg(rc, errmsg, 256);
-        LOGF_ERROR("Error writing to device %s (%d)", errmsg, rc);
-        return false;
-    }
-
-    tcflush(PortFD, TCIFLUSH);
-
-    return true;
+    char empty[] = "";
+    return setGeminiProperty(131 + mode, empty);
 }
 
 bool LX200Gemini::SetTrackEnabled(bool enabled)
 {
-    if (enabled)
-    {
-        return wakeupMount();
-    }
-    else
-    {
-        return sleepMount();
-    }
+    return SetTrackMode(enabled ? IUFindOnSwitchIndex(&TrackModeSP) : GEMINI_TRACK_TERRESTRIAL);
 }
 
 uint8_t LX200Gemini::calculateChecksum(char *cmd)

--- a/drivers/telescope/lx200gemini.h
+++ b/drivers/telescope/lx200gemini.h
@@ -212,8 +212,8 @@ class LX200Gemini : public LX200Generic
             GEMINI_TRACK_SIDEREAL,
             GEMINI_TRACK_KING,
             GEMINI_TRACK_LUNAR,
-            GEMINI_TRACK_SOLAR
-
+            GEMINI_TRACK_SOLAR,
+            GEMINI_TRACK_TERRESTRIAL
         };
 
         enum MovementState


### PR DESCRIPTION
The old code says to change track mode we set the 130 property to
(131 + mode) value. That is not correct. Instead we should set the
(131 + mode) property with no value. I validated this change by
monitoring the track mode with handset.

Disabling tracking with parking sleep makes sense but seems to
interfere with INDI's state management badly. I did not figure out
what exactly was wrong.
This bug looks relevant: https://bugs.kde.org/show_bug.cgi?id=438995
Inspired by how other LX200 flavors work (AP for example), I disable
tracking by engaging the Terrestrial mode. This is also what user
is suggested to do manually if they want to stop tracking. Validated
in KStars by un/parking, toggling tracking, and slewing in different
permutations.