### PR TITLE
Add one more check to ensure minimum count is met

### DIFF
--- a/drivers/telescope/ioptronv3driver.cpp
+++ b/drivers/telescope/ioptronv3driver.cpp
@@ -73,7 +73,12 @@ bool Driver::sendCommandOk(const char *command)
     return false;
 }
 
-bool Driver::sendCommand(const char *command, int count, char *response, uint8_t timeout, uint8_t debugLog)
+bool Driver::sendCommand(const char *command,
+                         int count,
+                         char *response,
+                         int minimumCount,
+                         uint8_t timeout,
+                         uint8_t debugLog)
 {
     int errCode = 0;
     int nbytes_read    = 0;
@@ -106,7 +111,7 @@ bool Driver::sendCommand(const char *command, int count, char *response, uint8_t
         else
             errCode = tty_read(PortFD, res, count, timeout, &nbytes_read);
 
-        if (errCode == TTY_OK)
+        if (errCode == TTY_OK && (minimumCount < 0 || minimumCount <= count))
             break;
     }
 
@@ -146,7 +151,7 @@ bool Driver::checkConnection(int fd)
 
     for (int i = 0; i < 2; i++)
     {
-        if (sendCommand(":MountInfo#", 4, res, 3) == false)
+        if (sendCommand(":MountInfo#", 4, res, -1, 3) == false)
         {
             usleep(50000);
             continue;
@@ -250,7 +255,7 @@ bool Driver::getStatus(IOPInfo *info)
                  iopLongitude, iopLatitude, simData.simInfo.gpsStatus, simData.simInfo.systemStatus, simData.simInfo.trackRate,
                  simData.simInfo.slewRate, simData.simInfo.timeSource, simData.simInfo.hemisphere);
     }
-    else if (sendCommand(":GLS#", -1, res) == false)
+    else if (sendCommand(":GLS#", -1, res, 23) == false)
         return false;
 
 
@@ -712,7 +717,7 @@ bool Driver::getCoords(double *ra, double *de, IOP_PIER_STATE *pierState, IOP_CW
                  static_cast<uint32_t>(fabs(simData.de) * 60 * 60 * 100),
                  static_cast<uint32_t>(simData.ra * 15 * 60 * 60 * 100), simData.pier_state, simData.cw_state);
     }
-    else if (sendCommand(":GEP#", -1, res, IOP_TIMEOUT, INDI::Logger::DBG_EXTRA_1) == false)
+    else if (sendCommand(":GEP#", -1, res, 20, IOP_TIMEOUT, INDI::Logger::DBG_EXTRA_1) == false)
         return false;
 
     if (strlen(res) != 20)
@@ -753,7 +758,7 @@ bool Driver::getUTCDateTime(double *JD, int *utcOffsetMinutes, bool *dayLightSav
                  abs(simData.utc_offset_minutes),
                  (simData.day_light_saving ? '1' : '0'), static_cast<uint64_t>((simData.JD - J2000) * 8.64e+7));
     }
-    else if (sendCommand(":GUT#", -1, res) == false)
+    else if (sendCommand(":GUT#", -1, res, 18) == false)
         return false;
 
     if (strlen(res) != 18)

--- a/drivers/telescope/ioptronv3driver.h
+++ b/drivers/telescope/ioptronv3driver.h
@@ -94,7 +94,11 @@ class Driver
         /**************************************************************************
          Communication
         **************************************************************************/
-        bool sendCommand(const char *command, int count = 1, char *response = nullptr, uint8_t timeout = IOP_TIMEOUT,
+        bool sendCommand(const char *command,
+                         int count = 1,
+                         char *response = nullptr,
+                         int minimumCount = -1,
+                         uint8_t timeout = IOP_TIMEOUT,
                          uint8_t debugLog = INDI::Logger::DBG_DEBUG);
         bool sendCommandOk(const char *command);
         bool checkConnection(int fd);


### PR DESCRIPTION
When sending commands, sometimes we receive response from another command in the buffer despite flushing the buffer. So in case the response does not meet the minimum count then we retry.