### PR TITLE
drivers: auxiliary: use stdint.h types (fix musl build)

### DIFF
--- a/drivers/auxiliary/pegasus_upb.cpp
+++ b/drivers/auxiliary/pegasus_upb.cpp
@@ -1356,7 +1356,7 @@ bool PegasusUPB::sensorUpdated(const std::vector<std::string> &result, uint8_t s
 //////////////////////////////////////////////////////////////////////
 ///
 //////////////////////////////////////////////////////////////////////
-bool PegasusUPB::stepperUpdated(const std::vector<std::string> &result, u_int8_t index)
+bool PegasusUPB::stepperUpdated(const std::vector<std::string> &result, uint8_t index)
 {
     if (lastStepperData.empty())
         return true;

--- a/drivers/auxiliary/pegasus_upb.h
+++ b/drivers/auxiliary/pegasus_upb.h
@@ -141,7 +141,7 @@ class PegasusUPB : public INDI::DefaultDevice, public INDI::FocuserInterface, pu
          * If the previous stepper data is empty then this will always
          * return true.
          */
-        bool stepperUpdated(const std::vector<std::string> &result, u_int8_t index);
+        bool stepperUpdated(const std::vector<std::string> &result, uint8_t index);
 
         int PortFD { -1 };
         bool setupComplete { false };


### PR DESCRIPTION
Followup to 7df8ca6d0de4157268de625c88705c2d96349876. This regressed in 37860f05cb3e4aa55cf7f0d67968b1bcf579e6c3 with the addition of non-standard u_int* types (note the extra underscore).

Bug: https://bugs.gentoo.org/873403