### PR TITLE
Force enable tracking after slew and unpark

### DIFF
--- a/drivers/telescope/lx200gemini.cpp
+++ b/drivers/telescope/lx200gemini.cpp
@@ -1607,6 +1607,11 @@ bool LX200Gemini::ReadScopeStatus()
             EqNP.s = IPS_OK;
             IDSetNumber(&EqNP, nullptr);
 
+            if (TrackState == SCOPE_IDLE) {
+                SetTrackEnabled(true);
+                updateMovementState();
+            }
+
             LOG_INFO("Slew is complete. Tracking...");
         }
     }
@@ -1744,9 +1749,10 @@ bool LX200Gemini::UnPark()
     wakeupMount();
 
     SetParked(false);
-    TrackState = SCOPE_TRACKING;
+    SetTrackEnabled(true);
 
     updateParkingState();
+    updateMovementState();
     return true;
 }
 


### PR DESCRIPTION
Gemini maintains tracking mode across slews and park/unpark.
Ekos seems to expect that mount tracks after slew and unpark in some cases.
A few other mount drivers also explicitly start tracking and some other mounts
do that themselves without nudge from the driver.

Broken Ekos cases for me:
 - Disable tracking and park the mount. Start a schedule with unpark option enabled.
   It starts and go to focus phase with tracking still disabled.
 - Have a couple of sky flats sequences added to the end of a schedule as separate entries.
   In most (?) cases those sequences are stuck in the very beginning for an obscure reason.
   With this change it works.