### PR TITLE
Snapcap driver with network connections

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -667,7 +667,7 @@
         </device>
         <device label="SnapCap" manufacturer="GTD">
             <driver name="SnapCap">indi_snapcap</driver>
-            <version>1.2</version>
+            <version>1.3</version>
         </device>
         <device label="RBF Excalibur" manufacturer="RB Focus">
             <driver name="RBF Excalibur">indi_Excalibur</driver>

--- a/drivers/auxiliary/snapcap.cpp
+++ b/drivers/auxiliary/snapcap.cpp
@@ -591,7 +591,7 @@ bool SnapCap::getFirmwareVersion()
         return false;
 
     char versionString[4] = { 0 };
-    snprintf(versionString, 3, "%s", response + 4);
+    snprintf(versionString, 4, "%s", response + 2);
     FirmwareTP[0].setText(versionString);
     FirmwareTP.apply();
 

--- a/drivers/auxiliary/snapcap.cpp
+++ b/drivers/auxiliary/snapcap.cpp
@@ -591,7 +591,7 @@ bool SnapCap::getFirmwareVersion()
         return false;
 
     char versionString[4] = { 0 };
-    snprintf(versionString, 4, "%s", response + 2);
+    snprintf(versionString, 3, "%s", response + 4);
     FirmwareTP[0].setText(versionString);
     FirmwareTP.apply();
 

--- a/drivers/auxiliary/snapcap.cpp
+++ b/drivers/auxiliary/snapcap.cpp
@@ -231,8 +231,8 @@ bool SnapCap::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
     }
     if (ForceSP.isNameMatch(name))
     {
-        AbortSP.update(states, names, n);
-        AbortSP.apply();
+    	ForceSP.update(states, names, n);
+    	ForceSP.apply();
         return true;
     }
 

--- a/drivers/auxiliary/snapcap.cpp
+++ b/drivers/auxiliary/snapcap.cpp
@@ -28,6 +28,7 @@
 
 #include "indicom.h"
 #include "connectionplugins/connectionserial.h"
+#include "connectionplugins/connectiontcp.h"
 
 #include <cerrno>
 #include <cstring>
@@ -44,7 +45,13 @@ std::unique_ptr<SnapCap> snapcap(new SnapCap());
 
 SnapCap::SnapCap() : LightBoxInterface(this, true)
 {
-    setVersion(1, 2);
+    setVersion(1, 3);
+}
+
+SnapCap::~SnapCap(){
+
+    delete serialConnection;
+    delete tcpConnection;
 }
 
 bool SnapCap::initProperties()
@@ -82,13 +89,27 @@ bool SnapCap::initProperties()
 
     addAuxControls();
 
-    serialConnection = new Connection::Serial(this);
-    serialConnection->registerHandshake([&]()
+    if (dustcapConnection & CONNECTION_SERIAL)
     {
-        return Handshake();
-    });
-    registerConnection(serialConnection);
-    serialConnection->setDefaultBaudRate(Connection::Serial::B_38400);
+        serialConnection = new Connection::Serial(this);
+        serialConnection->registerHandshake([&]()
+        {
+            return callHandshake();
+        });
+        registerConnection(serialConnection);
+    }
+
+    if (dustcapConnection & CONNECTION_TCP)
+    {
+        tcpConnection = new Connection::TCP(this);
+        tcpConnection->registerHandshake([&]()
+        {
+            return callHandshake();
+        });
+        registerConnection(tcpConnection);
+    }
+
+
     return true;
 }
 
@@ -152,8 +173,6 @@ bool SnapCap::Handshake()
         return true;
     }
 
-    PortFD = serialConnection->getPortFD();
-
     if (!ping())
     {
         LOG_ERROR("Device ping failed.");
@@ -161,6 +180,19 @@ bool SnapCap::Handshake()
     }
 
     return true;
+}
+
+bool SnapCap::callHandshake()
+{
+    if (dustcapConnection > 0)
+    {
+        if (getActiveConnection() == serialConnection)
+            PortFD = serialConnection->getPortFD();
+        else if (getActiveConnection() == tcpConnection)
+            PortFD = tcpConnection->getPortFD();
+    }
+
+    return Handshake();
 }
 
 bool SnapCap::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
@@ -642,3 +674,22 @@ bool SnapCap::SetLightBoxBrightness(uint16_t value)
 
     return true;
 }
+
+uint8_t SnapCap::getDustcapConnection() const
+{
+    return dustcapConnection;
+}
+
+void SnapCap::setDustcapConnection(const uint8_t &value)
+{
+    uint8_t mask = CONNECTION_SERIAL | CONNECTION_TCP | CONNECTION_NONE;
+
+    if (value == 0 || (mask & value) == 0)
+    {
+        LOGF_ERROR( "Invalid connection mode %d", value);
+        return;
+    }
+
+    dustcapConnection = value;
+}
+

--- a/drivers/auxiliary/snapcap.h
+++ b/drivers/auxiliary/snapcap.h
@@ -42,7 +42,7 @@ class SnapCap : public INDI::DefaultDevice, public INDI::LightBoxInterface, publ
 {
     public:
         SnapCap();
-        virtual ~SnapCap() = default;
+        virtual ~SnapCap();
 
         virtual bool initProperties() override;
         virtual void ISGetProperties(const char *dev) override;

--- a/drivers/auxiliary/snapcap.h
+++ b/drivers/auxiliary/snapcap.h
@@ -127,5 +127,5 @@ class SnapCap : public INDI::DefaultDevice, public INDI::LightBoxInterface, publ
         Connection::TCP *tcpConnection       = nullptr;
 
     private:
-		bool callHandshake();
+        bool callHandshake();
         uint8_t dustcapConnection = CONNECTION_SERIAL | CONNECTION_TCP;};

--- a/drivers/auxiliary/snapcap.h
+++ b/drivers/auxiliary/snapcap.h
@@ -35,6 +35,7 @@
 namespace Connection
 {
 class Serial;
+class TCP;
 }
 
 class SnapCap : public INDI::DefaultDevice, public INDI::LightBoxInterface, public INDI::DustCapInterface
@@ -51,6 +52,28 @@ class SnapCap : public INDI::DefaultDevice, public INDI::LightBoxInterface, publ
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISSnoopDevice(XMLEle *root) override;
+
+        /** \struct SnapcapConnection
+                \brief Holds the connection mode of the Dome.
+            */
+        enum
+        {
+            CONNECTION_NONE   = 1 << 0, /** Do not use any connection plugin */
+            CONNECTION_SERIAL = 1 << 1, /** For regular serial and bluetooth connections */
+            CONNECTION_TCP    = 1 << 2  /** For Wired and WiFI connections */
+        } DustcapConnection;
+
+        /**
+             * @brief setDustcapConnection Set Dustcap connection mode. Child class should call this in the constructor before Dustcap registers
+             * any connection interfaces
+             * @param value ORed combination of DustcapConnection values.
+             */
+        void setDustcapConnection(const uint8_t &value);
+
+        /**
+             * @return Get current Dustcap connection mode
+             */
+        uint8_t getDustcapConnection() const;
 
     protected:
         const char *getDefaultName() override;
@@ -100,5 +123,9 @@ class SnapCap : public INDI::DefaultDevice, public INDI::LightBoxInterface, publ
         uint8_t prevMotorStatus{ 0xFF };
         uint8_t prevBrightness{ 0xFF };
 
-        Connection::Serial *serialConnection{ nullptr };
-};
+        Connection::Serial *serialConnection = nullptr;
+        Connection::TCP *tcpConnection       = nullptr;
+
+    private:
+		bool callHandshake();
+        uint8_t dustcapConnection = CONNECTION_SERIAL | CONNECTION_TCP;};


### PR DESCRIPTION
This PR adds a new feature to SnapCap driver: TCP connections.

It also fixes an issue related to the Force button.