### PR TITLE
Fix PyIndi build fail - revert code formatting changes

### DIFF
--- a/libs/indidevice/indibase.h
+++ b/libs/indidevice/indibase.h
@@ -7,7 +7,7 @@
 
 #ifdef SWIG
 // api version for swig
-% include "indiapi.h"
+%include "indiapi.h"
 #endif
 
 #define MAXRBUF 2048


### PR DESCRIPTION
Referring to the question asked in: https://github.com/indilib/indi/pull/1946

The problem is the white space in `%include` that appeared earlier.
The change was detected based on subsequent commits on the master. Below are screenshots.

![image](https://github.com/indilib/indi/assets/73316926/61fb12f9-9973-44fb-b299-a1750babae35)

![image](https://github.com/indilib/indi/assets/73316926/1c6a1f55-fda9-482e-9a5d-2b6359b274db)

I'm submitting a pull request to confirm the issue.
