### PR TITLE
Removed the m_isSleeping boolean to fix the "tracking" status in ekos.

### DIFF
--- a/drivers/telescope/lx200gemini.cpp
+++ b/drivers/telescope/lx200gemini.cpp
@@ -1576,11 +1576,6 @@ bool LX200Gemini::ReadScopeStatus()
     if (isSimulation())
         return LX200Generic::ReadScopeStatus();
 
-    if(m_isSleeping)
-    {
-        return true;
-    }
-
     if (TrackState == SCOPE_SLEWING)
     {
         updateMovementState();
@@ -1763,7 +1758,6 @@ bool LX200Gemini::sleepMount()
 
     tcflush(PortFD, TCIOFLUSH);
 
-    m_isSleeping = true;
     LOG_INFO("Mount is sleeping...");
     return true;
 }
@@ -1789,7 +1783,6 @@ bool LX200Gemini::wakeupMount()
 
     tcflush(PortFD, TCIOFLUSH);
 
-    m_isSleeping = false;
     LOG_INFO("Mount is awake...");
     return true;
 }

--- a/drivers/telescope/lx200gemini.h
+++ b/drivers/telescope/lx200gemini.h
@@ -268,6 +268,5 @@ class LX200Gemini : public LX200Generic
         ParkingState getParkingState();
 
         ParkingState priorParkingState = PARK_IN_PROGRESS;
-        bool m_isSleeping { false };
 
 };


### PR DESCRIPTION
This switch was incorrectly disabling comunication with the mount when it was set to be sleeping. The mount is still fully functional when sleeping, it is just not tracking.