### PR TITLE
PLL: Treat ERR messages as out-of-bound warnings

### DIFF
--- a/drivers/focuser/primalucacommandset.cpp
+++ b/drivers/focuser/primalucacommandset.cpp
@@ -73,14 +73,17 @@ bool Communication::sendRequest(const json &command, json *response)
     if (response == nullptr)
         return true;
 
-    char read_buf[DRIVER_LEN] = {0};
-    if ( (tty_rc = tty_read_section(m_PortFD, read_buf, DRIVER_STOP_CHAR, DRIVER_TIMEOUT, &nbytes_read)) != TTY_OK)
-    {
-        char errorMessage[MAXRBUF] = {0};
-        tty_error_msg(tty_rc, errorMessage, MAXRBUF);
-        LOGF_ERROR("Serial write error: %s", errorMessage);
-        return false;
-    }
+    char read_buf[DRIVER_LEN];
+    do {
+        memset(read_buf, 0, sizeof(read_buf));
+        if ( (tty_rc = tty_read_section(m_PortFD, read_buf, DRIVER_STOP_CHAR, DRIVER_TIMEOUT, &nbytes_read)) != TTY_OK)
+        {
+            char errorMessage[MAXRBUF] = {0};
+            tty_error_msg(tty_rc, errorMessage, MAXRBUF);
+            LOGF_ERROR("Serial write error: %s", errorMessage);
+            return false;
+        }
+    } while (strncmp(read_buf, "ERR:", 4) == 0 && (LOGF_WARN("%s", read_buf), true));
 
     LOGF_DEBUG("<RES> %s", read_buf);
 


### PR DESCRIPTION
My Esatto unit sends these `ERR: ...` messages along with normal JSON responses.
I don't know the formal protocol. Simple ignoring these messages works fine.