### PR TITLE
Update ioptronv3driver.cpp

### DIFF
--- a/drivers/telescope/ioptronv3driver.cpp
+++ b/drivers/telescope/ioptronv3driver.cpp
@@ -56,7 +56,9 @@ const std::map<std::string, std::string> Driver::models =
     {"0122", "CEM120-EC2"},
     {"5010", "Cube II AA"},
     {"5035", "AZ Mount Pro"},
-    {"5045", "iEQ45 Pro AA"}
+    {"5045", "iEQ45 Pro AA"},
+    {"0063", "HAE-69EC"}
+
 };
 
 const uint16_t Driver::IOP_SLEW_RATES[] = {1, 2, 8, 16, 64, 128, 256, 512, 1024};
@@ -156,6 +158,7 @@ bool Driver::checkConnection(int fd)
     }
 
     return false;
+    DEBUGDEVICE(m_DeviceName, INDI::Logger::DBG_DEBUG, res);
 }
 
 void Driver::setDebug(bool enable)


### PR DESCRIPTION
Add iOptron HAE-69EC (Will add the others once iOptron sends me a full list of device numbering scheme they used for the new mounts.

This change allows FindHome and all CEM120 features.

Added debug send hardware ID to debug file.  (That's how I found my new mount info).
