### PR TITLE
Link against httplib if using system libraries

### DIFF
--- a/drivers/telescope/CMakeLists.txt
+++ b/drivers/telescope/CMakeLists.txt
@@ -262,6 +262,6 @@ install(TARGETS indi_skywatcherAltAzMount RUNTIME DESTINATION bin)
 add_executable(indi_planewave_telescope
     planewave_mount.cpp)
 
-target_link_libraries(indi_planewave_telescope indidriver)
+target_link_libraries(indi_planewave_telescope indidriver ${HTTPLIB_LIBRARY})
 
 install(TARGETS indi_planewave_telescope RUNTIME DESTINATION bin)


### PR DESCRIPTION
This patch fixes the following build error if system provided httplib is used.

```
FAILED: drivers/telescope/indi_planewave_telescope 
: && /usr/bin/x86_64-pc-linux-gnu-g++ -march=native -O2 -pipe -D_FORTIFY_SOURCE=2 -O1 -Wa,--noexecstack  -Wall -Wextra -Wno-format-truncation -g -DHAVE_MREMAP -Wl,-O1 -Wl,--as-needed  -Wl,-z,nodump -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now drivers/telescope/CMakeFiles/indi_planewave_telescope.dir/planewave_mount.cpp.o -o drivers/telescope/indi_planewave_telescope  -Wl,-rpath,/var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5_build/libs/indibase:  libs/indibase/libindidriver.so.2.0.5  -lusb-1.0  /usr/lib64/libnova.so  /usr/lib64/libcfitsio.so  -lz  /usr/lib64/libjpeg.so  /usr/lib64/libfftw3.so  -lm  /usr/lib64/libtheoraenc.so  /usr/lib64/libtheoradec.so  /usr/lib64/libogg.so && :
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/telescope/CMakeFiles/indi_planewave_telescope.dir/planewave_mount.cpp.o: in function `PlaneWave::Abort()':
/var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:252: undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:254: undefined reference to `httplib::Client::Get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:255: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:255: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/telescope/CMakeFiles/indi_planewave_telescope.dir/planewave_mount.cpp.o: in function `PlaneWave::SetTrackMode(unsigned char)':
/var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:374: undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:376: undefined reference to `httplib::Client::Get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:377: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:377: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/telescope/CMakeFiles/indi_planewave_telescope.dir/planewave_mount.cpp.o: in function `PlaneWave::Park()':
/var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:196: undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:198: undefined reference to `httplib::Client::Get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:199: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:199: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/telescope/CMakeFiles/indi_planewave_telescope.dir/planewave_mount.cpp.o: in function `PlaneWave::SetTrackEnabled(bool)':
/var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:390: undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:392: undefined reference to `httplib::Client::Get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:393: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:393: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/telescope/CMakeFiles/indi_planewave_telescope.dir/planewave_mount.cpp.o: in function `PlaneWave::Goto(double, double)':
/var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:151: undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:154: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:153: undefined reference to `httplib::Client::Get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:154: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/telescope/CMakeFiles/indi_planewave_telescope.dir/planewave_mount.cpp.o: in function `PlaneWave::dispatch(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:411: undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:413: undefined reference to `httplib::Client::Get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:435: undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.5/work/indi-2.0.5/drivers/telescope/planewave_mount.cpp:435: undefined reference to `httplib::Client::~Client()'
collect2: error: ld returned 1 exit status
```