### PR TITLE
Fixed SestoSenso2 calibration

### DIFF
--- a/drivers/focuser/primalucacommandset.cpp
+++ b/drivers/focuser/primalucacommandset.cpp
@@ -402,7 +402,7 @@ bool SestoSenso2::storeAsMinPosition()
 *******************************************************************************************************/
 bool SestoSenso2::goOutToFindMaxPos()
 {
-    return m_Communication->command(MOT_1, {"CAL_FOCUSER", "GoOutToFindMaxPos"});
+    return m_Communication->command(MOT_1, {{"CAL_FOCUSER", "GoOutToFindMaxPos"}});
 }
 
 /******************************************************************************************************

--- a/drivers/focuser/sestosenso2.cpp
+++ b/drivers/focuser/sestosenso2.cpp
@@ -92,7 +92,7 @@ bool SestoSenso2::initProperties()
     // Calibration
     CalibrationSP[CALIBRATION_START].fill("CALIBRATION_START", "Start", ISS_OFF);
     CalibrationSP[CALIBRATION_NEXT].fill("CALIBRATION_NEXT", "Next", ISS_OFF);
-    CalibrationSP.fill(getDeviceName(), "FOCUS_CALIBRATION", "Calibration", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0, IPS_IDLE);
+    CalibrationSP.fill(getDeviceName(), "FOCUS_CALIBRATION", "Calibration", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 0, IPS_IDLE);
 
     // Speed Moves
     FastMoveSP[FASTMOVE_IN].fill("FASTMOVE_IN", "Move In", ISS_OFF);


### PR DESCRIPTION
This contains 2 fixes:

1. A rather small JSON fix for goOutToFindMaxPos command
2. A more complex UI flow issue

The UI flow issue occured, when you needed to press the "CALIBRATION_NEXT" button for the second time. Apparently clicking the button for a second time de-selected it, causing the call in line 514 of sestosenso2.cpp to return -1:
auto current_switch = CalibrationSP.findOnSwitchIndex();

Which in turn caused a crash in the followup array access.
The proposed fix is to turn the button group into a radiogroup ( ISR_1OFMANY ), which will not de-select the button, thus returning the wanted index.

Calibration worked fine after those 2 fixes on my own SestoSenso2.

Greetings,
Frostregen

PS: SestoSenso2 has the latest firmware: 03.05.01