### PR TITLE
Fix bug in relative positioning of Lacerta MFOC

### DIFF
--- a/drivers/focuser/lacerta_mfoc.cpp
+++ b/drivers/focuser/lacerta_mfoc.cpp
@@ -436,7 +436,10 @@ IPState lacerta_mfoc::MoveAbsFocuser(uint32_t targetTicks)
 IPState lacerta_mfoc::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
     // Calculation of the demand absolute position
-    auto targetTicks = std::clamp(FocusAbsPosN[0].value + (ticks * (dir == FOCUS_INWARD ? -1 : 1)), FocusAbsPosN[0].min, FocusAbsPosN[0].max);
+    auto targetTicks = FocusAbsPosN[0].value;
+    if (dir == FOCUS_INWARD) targetTicks -= ticks;
+    else targetTicks += ticks;
+    targetTicks = std::clamp(targetTicks, FocusAbsPosN[0].min, FocusAbsPosN[0].max);
 
     FocusAbsPosNP.s = IPS_BUSY;
     IDSetNumber(&FocusAbsPosNP, nullptr);

--- a/drivers/focuser/lacerta_mfoc_fmc.cpp
+++ b/drivers/focuser/lacerta_mfoc_fmc.cpp
@@ -560,7 +560,10 @@ IPState lacerta_mfoc_fmc::MoveAbsFocuser(uint32_t targetTicks)
 IPState lacerta_mfoc_fmc::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 {
     // Calculation of the demand absolute position
-    auto targetTicks = std::clamp(FocusAbsPosN[0].value + (ticks * (dir == FOCUS_INWARD ? -1 : 1)), FocusAbsPosN[0].min, FocusAbsPosN[0].max);
+    auto targetTicks = FocusAbsPosN[0].value;
+    if (dir == FOCUS_INWARD) targetTicks -= ticks;
+    else targetTicks += ticks;
+    targetTicks = std::clamp(targetTicks, FocusAbsPosN[0].min, FocusAbsPosN[0].max);
     
     FocusAbsPosNP.s = IPS_BUSY;
     IDSetNumber(&FocusAbsPosNP, nullptr);


### PR DESCRIPTION
Fixes issue #1842. Lacerta MFOC with newer firmware (tested with version 3.1.01, driver `indi_lacerta_mfoc_fmc_focus`) fails to correctly change position when a relative change in the `Focus In` direction is selected.

The problematic code is `(ticks * (dir == FOCUS_INWARD ? -1 : 1))`, where `ticks` is an unsigned and `-1` a signed integer. `-1` gets converted into a huge unsigned value before the multiplication is carried out. Hence, the new desired `targetTicks` value is huge instead of decreased by the desired amount.

The same code can be found in the "old" driver `lacerta_mfoc.cpp`, the patch is applied there as well (untested).