### PR TITLE
Bugfix empty active telescope

### DIFF
--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -465,20 +465,22 @@ bool CCD::initProperties()
     IUFillTextVector(&ActiveDeviceTP, ActiveDeviceT, 5, getDeviceName(), "ACTIVE_DEVICES", "Snoop devices", OPTIONS_TAB,
                      IP_RW, 60, IPS_IDLE);
 
-    // Snooped RA/DEC Property
-    IUFillNumber(&EqN[0], "RA", "Ra (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-    IUFillNumber(&EqN[1], "DEC", "Dec (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-    IUFillNumberVector(&EqNP, EqN, 2, ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD", "EQ Coord", "Main Control",
-                       IP_RW,
-                       60, IPS_IDLE);
+    // Snooped RA/DEC Property if an active telescope is set
+    if (ActiveDeviceT[ACTIVE_TELESCOPE].text != nullptr)
+    {
+        IUFillNumber(&EqN[0], "RA", "Ra (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        IUFillNumber(&EqN[1], "DEC", "Dec (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+        IUFillNumberVector(&EqNP, EqN, 2, ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_EOD_COORD", "EQ Coord", "Main Control",
+                           IP_RW,
+                           60, IPS_IDLE);
 
-    // Snooped J2000 RA/DEC Property
-    IUFillNumber(&J2000EqN[0], "RA", "Ra (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
-    IUFillNumber(&J2000EqN[1], "DEC", "Dec (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
-    IUFillNumberVector(&J2000EqNP, J2000EqN, 2, ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_COORD", "J2000 EQ Coord",
-                       "Main Control", IP_RW,
-                       60, IPS_IDLE);
-
+        // Snooped J2000 RA/DEC Property
+        IUFillNumber(&J2000EqN[0], "RA", "Ra (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
+        IUFillNumber(&J2000EqN[1], "DEC", "Dec (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+        IUFillNumberVector(&J2000EqNP, J2000EqN, 2, ActiveDeviceT[ACTIVE_TELESCOPE].text, "EQUATORIAL_COORD", "J2000 EQ Coord",
+                           "Main Control", IP_RW,
+                           60, IPS_IDLE);
+    }
     // Snoop properties of interest
 
     // Snoop mount

--- a/libs/indicore/indidevapi.c
+++ b/libs/indicore/indidevapi.c
@@ -11,6 +11,8 @@
 #include <assert.h>
 #include <sys/stat.h>
 
+#define MAXRBUF 2048
+
 /** \section IUSave */
 
 void IUSaveConfigNumber(FILE *fp, const INumberVectorProperty *nvp)
@@ -55,7 +57,6 @@ int IUSaveBLOB(IBLOB *bp, int size, int blobsize, char *blob, char *format)
  *  N.B. Must be freed by the caller */
 XMLEle *configRootFP(const char *device)
 {
-    static const int MAXRBUF = 2048;
     char configFileName[MAXRBUF];
     char configDir[MAXRBUF];
     char errmsg[MAXRBUF];

--- a/libs/indicore/indidevapi.c
+++ b/libs/indicore/indidevapi.c
@@ -11,6 +11,11 @@
 #include <assert.h>
 #include <sys/stat.h>
 
+#ifdef _WIN32
+#include <direct.h>
+#include <Windows.h>
+#endif
+
 #define MAXRBUF 2048
 
 /** \section IUSave */
@@ -73,14 +78,33 @@ XMLEle *configRootFP(const char *device)
 
     if (stat(configDir, &st) != 0)
     {
+#ifdef _WIN32
+        if (mkdir(configDir) != 0)
+#else
         if (mkdir(configDir, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) < 0)
+#endif
             return NULL;
     }
 
     stat(configFileName, &st);
+    
+#ifdef _WIN32
+    BOOL isAdmin = FALSE;
+    SID_IDENTIFIER_AUTHORITY NtAuthority = SECURITY_NT_AUTHORITY;
+    PSID AdministratorsGroup;
+    if (AllocateAndInitializeSid(&NtAuthority, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, &AdministratorsGroup))
+    {
+        if (CheckTokenMembership(NULL, AdministratorsGroup, &isAdmin) == FALSE)
+            isAdmin = FALSE;
+        FreeSid(AdministratorsGroup);
+    }
+    if ((st.st_uid == 0 && st.st_mode & S_IFDIR) || (st.st_gid == 0 && isAdmin == TRUE))
+        return NULL;
+#else
     /* If file is owned by root and current user is NOT root then abort */
     if ( (st.st_uid == 0 && getuid() != 0) || (st.st_gid == 0 && getgid() != 0) )
         return NULL;
+#endif
 
     fp = fopen(configFileName, "r");
     if (fp == NULL)


### PR DESCRIPTION
Avoid driver crash if active telescope is not set

The current coordinates are snooped only if ACTIVE_TELESCOPE value is not empty. An attempt to an empty value leads to a crash.
