### PR TITLE
Use ZSTD compression for XISF images when available

### DIFF
--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -2456,7 +2456,10 @@ bool CCD::ExposureCompletePrivate(CCDChip * targetChip)
 
                 if (targetChip->SendCompressed)
                 {
-                    image.setCompression(LibXISF::DataBlock::LZ4);
+                    if(LibXISF::DataBlock::CompressionCodecSupported(LibXISF::DataBlock::ZSTD))
+                        image.setCompression(LibXISF::DataBlock::ZSTD);
+                    else
+                        image.setCompression(LibXISF::DataBlock::LZ4);
                     image.setByteshuffling(targetChip->getBPP() / 8);
                 }
 


### PR DESCRIPTION
PixInsight 1.8.9-2 added support for ZSTD compression which is much better than LZ4. So when compression is enabled use ZSTD.