### PR TITLE
Fix various typos throughout the codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ You can base a new driver from an existing driver. Look in either the examples o
 
 # Unit tests
 
-In order to run the unit test suite you must first install the [Google Test Framework](https://github.com/google/googletest). You will need to build and install this from source code as Google does not recommend package managers for distributing distros.(This is because each build system is often unique and a one size fits all aproach does not work well).
+In order to run the unit test suite you must first install the [Google Test Framework](https://github.com/google/googletest). You will need to build and install this from source code as Google does not recommend package managers for distributing distros.(This is because each build system is often unique and a one size fits all approach does not work well).
 
 Once you have the Google Test Framework installed follow this alternative build sequence:-
 

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -110,7 +110,7 @@ sudo apt-get update &amp;&amp; sudo apt-get install indi-DRIVER_NAME
 </ul>
 <p class="alert alert-info">The <b>Slew Rate</b> dropdown is used to control the <b>manual</b> speeds when using the NSWE controls either directly or via a joystick. To set the <b>GOTO</b> speeds (when mount moves from one target to another via a GOTO command), you need to update the <b>Custom Speeds</b> control.</p>
 <h3>Site Management</h3>
-<p>Time, Locaiton, and Park settings are configured in the Site Management tab.</p>
+<p>Time, Location, and Park settings are configured in the Site Management tab.</p>
 <p><img style="display: block; margin-right: auto; margin-left: auto;" src="/images/devices/DRIVER_NAME/site_management.jpg" alt="Site Management" /></p>
 <ul>
 	<li><strong>UTC</strong>: UTC time and offsets must be set for proper operation of the driver upon connection. The UTC offset is in hours. East is positive and west is negative.</li>

--- a/drivers/auxiliary/STAR2kdriver.c
+++ b/drivers/auxiliary/STAR2kdriver.c
@@ -106,7 +106,7 @@ int ConnectSTAR2k(char *port)
 }
 
 /* Start a slew in chosen direction at slewRate */
-/* Use auxilliary NexStar command set through the hand control computer */
+/* Use auxiliary NexStar command set through the hand control computer */
 
 void StartPulse(int direction)
 {

--- a/drivers/auxiliary/astrometrydriver.cpp
+++ b/drivers/auxiliary/astrometrydriver.cpp
@@ -297,7 +297,7 @@ bool AstrometryDriver::processBLOB(uint8_t *data, uint32_t size, uint32_t len)
 
         if (destLen != size)
         {
-            LOGF_WARN("Discrepency between uncompressed data size %ld and expected size %ld",
+            LOGF_WARN("Discrepancy between uncompressed data size %ld and expected size %ld",
                       size, destLen);
         }
 

--- a/drivers/auxiliary/astrometrydriver.h
+++ b/drivers/auxiliary/astrometrydriver.h
@@ -39,7 +39,7 @@
  * The solver settings should be set before running the solver in order to ensure correct and timely response from astrometry.net
  * It is assumed that astrometry.net is property set-up in the same machine the driver is running along with the appropriate index files.
  *
- * If the solver is successfull, the driver sets the solver results which include:
+ * If the solver is successful, the driver sets the solver results which include:
  * + Pixel Scale (arcsec/pixel).
  * + Orientation (E or W) degrees.
  * + Center RA (J2000) Hours.

--- a/drivers/auxiliary/mydcp4esp32.cpp
+++ b/drivers/auxiliary/mydcp4esp32.cpp
@@ -305,7 +305,7 @@ bool MyDCP4ESP::sendCommand(const char *cmd, char *resp)
 
 // Determine which of the 4 channels have temperature probes attached. Only those with probes can be active
 // except for Channel 3 which can mirrior Channels 1 & 2 or be controlled manually.
-// Check to see if each channel can be set to Overide if it doesn't currently have a power output
+// Check to see if each channel can be set to Override if it doesn't currently have a power output
 bool MyDCP4ESP::getActiveChannels()
 {
     char cmd[MDCP_CMD_LENGTH] = {};
@@ -519,7 +519,7 @@ bool MyDCP4ESP::setAmbientOffset(float value)
     return sendCommand(cmd, nullptr); 
 }
 
-// set or reset Channel overide. Channel = 5 resets all channels
+// set or reset Channel override. Channel = 5 resets all channels
 bool MyDCP4ESP::setChannelBoost( unsigned int channel, unsigned int value)
 {
     char cmd[MDCP_CMD_LENGTH] = {};
@@ -839,7 +839,7 @@ bool MyDCP4ESP::readSettings()
 
     if ((ok == 1) && (ch3_mode <= 4))
     {
-        // Enabel/Disable Ch3 Manual Power setting if Ch3 Mode Manual enabled
+        // Enable/Disable Ch3 Manual Power setting if Ch3 Mode Manual enabled
         if ((ch3_mode == CH3MODE_MANUAL) && (!ch3ManualPower))
         {
             defineProperty(Ch3ManualPowerNP);

--- a/drivers/auxiliary/mydcp4esp32.h
+++ b/drivers/auxiliary/mydcp4esp32.h
@@ -85,7 +85,7 @@
 #define MDCP_GET_ALL_CH_POWER_CMD           ":40#"    // Get the power settings for ch1/ch2/ch3/ch4 - Response: lch1pwr,ch2pwr,ch3pwr,ch4pwr#
 #define MDCP_SET_CH3_MODE_CMD               ":41%d#"  // Set the Channel 3 mode (0=disabled, 1=dewstrap1, 2=dewstrap2, 3=Manual, 4=use temp probe3) - Response: none
 #define MDCP_GET_CH3_MODE_CMD               ":42#"    // Get the Channel 3 mode (0=disabled, 1=dewstrap1, 2=dewstrap2, 3=Manual, 4=use temp probe3) - Response: mmode#
-#define MDCP_SET_CH3_MANUAL_POWER_CMD       ":43%d#"  // Set the Channel 3 power to a manual seting of Num - Response: none    
+#define MDCP_SET_CH3_MANUAL_POWER_CMD       ":43%d#"  // Set the Channel 3 power to a manual setting of Num - Response: none    
 
 /**************************** myDCP4ESP32 Command Responses **************************/
 
@@ -128,7 +128,7 @@
 #define MDCP_GET_ALL_CH_POWER_RES           "l%d,%d,%d,%d"    // Get the power settings for ch1/ch2/ch3/ch4 - Response: lch1pwr,ch2pwr,ch3pwr,ch4pwr#
 #define MDCP_SET_CH3_MODE_RES               ""      // Set the Channel 3 mode (0=disabled, 1=dewstrap1, 2=dewstrap2, 3=Manual, 4=use temp probe3) - Response: none
 #define MDCP_GET_CH3_MODE_RES               "m%d"   // Get the Channel 3 mode (0=disabled, 1=dewstrap1, 2=dewstrap2, 3=Manual, 4=use temp probe3) - Response: mmode#
-#define MDCP_SET_CH3_MANUAL_POWER_RES       ""      // Set the Channel 3 power to a manual seting of Num - Response: none 
+#define MDCP_SET_CH3_MANUAL_POWER_RES       ""      // Set the Channel 3 power to a manual setting of Num - Response: none 
 
 /******************************************************************************/
 

--- a/drivers/auxiliary/pegasus_upb.cpp
+++ b/drivers/auxiliary/pegasus_upb.cpp
@@ -98,7 +98,7 @@ bool PegasusUPB::initProperties()
     /// Power Group
     ////////////////////////////////////////////////////////////////////////////
 
-    // Dew Labels. Need to delare them here to use in the Power usage section
+    // Dew Labels. Need to declare them here to use in the Power usage section
     IUFillText(&DewControlsLabelsT[0], "DEW_LABEL_1", "Dew A", "Dew A");
     IUFillText(&DewControlsLabelsT[1], "DEW_LABEL_2", "Dew B", "Dew B");
     IUFillText(&DewControlsLabelsT[2], "DEW_LABEL_3", "Dew C", "Dew C");

--- a/drivers/auxiliary/planewave_delta.h
+++ b/drivers/auxiliary/planewave_delta.h
@@ -116,7 +116,7 @@ class DeltaT : public INDI::DefaultDevice
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////////
 
-        // Delta-T Informatin
+        // Delta-T Information
         ITextVectorProperty InfoTP;
         IText InfoT[1] {};
         enum

--- a/drivers/auxiliary/skysafariclient.cpp
+++ b/drivers/auxiliary/skysafariclient.cpp
@@ -187,7 +187,7 @@ bool SkySafariClient::setSlewRate(int slewRate)
 
     int finalSlewRate = slewRate;
 
-    // If slew rate is betwee min and max, we intepolate
+    // If slew rate is between min and max, we interpolate
     if (slewRate > 0 && slewRate < maxSlewRate)
         finalSlewRate = static_cast<int>(ceil(slewRate * maxSlewRate / 3.0));
 

--- a/drivers/auxiliary/sqm.h
+++ b/drivers/auxiliary/sqm.h
@@ -103,6 +103,6 @@ class SQM : public INDI::DefaultDevice
         static const char DRIVER_STOP_CHAR { 0x0A };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {128};
 };

--- a/drivers/auxiliary/wanderer_cover.cpp
+++ b/drivers/auxiliary/wanderer_cover.cpp
@@ -124,7 +124,7 @@ bool WandererCover::Handshake()
 {
     if (isSimulation())
     {
-        LOGF_INFO("Connected successfuly to simulated %s. Retrieving startup data...", getDeviceName());
+        LOGF_INFO("Connected successfully to simulated %s. Retrieving startup data...", getDeviceName());
 
         // SetTimer(getCurrentPollingPeriod());
         IUSaveText(&FirmwareT[0], "Simulation version");
@@ -716,7 +716,7 @@ void WandererCover::displayConfigurationMessage()
     LOG_WARN(" - Click on 'Set current position as close' to define the park position");
     LOG_WARN(" - Use again the select list to move your cover panel in close position on the scope");
     LOG_WARN(" - Click on 'Set current position as open' to define the unpark position");
-    LOG_WARN(" - Use the select controler to move your panel to the open position");
+    LOG_WARN(" - Use the select controller to move your panel to the open position");
     LOG_WARN("In order to do so, go to 'Dust cover configurtation' tab and do the following steps :");
     LOG_WARN("Before first use, or when you change your setup, you need to configure Open and closed position first in 'Dust cover configurtation' tab.");
 }

--- a/drivers/auxiliary/watchdog.cpp
+++ b/drivers/auxiliary/watchdog.cpp
@@ -606,7 +606,7 @@ void WatchDog::TimerHit()
                 break;
             }
 
-            // Watch mount if requied
+            // Watch mount if required
             if (ShutdownProcedureS[PARK_MOUNT].s == ISS_ON)
                 m_WatchDogClientInstance->setMount(ActiveDeviceT[ACTIVE_TELESCOPE].text);
             // Watch dome

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -411,7 +411,7 @@ void CCDSim::TimerHit()
             float timeleft;
             timeleft = CalcTimeLeft(ExpStart, ExposureRequest);
 
-            //IDLog("CCD Exposure left: %g - Requset: %g\n", timeleft, ExposureRequest);
+            //IDLog("CCD Exposure left: %g - Request: %g\n", timeleft, ExposureRequest);
             if (timeleft < 0)
                 timeleft = 0;
 
@@ -724,7 +724,7 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
 
                 while (fgets(line, 256, pp) != nullptr)
                 {
-                    //  ok, lets parse this line for specifcs we want
+                    //  ok, lets parse this line for specifics we want
                     char id[20];
                     char plate[6];
                     char ob[6];

--- a/drivers/ccd/guide_simulator.cpp
+++ b/drivers/ccd/guide_simulator.cpp
@@ -333,7 +333,7 @@ void GuideSim::TimerHit()
             float timeleft;
             timeleft = CalcTimeLeft(ExpStart, ExposureRequest);
 
-            //IDLog("CCD Exposure left: %g - Requset: %g\n", timeleft, ExposureRequest);
+            //IDLog("CCD Exposure left: %g - Request: %g\n", timeleft, ExposureRequest);
             if (timeleft < 0)
                 timeleft = 0;
 

--- a/drivers/dome/domepro2.h
+++ b/drivers/dome/domepro2.h
@@ -119,7 +119,7 @@ class DomePro2 : public INDI::Dome
                  * after the command is successfully sent.
                  * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
                  * the @a cmd buffer.
-                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
                  *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
                  * @return True if successful, false otherwise.
         */
@@ -174,7 +174,7 @@ class DomePro2 : public INDI::Dome
         static const char DRIVER_STOP_CHAR { 0x3B };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
         // Dome AZ Threshold
         static constexpr const double DOME_AZ_THRESHOLD {0.01};
@@ -225,7 +225,7 @@ class DomePro2 : public INDI::Dome
             {"Parking", "Parking"},
             {"Gauging", "Gauging"},
             {"Timeout", "Azimuth movement timeout"},
-            {"Stall", "Azimuth encoder registering insufficent counts… motor stalled"},
+            {"Stall", "Azimuth encoder registering insufficient counts… motor stalled"},
             {"OCP", "Over Current Protection was tripped"}
         };
 

--- a/drivers/dome/nexdome_beaver.h
+++ b/drivers/dome/nexdome_beaver.h
@@ -200,7 +200,7 @@ class Beaver : public INDI::Dome
         static const char DRIVER_STOP_CHAR { 0x23 };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {128};
         int domeDir = 1;
         double lastAzDiff = 1;

--- a/drivers/dome/rigel_dome.h
+++ b/drivers/dome/rigel_dome.h
@@ -134,6 +134,6 @@ class RigelDome : public INDI::Dome
         static const char DRIVER_STOP_CHAR { 0x0D };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
 };

--- a/drivers/dome/scopedome_dome.h
+++ b/drivers/dome/scopedome_dome.h
@@ -256,7 +256,7 @@ class ScopeDome : public INDI::Dome
 
         INDI::PropertyText CredentialsTP{2};
 
-        // Dynamic properies initialized based on card type
+        // Dynamic properties initialized based on card type
         INDI::PropertySwitch RelaysSP{0};
         INDI::PropertyNumber SensorsNP{0};
         INDI::PropertySwitch InputsSP{0};

--- a/drivers/filter_wheel/ifwoptec.cpp
+++ b/drivers/filter_wheel/ifwoptec.cpp
@@ -418,7 +418,7 @@ bool FilterIFW::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 ************************************************************************************/
 void FilterIFW::simulationTriggered(bool enable)
 {
-    // toogle buttons to select 5 or 8 filters depend if Simulation active or not
+    // toggle buttons to select 5 or 8 filters depend if Simulation active or not
     if (enable)
     {
         if (isConnected())
@@ -738,7 +738,7 @@ bool FilterIFW::SetFilterNames()
 
     LOG_INFO("Filters name are saved in IFW");
 
-    // Interface not ready before the message "DATA OK" disapear from the display IFW
+    // Interface not ready before the message "DATA OK" disappear from the display IFW
     for (int i = OPTEC_WAIT_DATA_OK; i > 0; i--)
     {
         LOGF_INFO("Please wait for HOME command start... %d", i);
@@ -943,7 +943,7 @@ bool FilterIFW::GetFirmware()
         return false;
     }
 
-    // remove chars fomr the string to get only the nzuméric value of the Firmware version
+    // remove chars from the string to get only the nzuméric value of the Firmware version
     char *p = nullptr;
 
     for (int i = 0; i < (int)strlen(response); i++)

--- a/drivers/filter_wheel/ifwoptec.h
+++ b/drivers/filter_wheel/ifwoptec.h
@@ -119,7 +119,7 @@ class FilterIFW : public INDI::FilterWheel
         ISwitchVectorProperty CharSetSP;
         ISwitch CharSetS[2];
 
-        // Firmware of teh IFW
+        // Firmware of the IFW
         ITextVectorProperty FirmwareTP;
         IText FirmwareT[1] {};
 

--- a/drivers/filter_wheel/pegasus_indigo.h
+++ b/drivers/filter_wheel/pegasus_indigo.h
@@ -58,7 +58,7 @@ class PegasusINDIGO : public INDI::FilterWheel
                  * after the command is successfully sent.
                  * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
                  * the @a cmd buffer.
-                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
                  *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
                  * @return True if successful, false otherwise.
         */

--- a/drivers/filter_wheel/xagyl_wheel.h
+++ b/drivers/filter_wheel/xagyl_wheel.h
@@ -148,6 +148,6 @@ class XAGYLWheel : public INDI::FilterWheel
         // Some commands optionally return an extra string.
         static constexpr const int OPTIONAL_TIMEOUT {1};
 
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const int DRIVER_LEN {64};
 };

--- a/drivers/focuser/aaf2.h
+++ b/drivers/focuser/aaf2.h
@@ -69,8 +69,8 @@ class AAF2 : public INDI::Focuser
         bool Ack();
         /**
          * @brief sendCommand Send a string command to AAF2.
-         * @param cmd Command to be sent, must already have the necessary delimeter ('#')
-         * @param res If not nullptr, the function will read until it detects the default delimeter ('#') up to ML_RES length.
+         * @param cmd Command to be sent, must already have the necessary delimiter ('#')
+         * @param res If not nullptr, the function will read until it detects the default delimiter ('#') up to ML_RES length.
          *        if nullptr, no read back is done and the function returns true.
          * @return True if successful, false otherwise.
          */
@@ -93,8 +93,8 @@ class AAF2 : public INDI::Focuser
 
         // AAF2 Buffer
         static const uint8_t DRIVER_RES { 32 };
-        // AAF2 Delimeter
+        // AAF2 Delimiter
         static const char DRIVER_DEL { '#' };
-        // AAF2 Tiemout
+        // AAF2 Timeout
         static const uint8_t DRIVER_TIMEOUT { 3 };
 };

--- a/drivers/focuser/celestron.cpp
+++ b/drivers/focuser/celestron.cpp
@@ -93,7 +93,7 @@ bool CelestronSCT::initProperties()
     FocusRelPosN[0].value = 0;
     FocusRelPosN[0].step  = 1000;
 
-    // Absolute Postition Range
+    // Absolute Position Range
     FocusAbsPosN[0].min   = 0.;
     FocusAbsPosN[0].max   = 60000.;
     FocusAbsPosN[0].value = 0;
@@ -116,7 +116,7 @@ bool CelestronSCT::initProperties()
 
     communicator.setDeviceName(getDeviceName());
 
-    // Defualt port to /dev/ttyACM0
+    // Default port to /dev/ttyACM0
     //serialConnection->setDefaultPort("/dev/ttyACM0");
 
     //LOG_INFO("initProperties end");

--- a/drivers/focuser/celestron.h
+++ b/drivers/focuser/celestron.h
@@ -124,8 +124,8 @@ class CelestronSCT : public INDI::Focuser
         /////////////////////////////////////////////////////////////////////////////
         //        // Celestron Buffer
         //        static const uint8_t CELESTRON_LEN { 32 };
-        //        // Celestorn Delimeter
+        //        // Celestorn Delimiter
         //        static const char CELESTRON_DEL { '#' };
-        //        // Celestron Tiemout in seconds
+        //        // Celestron Timeout in seconds
         //        static const uint8_t CELESTRON_TIMEOUT { 3 };
 };

--- a/drivers/focuser/focuslynx.cpp
+++ b/drivers/focuser/focuslynx.cpp
@@ -120,7 +120,7 @@ const char *FocusLynxF1::getDefaultName()
  *
 * ***********************************************************************************/
 bool FocusLynxF1::Connect()
-/* Overide of connect() function
+/* Override of connect() function
  * different for F1 or F2 focuser
  * F1 connect only himself to the driver and
  * it is the only one who's connect to the communication port to establish the physical communication
@@ -304,7 +304,7 @@ bool FocusLynxF1::getHubConfig()
         IUSaveText(&HubT[0], text);
         IDSetText(&HubTP, nullptr);
 
-        //Save localy the Version of the firmware's Hub
+        //Save locally the Version of the firmware's Hub
         strncpy(version, text, sizeof(version));
 
         LOGF_DEBUG("Text =  %s,  Key = %s", text, key);
@@ -550,7 +550,7 @@ bool FocusLynxF1::getHubConfig()
     memset(response, 0, sizeof(response));
     memset(text, 0, sizeof(text));
 
-    // WIFI IP adress
+    // WIFI IP address
     if (isSimulation())
     {
         strncpy(response, "WF IP = 192.168.1.11\n", 32);
@@ -691,7 +691,7 @@ bool FocusLynxF1::getHubConfig()
     {
         response[nbytes_read - 1] = '\0';
 
-        // Display the response to be sure to have read the complet TTY Buffer.
+        // Display the response to be sure to have read the complete TTY Buffer.
         LOGF_DEBUG("RES <%s>", response);
 
         if (strcmp(response, "END"))
@@ -791,7 +791,7 @@ const char *FocusLynxF2::getDefaultName()
  *
 * ***********************************************************************************/
 bool FocusLynxF2::Connect()
-/* Overide of connect() function
+/* Override of connect() function
  * different for F2 or F1 focuser
  * F2 don't connect himself to the hub
  */
@@ -846,7 +846,7 @@ bool FocusLynxF2::RemoteDisconnect()
         updateProperties();
     }
 
-    // When called by F1, the PortFD should be -1; For debbug purpose
+    // When called by F1, the PortFD should be -1; For debug purposes
     PortFD = lynxDriveF1->getPortFD();
     LOGF_INFO("Remote disconnection: %s is offline.", getDeviceName());
     LOGF_INFO("Value of F2 PortFD = %d", PortFD);

--- a/drivers/focuser/focuslynxbase.cpp
+++ b/drivers/focuser/focuslynxbase.cpp
@@ -38,7 +38,7 @@ FocusLynxBase::FocusLynxBase()
     lynxModels["Optec TCF-Lynx 3"] = "OB";
 
     // "OC" is now reserved, it is hard coded into focusers that use it
-    // Allthough it can be selected it should not be
+    // Although it can be selected it should not be
     // lynxModels["Optec TCF-Lynx 2 with Extended Travel"] = "OC";
     lynxModels["Optec Fast Focus Secondary Focuser"] = "OD";
 
@@ -324,7 +324,7 @@ bool FocusLynxBase::Handshake()
 * ***********************************************************************************/
 const char *FocusLynxBase::getDefaultName()
 {
-    // Has to be overide by child instance
+    // Has to be overridden by child instance
     return "FocusLynxBase";
 }
 
@@ -874,7 +874,7 @@ bool FocusLynxBase::getFocusConfig()
             defineProperty(&GotoSP);
 
             // If not 'No Focuser' then do iterator
-            // iterate throught all elements in std::map<std::string, std::string> and search the index from the code.
+            // iterate through all elements in std::map<std::string, std::string> and search the index from the code.
             std::map<std::string, std::string>::iterator it = lynxModels.begin();
             while(it != lynxModels.end())
             {
@@ -1007,7 +1007,7 @@ bool FocusLynxBase::getFocusConfig()
     FocusBacklashNP.s       = IPS_OK;
     IDSetNumber(&FocusBacklashNP, nullptr);
 
-    // Led brightnesss
+    // Led brightness
     memset(response, 0, sizeof(response));
     if (isSimulation())
     {
@@ -1082,7 +1082,7 @@ bool FocusLynxBase::getFocusConfig()
     {
         response[nbytes_read - 1] = '\0';
 
-        // Display the response to be sure to have read the complet TTY Buffer.
+        // Display the response to be sure to have read the complete TTY Buffer.
         LOGF_DEBUG("RES (%s)", response);
 
         if (strcmp(response, "END"))
@@ -1461,7 +1461,7 @@ bool FocusLynxBase::getFocusStatus()
         {
             response[nbytes_read - 1] = '\0';
 
-            // Display the response to be sure to have read the complet TTY Buffer.
+            // Display the response to be sure to have read the complete TTY Buffer.
             LOGF_DEBUG("RES (%s)", response);
             if (strcmp(response, "END"))
                 return false;
@@ -1949,7 +1949,7 @@ bool FocusLynxBase::getFocusTemp()
         {
             response[nbytes_read - 1] = '\0';
 
-            // Display the response to be sure to have read the complet TTY Buffer.
+            // Display the response to be sure to have read the complete TTY Buffer.
             LOGF_DEBUG("RES (%s)", response);
             if (strcmp(response, "END"))
                 return false;

--- a/drivers/focuser/lacerta_mfoc.cpp
+++ b/drivers/focuser/lacerta_mfoc.cpp
@@ -446,7 +446,7 @@ IPState lacerta_mfoc::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
 
     return MoveAbsFocuser(targetTicks);
 }
-    //Waiting makes no sense - will be immediatly interrupted by the ekos system...
+    //Waiting makes no sense - will be immediately interrupted by the ekos system...
     //int ticks = std::abs((int)(targetTicks - pos) * FOCUS_MOTION_DELAY);
     //LOGF_INFO("sleep for %d ms", ticks);
     //usleep(ticks + 5000);

--- a/drivers/focuser/lakeside.cpp
+++ b/drivers/focuser/lakeside.cpp
@@ -431,7 +431,7 @@ bool Lakeside::updateMoveDirection()
 //          K : Temperature in Kelvin update found - TemperatureKN[0].value
 //          D : DONE# received
 //          O : OK# received
-//          E : Error due to unknown/misformed command having been sent
+//          E : Error due to unknown/malformed command having been sent
 //          ? : unknown response received
 char Lakeside::DecodeBuffer(char * in_response)
 {
@@ -451,7 +451,7 @@ char Lakeside::DecodeBuffer(char * in_response)
         return 'O';
     }
 
-    // if focuser returns an error for unknow command
+    // if focuser returns an error for unknown command
     if (!strncmp(in_response, "!#", 2))
     {
         return 'E';

--- a/drivers/focuser/moonlite.h
+++ b/drivers/focuser/moonlite.h
@@ -87,8 +87,8 @@ class MoonLite : public INDI::Focuser
         bool Ack();
         /**
          * @brief sendCommand Send a string command to MoonLite.
-         * @param cmd Command to be sent, must already have the necessary delimeter ('#')
-         * @param res If not nullptr, the function will read until it detects the default delimeter ('#') up to ML_RES length.
+         * @param cmd Command to be sent, must already have the necessary delimiter ('#')
+         * @param res If not nullptr, the function will read until it detects the default delimiter ('#') up to ML_RES length.
          *        if nullptr, no read back is done and the function returns true.
          * @param silent if true, do not print any error messages.
          * @param nret if > 0 read nret chars, otherwise read to the terminator
@@ -139,8 +139,8 @@ class MoonLite : public INDI::Focuser
 
         // MoonLite Buffer
         static const uint8_t ML_RES { 32 };
-        // MoonLite Delimeter
+        // MoonLite Delimiter
         static const char ML_DEL { '#' };
-        // MoonLite Tiemout
+        // MoonLite Timeout
         static const uint8_t ML_TIMEOUT { 3 };
 };

--- a/drivers/focuser/myfocuserpro2.cpp
+++ b/drivers/focuser/myfocuserpro2.cpp
@@ -277,7 +277,7 @@ bool MyFocuserPro2::Ack()
 
     if (rc > 0)
     {
-        // remove check for firmare => 291, assume user is not using older firmware
+        // remove check for firmware => 291, assume user is not using older firmware
         LOGF_INFO("MyFP2 reported firmware %d", firmWareVersion);
         LOG_INFO("Connection to focuser is successful.");
         return true;
@@ -1292,7 +1292,7 @@ IPState MyFocuserPro2::MoveRelFocuser(FocusDirection dir, uint32_t ticks)
     return IPS_BUSY;
 }
 
-// this is occuring every 500ms
+// this is occurring every 500ms
 void MyFocuserPro2::TimerHit()
 {
     if (!isConnected())

--- a/drivers/focuser/myfocuserpro2.h
+++ b/drivers/focuser/myfocuserpro2.h
@@ -119,8 +119,8 @@ class MyFocuserPro2 : public INDI::Focuser
         bool Ack();
         /**
          * @brief sendCommand Send a string command to MyFocuserPro2.
-         * @param cmd Command to be sent, must already have the necessary delimeter ('#')
-         * @param res If not nullptr, the function will read until it detects the default delimeter ('#') up to ML_RES length.
+         * @param cmd Command to be sent, must already have the necessary delimiter ('#')
+         * @param res If not nullptr, the function will read until it detects the default delimiter ('#') up to ML_RES length.
          *        if nullptr, no read back is done and the function returns true.
          * @return True if successful, false otherwise.
          */
@@ -249,7 +249,7 @@ class MyFocuserPro2 : public INDI::Focuser
         // MyFocuserPro2 Buffer
         static const uint8_t ML_RES { 32 };
 
-        // MyFocuserPro2 Delimeter
+        // MyFocuserPro2 Delimiter
         static const char ML_DEL { '#' };
 
         // mutex controls access to serial port

--- a/drivers/focuser/nfocus.h
+++ b/drivers/focuser/nfocus.h
@@ -104,6 +104,6 @@ class NFocus : public INDI::Focuser
         static constexpr const uint8_t NFOCUS_TEMPERATURE_FREQ {10};
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t NFOCUS_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t NFOCUS_LEN {64};
 };

--- a/drivers/focuser/nstep.h
+++ b/drivers/focuser/nstep.h
@@ -149,6 +149,6 @@ class NStep : public INDI::Focuser
         static constexpr const uint8_t NSTEP_TEMPERATURE_FREQ {10};
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t NSTEP_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t NSTEP_LEN {64};
 };

--- a/drivers/focuser/planewave_efa.cpp
+++ b/drivers/focuser/planewave_efa.cpp
@@ -765,7 +765,7 @@ bool EFA::sendCommand(const uint8_t * cmd, uint8_t *res, uint32_t cmd_len, uint3
         }
         else if (efaDump(hexbuf, hexbuflen, cmd, cmd_len) != NULL)
         {
-            // expected there to always be an echo, so note this occurence
+            // expected there to always be an echo, so note this occurrence
             LOGF_DEBUG("no echo for command packet: %s", hexbuf);
         }
 

--- a/drivers/focuser/planewave_efa.h
+++ b/drivers/focuser/planewave_efa.h
@@ -125,7 +125,7 @@ class EFA : public INDI::Focuser
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////////
 
-        // Focuser Informatin
+        // Focuser Information
         ITextVectorProperty InfoTP;
         IText InfoT[1] {};
         enum

--- a/drivers/focuser/primalucacommandset.h
+++ b/drivers/focuser/primalucacommandset.h
@@ -60,7 +60,7 @@ typedef enum
 } Units;
 
 /*****************************************************************************************
- * Communicaton class handle the serial communication with SestoSenso2/Esatto/Arco
+ * Communication class handle the serial communication with SestoSenso2/Esatto/Arco
  * models according to the USB Protocol specifications document in JSON.
 ******************************************************************************************/
 class Communication
@@ -77,9 +77,9 @@ class Communication
         bool sendRequest(const json &command, json *response = nullptr);
         template <typename T = int32_t> bool genericRequest(const std::string &node, const std::string &type, const json &command, T *response = nullptr);
         /**
-         * @brief Get paramter from device.
+         * @brief Get parameter from device.
          * @param type motor type, if MOT_NONE, then it's a generic device-wide get.
-         * @param paramter paramter name (e.g.SN)
+         * @param parameter parameter name (e.g.SN)
          * @param value where to store the queried value.
          * @return True if successful, false otherwise.
          * @example {"req":{"get":{"SN":""}}} --> {"res":{"get":{"SN":" ESATTO30001"}}
@@ -118,7 +118,7 @@ class Communication
         std::string m_DeviceName;
         int m_PortFD {-1};
 
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const int DRIVER_LEN {4096};
         static const char DRIVER_STOP_CHAR { 0xD };
         static const char DRIVER_TIMEOUT { 5 };

--- a/drivers/focuser/rainbowRSF.h
+++ b/drivers/focuser/rainbowRSF.h
@@ -91,6 +91,6 @@ class RainbowRSF : public INDI::Focuser
         static constexpr const uint8_t DRIVER_TEMPERATURE_FREQ {10};
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {16};
 };

--- a/drivers/focuser/rbfocus.h
+++ b/drivers/focuser/rbfocus.h
@@ -53,8 +53,8 @@ class RBFOCUS : public INDI::Focuser
         bool Ack();
         /**
          * @brief sendCommand Send a string command to RBFocus.
-         * @param cmd Command to be sent, must already have the necessary delimeter ('#')
-         * @param res If not nullptr, the function will read until it detects the default delimeter ('#') up to ML_RES length.
+         * @param cmd Command to be sent, must already have the necessary delimiter ('#')
+         * @param res If not nullptr, the function will read until it detects the default delimiter ('#') up to ML_RES length.
          *        if nullptr, no read back is done and the function returns true.
          * @return True if successful, false otherwise.
          */

--- a/drivers/focuser/robofocus.cpp
+++ b/drivers/focuser/robofocus.cpp
@@ -78,7 +78,7 @@ bool RoboFocus::initProperties()
     IUFillSwitch(&PowerSwitchesS[1], "2", "Switch 2", ISS_OFF);
     IUFillSwitch(&PowerSwitchesS[2], "3", "Switch 3", ISS_OFF);
     IUFillSwitch(&PowerSwitchesS[3], "4", "Switch 4", ISS_ON);
-    IUFillSwitchVector(&PowerSwitchesSP, PowerSwitchesS, 4, getDeviceName(), "SWTICHES", "Power", SETTINGS_TAB, IP_RW,
+    IUFillSwitchVector(&PowerSwitchesSP, PowerSwitchesS, 4, getDeviceName(), "SWITCHES", "Power", SETTINGS_TAB, IP_RW,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
     /* Robofocus should stay within these limits */

--- a/drivers/focuser/sestosenso.cpp
+++ b/drivers/focuser/sestosenso.cpp
@@ -27,7 +27,7 @@
     #SC;HOLD;RUN;ACC;DEC! Shell_set_current_supply in HOLD, RUN, ACC, DEC situations (Value must be from 0 to 24, maximum hold value 10)
     #QM! Query max value
     #Qm! Query min value
-    #QT! Qeury temperature
+    #QT! Query temperature
     #QF! Query firmware version
     #QN! Read the device name	-> reply	QN;SESTOSENSO!
     #QP! Query_position

--- a/drivers/focuser/sestosenso.h
+++ b/drivers/focuser/sestosenso.h
@@ -107,7 +107,7 @@ class SestoSenso : public INDI::Focuser
         static constexpr const uint8_t SESTO_TEMPERATURE_FREQ {10};
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t SESTO_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t SESTO_LEN {64};
 
 };

--- a/drivers/focuser/sestosenso2.cpp
+++ b/drivers/focuser/sestosenso2.cpp
@@ -709,7 +709,7 @@ bool SestoSenso2::ISNewSwitch(const char *dev, const char *name, ISState *states
                 LOG_INFO("Motor hold ON. Do NOT attempt to manually adjust the focuser!");
                 if (MotorCurrentNP[MOTOR_CURR_HOLD].getValue() < 2.0)
                 {
-                    LOGF_WARN("Motor hold current set to %.1f: This may be insufficent to hold focus",
+                    LOGF_WARN("Motor hold current set to %.1f: This may be insufficient to hold focus",
                               MotorCurrentNP[MOTOR_CURR_HOLD].getValue());
                 }
             }
@@ -985,7 +985,7 @@ void SestoSenso2::TimerHit()
             }
         }
 
-        // Also use temparature poll rate for tracking input voltage
+        // Also use temperature poll rate for tracking input voltage
         rc = updateVoltageIn();
         if (rc)
         {

--- a/drivers/focuser/sestosenso2.h
+++ b/drivers/focuser/sestosenso2.h
@@ -186,7 +186,7 @@ class SestoSenso2 : public INDI::Focuser
         static constexpr const uint8_t SESTO_TEMPERATURE_FREQ {10};
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t SESTO_TIMEOUT {5};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const int SESTO_LEN {1024};
 
 };

--- a/drivers/focuser/steeldrive.cpp
+++ b/drivers/focuser/steeldrive.cpp
@@ -97,7 +97,7 @@ bool SteelDrive::initProperties()
     IUFillNumberVector(&CustomSettingNP, CustomSettingN, 2, getDeviceName(), "Custom Settings", "", FOCUS_SETTINGS_TAB,
                        IP_RW, 0, IPS_IDLE);
 
-    // Focuser Accleration
+    // Focuser Acceleration
     IUFillNumber(&AccelerationN[0], "Ramp", "", "%3.0f", 1500., 3000., 100., 2000.);
     IUFillNumberVector(&AccelerationNP, AccelerationN, 1, getDeviceName(), "FOCUS_ACCELERATION", "Acceleration",
                        FOCUS_SETTINGS_TAB, IP_RW, 0, IPS_IDLE);

--- a/drivers/focuser/steeldrive2.h
+++ b/drivers/focuser/steeldrive2.h
@@ -82,7 +82,7 @@ class SteelDriveII : public INDI::Focuser
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////////
 
-        // Focuser Informatin
+        // Focuser Information
         ITextVectorProperty InfoTP;
         IText InfoT[2] {};
         enum
@@ -164,6 +164,6 @@ class SteelDriveII : public INDI::Focuser
         static const char DRIVER_STOP_CHAR { 0x0A };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {192};
 };

--- a/drivers/focuser/tcfs.h
+++ b/drivers/focuser/tcfs.h
@@ -72,7 +72,7 @@ class TCFS : public INDI::Focuser
         TCFS();
         virtual ~TCFS() = default;
 
-        // Standard INDI interface fucntions
+        // Standard INDI interface functions
         virtual bool Handshake() override;
         virtual bool Disconnect() override;
         const char *getDefaultName() override;

--- a/drivers/receiver/indi_rtlsdr.cpp
+++ b/drivers/receiver/indi_rtlsdr.cpp
@@ -209,7 +209,7 @@ bool RTLSDR::initProperties()
 
 /********************************************************************************************
 ** INDI is asking us to update the properties because there is a change in CONNECTION status
-** This fucntion is called whenever the device is connected or disconnected.
+** This function is called whenever the device is connected or disconnected.
 *********************************************************************************************/
 bool RTLSDR::updateProperties()
 {
@@ -218,7 +218,7 @@ bool RTLSDR::updateProperties()
 
     if (isConnected())
     {
-        // Inital values
+        // Initial values
         setupParams(1000000, 1420000000, 10);
 
         // Start the timer

--- a/drivers/receiver/receiver_simulator.cpp
+++ b/drivers/receiver/receiver_simulator.cpp
@@ -117,13 +117,13 @@ bool RadioSim::initProperties()
 
 /********************************************************************************************
 ** INDI is asking us to update the properties because there is a change in CONNECTION status
-** This fucntion is called whenever the device is connected or disconnected.
+** This function is called whenever the device is connected or disconnected.
 *********************************************************************************************/
 bool RadioSim::updateProperties()
 {
     if (isConnected())
     {
-        // Inital values
+        // Initial values
         setupParams(1000000, 1420000000, 10000, 10);
 
         // Start the timer

--- a/drivers/rotator/gemini.cpp
+++ b/drivers/rotator/gemini.cpp
@@ -338,7 +338,7 @@ bool Gemini::Handshake()
 * ***********************************************************************************/
 const char *Gemini::getDefaultName()
 {
-    // Has to be overide by child instance
+    // Has to be overridden by child instance
     return "Gemini Focusing Rotator";
 }
 
@@ -1229,7 +1229,7 @@ bool Gemini::getFocusConfig()
     FocuserHomeOnStartSP.s   = IPS_OK;
     IDSetSwitch(&FocuserHomeOnStartSP, nullptr);
 
-    // Added By Philippe Besson the 28th of June for 'END' evalution
+    // Added By Philippe Besson the 28th of June for 'END' evaluation
     // END is reached
     memset(response, 0, sizeof(response));
     if (isSimulation())
@@ -1248,7 +1248,7 @@ bool Gemini::getFocusConfig()
     {
         response[nbytes_read - 1] = '\0';
 
-        // Display the response to be sure to have read the complet TTY Buffer.
+        // Display the response to be sure to have read the complete TTY Buffer.
         LOGF_DEBUG("RES (%s)", response);
 
         if (strcmp(response, "END"))
@@ -1490,7 +1490,7 @@ bool Gemini::getRotatorStatus()
     RotatorStatusL[STATUS_HOMED].s = isHomed ? IPS_OK : IPS_IDLE;
     IDSetLight(&RotatorStatusLP, nullptr);
 
-    // Added By Philippe Besson the 28th of June for 'END' evalution
+    // Added By Philippe Besson the 28th of June for 'END' evaluation
     // END is reached
     memset(response, 0, sizeof(response));
     if (isSimulation())
@@ -1509,7 +1509,7 @@ bool Gemini::getRotatorStatus()
     {
         response[nbytes_read - 1] = '\0';
 
-        // Display the response to be sure to have read the complet TTY Buffer.
+        // Display the response to be sure to have read the complete TTY Buffer.
         LOGF_DEBUG("RES (%s)", response);
 
         if (strcmp(response, "END"))
@@ -1801,7 +1801,7 @@ bool Gemini::getRotatorConfig()
     response[nbytes_read - 1] = '\0';
     DEBUGF(DBG_FOCUS, "RES (%s)", response);
 
-    // Added By Philippe Besson the 28th of June for 'END' evalution
+    // Added By Philippe Besson the 28th of June for 'END' evaluation
     // END is reached
     memset(response, 0, sizeof(response));
     if (isSimulation())
@@ -1820,7 +1820,7 @@ bool Gemini::getRotatorConfig()
     {
         response[nbytes_read - 1] = '\0';
 
-        // Display the response to be sure to have read the complet TTY Buffer.
+        // Display the response to be sure to have read the complete TTY Buffer.
         LOGF_DEBUG("RES (%s)", response);
 
         if (strcmp(response, "END"))
@@ -2133,7 +2133,7 @@ bool Gemini::getFocusStatus()
     FocuserStatusLP.s = IPS_OK;
     IDSetLight(&FocuserStatusLP, nullptr);
 
-    // Added By Philippe Besson the 28th of June for 'END' evalution
+    // Added By Philippe Besson the 28th of June for 'END' evaluation
     // END is reached
     memset(response, 0, sizeof(response));
     if (isSimulation())
@@ -2152,7 +2152,7 @@ bool Gemini::getFocusStatus()
     {
         response[nbytes_read - 1] = '\0';
 
-        // Display the response to be sure to have read the complet TTY Buffer.
+        // Display the response to be sure to have read the complete TTY Buffer.
         LOGF_DEBUG("RES (%s)", response);
 
         if (strcmp(response, "END"))

--- a/drivers/rotator/integra.cpp
+++ b/drivers/rotator/integra.cpp
@@ -948,7 +948,7 @@ bool Integra::genericIntegraCommand(const char *name, const char *cmd, const cha
     // check begin of result string
     if (expectStart != nullptr)
     {
-        correctRes = strstr(res, expectStart);      // the hw sometimes returns /r or /n at the beginning ot the response
+        correctRes = strstr(res, expectStart);      // the hw sometimes returns /r or /n at the beginning of the response
         if (correctRes == nullptr)
         {
             LOGF_ERROR("%s error: invalid response (%s)", name, res);

--- a/drivers/rotator/nframe.h
+++ b/drivers/rotator/nframe.h
@@ -120,7 +120,7 @@ class nFrameRotator : public INDI::Rotator
         static const char DRIVER_STOP_CHAR { 0x23 };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {128};
         // Operatives
         static constexpr const uint8_t DRIVER_OPERATIVES {2};
@@ -173,7 +173,7 @@ class nFrameRotator : public INDI::Rotator
         static const char NFRAME_STOP_CHAR { 0x23 };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t NFRAME_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t NFRAME_LEN {64};
 
 

--- a/drivers/rotator/pegasus_falcon.cpp
+++ b/drivers/rotator/pegasus_falcon.cpp
@@ -173,7 +173,7 @@ bool PegasusFalcon::ISNewSwitch(const char * dev, const char * name, ISState * s
 }
 
 //////////////////////////////////////////////////////////////////////
-/// move to degrees (Commmand "MD:nn.nn"; Response "MD:nn.nn")
+/// move to degrees (Command "MD:nn.nn"; Response "MD:nn.nn")
 //////////////////////////////////////////////////////////////////////
 IPState PegasusFalcon::MoveRotator(double angle)
 {

--- a/drivers/rotator/pegasus_falcon.h
+++ b/drivers/rotator/pegasus_falcon.h
@@ -76,7 +76,7 @@ class PegasusFalcon : public INDI::Rotator
                  * after the command is successfully sent.
                  * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
                  * the @a cmd buffer.
-                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
                  *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
                  * @return True if successful, false otherwise.
         */

--- a/drivers/rotator/pyxis.cpp
+++ b/drivers/rotator/pyxis.cpp
@@ -472,7 +472,7 @@ IPState Pyxis::MoveRotator(double angle)
     if (targetPA > 359)
         targetPA = 0;
 
-    // Rotator will only rotation +-180 degress from home (0 degrees) so it make take
+    // Rotator will only rotation +-180 degrees from home (0 degrees) so it make take
     // the long way to avoid cable wrap
     if (current <= 180 && targetPA < 180)
         direction = (targetPA >= current ? 1 : -1) ;

--- a/drivers/skeleton/focuser_driver.cpp
+++ b/drivers/skeleton/focuser_driver.cpp
@@ -119,7 +119,7 @@ bool FocuserDriver::updateProperties()
 
 bool FocuserDriver::Handshake()
 {
-    // This functin is ensure that we have communication with the focuser
+    // This function is ensure that we have communication with the focuser
     // Below we send it 0x6 byte and check for 'S' in the return. Change this
     // to be valid for your driver. It could be anything, you can simply put this below
     // return readPosition()

--- a/drivers/skeleton/focuser_driver.h
+++ b/drivers/skeleton/focuser_driver.h
@@ -42,7 +42,7 @@ class FocuserDriver : public INDI::Focuser
 
         bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
-        // If you define any Number properties, then you need to override ISNewNumber to repond to number property requests.
+        // If you define any Number properties, then you need to override ISNewNumber to respond to number property requests.
         //bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
 
     protected:
@@ -94,7 +94,7 @@ class FocuserDriver : public INDI::Focuser
          * after the command is successfully sent.
          * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
          * the @a cmd buffer.
-         * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+         * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
          *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
          * @return True if successful, false otherwise.
          */
@@ -137,6 +137,6 @@ class FocuserDriver : public INDI::Focuser
         static constexpr const uint8_t DRIVER_TEMPERATURE_FREQ {10};
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
 };

--- a/drivers/skeleton/mount_driver.cpp
+++ b/drivers/skeleton/mount_driver.cpp
@@ -139,7 +139,7 @@ bool MountDriver::updateProperties()
 
 bool MountDriver::Handshake()
 {
-    // This functin is ensure that we have communication with the mount
+    // This function is ensure that we have communication with the mount
     // Below we send it 0x6 byte and check for 'S' in the return. Change this
     // to be valid for your driver. It could be anything, you can simply put this below
     // return readScopeStatus()

--- a/drivers/skeleton/mount_driver.h
+++ b/drivers/skeleton/mount_driver.h
@@ -26,9 +26,9 @@
  * mount driver. Modify the driver to fit your needs.
  *
  * It supports the following features:
- * + Sideral and Custom Tracking rates.
+ * + Sidereal and Custom Tracking rates.
  * + Goto & Sync
- * + NWSE Hand controller direciton key slew.
+ * + NWSE Hand controller direction key slew.
  * + Tracking On/Off.
  * + Parking & Unparking with custom parking positions.
  * + Setting Time & Location.
@@ -134,7 +134,7 @@ class MountDriver : public INDI::Telescope, public INDI::GuiderInterface
          * after the command is successfully sent.
          * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
          * the @a cmd buffer.
-         * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+         * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
          *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
          * @return True if successful, false otherwise.
          */
@@ -168,7 +168,7 @@ class MountDriver : public INDI::Telescope, public INDI::GuiderInterface
         static const char DRIVER_STOP_CHAR { 0x23 };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
 
 };

--- a/drivers/spectrograph/shelyak/indi_shelyak_usis.cpp
+++ b/drivers/spectrograph/shelyak/indi_shelyak_usis.cpp
@@ -211,7 +211,7 @@ void ShelyakDriver::scanProperties( )
     if ( sendCmd( &rsp, "GET;DEVICE_NAME;VALUE" ) )
     {
 
-        // try to find dthe device definition in the .json
+        // try to find the device definition in the .json
         json device;
         if( !findBoard( rsp.parts[4], &device ) )
         {

--- a/drivers/telescope/astrotrac.cpp
+++ b/drivers/telescope/astrotrac.cpp
@@ -593,10 +593,10 @@ double AstroTrac::calculateSlewTime(double distance)
     // Firstly throw away sign of distance - don't care about direction - and convert to arcsec
     distance = fabs(distance) * 3600.0;
 
-    // Now estimate how far mount travels during accelertion and deceleration period
+    // Now estimate how far mount travels during acceleration and deceleration period
     double accelerate_decelerate = MAX_SLEW_VELOCITY * MAX_SLEW_VELOCITY / AccelerationNP[AXIS_RA].getValue();
 
-    // If distance less than this, then calulate using accleration forumlae:
+    // If distance less than this, then calculate using acceleration forumlae:
     if (distance < accelerate_decelerate)
     {
         return (2 * sqrt(distance / AccelerationNP[AXIS_RA].getValue()));

--- a/drivers/telescope/astrotrac.h
+++ b/drivers/telescope/astrotrac.h
@@ -140,7 +140,7 @@ class AstroTrac :
                  * after the command is successfully sent.
                  * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
                  * the @a cmd buffer.
-                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
                  *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
                  * @return True if successful, false otherwise.
         */
@@ -200,13 +200,13 @@ class AstroTrac :
         static const char DRIVER_STOP_CHAR { 0x3E };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
         // Slew Modes
         static constexpr const uint8_t SLEW_MODES {10};
         // Slew Speeds
         static const std::array<uint32_t, SLEW_MODES> SLEW_SPEEDS;
-        // Maximum Slew Velocity. This cannot be set now so it's considered contant until until it can be altered.
+        // Maximum Slew Velocity. This cannot be set now so it's considered constant until until it can be altered.
         // arcsec/sec
         static constexpr double MAX_SLEW_VELOCITY {10800.0};
         // Target threshold in degrees between mechanical target and current coordinates

--- a/drivers/telescope/celestrongps.cpp
+++ b/drivers/telescope/celestrongps.cpp
@@ -1388,7 +1388,7 @@ void CelestronGPS::mountSim()
         return;
     }
 
-    // Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly
+    // Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly
     switch (TrackState)
     {
         case SCOPE_IDLE:
@@ -1855,7 +1855,7 @@ void CelestronGPS::guideTimer(CELESTRON_DIRECTION dirn)
     {
         if (driver.get_pulse_status(dirn))
         {
-            // curent move not finished, add some more time
+            // current move not finished, add some more time
             AddGuideTimer(dirn, 100);
             return;
         }

--- a/drivers/telescope/ieqdriverbase.h
+++ b/drivers/telescope/ieqdriverbase.h
@@ -108,7 +108,7 @@ class Base
         **************************************************************************/
         /** Get iEQ current status info */
         bool getStatus(Info *info);
-        /** Initilizes communication with the mount and gets mount model */
+        /** Initializes communication with the mount and gets mount model */
         bool getModel();
         /** Get mainboard and controller firmware only */
         bool getMainFirmware();
@@ -152,7 +152,7 @@ class Base
          * after the command is successfully sent.
          * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
          * the @a cmd buffer.
-         * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+         * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
          *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
          * @return True if successful, false otherwise.
          */

--- a/drivers/telescope/ieqpro.cpp
+++ b/drivers/telescope/ieqpro.cpp
@@ -930,7 +930,7 @@ bool IEQPro::saveConfigItems(FILE *fp)
 //    ltv = tv;
 //    da  = SLEWRATE * dt;
 
-//    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+//    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
 //    switch (TrackState)
 //    {
 //        case SCOPE_IDLE:
@@ -1020,7 +1020,7 @@ bool IEQPro::SetCurrentPark()
 
 bool IEQPro::SetDefaultPark()
 {
-    // By defualt azimuth 0
+    // By default azimuth 0
     SetAxis1Park(0);
 
     // Altitude = latitude of observer

--- a/drivers/telescope/ieqprolegacy.cpp
+++ b/drivers/telescope/ieqprolegacy.cpp
@@ -817,7 +817,7 @@ void IEQProLegacy::mountSim()
     ltv = tv;
     da  = SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_IDLE:
@@ -911,7 +911,7 @@ bool IEQProLegacy::SetCurrentPark()
 
 bool IEQProLegacy::SetDefaultPark()
 {
-    // By defualt azimuth 0
+    // By default azimuth 0
     SetAxis1Park(0);
 
     // Altitude = latitude of observer

--- a/drivers/telescope/ieqprolegacydriver.h
+++ b/drivers/telescope/ieqprolegacydriver.h
@@ -95,7 +95,7 @@ bool check_ieqpro_connection(int fd);
 **************************************************************************/
 /** Get iEQ current status info */
 bool get_ieqpro_status(int fd, IEQInfo *info);
-/** Get All firmware informatin in addition to mount model */
+/** Get All firmware information in addition to mount model */
 bool get_ieqpro_firmware(int fd, FirmwareInfo *info);
 /** Get mainboard and controller firmware only */
 bool get_ieqpro_main_firmware(int fd, FirmwareInfo *info);

--- a/drivers/telescope/ioptronHC8406.cpp
+++ b/drivers/telescope/ioptronHC8406.cpp
@@ -30,7 +30,7 @@ INFO
 :Gg#            -003*18:03#  longitud
 :Gt#            +41*06:56#   latitude
 :GL#            7:02:47.0#   local time
-:GS#            20:12: 3.3#  Sideral Time
+:GS#            20:12: 3.3#  Sidereal Time
 :GR#            2:12:57.4#   RA
 :GD#            +90* 0: 0#   DEC
 :GA#            +41* 6:55#   ALT
@@ -48,10 +48,10 @@ COMMANDS
 This only works if the mount is not stopped (tracking)
 :RT0# -->       Lunar
 :RT1# -->       solar
-:RT2# -->       sideral
+:RT2# -->       sidereal
 :RT9# -->               zero but not work!!
 
-!!!There isn't a command to start/stop tracking !!! You have to do manualy
+!!!There isn't a command to start/stop tracking !!! You have to do manually
 
 This speeds only are taken into account for protocol buttons, not for the HC Buttons
 :RG#  -->  Select guide speed for :Mn#,:Ms# ....
@@ -68,7 +68,7 @@ V1.12 2011-08-12
 UPGRADE INFO ON: http://www.ioptron.com/Articles.asp?ID=268
 
 :RT9#     -> stop tracking
-:RT0#     -> start tracking at sidera speed. Formerly only preselect sideral speed but
+:RT0#     -> start tracking at sidera speed. Formerly only preselect sidereal speed but
              not start the tracking itself
 
 :Me#
@@ -359,7 +359,7 @@ void ioptronHC8406::getBasicData()
 void ioptronHC8406::ioptronHC8406Init()
 {
     //This mount doesn't report anything so we send some CMD
-    //just to get syncronize with the GUI at start time
+    //just to get synchronized with the GUI at start time
     LOG_WARN("Sending init CMDs. Unpark, Stop tracking");
     UnPark();
     TrackState = SCOPE_IDLE;
@@ -755,7 +755,7 @@ bool ioptronHC8406::SetTrackEnabled(bool enabled)
 {
     if (enabled)
     {
-        LOG_WARN("<SetTrackEnabled> START TRACKING AT SIDERAL SPEED (:RT2#)");
+        LOG_WARN("<SetTrackEnabled> START TRACKING AT SIDEREAL SPEED (:RT2#)");
         return setioptronHC8406TrackMode(0);
     }
     else
@@ -929,7 +929,7 @@ void ioptronHC8406::mountSim()
     ltv = tv;
     da  = SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_TRACKING:

--- a/drivers/telescope/ioptronv3.cpp
+++ b/drivers/telescope/ioptronv3.cpp
@@ -196,7 +196,7 @@ bool IOptronV3::initProperties()
     else
         serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
 
-    // Default WiFi connection parametes
+    // Default WiFi connection parameters
     tcpConnection->setDefaultHost("10.10.100.254");
     tcpConnection->setDefaultPort(8899);
 
@@ -1162,7 +1162,7 @@ void IOptronV3::mountSim()
     double currentSlewRate = Driver::IOP_SLEW_RATES[IUFindOnSwitchIndex(&SlewRateSP)] * TRACKRATE_SIDEREAL / 3600.0;
     da  = currentSlewRate * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_IDLE:
@@ -1253,7 +1253,7 @@ bool IOptronV3::SetCurrentPark()
 
 bool IOptronV3::SetDefaultPark()
 {
-    // By defualt azimuth 0
+    // By default azimuth 0
     SetAxis1Park(0);
     // Altitude = latitude of observer
     SetAxis2Park(LocationN[LOCATION_LATITUDE].value);

--- a/drivers/telescope/ioptronv3driver.h
+++ b/drivers/telescope/ioptronv3driver.h
@@ -108,7 +108,7 @@ class Driver
         **************************************************************************/
         /** Get iEQ current status info */
         bool getStatus(IOPInfo *info);
-        /** Get All firmware informatin in addition to mount model */
+        /** Get All firmware information in addition to mount model */
         bool getFirmwareInfo(FirmwareInfo *info);
         /** Get RA/DEC */
         bool getCoords(double *ra, double *de, IOP_PIER_STATE *pierState, IOP_CW_STATE *cwState);

--- a/drivers/telescope/lx200_10micron.cpp
+++ b/drivers/telescope/lx200_10micron.cpp
@@ -670,7 +670,7 @@ bool LX200_10MICRON::SyncConfigBehaviour(bool cmcfg)
     // #:CMCFGn#
     // Configures the behaviour of the :CM# and :CMR# commands depending on the value
     // of n. If n=0, :the commands :CM# and :CMR# work in the default mode, i.e. they
-    // synchronize the position ot the mount with the coordinates of the currently selected
+    // synchronize the position to the mount with the coordinates of the currently selected
     // target by correcting the axis offset values. If n=1, the commands :CM# and :CMR#
     // work by using the synchronization position as an additional alignment star for refining
     // the alignment model.
@@ -808,7 +808,7 @@ bool LX200_10MICRON::SetTLEfromDatabase(int tleN)
 bool LX200_10MICRON::CalculateSatTrajectory(std::string start_pass_isodatetime, std::string end_pass_isodatetime)
 {
     // #:TLEPJD,min#
-    // Precalulates the first transit of the satellite with the currently loaded orbital elements,
+    // Precalculates the first transit of the satellite with the currently loaded orbital elements,
     // starting from Julian Date JD and for a period of min minutes, where min is from 1 to 1440.
     // Two-line elements have to be loaded with the :TLEL command.
     // Returns:

--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -62,7 +62,7 @@ LX200_OnStep::LX200_OnStep() : LX200Generic(), WI(this), RotatorInterface(this)
     // 4 stands for the number of Slewrate Buttons as defined in Inditelescope.cpp
     //setLX200Capability(LX200_HAS_FOCUS | LX200_HAS_TRACKING_FREQ | LX200_HAS_ALIGNMENT_TYPE | LX200_HAS_SITES | LX200_HAS_PULSE_GUIDING);
     //
-    // Get generic capabilities but discard the followng:
+    // Get generic capabilities but discard the following:
     // LX200_HAS_FOCUS
 
 
@@ -1906,7 +1906,7 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
                 int res = getCommandSingleCharResponse(PortFD, response, cmd); //0 = 0 Success 1..9 failure, no # on reply
                 if(res > 0 && response[0]=='0')
                     {
-                    LOG_INFO("Command for Refine Polar Alignment Successfull");
+                    LOG_INFO("Command for Refine Polar Alignment Successful");
                     UpdateAlignStatus();
                     OSNAlignPolarRealignSP.s = IPS_OK;
                     IDSetSwitch(&OSNAlignPolarRealignSP, nullptr);
@@ -2186,7 +2186,7 @@ bool LX200_OnStep::ReadScopeStatus()
 #endif
 
         int error_or_fail = getCommandSingleCharErrorOrLongResponse(PortFD, OSStat,
-                            ":GU#"); // :GU# returns a string containg controller status
+                            ":GU#"); // :GU# returns a string containing controller status
         if (error_or_fail > 1) // check if successful read (strcmp(OSStat, OldOSStat) != 0) //if status changed
         {
             //If this fails, simply return;
@@ -2675,7 +2675,7 @@ bool LX200_OnStep::ReadScopeStatus()
     {
         //TODO: Check and recode :Gu# paths
         int error_or_fail = getCommandSingleCharErrorOrLongResponse(PortFD, OSStat,
-                            ":Gu#"); // :Gu# returns a string containg controller status that's bitpacked
+                            ":Gu#"); // :Gu# returns a string containing controller status that's bitpacked
         if (strcmp(OSStat, OldOSStat) != 0) //if status changed
         {
             //Ignored for now.
@@ -4213,7 +4213,7 @@ int LX200_OnStep::OSUpdateRotator()
             OSRotator1 = false;
             return 0; //Return 0, as this is not a communication error
         }
-        if (error_or_fail < 1)   //This does not neccessarily mean
+        if (error_or_fail < 1)   //This does not necessarily mean
         {
             LOG_WARN("Error talking to rotator, might be timeout (especially on network)");
             return -1;
@@ -4812,7 +4812,7 @@ IPState LX200_OnStep::AlignWrite()
     int res = getCommandSingleCharResponse(PortFD, response, cmd); //1 success , no # on reply
     if(res > 0 && response[0]=='1')
         {
-            LOG_INFO("Align Write Successfull");
+            LOG_INFO("Align Write Successful");
             UpdateAlignStatus();
             IUSaveText(&OSNAlignT[0], "Align FINISHED");
             IUSaveText(&OSNAlignT[1], "------");
@@ -5444,7 +5444,7 @@ bool LX200_OnStep::setUTCOffset(double offset)
     int utc_hour, utc_min;
     // strange thing offset is rounded up to first decimal so that .75 is .8
     utc_hour = int(offset) * -1;
-    utc_min = abs((offset - int(offset)) * 60); // negtive offsets require this abs()
+    utc_min = abs((offset - int(offset)) * 60); // negative offsets require this abs()
     if (utc_min > 30) utc_min = 45;
     snprintf(temp_string, sizeof(temp_string), ":SG%03d:%02d#", utc_hour, utc_min);
     result = (setStandardProcedure(PortFD, temp_string) == 0);

--- a/drivers/telescope/lx200_OnStep.h
+++ b/drivers/telescope/lx200_OnStep.h
@@ -31,7 +31,7 @@
     - fixed Onstep returning '9:9' when 9 star alignment is achieved thanks to Howard Dutton
     Version 1.20
     - fixed wrong messages due to different return with OnStepX
-    - fixed Focuser Temerature not shown on Ekos
+    - fixed Focuser Temperature not shown on Ekos
     - fixed Weather settings (P/T/Hr) when no sensor present
     - minor typos
     Version 1.19
@@ -39,7 +39,7 @@
     - fixed Autoflip Off update
     - fixed Elevation Limits update (was not read from OnStep) and format set to integer and gage for setup
     - fixed minutes passed meridian not showing actual values
-    - fixed missing slewrates defineProperty and deleteProperty causing redefinitions of overides
+    - fixed missing slewrates defineProperty and deleteProperty causing redefinitions of overrides
     - todo focuser stops working after some time ??? could not yet reproduce
     - fixed poll and update slew rates 
     - todo poll and update maximum slew speed SmartWebServer=>Settings
@@ -79,7 +79,7 @@
     Version 1.10: (finalized: INDI 1.9.1)
     - Weather support for setting temperature/humidity/pressure, values will be overridden in OnStep by any sensor values.
     - Ability to swap primary focuser.
-    - High precision on location, and not overridding GPS even when marked for Mount > KStars.
+    - High precision on location, and not overriding GPS even when marked for Mount > KStars.
     - Added Rotator & De-Rotator Support
     - TMC_SPI status reported (RAW) on the Status Tab. (ST = Standstill, Ox = open load A/B, Gx = grounded A/B, OT = Overtemp Shutdown, PW = Overtemp Prewarning)
     - Manage OnStep Auxiliary Feature Names in Output Tab
@@ -119,7 +119,7 @@
     - James lan Focuser Code
     - James lan PEC
     - James Lan Alignment
-    - Azwing set all com variable legth to RB_MAX_LEN otherwise crash due to overflow
+    - Azwing set all com variable length to RB_MAX_LEN otherwise crash due to overflow
     - Azwing set local variable size to RB_MAX_LEN otherwise erased by overflow preventing Align and other stuf to work
     - James Lan Align Tab implementation
     - Azwing Removed Alignment in main tab

--- a/drivers/telescope/lx200_TeenAstro.cpp
+++ b/drivers/telescope/lx200_TeenAstro.cpp
@@ -274,7 +274,7 @@ bool LX200_TeenAstro::ReadScopeStatus()
     }
 
     // update mount status
-    getCommandString(PortFD, OSStat, statusCommand);       // returns a string containg controller status
+    getCommandString(PortFD, OSStat, statusCommand);       // returns a string containing controller status
     if (OSStat[15] != '0')
     {
         updateMountStatus(OSStat[15]);              // error
@@ -1265,7 +1265,7 @@ void LX200_TeenAstro::mountSim()
     ltv = tv;
     da  = SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_TRACKING:

--- a/drivers/telescope/lx200am5.h
+++ b/drivers/telescope/lx200am5.h
@@ -70,7 +70,7 @@ class LX200AM5 : public LX200Generic
                  * after the command is successfully sent.
                  * @param cmd_len if -1, it is assumed that the @a cmd is a null-terminated string. Otherwise, it would write @a cmd_len bytes from
                  * the @a cmd buffer.
-                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimeter DRIVER_STOP_CHAR
+                 * @param res_len if -1 and if @a res is not nullptr, the function will read until it detects the default delimiter DRIVER_STOP_CHAR
                  *  up to DRIVER_LEN length. Otherwise, the function will read @a res_len from the device and store it in @a res.
                  * @return True if successful, false otherwise.
         */
@@ -134,7 +134,7 @@ class LX200AM5 : public LX200Generic
         static const char DRIVER_STOP_CHAR { 0x23 };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
         // Slew Modes
         static constexpr const uint8_t SLEW_MODES {10};

--- a/drivers/telescope/lx200ap_v2.cpp
+++ b/drivers/telescope/lx200ap_v2.cpp
@@ -65,7 +65,7 @@ enum APPECRecordingState
 // maximum guide pulse request to send to controller
 #define MAX_LX200AP_PULSE_LEN 999
 
-// The workaround for long pulses does't work!
+// The workaround for long pulses doesn't work!
 // #define DONT_SIMULATE_LONG_PULSES true
 // This didn't work. The driver simply doesn't send pulse
 // commands longer than 999ms since CP3 controllers don't support that.
@@ -996,7 +996,7 @@ bool LX200AstroPhysicsV2::ReadScopeStatus()
                    apInitializationChecked ? "Y" : "N", apIsInitialized ? "Y" : "N",
                    apTimeInitialized ? "Y" : "N", apLocationInitialized ? "Y" : "N");
 
-        // hope this return doen't delay the time & location. If it does return true?
+        // hope this return doesn't delay the time & location. If it does return true?
         return false;
     }
     double lng = LocationN[LOCATION_LONGITUDE].value;
@@ -1069,7 +1069,7 @@ bool LX200AstroPhysicsV2::ReadScopeStatus()
 
         LOGF_DEBUG("Slewing... currentRA: %.3f dx: %g currentDE: %.3f dy: %g", currentRA, dx, currentDEC, dy);
 
-        // Note, RA won't hit 0 if it's not tracking, becuase the RA changes when still.
+        // Note, RA won't hit 0 if it's not tracking, because the RA changes when still.
         // Dec might, though.
         // 0 might work now that I "fixed" slewing...perhaps not when tracking is off.
         if (dx < 1e-3 && dy < 1e-3)
@@ -1532,7 +1532,7 @@ bool LX200AstroPhysicsV2::isAPReady()
         {
             bool isAPParked = apStatusParked(statusString);
 
-            // A-P came up unitialized, but we can now fix.
+            // A-P came up uninitialized, but we can now fix.
             if (APUnParkMount(PortFD) != TTY_OK)
                 // Try again if we had a comm failure.
                 commWorked = APUnParkMount(PortFD) == TTY_OK;

--- a/drivers/telescope/lx200apdriver.cpp
+++ b/drivers/telescope/lx200apdriver.cpp
@@ -773,7 +773,7 @@ int selectAPV2CenterRate(int fd, int centerIndex, APRateTableState rateTable)
 //                                        'C'=Custom RA Tracking Rate (read specific value with :Rr# command)
 // C: Dec Tracking Status                 '9'=No Motion (to mimic RA Tracking), 'C'=Custom DEC Tracking Rate
 //                                        (read specific value with :Rd# command)
-// D: Slewing Satus (GOTO Slews)          'S'=Slewing, '0'=Not slewing
+// D: Slewing Status (GOTO Slews)         'S'=Slewing, '0'=Not slewing
 // E: Moving RA Axis                      'E'=Moving East, 'W'=Moving West, '0'=Not Moving
 //    (via a Move command/Slew/ST4 Port signal)
 // F: Moving Dec Axis                     'N'=Moving North (counter-clockwise), 'S'=Moving South (clockwise), '0'=Not Moving
@@ -840,7 +840,7 @@ int getApStatusStringInternal(int fd, char *statusString, bool complain)
 
 int getApStatusString(int fd, char *statusString)
 {
-    // I seem to get intermittant failures.
+    // I seem to get intermittent failures.
     // Try again on these after a 50ms delay, and the 250ms delay.
     if (getApStatusStringInternal(fd, statusString, false) != TTY_OK)
     {

--- a/drivers/telescope/lx200basic.cpp
+++ b/drivers/telescope/lx200basic.cpp
@@ -350,7 +350,7 @@ void LX200Basic::mountSim()
     ltv = tv;
     da  = SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_TRACKING:

--- a/drivers/telescope/lx200classic.cpp
+++ b/drivers/telescope/lx200classic.cpp
@@ -522,7 +522,7 @@ bool LX200Classic::ReadScopeStatus()
         {
             //allow scope to make internal state change to settled on target.
             //otherwise changing to landmode slews the scope to same
-            //coordinates intepreted in landmode.
+            //coordinates interpreted in landmode.
             //Between isSlewComplete() and the beep there is nearly 3 seconds!
             settling = 3; //n iterations of default 1000ms
         }

--- a/drivers/telescope/lx200driver.cpp
+++ b/drivers/telescope/lx200driver.cpp
@@ -663,7 +663,7 @@ int getTrackFreq(int fd, double *value)
     // :GT#
     // Get tracking rate
     // Returns: TT.T#
-    // Current Track Frequency expressed in hertz assuming a synchonous motor design where a 60.0 Hz motor clock
+    // Current Track Frequency expressed in hertz assuming a synchronous motor design where a 60.0 Hz motor clock
     // would produce 1 revolution of the telescope in 24 hours.
     if ((error_type = tty_write_string(fd, ":GT#", &nbytes_write)) != TTY_OK)
         return error_type;
@@ -1131,7 +1131,7 @@ int setCalenderDate(int fd, int dd, int mm, int yy, bool addSpace)
         return error_type;
 
     error_type = tty_nread_section(fd, read_buffer, RB_MAX_LEN, '#', LX200_TIMEOUT, &nbytes_read);
-    // Read the next section whih has 24 blanks and then a #
+    // Read the next section which has 24 blanks and then a #
     // Can't just use the tcflush to clear the stream because it doesn't seem to work correctly on sockets
     tty_nread_section(fd, dummy_buffer, RB_MAX_LEN, '#', LX200_TIMEOUT, &nbytes_read);
 
@@ -2041,7 +2041,7 @@ int checkLX200EquatorialFormat(int fd)
         // 10Micron Mount Command Protocol software version 2.14.11 2016.11
         // :U#
         // Toggle between low and high precision modes. This controls the format of some values
-        // that are returned by the mount. In extened LX200 emulation mode, switches always to
+        // that are returned by the mount. In extended LX200 emulation mode, switches always to
         // high precision (does not toggle).
         // Low precision: RA returned as HH:MM.T (hours, minutes and tenths of minutes),
         // Dec/Az/Alt returned as sDD*MM (sign, degrees, arcminutes).

--- a/drivers/telescope/lx200driver.h
+++ b/drivers/telescope/lx200driver.h
@@ -145,7 +145,7 @@ enum TFreq
 #define setFocuserSpeed(fd, x)          setCommandInt(fd, x, ":F")
 #define setSlewSpeed(fd, x)             setCommandInt(fd, x, ":Sw")
 
-/* GPS Specefic */
+/* GPS Specific */
 #define turnGPSOn(fd)                   write(fd, ":g+#", 4)
 #define turnGPSOff(fd)                  write(fd, ":g-#", 4)
 #define alignGPSScope(fd)               write(fd, ":Aa#", 4)
@@ -175,7 +175,7 @@ enum TFreq
 #define initTelescope(fd)             write(fd, ":I#", 3)
 
 /**************************************************************************
- Basic I/O - OBSELETE
+ Basic I/O - OBSOLETE
 **************************************************************************/
 /*int openPort(const char *portID);
 int portRead(char *buf, int nbytes, int timeout);
@@ -212,7 +212,7 @@ int getSiteLongitude(int fd, int *ddd, int *mm, double *ssf);
 int getSiteLatitudeAlt(int fd, int *dd, int *mm, double *ssf, const char *cmd);
 /* Get site Longitude */
 int getSiteLongitudeAlt(int fd, int *ddd, int *mm, double *ssf, const char *cmd);
-/* Get Calender data */
+/* Get Calendar data */
 int getCalendarDate(int fd, char *date);
 /* Get site Name */
 int getSiteName(int fd, char *siteName, int siteNum);
@@ -245,7 +245,7 @@ int setAlignmentMode(int fd, unsigned int alignMode);
 int setObjectRA(int fd, double ra, bool addSpace = false);
 /* set Object DEC */
 int setObjectDEC(int fd, double dec, bool addSpace = false);
-/* Set Calender date */
+/* Set Calendar date */
 int setCalenderDate(int fd, int dd, int mm, int yy, bool addSpace = false);
 /* Set UTC offset */
 int setUTCOffset(int fd, double hours);

--- a/drivers/telescope/lx200fs2.cpp
+++ b/drivers/telescope/lx200fs2.cpp
@@ -359,7 +359,7 @@ bool LX200FS2::SetCurrentPark()
 
 bool LX200FS2::SetDefaultPark()
 {
-    // By defualt azimuth 0
+    // By default azimuth 0
     SetAxis1Park(0);
 
     // Altitude = latitude of observer

--- a/drivers/telescope/lx200generic.cpp
+++ b/drivers/telescope/lx200generic.cpp
@@ -52,7 +52,7 @@ Updated driver to use INDI::Telescope (JM)
 
     /* There is _one_ binary for all LX200 drivers, but each binary is renamed
     ** to its device name (i.e. lx200gps, lx200_16..etc). The main function will
-    ** fetch from std args the binary name and ISInit will create the apporpiate
+    ** fetch from std args the binary name and ISInit will create the appropriate
     ** device afterwards. If the binary name does not match any known devices,
     ** we simply create a generic device.
     */

--- a/drivers/telescope/lx200gotonova.cpp
+++ b/drivers/telescope/lx200gotonova.cpp
@@ -777,7 +777,7 @@ void LX200GotoNova::mountSim()
     ltv = tv;
     da  = SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_TRACKING:

--- a/drivers/telescope/lx200pulsar2.cpp
+++ b/drivers/telescope/lx200pulsar2.cpp
@@ -700,7 +700,7 @@ bool setHomePosition(const int fd, double hp_alt, double hp_az)
     double safe_hp_alt = std::min(std::max(0.0, hp_alt), 90.0);
     // There are odd limits for azimuth because the controller rounds
     // strangely, and defaults to a 180-degree value if it sees a number
-    // as out-of-bounds. The min value here (0.0004) will be intepreted
+    // as out-of-bounds. The min value here (0.0004) will be interpreted
     // as zero, max (359.9994) as 360.
     double safe_hp_az = std::min(std::max(0.0004, hp_az), 359.9994);
     sprintf(cmd, "#:YSX%+08.4lf,%08.4lf#", safe_hp_alt, safe_hp_az);

--- a/drivers/telescope/lx200telescope.cpp
+++ b/drivers/telescope/lx200telescope.cpp
@@ -1076,7 +1076,7 @@ void LX200Telescope::mountSim()
     ltv = tv;
     da  = LX200_GENERIC_SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
 

--- a/drivers/telescope/lx200telescope.h
+++ b/drivers/telescope/lx200telescope.h
@@ -121,7 +121,7 @@ class LX200Telescope : public INDI::Telescope, public INDI::GuiderInterface, pub
         // Initial function to get data after connection is successful
         virtual void getBasicData();
 
-        // Get local calender date (NOT UTC) from mount. Expected format is YYYY-MM-DD
+        // Get local calendar date (NOT UTC) from mount. Expected format is YYYY-MM-DD
         virtual bool getLocalDate(char *dateString);
         virtual bool setLocalDate(uint8_t days, uint8_t months, uint16_t years);
 

--- a/drivers/telescope/lx200zeq25.cpp
+++ b/drivers/telescope/lx200zeq25.cpp
@@ -1226,7 +1226,7 @@ void LX200ZEQ25::mountSim()
     ltv = tv;
     da  = SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_TRACKING:

--- a/drivers/telescope/magellan1.h
+++ b/drivers/telescope/magellan1.h
@@ -24,7 +24,7 @@
 #include "indidevapi.h"
 
 /*
-   The device name below eventhough we have a Magellan I
+   The device name below even though we have a Magellan I
    should remain set to a KStars registered telescope so
    It allows the service to be stopped
 */

--- a/drivers/telescope/magellandriver.h
+++ b/drivers/telescope/magellandriver.h
@@ -67,7 +67,7 @@ int check_magellan_connection(int fd);
 /* Get Double from Sexagisemal */
 int getCommandSexa(int fd, double *value, const char *cmd);
 
-/* Get Calender data */
+/* Get Calendar data */
 int getCalendarDate(int fd, char *date);
 
 #ifdef __cplusplus

--- a/drivers/telescope/paramount.cpp
+++ b/drivers/telescope/paramount.cpp
@@ -224,7 +224,7 @@ bool Paramount::updateProperties()
 *
 *    |No error. Error = 0.
 *
-* This is true everwhere except for the Handshake(), which just returns "1" on success.
+* This is true everywhere except for the Handshake(), which just returns "1" on success.
 *
 * In order to know when the response is complete, we append the # character in
 * Javascript commands and read from the port until the # character is reached.
@@ -886,7 +886,7 @@ void Paramount::mountSim()
         return;
     }
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_IDLE:

--- a/drivers/telescope/planewave_mount.h
+++ b/drivers/telescope/planewave_mount.h
@@ -104,6 +104,6 @@ class PlaneWave : public INDI::Telescope
         static const char DRIVER_STOP_CHAR { 0xA };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {128};
 };

--- a/drivers/telescope/pmc8.cpp
+++ b/drivers/telescope/pmc8.cpp
@@ -313,7 +313,7 @@ void PMC8::getStartupData()
     LOG_INFO("Be prepared to intervene if something unexpected occurs.");
 
 #if 0
-    // FIXEME - Need to handle southern hemisphere for DEC?
+    // FIXME - Need to handle southern hemisphere for DEC?
     double HA  = ln_get_apparent_sidereal_time(ln_get_julian_from_sys());
     double DEC = CurrentDEC;
 
@@ -1392,7 +1392,7 @@ void PMC8::mountSim()
     ltv = tv;
     da  = SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_IDLE:

--- a/drivers/telescope/pmc8driver.cpp
+++ b/drivers/telescope/pmc8driver.cpp
@@ -1653,7 +1653,7 @@ bool convert_motor_to_radec(int racounts, int deccounts, double &ra_value, doubl
         else
             dec_value = 90 + motor_angle;
     }
-    // Sourthern Hemisphere
+    // Southern Hemisphere
     else
     {
         if (motor_angle >= 0)

--- a/drivers/telescope/pmc8driver.h
+++ b/drivers/telescope/pmc8driver.h
@@ -113,7 +113,7 @@ bool get_pmc8_reconnect_flag();
 **************************************************************************/
 /** Get PMC8 current status info */
 bool get_pmc8_status(int fd, PMC8Info *info);
-/** Get All firmware informatin in addition to mount model */
+/** Get All firmware information in addition to mount model */
 bool get_pmc8_firmware(int fd, FirmwareInfo *info);
 /** Get RA/DEC */
 bool get_pmc8_coords(int fd, double &ra, double &dec);

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -208,6 +208,6 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         static const char DRIVER_STOP_CHAR { 0x23 };
         // Wait up to a maximum of 3 seconds for serial input
         static constexpr const uint8_t DRIVER_TIMEOUT {3};
-        // Maximum buffer for sending/receving.
+        // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
 };

--- a/drivers/telescope/scopesim_helper.cpp
+++ b/drivers/telescope/scopesim_helper.cpp
@@ -283,7 +283,7 @@ void Alignment::apparentHaDecToMount(Angle apparentHa, Angle apparentDec, Angle*
         LOGF_EXTRA1("a2M haDec %f, %f Azm Alt %f, %f", apparentHa.Degrees(), apparentDec.Degrees(), primary->Degrees(),
                     secondary->Degrees() );
     }
-    // ignore diurnal abberations and refractions to get observed ha, dec
+    // ignore diurnal aberrations and refractions to get observed ha, dec
     // apply telescope pointing to get instrument
     Angle instrumentHa, instrumentDec;
     observedToInstrument(apparentHa, apparentDec, &instrumentHa, &instrumentDec);

--- a/drivers/telescope/scopesim_helper.h
+++ b/drivers/telescope/scopesim_helper.h
@@ -394,7 +394,7 @@ class Axis
 ///  Observed Place  These are the mount coordinates for a perfect mount, positions are observedHa and observedDec
 ///     apply telescope pointing corrections
 ///  Instrument Place these are the mount coordinates for the mount with corrections, values are instrumentHa and instrumentDec
-///     for a  GEM convert to axis cooordinates ( this isn't in the paper).
+///     for a  GEM convert to axis coordinates ( this isn't in the paper).
 ///  Mount Place these give primary (ha) and secondary (dec) positions
 ///
 /// At present AltAz mounts are not implemented
@@ -583,7 +583,7 @@ class Vector
         Vector(double l, double m, double n);
 
         ///
-        /// \brief Vector creats a vector from two angles (Ra, Dec), (Ha, Dec), (Azimuth, Altitude)
+        /// \brief Vector creates a vector from two angles (Ra, Dec), (Ha, Dec), (Azimuth, Altitude)
         /// \param primary
         /// \param secondary
         ///

--- a/drivers/telescope/skywatcherAPI.h
+++ b/drivers/telescope/skywatcherAPI.h
@@ -318,7 +318,7 @@ class SkywatcherAPI
         /// \return false failure
         bool SlowStop(AXISID Axis);
 
-        /// \brief Start the axis slewing in the prevously selected mode
+        /// \brief Start the axis slewing in the previously selected mode
         /// \param[in] Axis - The axis to use.
         /// \return false failure
         bool StartAxisMotion(AXISID Axis);

--- a/drivers/telescope/synscandriver.cpp
+++ b/drivers/telescope/synscandriver.cpp
@@ -266,7 +266,7 @@ bool SynscanDriver::ISNewNumber(const char * dev, const char * name, double valu
             return true;
         }
 
-        // Horizonal Coords
+        // Horizontal Coords
         if (!strcmp(name, HorizontalCoordsNP.name))
         {
             if (isParked())
@@ -1298,7 +1298,7 @@ void SynscanDriver::mountSim()
     double currentSlewRate = SIM_SLEW_RATE[IUFindOnSwitchIndex(&SlewRateSP)] * TRACKRATE_SIDEREAL / 3600.0;
     da  = currentSlewRate * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_IDLE:
@@ -1442,7 +1442,7 @@ IPState SynscanDriver::GuideEast(uint32_t ms)
 
     // So if we SID_RATE + 0.5 * SID_RATE for example, that's 150% of sidereal rate
     // but for east we'd be going a lot faster since the stars are moving toward the west
-    // in sideral rate. Just standing still we would SID_RATE moving across. So for east
+    // in sidereal rate. Just standing still we would SID_RATE moving across. So for east
     // we just go GuideRate * SID_RATE without adding any more values.
     //m_CustomGuideRA = TRACKRATE_SIDEREAL + GuideRateN[AXIS_RA].value * TRACKRATE_SIDEREAL;
     m_CustomGuideRA = GuideRateN[AXIS_RA].value * TRACKRATE_SIDEREAL;

--- a/drivers/telescope/synscandriver.h
+++ b/drivers/telescope/synscandriver.h
@@ -79,9 +79,9 @@ class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
          * @brief sendCommand Send a string command to mount.
          * @param cmd Command to be sent
          * @param cmd_len length of command in bytes. If not specified it is treated as null-terminating string
-         * @param res If not nullptr, the function will read until it detects the default delimeter ('#') up to SYN_RES length.
+         * @param res If not nullptr, the function will read until it detects the default delimiter ('#') up to SYN_RES length.
          *        if nullptr, no read back is done and the function returns true.
-         * @param res_len length of buffer to read. If not specified, the buffer will be read until the delimeter is met.
+         * @param res_len length of buffer to read. If not specified, the buffer will be read until the delimiter is met.
          *        if specified, only res_len bytes are ready.
          * @return True if successful, false otherwise.
          */
@@ -184,7 +184,7 @@ class SynscanDriver : public INDI::Telescope, public INDI::GuiderInterface
         static const uint8_t SYN_RES = 64;
         // Timeout
         static const uint8_t SYN_TIMEOUT = 3;
-        // Delimeter
+        // Delimiter
         static const char SYN_DEL = {'#'};
         // Mount Information Tab
         static constexpr const char * MOUNT_TAB = "Mount Information";

--- a/drivers/telescope/synscandriverlegacy.cpp
+++ b/drivers/telescope/synscandriverlegacy.cpp
@@ -1530,7 +1530,7 @@ void SynscanLegacyDriver::MountSim()
     double currentSlewRate = SLEW_RATE[IUFindOnSwitchIndex(&SlewRateSP)] * TRACKRATE_SIDEREAL / 3600.0;
     da  = currentSlewRate * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
         case SCOPE_IDLE:

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -47,7 +47,7 @@ ScopeSim::ScopeSim()
     /* initialize random seed: */
     srand(static_cast<uint32_t>(time(nullptr)));
 
-    // initalise axis positions, for GEM pointing at pole, counterweight down
+    // initialise axis positions, for GEM pointing at pole, counterweight down
     axisPrimary.setDegrees(90.0);
     axisPrimary.TrackRate(Axis::SIDEREAL);
     axisSecondary.setDegrees(90.0);
@@ -568,7 +568,7 @@ bool ScopeSim::SetCurrentPark()
 
 bool ScopeSim::SetDefaultPark()
 {
-    // mount points to East (couter weights down) at the horizon
+    // mount points to East (counterweights down) at the horizon
     // works for both hemispheres
     SetAxis1Park(-6.);
     SetAxis2Park(0.);

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -28,9 +28,9 @@
  * @brief The ScopeSim class provides a simple mount simulator of an equatorial mount.
  *
  * It supports the following features:
- * + Sideral and Custom Tracking rates.
+ * + Sidereal and Custom Tracking rates.
  * + Goto & Sync
- * + NWSE Hand controller direciton key slew.
+ * + NWSE Hand controller direction key slew.
  * + Tracking On/Off.
  * + Parking & Unparking with custom parking positions.
  * + Setting Time & Location.

--- a/drivers/telescope/temmadriver.cpp
+++ b/drivers/telescope/temmadriver.cpp
@@ -193,7 +193,7 @@ bool TemmaMount::updateProperties()
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
 
-        // Load location so that it could trigger mount initiailization
+        // Load location so that it could trigger mount initialization
         loadConfig(true, "GEOGRAPHIC_COORD");
 
     }
@@ -489,9 +489,9 @@ bool TemmaMount::Sync(double ra, double dec)
     targetDEC = dec;
 
     /*  sync involves jumping thru considerable hoops
-    first we have to set local sideral time
+    first we have to set local sidereal time
     then we have to send a Z
-    then we set local sideral time again
+    then we set local sidereal time again
     and finally we send the co-ordinates we are syncing on
     */
     LOG_DEBUG("Sending LST --> Z --> LST before Sync.");
@@ -539,7 +539,7 @@ bool TemmaMount::Goto(double ra, double dec)
     targetDEC = dec;
 
     /*  goto involves hoops, but, not as many as a sync
-        first set sideral time
+        first set sidereal time
         then issue the goto command
     */
     if (MotorStatus == false)
@@ -992,7 +992,7 @@ INDI::IEquatorialCoordinates TemmaMount::SkyToTelescope(double ra, double dec)
         //  to using raw co-ordinates from the mount
         if (TransformCelestialToTelescope(ra, dec, 0.0, TDV))
         {
-            /*  Initial attemp, using RA/DEC co-ordinates talking to alignment system
+            /*  Initial attempt, using RA/DEC co-ordinates talking to alignment system
             EquatorialCoordinatesFromTelescopeDirectionVector(TDV,eq);
             RightAscension=eq.ra*24.0/360;
             Declination=eq.dec;
@@ -1292,7 +1292,7 @@ void TemmaMount::mountSim()
     ltv = tv;
     da  = TEMMA_SLEWRATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_COORDS and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_COORDS and act accordingly */
     switch (TrackState)
     {
 

--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -333,7 +333,7 @@ bool V4L2_Driver::updateProperties()
             std::string infoDeviceLabel = std::string(info->deviceLabel);
             std::transform(infoDeviceLabel.begin(), infoDeviceLabel.end(), infoDeviceLabel.begin(), ::tolower);
 
-            // Case insensitive comparision
+            // Case insensitive comparison
             if (infoDeviceName == deviceName || infoDeviceLabel == deviceName)
                 break;
             ++info;
@@ -852,7 +852,7 @@ bool V4L2_Driver::ISNewNumber(const char * dev, const char * name, double values
                 LOGF_WARN("Unable to adjust %s (ctrl_id =  0x%X)", ImageAdjustNP.np[i].label,
                           ctrl_id);
             }
-            /* Some controls may have been ajusted by the driver */
+            /* Some controls may have been adjusted by the driver */
             /* a read is mandatory as VIDIOC_S_CTRL is write only and does not return the actual new value */
             v4l_base->getControl(ctrl_id, &(ImageAdjustNP.np[i].value), errmsg);
 
@@ -1739,7 +1739,7 @@ bool V4L2_Driver::Connect()
             return false;
         }
 
-        /* Sucess! */
+        /* Success! */
         LOGF_INFO("%s is online.", getDeviceName());
 
         // If port not stored in config already then save it.

--- a/drivers/video/v4l2driver.h
+++ b/drivers/video/v4l2driver.h
@@ -157,7 +157,7 @@ public:
         INumber *AbsExposureN;
         ISwitchVectorProperty *ManualExposureSP;
 
-        /* Initilization functions */
+        /* Initialization functions */
         //virtual void connectCamera();
         virtual void getBasicData();
         bool getPixelFormat(uint32_t v4l2format, INDI_PIXEL_FORMAT &pixelFormat, uint8_t &pixelDepth);

--- a/drivers/weather/mbox.cpp
+++ b/drivers/weather/mbox.cpp
@@ -220,7 +220,7 @@ MBox::AckResponse MBox::ack()
             return ACK_ERROR;
         }
 
-        // Read again if we only recieved a newline character
+        // Read again if we only received a newline character
         if (response[0] == '\n')
         {
             if ((rc = tty_read_section(PortFD, response, 0xA, MBOX_TIMEOUT, &nbytes_read)) != TTY_OK)

--- a/drivers/weather/vantage.cpp
+++ b/drivers/weather/vantage.cpp
@@ -296,7 +296,7 @@ bool Vantage::wakeup()
         if ((rc = tty_write(PortFD, command, 1, &nbytes_written)) != TTY_OK)
         {
             tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("Wakup error: %s.", errstr);
+            LOGF_ERROR("Wakeup error: %s.", errstr);
             return false;
         }
 

--- a/examples/README
+++ b/examples/README
@@ -58,7 +58,7 @@ $ indiserver -v -p 8000 ./tutorial_four
 
 Now Tutorial Four shall run and load the Skeleton file. Usually skeleton files for drivers are stored under /usr/share/indi/ and end with _sk.xml
 ------------------------------------------------------------------------------------------
-For the inter-driver communications tutorial where it shows have a dome driver and a rain detector driver share information between each other, type the folliwng:
+For the inter-driver communications tutorial where it shows have a dome driver and a rain detector driver share information between each other, type the following:
 
 $ indiserver -v -p 8000 ./tutorial_dome ./tutorial_rain
 

--- a/examples/tutorial_eight/simple_receiver.cpp
+++ b/examples/tutorial_eight/simple_receiver.cpp
@@ -81,7 +81,7 @@ bool SimpleReceiver::initProperties()
 
 /********************************************************************************************
 ** INDI is asking us to update the properties because there is a change in CONNECTION status
-** This fucntion is called whenever the device is connected or disconnected.
+** This function is called whenever the device is connected or disconnected.
 *********************************************************************************************/
 bool SimpleReceiver::updateProperties()
 {
@@ -232,7 +232,7 @@ void SimpleReceiver::TimerHit()
             /* If target temperature is higher, then increase current Receiver temperature */
             if (currentReceiverTemperature < TemperatureRequest)
                 currentReceiverTemperature++;
-            /* If target temperature is lower, then decrese current Receiver temperature */
+            /* If target temperature is lower, then decrease current Receiver temperature */
             else if (currentReceiverTemperature > TemperatureRequest)
                 currentReceiverTemperature--;
             /* If they're equal, stop updating */

--- a/examples/tutorial_five/dome.cpp
+++ b/examples/tutorial_five/dome.cpp
@@ -113,7 +113,7 @@ bool Dome::initProperties()
 
 /********************************************************************************************
 ** INDI is asking us to update the properties because there is a change in CONNECTION status
-** This fucntion is called whenever the device is connected or disconnected.
+** This function is called whenever the device is connected or disconnected.
 *********************************************************************************************/
 bool Dome::updateProperties()
 {

--- a/examples/tutorial_five/raindetector.cpp
+++ b/examples/tutorial_five/raindetector.cpp
@@ -84,7 +84,7 @@ bool RainDetector::initProperties()
 
 /********************************************************************************************
 ** INDI is asking us to update the properties because there is a change in CONNECTION status
-** This fucntion is called whenever the device is connected or disconnected.
+** This function is called whenever the device is connected or disconnected.
 *********************************************************************************************/
 bool RainDetector::updateProperties()
 {

--- a/examples/tutorial_six/tutorial_client.cpp
+++ b/examples/tutorial_six/tutorial_client.cpp
@@ -91,7 +91,7 @@ MyClient::MyClient()
             // call lambda function if property changed
             property.onUpdate([property, this]()
             {
-                IDLog("Receving new CCD Temperature: %g C\n", property[0].getValue());
+                IDLog("Receiving new CCD Temperature: %g C\n", property[0].getValue());
                 if (property[0].getValue() == -20)
                 {
                     IDLog("CCD temperature reached desired value!\n");

--- a/examples/tutorial_three/simpleccd.cpp
+++ b/examples/tutorial_three/simpleccd.cpp
@@ -80,7 +80,7 @@ bool SimpleCCD::initProperties()
 
 /********************************************************************************************
 ** INDI is asking us to update the properties because there is a change in CONNECTION status
-** This fucntion is called whenever the device is connected or disconnected.
+** This function is called whenever the device is connected or disconnected.
 *********************************************************************************************/
 bool SimpleCCD::updateProperties()
 {
@@ -201,7 +201,7 @@ void SimpleCCD::TimerHit()
             /* If target temperature is higher, then increase current CCD temperature */
             if (currentCCDTemperature < TemperatureRequest)
                 currentCCDTemperature++;
-            /* If target temperature is lower, then decrese current CCD temperature */
+            /* If target temperature is lower, then decrease current CCD temperature */
             else if (currentCCDTemperature > TemperatureRequest)
                 currentCCDTemperature--;
             /* If they're equal, stop updating */

--- a/examples/tutorial_two/simplescope.cpp
+++ b/examples/tutorial_two/simplescope.cpp
@@ -42,7 +42,7 @@ bool SimpleScope::initProperties()
     // ALWAYS call initProperties() of parent first
     INDI::Telescope::initProperties();
 
-    // Add Debug control so end user can turn debugging/loggin on and off
+    // Add Debug control so end user can turn debugging/logging on and off
     addDebugControl();
 
     // Enable simulation mode so that serial connection in INDI::Telescope does not try
@@ -60,7 +60,7 @@ bool SimpleScope::initProperties()
 ***************************************************************************************/
 bool SimpleScope::Handshake()
 {
-    // When communicating with a real mount, we check here if commands are receieved
+    // When communicating with a real mount, we check here if commands are received
     // and acknolowedged by the mount. For SimpleScope, we simply return true.
     return true;
 }
@@ -133,11 +133,11 @@ bool SimpleScope::ReadScopeStatus()
     da_ra  = SLEW_RATE * dt;
     da_dec = SLEW_RATE * dt;
 
-    /* Process per current state. We check the state of EQUATORIAL_EOD_COORDS_REQUEST and act acoordingly */
+    /* Process per current state. We check the state of EQUATORIAL_EOD_COORDS_REQUEST and act accordingly */
     switch (TrackState)
     {
         case SCOPE_SLEWING:
-            // Wait until we are "locked" into positon for both RA & DEC axis
+            // Wait until we are "locked" into position for both RA & DEC axis
             nlocked = 0;
 
             // Calculate diff in RA
@@ -172,7 +172,7 @@ bool SimpleScope::ReadScopeStatus()
             else
                 currentDEC -= da_dec;
 
-            // Let's check if we recahed position for both RA/DEC
+            // Let's check if we reached position for both RA/DEC
             if (nlocked == 2)
             {
                 // Let's set state to TRACKING

--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -451,7 +451,7 @@ class Msg
         friend class SerializedMsgWithSharedBuffer;
         friend class SerializedMsgWithoutSharedBuffer;
     private:
-        // Present for sure until message queing is doned. Prune asap then
+        // Present for sure until message queueing is doned. Prune asap then
         XMLEle * xmlContent;
 
         // Present until message was queued.
@@ -476,7 +476,7 @@ class Msg
         void releaseSharedBuffers(const std::set<int> &keep);
 
         // Remove resources that can be removed.
-        // Will be called when queuingDone is true and for every change of staus from convertionToXXX
+        // Will be called when queuingDone is true and for every change of status from convertionToXXX
         void prune();
 
         void releaseSerialization(SerializedMsg * form);
@@ -1949,7 +1949,7 @@ void DvrInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
         /* send to interested chained servers upstream */
         // FIXME: no use of root here
         ClInfo::q2Servers(this, mp, root);
-        /* Send to snooped drivers if they exist so that they can echo back the snooped propertly immediately */
+        /* Send to snooped drivers if they exist so that they can echo back the snooped property immediately */
         // FIXME: no use of root here
         q2RDrivers(dev, mp, root);
 
@@ -2109,7 +2109,7 @@ void DvrInfo::q2RDrivers(const std::string &dev, Msg *mp, XMLEle *root)
             continue;
 
         /* Only send message to each *unique* remote driver at a particular host:port
-         * Since it will be propogated to all other devices there */
+         * Since it will be propagated to all other devices there */
         if (dev.empty() && isRemote)
         {
             if (remoteAdvertised.find(remoteUid) != remoteAdvertised.end())
@@ -2294,7 +2294,7 @@ void ClInfo::q2Servers(DvrInfo *me, Msg *mp, XMLEle *root)
         auto cp = clients[cpId];
         if (cp == nullptr) continue;
 
-        // Only send the message to the upstream server that is connected specfically to the device in driver dp
+        // Only send the message to the upstream server that is connected specifically to the device in driver dp
         switch (cp->allprops)
         {
             // 0 --> not all props are requested. Check for specific combination
@@ -3107,7 +3107,7 @@ Msg::Msg(MsgQueue * from, XMLEle * ele): sharedBuffers()
 
 Msg::~Msg()
 {
-    // Assume convertionToSharedBlob and convertionToInlineBlob were already droped
+    // Assume convertionToSharedBlob and convertionToInlineBlob were already dropped
     assert(convertionToSharedBuffer == nullptr);
     assert(convertionToInline == nullptr);
 
@@ -3158,7 +3158,7 @@ void Msg::releaseSharedBuffers(const std::set<int> &keep)
 
 void Msg::prune()
 {
-    // Collect ressources required.
+    // Collect resources required.
     SerializationRequirement req;
     if (convertionToSharedBuffer)
     {
@@ -3464,7 +3464,7 @@ void SerializedMsgWithoutSharedBuffer::generateContent()
             {
                 async_pushChunck(MsgChunck(model + modelOffset, cdataOffset - modelOffset));
             }
-            // Skip the dummy cdata completly
+            // Skip the dummy cdata completely
             modelOffset = cdataOffset + 1;
 
             // Perform inplace base64
@@ -3477,7 +3477,7 @@ void SerializedMsgWithoutSharedBuffer::generateContent()
                 unsigned long buffSze = sizes[i];
                 const unsigned char* src = (const unsigned char*)blobs[i];
 
-                // split here in smaller chuncks for faster startup
+                // split here in smaller chunks for faster startup
                 // This allow starting write before the whole blob is converted
                 while(buffSze > 0)
                 {

--- a/integs/ProcessController.cpp
+++ b/integs/ProcessController.cpp
@@ -162,7 +162,7 @@ void ProcessController::expectExitCode(int e) {
             throw std::runtime_error(cmd + " got signal " + strsignal(WTERMSIG(status)));
         }
         // Not sure this is possible at all
-        throw std::runtime_error(cmd + " exited abnormaly");
+        throw std::runtime_error(cmd + " exited abnormally");
     }
     int actual = WEXITSTATUS(status);
     if (actual != e) {

--- a/integs/ServerMock.h
+++ b/integs/ServerMock.h
@@ -25,7 +25,7 @@
 class IndiClientMock;
 
 /**
- * Instanciate a fake indi server
+ * Instantiate a fake indi server
  */
 class ServerMock
 {

--- a/integs/TestClientQueries.cpp
+++ b/integs/TestClientQueries.cpp
@@ -47,7 +47,7 @@ static void driverSendsProps(DriverMock &fakeDriver)
 
 static void clientReceivesProps(IndiClientMock &indiClient)
 {
-    fprintf(stderr, "Client reveives properties\n");
+    fprintf(stderr, "Client receives properties\n");
     for(int i = 0; i < PROP_COUNT; ++i)
     {
         indiClient.cnx.expectXml("<defNumberVector device='fakedev1' name='testnumber" + std::to_string(

--- a/integs/customTestProps.cmake
+++ b/integs/customTestProps.cmake
@@ -1,4 +1,4 @@
-# This is used by ctest after test discovery occured
+# This is used by ctest after test discovery occurred
 set_tests_properties(${TestIndiserverSingleDriver_TESTS} PROPERTIES
     TIMEOUT 5
 )

--- a/libs/alignment/AlignmentSubsystemForDrivers.h
+++ b/libs/alignment/AlignmentSubsystemForDrivers.h
@@ -36,7 +36,7 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
         /// \brief Virtual destructor
         virtual ~AlignmentSubsystemForDrivers() {}
 
-        /** \brief Initilize alignment subsystem properties. It is recommended to call this function within initProperties() of your primary device
+        /** \brief Initialize alignment subsystem properties. It is recommended to call this function within initProperties() of your primary device
            * \param[in] pTelescope Pointer to the child INDI::Telecope class
           */
         void InitAlignmentProperties(Telescope *pTelescope);
@@ -173,7 +173,7 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
            * the in memory database module. This registration is performed in the constructor of
            * of this class. The callback is called whenever the database is
            * is loaded or reloaded, by default it calls the Initialise function of the MathPluginManagment module.
-           * \param[in] ThisPointer Pointer to the instance of this class which registered the callbck
+           * \param[in] ThisPointer Pointer to the instance of this class which registered the callback
           */
         static void MyDatabaseLoadCallback(void *ThisPointer);
 };

--- a/libs/alignment/BasicMathPlugin.cpp
+++ b/libs/alignment/BasicMathPlugin.cpp
@@ -464,7 +464,7 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
 #ifdef CONVEX_HULL_DEBUGGING
                     ActualFaces++;
 #endif
-                    // Ignore faces containg vertex 0 (nadir).
+                    // Ignore faces containing vertex 0 (nadir).
                     if ((0 == CurrentFace->vertex[0]->vnum) || (0 == CurrentFace->vertex[1]->vnum) ||
                             (0 == CurrentFace->vertex[2]->vnum))
                     {
@@ -695,7 +695,7 @@ bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVect
 #ifdef CONVEX_HULL_DEBUGGING
                     ApparentFaces++;
 #endif
-                    // Ignore faces containg vertex 0 (nadir).
+                    // Ignore faces containing vertex 0 (nadir).
                     if ((0 == CurrentFace->vertex[0]->vnum) || (0 == CurrentFace->vertex[1]->vnum) ||
                             (0 == CurrentFace->vertex[2]->vnum))
                     {

--- a/libs/alignment/BasicMathPlugin.h
+++ b/libs/alignment/BasicMathPlugin.h
@@ -42,7 +42,7 @@ class BasicMathPlugin : public AlignmentSubsystemForMathPlugins
                 double &RightAscension, double &Declination);
 
     protected:
-        /// \brief Calculate tranformation matrices from the supplied vectors
+        /// \brief Calculate transformation matrices from the supplied vectors
         /// \param[in] Alpha1 Pointer to the first coordinate in the alpha reference frame
         /// \param[in] Alpha2 Pointer to the second coordinate in the alpha reference frame
         /// \param[in] Alpha3 Pointer to the third coordinate in the alpha reference frame
@@ -67,7 +67,7 @@ class BasicMathPlugin : public AlignmentSubsystemForMathPlugins
         /// \param[in] pMatrix The matrix to print
         void Dump3x3(const char *Label, gsl_matrix *pMatrix);
 
-        /// \brief Caluclate the determinant of the supplied matrix
+        /// \brief Calculate the determinant of the supplied matrix
         /// \param[in] pMatrix Pointer to the 3x3 matrix
         /// \return The determinant
         double Matrix3x3Determinant(gsl_matrix *pMatrix);

--- a/libs/alignment/BuiltInMathPlugin.h
+++ b/libs/alignment/BuiltInMathPlugin.h
@@ -20,7 +20,7 @@ namespace AlignmentSubsystem
 class BuiltInMathPlugin : public BasicMathPlugin
 {
     private:
-        /// \brief Calculate tranformation matrices from the supplied vectors
+        /// \brief Calculate transformation matrices from the supplied vectors
         /// \param[in] Alpha1 Pointer to the first coordinate in the alpha reference frame
         /// \param[in] Alpha2 Pointer to the second coordinate in the alpha reference frame
         /// \param[in] Alpha3 Pointer to the third coordinate in the alpha reference frame

--- a/libs/alignment/ClientAPIForAlignmentDatabase.cpp
+++ b/libs/alignment/ClientAPIForAlignmentDatabase.cpp
@@ -28,7 +28,7 @@ ClientAPIForAlignmentDatabase::~ClientAPIForAlignmentDatabase()
 
 bool ClientAPIForAlignmentDatabase::AppendSyncPoint(const AlignmentDatabaseEntry &CurrentValues)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction = Action->getSwitch();
@@ -69,7 +69,7 @@ bool ClientAPIForAlignmentDatabase::AppendSyncPoint(const AlignmentDatabaseEntry
 
 bool ClientAPIForAlignmentDatabase::ClearSyncPoints()
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction = Action->getSwitch();
@@ -107,7 +107,7 @@ bool ClientAPIForAlignmentDatabase::ClearSyncPoints()
 
 bool ClientAPIForAlignmentDatabase::DeleteSyncPoint(unsigned int Offset)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction       = Action->getSwitch();
@@ -158,7 +158,7 @@ bool ClientAPIForAlignmentDatabase::DeleteSyncPoint(unsigned int Offset)
 
 bool ClientAPIForAlignmentDatabase::EditSyncPoint(unsigned int Offset, const AlignmentDatabaseEntry &CurrentValues)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction           = Action->getSwitch();
@@ -222,7 +222,7 @@ void ClientAPIForAlignmentDatabase::Initialise(INDI::BaseClient *BaseClient)
 
 bool ClientAPIForAlignmentDatabase::InsertSyncPoint(unsigned int Offset, const AlignmentDatabaseEntry &CurrentValues)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction           = Action->getSwitch();
@@ -276,7 +276,7 @@ bool ClientAPIForAlignmentDatabase::InsertSyncPoint(unsigned int Offset, const A
 
 bool ClientAPIForAlignmentDatabase::LoadDatabase()
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction = Action->getSwitch();
@@ -379,7 +379,7 @@ void ClientAPIForAlignmentDatabase::ProcessNewProperty(INDI::Property *PropertyP
     else
         GotOneOfMine = false;
 
-    // Tell the client when all the database proeprties have been set up
+    // Tell the client when all the database properties have been set up
     if (GotOneOfMine && (nullptr != MandatoryNumbers) && (nullptr != OptionalBinaryBlob) && (nullptr != PointsetSize) &&
             (nullptr != CurrentEntry) && (nullptr != Action) && (nullptr != Commit))
     {
@@ -406,7 +406,7 @@ void ClientAPIForAlignmentDatabase::ProcessNewSwitch(ISwitchVectorProperty *Swit
 
 bool ClientAPIForAlignmentDatabase::ReadIncrementSyncPoint(AlignmentDatabaseEntry &CurrentValues)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction           = Action->getSwitch();
@@ -458,7 +458,7 @@ bool ClientAPIForAlignmentDatabase::ReadIncrementSyncPoint(AlignmentDatabaseEntr
 
 bool ClientAPIForAlignmentDatabase::ReadSyncPoint(unsigned int Offset, AlignmentDatabaseEntry &CurrentValues)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction           = Action->getSwitch();
@@ -520,7 +520,7 @@ bool ClientAPIForAlignmentDatabase::ReadSyncPoint(unsigned int Offset, Alignment
 
 bool ClientAPIForAlignmentDatabase::SaveDatabase()
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pAction = Action->getSwitch();

--- a/libs/alignment/ClientAPIForMathPluginManagement.cpp
+++ b/libs/alignment/ClientAPIForMathPluginManagement.cpp
@@ -18,7 +18,7 @@ namespace AlignmentSubsystem
 
 bool ClientAPIForMathPluginManagement::EnumerateMathPlugins(MathPluginsList &AvailableMathPlugins)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     AvailableMathPlugins.clear();
@@ -52,7 +52,7 @@ void ClientAPIForMathPluginManagement::ProcessNewProperty(INDI::Property *Proper
     else
         GotOneOfMine = false;
 
-    // Tell the client when all the database proeprties have been set up
+    // Tell the client when all the database properties have been set up
     if (GotOneOfMine && (nullptr != MathPlugins) && (nullptr != PluginInitialise))
     {
         // The DriverActionComplete state variable is initialised to false
@@ -78,7 +78,7 @@ void ClientAPIForMathPluginManagement::ProcessNewSwitch(ISwitchVectorProperty *S
 
 bool ClientAPIForMathPluginManagement::SelectMathPlugin(const std::string &MathPluginName)
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pPlugins = MathPlugins->getSwitch();
@@ -107,7 +107,7 @@ bool ClientAPIForMathPluginManagement::SelectMathPlugin(const std::string &MathP
 
 bool ClientAPIForMathPluginManagement::ReInitialiseMathPlugin()
 {
-    // Wait for driver to initialise if neccessary
+    // Wait for driver to initialise if necessary
     WaitForDriverCompletion();
 
     auto pPluginInitialise = PluginInitialise->getSwitch();

--- a/libs/alignment/ClientAPIForMathPluginManagement.h
+++ b/libs/alignment/ClientAPIForMathPluginManagement.h
@@ -41,7 +41,7 @@ class ClientAPIForMathPluginManagement
              */
         bool EnumerateMathPlugins(MathPluginsList &AvailableMathPlugins);
 
-        /// \brief Intialise the API
+        /// \brief Initialise the API
         /// \param[in] BaseClient Pointer to the INDI:BaseClient class
         void Initialise(INDI::BaseClient *BaseClient);
 

--- a/libs/alignment/Common.h
+++ b/libs/alignment/Common.h
@@ -25,7 +25,7 @@ namespace AlignmentSubsystem
 {
 /** \enum MountAlignment
     \brief Describe the alignment of a telescope axis. This is normally used to differentiate between
-    equatorial mounts in differnet hemispheres and altaz or dobsonian mounts.
+    equatorial mounts in different hemispheres and altaz or dobsonian mounts.
 */
 typedef enum MountAlignment { ZENITH, NORTH_CELESTIAL_POLE, SOUTH_CELESTIAL_POLE } MountAlignment_t;
 
@@ -59,7 +59,7 @@ enum AlignmentPointSetEnum
 
 /*!
  * \struct TelescopeDirectionVector
- * \brief Holds a nomalised direction vector (direction cosines)
+ * \brief Holds a normalised direction vector (direction cosines)
  *
  * The x y,z fields of this class should normally represent a normalised (unit length)
  * vector in a right handed rectangular coordinate space. However, for convenience a number

--- a/libs/alignment/InMemoryDatabase.h
+++ b/libs/alignment/InMemoryDatabase.h
@@ -52,7 +52,7 @@ class InMemoryDatabase
         }
 
         /// \brief Get the database reference position
-        /// \param[in] Position A pointer to a IGeographicCoordinates object to retunr the current position in
+        /// \param[in] Position A pointer to a IGeographicCoordinates object to return the current position in
         /// \return True if successful
         bool GetDatabaseReferencePosition(IGeographicCoordinates &Position);
 

--- a/libs/alignment/MapPropertiesToInMemoryDatabase.h
+++ b/libs/alignment/MapPropertiesToInMemoryDatabase.h
@@ -59,7 +59,7 @@ namespace AlignmentSubsystem
  *   - READ INCREMENT\n
  *     Increment the pointer before reading the entry.
  *   - LOAD DATABASE\n
- *     Load the databse from local storage.
+ *     Load the database from local storage.
  *   - SAVE DATABASE\n
  *     Save the database to local storage.
  * - ALIGNMENT_POINTSET_COMMIT\n

--- a/libs/alignment/MathPlugin.h
+++ b/libs/alignment/MathPlugin.h
@@ -39,7 +39,7 @@ class MathPlugin
         virtual ~MathPlugin() {}
 
         // Public methods
-        /// \brief Get the approximate alognment of the mount
+        /// \brief Get the approximate alignment of the mount
         /// \return the approximate alignment
         virtual MountAlignment_t GetApproximateMountAlignment()
         {
@@ -50,7 +50,7 @@ class MathPlugin
         /// \return True if successful
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
 
-        /// \brief Set the approximate alognment of the mount
+        /// \brief Set the approximate alignment of the mount
         /// \param[in] ApproximateAlignment - the approximate alignment of the mount
         virtual void SetApproximateMountAlignment(MountAlignment_t ApproximateAlignment)
         {

--- a/libs/alignment/NearestMathPlugin.cpp
+++ b/libs/alignment/NearestMathPlugin.cpp
@@ -87,7 +87,7 @@ bool NearestMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
 
     // JM: We iterate over all the sync point and compute the celestial and telescope horizontal coordinates
     // Since these are used to sort the nearest alignment points to the current target. The offsets of the
-    // nearest point celestial coordintes are then applied to the current target to correct for its position.
+    // nearest point celestial coordinates are then applied to the current target to correct for its position.
     // No complex transformations used.
     for (auto &oneSyncPoint : SyncPoints)
     {

--- a/libs/alignment/SVDMathPlugin.cpp
+++ b/libs/alignment/SVDMathPlugin.cpp
@@ -72,7 +72,7 @@ void SVDMathPlugin::CalculateTransformMatrices(const TelescopeDirectionVector &A
     gsl_matrix *pIntermediateMatrix1 = gsl_matrix_alloc(3, 3);
     MatrixMatrixMultiply(pBetaMatrix, pAlphaMatrix, pIntermediateMatrix1);
 
-    // 3. Compute the singular value decomoposition of the intermediate matrix
+    // 3. Compute the singular value decomposition of the intermediate matrix
     gsl_matrix *pV    = gsl_matrix_alloc(3, 3);
     gsl_vector *pS    = gsl_vector_alloc(3);
     gsl_vector *pWork = gsl_vector_alloc(3);

--- a/libs/alignment/SVDMathPlugin.h
+++ b/libs/alignment/SVDMathPlugin.h
@@ -20,7 +20,7 @@ namespace AlignmentSubsystem
 class SVDMathPlugin : public BasicMathPlugin
 {
     private:
-        /// \brief Calculate tranformation matrices from the supplied vectors
+        /// \brief Calculate transformation matrices from the supplied vectors
         /// \param[in] Alpha1 Pointer to the first coordinate in the alpha reference frame
         /// \param[in] Alpha2 Pointer to the second coordinate in the alpha reference frame
         /// \param[in] Alpha3 Pointer to the third coordinate in the alpha reference frame

--- a/libs/alignment/TelescopeDirectionVectorSupportFunctions.h
+++ b/libs/alignment/TelescopeDirectionVectorSupportFunctions.h
@@ -19,7 +19,7 @@ namespace AlignmentSubsystem
 /*! \class TelescopeDirectionVectorSupportFunctions
  *  \brief These functions are used to convert different coordinate systems to and from the
  *  telescope direction vectors (normalised vector/direction cosines) used for telescope coordinates in the
- *  alignment susbsystem.
+ *  alignment subsystem.
  */
 class TelescopeDirectionVectorSupportFunctions
 {

--- a/libs/alignment/alignment_white_paper.md
+++ b/libs/alignment/alignment_white_paper.md
@@ -418,7 +418,7 @@ The final step is to add coordinate conversion to ReadScopeStatus, TimerHit (for
                     {
                         if (AzimuthOffsetMicrosteps < MICROSTEPS_PER_REVOLUTION / 2.0)
                         {
-                            // Foward
+                            // Forward
                             AxisDirectionRA = FORWARD;
                             AxisSlewRateRA = AzimuthOffsetMicrosteps;
                         }
@@ -434,7 +434,7 @@ The final step is to add coordinate conversion to ReadScopeStatus, TimerHit (for
                         AzimuthOffsetMicrosteps = abs(AzimuthOffsetMicrosteps);
                         if (AzimuthOffsetMicrosteps < MICROSTEPS_PER_REVOLUTION / 2.0)
                         {
-                            // Foward
+                            // Forward
                             AxisDirectionRA = REVERSE;
                             AxisSlewRateRA = AzimuthOffsetMicrosteps;
                         }
@@ -615,7 +615,7 @@ The Alignment Subsystem provides two API classes for use in clients. These are C
 
 	class LoaderClient : public INDI::BaseClient, INDI::AlignmentSubsystem::AlignmentSubsystemForClients
 
-Somewhere in the initialisation of your client make a call to the Initalise method of the AlignmentSubsystemForClients class for example:
+Somewhere in the initialisation of your client make a call to the Initialise method of the AlignmentSubsystemForClients class for example:
 
     void LoaderClient::Initialise(int argc, char* argv[])
     {
@@ -643,7 +643,7 @@ Somewhere in the initialisation of your client make a call to the Initalise meth
         setBLOBMode(B_ALSO, DeviceName.c_str(), NULL);
     }
 
-To hook the Alignment Subsystem into the clients property handling you must ensure that the following virtual functions are overriden.
+To hook the Alignment Subsystem into the clients property handling you must ensure that the following virtual functions are overridden.
 
     virtual void newBLOB(IBLOB *bp);
     virtual void newDevice(INDI::BaseDevice *dp);

--- a/libs/dsp/dsp.h
+++ b/libs/dsp/dsp.h
@@ -58,8 +58,8 @@ extern "C" {
 * The DSP API is a collection of essential routines used in astronomy signal processing<br>
 *
 * The DSP API is used for processing monodimensional or multidimensional buffers,<br>
-* generating, tranforming, stack, processing buffers, aligning, convoluting arrays,<br>
-* converting array element types, generate statistics, extract informations from buffers, convolute or<br>
+* generating, transforming, stack, processing buffers, aligning, convoluting arrays,<br>
+* converting array element types, generate statistics, extract information from buffers, convolute or<br>
 * cross-correlate different single or multi dimensional streams, rotate, scale, crop images.<br>
 *
 * \author Ilia Platone
@@ -280,7 +280,7 @@ typedef struct dsp_triangle_t
 } dsp_triangle;
 
 /**
-* \brief Alignment informations needed
+* \brief Alignment information needed
 */
 typedef struct dsp_align_info_t
 {
@@ -366,7 +366,7 @@ typedef union dsp_location_t
 typedef void *(*dsp_func_t) (void *, ...);
 
 /**
-* \brief Contains a set of informations and data relative to a buffer and how to use it
+* \brief Contains a set of information and data relative to a buffer and how to use it
 * \sa dsp_stream_new
 * \sa dsp_stream_add_dim
 * \sa dsp_stream_del_dim
@@ -469,7 +469,7 @@ DLL_EXPORT void dsp_fourier_idft(dsp_stream_p stream);
 DLL_EXPORT void dsp_fourier_2dsp(dsp_stream_p stream);
 
 /**
-* \brief Obtain the complex fourier tranform from the current magnitude and phase buffers
+* \brief Obtain the complex fourier transform from the current magnitude and phase buffers
 * \param stream the inout stream.
 */
 DLL_EXPORT void dsp_fourier_2complex_t(dsp_stream_p stream);
@@ -774,7 +774,7 @@ DLL_EXPORT void dsp_convolution_correlation(dsp_stream_p stream, dsp_stream_p ma
 * \brief Histogram of the inut stream
 * \param stream the stream on which execute
 * \param size the length of the median.
-* \return the output stream if successfull elaboration. NULL if an
+* \return the output stream if successful elaboration. NULL if an
 * error is encountered.
 */
 DLL_EXPORT double* dsp_stats_histogram(dsp_stream_p stream, int size);
@@ -1532,7 +1532,7 @@ DLL_EXPORT dsp_t* dsp_file_composite_2_bayer(dsp_stream_p *src, int red, int wid
 DLL_EXPORT void dsp_file_write_fits_bayer(const char* filename, int components, int bpp, dsp_stream_p* stream);
 
 /**
-* \brief Convert a bayer pattern dsp_t array into a contiguos component array
+* \brief Convert a bayer pattern dsp_t array into a contiguous component array
 * \param src the input buffer
 * \param red the location of the red pixel within the bayer pattern
 * \param width the picture width

--- a/libs/dsp/fits.h
+++ b/libs/dsp/fits.h
@@ -243,7 +243,7 @@ DLL_EXPORT long dsp_fits_alloc_fits_rows(fitsfile *fptr, unsigned long num_rows)
 * \param typecode The element type size
 * \param num_elements The total field size in elements, this should take into account the width and repeat multipliers
 * \param rown The row number where the field is located
-* \return non-zero if any error occured
+* \return non-zero if any error occurred
 * \sa dsp_fits_create_fits
 */
 DLL_EXPORT int dsp_fits_fill_fits_col(fitsfile *fptr, char* name, unsigned char *buf, int typecode, long num_elements,
@@ -254,7 +254,7 @@ DLL_EXPORT int dsp_fits_fill_fits_col(fitsfile *fptr, char* name, unsigned char 
 * \param fptr The fits file pointer created by dsp_fits_create_fits
 * \param name The name of the column
 * \param format This field should indicate the element size, width of each element and repetition eventually
-* \return non-zero if any error occured
+* \return non-zero if any error occurred
 */
 DLL_EXPORT int dsp_fits_append_fits_col(fitsfile *fptr, char* name, char* format);
 
@@ -278,7 +278,7 @@ DLL_EXPORT size_t dsp_fits_get_element_size(int typecode);
 * \param typecode This function will return the typecode to this variable
 * \param width This function will return the width to this variable
 * \param repeat This function will return the repeatition count to this variable
-* \return non-zero if any error occured
+* \return non-zero if any error occurred
 */
 DLL_EXPORT int dsp_fits_read_typecode(char* typestr, int *typecode, long *width, long *repeat);
 
@@ -288,7 +288,7 @@ DLL_EXPORT int dsp_fits_read_typecode(char* typestr, int *typecode, long *width,
 * \param column The column name of the selected field
 * \param rown The row position of the field
 * \param retval A preallocated buffer where the field value will be stored into
-* \return non-zero if any error occured
+* \return non-zero if any error occurred
 */
 DLL_EXPORT int dsp_fits_get_value(fitsfile *fptr, char* column, long rown, void **retval);
 
@@ -316,14 +316,14 @@ DLL_EXPORT fitsfile* dsp_fits_create_fits(size_t *size, void **buf);
 * \param columns An array of dsp_fits_column structs
 * \param ncols The dsp_fits_column array length
 * \param tablename The extension table name
-* \return non-zero if any error occured
+* \return non-zero if any error occurred
 */
 DLL_EXPORT int dsp_fits_add_table(fitsfile* fptr, dsp_fits_column *columns, int ncols,  const char* tablename);
 
 /**
 * \brief Close a fits file pointer
 * \param fptr The fits file pointer created by dsp_fits_create_fits
-* \return non-zero if any error occured
+* \return non-zero if any error occurred
 */
 DLL_EXPORT int dsp_fits_close_fits(fitsfile *fptr);
 /**\}*/

--- a/libs/dsp/sdfits.h
+++ b/libs/dsp/sdfits.h
@@ -194,8 +194,8 @@ extern "C" {
 #define SDFITS_COLUMN_WINDDIRE (dsp_fits_column){"WINDDIRE", EXTFITS_ELEMENT_DOUBLE.typestr, EXTFITS_MEASURE_UNIT_DEGREE, "", "Degrees West of North", (char*[]){""}}
 ///Main-beam efficiency
 #define SDFITS_COLUMN_BEAMEFF (dsp_fits_column){"BEAMEFF", EXTFITS_ELEMENT_DOUBLE.typestr, EXTFITS_MEASURE_UNIT_PERCENT, "", "Main-beam efficiency", (char*[]){""}}
-///Antenna Aperature Efficiency
-#define SDFITS_COLUMN_APEREFF (dsp_fits_column){"APEREFF", EXTFITS_ELEMENT_DOUBLE.typestr, EXTFITS_MEASURE_UNIT_PERCENT, "", "Antenna Aperature Efficiency", (char*[]){""}}
+///Antenna Aperture Efficiency
+#define SDFITS_COLUMN_APEREFF (dsp_fits_column){"APEREFF", EXTFITS_ELEMENT_DOUBLE.typestr, EXTFITS_MEASURE_UNIT_PERCENT, "", "Antenna Aperture Efficiency", (char*[]){""}}
 ///Rear spillover
 #define SDFITS_COLUMN_ETAL (dsp_fits_column){"ETAL", EXTFITS_ELEMENT_DOUBLE.typestr, "", "", "Rear spillover", (char*[]){""}}
 ///Accounts for forward loss

--- a/libs/fpack/fpackutil.c
+++ b/libs/fpack/fpackutil.c
@@ -398,7 +398,7 @@ int fp_preflight (int argc, char *argv[], int unpack, fpstate *fpptr)
             /* check that input file  exists */
             if (infits[0] != '-') {  /* if not reading from stdin stream */
                 if (fp_access (infits) != 0) {  /* if not, then check if */
-                    strcat(infits, ".fz");       /* a .fz version exsits */
+                    strcat(infits, ".fz");       /* a .fz version exists */
                     if (fp_access (infits) != 0) {
                         namelen = strlen(infits);
                         infits[namelen - 3] = '\0';  /* remove the .fz suffix */
@@ -511,7 +511,7 @@ int fp_preflight (int argc, char *argv[], int unpack, fpstate *fpptr)
                         fp_msg ("Error: input file name too long:\n "); fp_msg (infits);
                         fp_msg ("\n "); fp_noop (); exit (-1);
                     }
-                    strcat(infits, ".gz");     /* a gzipped version exsits */
+                    strcat(infits, ".gz");     /* a gzipped version exists */
                     if (fp_access (infits) != 0) {
                         namelen = strlen(infits);
                         infits[namelen - 3] = '\0';  /* remove the .gz suffix */
@@ -632,7 +632,7 @@ int fp_loop (int argc, char *argv[], int unpack, char *output_filename, fpstate 
             /* find input file */
             if (infits[0] != '-') {  /* if not reading from stdin stream */
                 if (fp_access (infits) != 0) {  /* if not, then */
-                    strcat(infits, ".fz");       /* a .fz version must exsit */
+                    strcat(infits, ".fz");       /* a .fz version must exist */
                 }
             }
 

--- a/libs/hid/hid_libusb.c
+++ b/libs/hid/hid_libusb.c
@@ -152,7 +152,7 @@ static void free_hid_device(hid_device *dev)
 }
 
 #if 0
-//TODO: Implement this funciton on hidapi/libusb..
+//TODO: Implement this function on hidapi/libusb..
 static void register_error(hid_device * device, const char * op)
 {
 
@@ -770,7 +770,7 @@ static void *read_thread(void *param)
     /* Now that the read thread is stopping, Wake any threads which are
        waiting on data (in hid_read_timeout()). Do this under a mutex to
        make sure that a thread which is about to go to sleep waiting on
-       the condition acutally will go to sleep before the condition is
+       the condition actually will go to sleep before the condition is
        signaled. */
     pthread_mutex_lock(&dev->mutex);
     pthread_cond_broadcast(&dev->condition);
@@ -885,7 +885,7 @@ hid_device *HID_API_EXPORT hid_open_path(const char *path)
                             int is_output = (ep->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_OUT;
                             int is_input  = (ep->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) == LIBUSB_ENDPOINT_IN;
 
-                            /* Decide whether to use it for intput or output. */
+                            /* Decide whether to use it for input or output. */
                             if (dev->input_endpoint == 0 && is_interrupt && is_input)
                             {
                                 /* Use this endpoint for INPUT */
@@ -941,7 +941,7 @@ int HID_API_EXPORT hid_write(hid_device *dev, const unsigned char *data, size_t 
 
     if (dev->output_endpoint <= 0)
     {
-        /* No interrput out endpoint. Use the Control Endpoint */
+        /* No interrupt out endpoint. Use the Control Endpoint */
         res = libusb_control_transfer(dev->device_handle,
                                       LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE | LIBUSB_ENDPOINT_OUT,
                                       0x09 /*HID Set_Report*/, (2 /*HID output*/ << 8) | report_number, dev->interface,

--- a/libs/hid/hid_mac.c
+++ b/libs/hid/hid_mac.c
@@ -671,7 +671,7 @@ static void *read_thread(void *param)
     /* Now that the read thread is stopping, Wake any threads which are
        waiting on data (in hid_read_timeout()). Do this under a mutex to
        make sure that a thread which is about to go to sleep waiting on
-       the condition acutally will go to sleep before the condition is
+       the condition actually will go to sleep before the condition is
        signaled. */
     pthread_mutex_lock(&dev->mutex);
     pthread_cond_broadcast(&dev->condition);
@@ -829,7 +829,7 @@ static int cond_wait(const hid_device *dev, pthread_cond_t *cond, pthread_mutex_
             return res;
 
         /* A res of 0 means we may have been signaled or it may
-           be a spurious wakeup. Check to see that there's acutally
+           be a spurious wakeup. Check to see that there's actually
            data in the queue before returning, and if not, go back
            to sleep. See the pthread_cond_timedwait() man page for
            details. */
@@ -851,7 +851,7 @@ static int cond_timedwait(const hid_device *dev, pthread_cond_t *cond, pthread_m
             return res;
 
         /* A res of 0 means we may have been signaled or it may
-           be a spurious wakeup. Check to see that there's acutally
+           be a spurious wakeup. Check to see that there's actually
            data in the queue before returning, and if not, go back
            to sleep. See the pthread_cond_timedwait() man page for
            details. */

--- a/libs/hid/hid_win.c
+++ b/libs/hid/hid_win.c
@@ -154,7 +154,7 @@ static hid_device *new_hid_device()
     dev->read_pending         = FALSE;
     dev->read_buf             = NULL;
     memset(&dev->ol, 0, sizeof(dev->ol));
-    dev->ol.hEvent = CreateEvent(NULL, FALSE, FALSE /*inital state f=nonsignaled*/, NULL);
+    dev->ol.hEvent = CreateEvent(NULL, FALSE, FALSE /*initial state f=nonsignaled*/, NULL);
 
     return dev;
 }

--- a/libs/hid/hidtest.cpp
+++ b/libs/hid/hidtest.cpp
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
     // Set the hid_read() function to be non-blocking.
     hid_set_nonblocking(handle, 1);
 
-    // Try to read from the device. There shoud be no
+    // Try to read from the device. There should be no
     // data here, but execution should not block.
     res = hid_read(handle, buf, 17);
 

--- a/libs/indiabstractclient/abstractbaseclient.cpp
+++ b/libs/indiabstractclient/abstractbaseclient.cpp
@@ -32,7 +32,7 @@
 #if defined(_MSC_VER)
 #define snprintf _snprintf
 #pragma warning(push)
-///@todo Introduce plattform indipendent safe functions as macros to fix this
+///@todo Introduce platform independent safe functions as macros to fix this
 #pragma warning(disable : 4996)
 #endif
 

--- a/libs/indiabstractclient/abstractbaseclient.h
+++ b/libs/indiabstractclient/abstractbaseclient.h
@@ -58,7 +58,7 @@ class AbstractBaseClient : public INDI::BaseMediator
     public:
         /** @brief Connect to INDI server.
          *  @returns True if the connection is successful, false otherwise.
-         *  @note This function blocks until connection is either successull or unsuccessful.
+         *  @note This function blocks until connection is either successfull or unsuccessful.
         */
         virtual bool connectServer() = 0;
 

--- a/libs/indibase/connectionplugins/connectioninterface.h
+++ b/libs/indibase/connectionplugins/connectioninterface.h
@@ -115,7 +115,7 @@ class Interface
         virtual bool saveConfigItems(FILE *fp);
 
         /**
-         * @brief registerHandshake Register a handshake function to be called once the intial connection to the device is established.
+         * @brief registerHandshake Register a handshake function to be called once the initial connection to the device is established.
          * @param callback Handshake function callback
          * @see INDI::Telescope
          */

--- a/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libs/indibase/connectionplugins/connectiontcp.h
@@ -30,7 +30,7 @@ namespace Connection
 {
 /**
  * @brief The TCP class manages connection with devices over the network via TCP/IP.
- * Upon successfull connection, reads & writes from and to the device are performed via the returned file descriptor
+ * Upon successful connection, reads & writes from and to the device are performed via the returned file descriptor
  * using standard UNIX read/write functions.
  */
 

--- a/libs/indibase/connectionplugins/ttybase.cpp
+++ b/libs/indibase/connectionplugins/ttybase.cpp
@@ -66,7 +66,7 @@
 #if defined(_MSC_VER)
 #define snprintf _snprintf
 #pragma warning(push)
-///@todo Introduce plattform indipendent safe functions as macros to fix this
+///@todo Introduce platform independent safe functions as macros to fix this
 #pragma warning(disable : 4996)
 #endif
 

--- a/libs/indibase/connectionplugins/ttybase.h
+++ b/libs/indibase/connectionplugins/ttybase.h
@@ -70,7 +70,7 @@ class TTYBase
 
         /** \brief read buffer from terminal with a delimiter
             \param fd file descriptor
-            \param buf pointer to store data. Must be initilized and big enough to hold data.
+            \param buf pointer to store data. Must be initialized and big enough to hold data.
             \param stop_char if the function encounters \e stop_char then it stops reading and returns the buffer.
             \param nsize size of buf. If stop character is not encountered before nsize, the function aborts.
             \param timeout number of seconds to wait for terminal before a timeout error is issued.

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -451,7 +451,7 @@ bool DefaultDevice::loadDefaultConfig()
     if (pResult)
         LOG_INFO("Default configuration loaded.");
     else
-        LOGF_INFO("Error loading default configuraiton. %s", errmsg);
+        LOGF_INFO("Error loading default configuration. %s", errmsg);
 
     return pResult;
 }
@@ -806,7 +806,7 @@ int DefaultDevice::SetTimer(uint32_t ms)
 }
 
 // Remove main timer. ID is not used.
-// Kept for backward compatiblity
+// Kept for backward compatibility
 void DefaultDevice::RemoveTimer(int id)
 {
     INDI_UNUSED(id);
@@ -816,7 +816,7 @@ void DefaultDevice::RemoveTimer(int id)
 }
 
 //  This is just a placeholder
-//  This function should be overriden by child classes if they use timers
+//  This function should be overridden by child classes if they use timers
 //  So we should never get here
 void DefaultDevice::TimerHit()
 {

--- a/libs/indibase/defaultdevice.h
+++ b/libs/indibase/defaultdevice.h
@@ -204,7 +204,7 @@ class DefaultDevice : public ParentDevice
          * @brief deleteProperty Delete a property and unregister it. It will also be deleted from all clients.
          * @param property Property to be deleted.
          * @return True if successful, false otherwise.
-         * @note This is a convience function that internally calls deleteProperty with the property name.
+         * @note This is a convenience function that internally calls deleteProperty with the property name.
          */
         bool deleteProperty(INDI::Property &property);
 
@@ -316,7 +316,7 @@ class DefaultDevice : public ParentDevice
          * You may send an ORed list of DeviceInterface values.
          * @param value ORed list of DeviceInterface values.
          * @warning This only updates the internal driver interface property and does not send it to the
-         * client. To synchronize the client, use syncDriverInfo funciton.
+         * client. To synchronize the client, use syncDriverInfo function.
          */
         void setDriverInterface(uint16_t value);
 
@@ -329,7 +329,7 @@ class DefaultDevice : public ParentDevice
 
     protected:
         /**
-         * @brief setDynamicPropertiesBehavior controls handling of dynamic properties. Dyanmic properties
+         * @brief setDynamicPropertiesBehavior controls handling of dynamic properties. Dynamic properties
          * are those generated from an external skeleton XML file. By default all properties, including
          * dynamic properties, are defined to the client in ISGetProperties(). Furthermore, when
          * űdeleteProperty(properyName) is called, the dynamic property is deleted by default, and can only
@@ -451,8 +451,8 @@ class DefaultDevice : public ParentDevice
         bool isSimulation() const;
 
         /**
-         * \brief Initilize properties initial state and value. The child class must implement this function.
-         * \return True if initilization is successful, false otherwise.
+         * \brief Initialize properties initial state and value. The child class must implement this function.
+         * \return True if initialization is successful, false otherwise.
          */
         virtual bool initProperties();
 

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -991,7 +991,7 @@ bool CCD::ISNewText(const char * dev, const char * name, char * texts[], char * 
             else
             {
                 FITSHeaderTP.setState(IPS_OK);
-                // Specical keyword
+                // Special keyword
                 if (name == "INDI_CLEAR")
                 {
                     m_CustomFITSKeywords.clear();

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -91,7 +91,7 @@ class XISFWrapper;
  * It requires the client to explicitly support websockets. It is not recommended to use this
  * approach unless for the most demanding and FPS sensitive tasks.
  *
- * INDI::CCD and INDI::StreamManager both upload frames asynchrounously in a worker thread.
+ * INDI::CCD and INDI::StreamManager both upload frames asynchronously in a worker thread.
  * The CCD Buffer data is protected by the ccdBufferLock mutex. When reading the camera data
  * and writing to the buffer, it must be first locked by the mutex. After the write is complete
  * release the lock. For example:
@@ -103,7 +103,7 @@ class XISFWrapper;
  * ExposureComplete();
  * \endcode
  *
- * Similiary, before calling Streamer->newFrame, the buffer needs to be protected in a similiar fashion using
+ * Similarly, before calling Streamer->newFrame, the buffer needs to be protected in a similar fashion using
  * the same ccdBufferLock mutex.
  *
  * \example CCD Simulator
@@ -305,7 +305,7 @@ class CCD : public DefaultDevice, GuiderInterface
         virtual bool StartExposure(float duration);
 
         /**
-         * \brief Uploads target Chip exposed buffer as FITS to the client. Dervied classes should class
+         * \brief Uploads target Chip exposed buffer as FITS to the client. Derived classes should class
          * this function when an exposure is complete.
          * @param targetChip chip that contains upload image data
          * \note This function is not implemented in CCD, it must be implemented in the child class
@@ -414,7 +414,7 @@ class CCD : public DefaultDevice, GuiderInterface
         virtual bool UpdateGuiderFrameType(CCDChip::CCD_FRAME fType);
 
         /**
-         * \brief Setup CCD paramters for primary CCD. Child classes call this function to update
+         * \brief Setup CCD parameters for primary CCD. Child classes call this function to update
          * CCD parameters
          * \param x Frame X coordinates in pixels.
          * \param y Frame Y coordinates in pixels.
@@ -425,7 +425,7 @@ class CCD : public DefaultDevice, GuiderInterface
         virtual void SetCCDParams(int x, int y, int bpp, float xf, float yf);
 
         /**
-         * \brief Setup CCD paramters for guide head CCD. Child classes call this function to update
+         * \brief Setup CCD parameters for guide head CCD. Child classes call this function to update
          * CCD parameters
          * \param x Frame X coordinates in pixels.
          * \param y Frame Y coordinates in pixels.

--- a/libs/indibase/indiccdchip.h
+++ b/libs/indibase/indiccdchip.h
@@ -304,7 +304,7 @@ class CCDChip
 
         /**
          * @brief setPixelSize Set CCD Chip pixel size
-         * @param x Horziontal pixel size in microns.
+         * @param x Horizontal pixel size in microns.
          * @param y Vertical pixel size in microns.
          */
         void setPixelSize(double x, double y);
@@ -380,7 +380,7 @@ class CCDChip
         void setNAxis(int value);
 
         /**
-         * @brief setImageExtension Set image exntension
+         * @brief setImageExtension Set image extension
          * @param ext extension (fits, jpeg, raw..etc)
          */
         void setImageExtension(const char *ext);

--- a/libs/indibase/indicontroller.h
+++ b/libs/indibase/indicontroller.h
@@ -47,7 +47,7 @@ namespace INDI
  *       ISNewXXX functions from the same standard functions in your driver.
  *
  * The class communicates with INDI joystick driver which in turn enumerates the game pad and provides
- * three types of constrcuts:
+ * three types of constructs:
  * <ul>
  * <li><b>Joysticks</b>: Each joystick displays a normalized magnitude [0 to 1] and an angle. The angle is measured counter clock wise starting from
  *  the right/east direction [0 to 360]. They are defined as JOYSTICK_# where # is the joystick number.</li>

--- a/libs/indibase/indicorrelator.h
+++ b/libs/indibase/indicorrelator.h
@@ -93,7 +93,7 @@ class Correlator : public SensorInterface
 
         /**
          * \enum Correlation
-         * \brief Struct containing the correlation, coordinate and baseline informations.
+         * \brief Struct containing the correlation, coordinate and baseline information.
          */
         typedef struct
         {

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -3,7 +3,7 @@
  Copyright(c) 2014 Jasem Mutlaq. All rights reserved.
 
  The code used calculate dome target AZ and ZD is written by Ferran Casarramona, and adapted from code from Markus Wildi.
- The transformations are based on the paper Matrix Method for Coodinates Transformation written by Toshimi Taki (http://www.asahi-net.or.jp/~zs3t-tk).
+ The transformations are based on the paper Matrix Method for Coordinates Transformation written by Toshimi Taki (http://www.asahi-net.or.jp/~zs3t-tk).
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public
@@ -1305,7 +1305,7 @@ bool Dome::GetTargetAz(double &Az, double &Alt, double &minAz, double &maxAz)
     {
         if(OTASideS[DM_OTA_SIDE_HA].s == ISS_ON || (UseHourAngle && OTASideS[DM_OTA_SIDE_MOUNT].s == ISS_ON))
         {
-            // Note if the telescope points West, OTA is at east of the pier, and viceversa.
+            // Note if the telescope points West, OTA is at east of the pier, and vice-versa.
             if(hourAngle > 0)
                 OTASide = -1;
             else

--- a/libs/indibase/indidome.h
+++ b/libs/indibase/indidome.h
@@ -3,7 +3,7 @@
  Copyright(c) 2014 Jasem Mutlaq. All rights reserved.
 
  The code used calculate dome target AZ and ZD is written by Ferran Casarramona, and adapted from code from Markus Wildi.
- The transformations are based on the paper Matrix Method for Coodinates Transformation written by Toshimi Taki (http://www.asahi-net.or.jp/~zs3t-tk).
+ The transformations are based on the paper Matrix Method for Coordinates Transformation written by Toshimi Taki (http://www.asahi-net.or.jp/~zs3t-tk).
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Library General Public
@@ -63,7 +63,7 @@ class TCP;
 
    Developers need to subclass INDI::Dome to implement any driver for Domes within INDI.
 
-  \note The code used calculate dome target AZ and ZD is written by Ferran Casarramona, and adapted from code from Markus Wildi. The transformations are based on the paper Matrix Method for Coodinates
+  \note The code used calculate dome target AZ and ZD is written by Ferran Casarramona, and adapted from code from Markus Wildi. The transformations are based on the paper Matrix Method for Coordinates
  Transformation written by Toshimi Taki (http://www.asahi-net.or.jp/~zs3t-tk).
 
 \author Jasem Mutlaq
@@ -155,7 +155,7 @@ class Dome : public DefaultDevice
         {
             DOME_CAN_ABORT          = 1 << 0, /*!< Can the dome motion be aborted? */
             DOME_CAN_ABS_MOVE       = 1 << 1, /*!< Can the dome move to an absolute azimuth position? */
-            DOME_CAN_REL_MOVE       = 1 << 2, /*!< Can the dome move to a relative position a number of degrees away from current position? Positive degress is Clockwise direction. Negative Degrees is counter clock wise direction */
+            DOME_CAN_REL_MOVE       = 1 << 2, /*!< Can the dome move to a relative position a number of degrees away from current position? Positive degrees is Clockwise direction. Negative Degrees is counter clock wise direction */
             DOME_CAN_PARK           = 1 << 3, /*!< Can the dome park and unpark itself? */
             DOME_CAN_SYNC           = 1 << 4, /*!< Can the dome sync to arbitrary position? */
             DOME_HAS_SHUTTER        = 1 << 5, /*!< Does the dome has a shutter than can be opened and closed electronically? */
@@ -420,13 +420,13 @@ class Dome : public DefaultDevice
 
         /**
              * @brief SetRAPark Set current AZ parking position. The data park file (stored in ~/.indi/ParkData.xml) is updated in the process.
-             * @param value current Axis 1 value (AZ either in angles or encoder values as specificed by the DomeParkData type).
+             * @param value current Axis 1 value (AZ either in angles or encoder values as specified by the DomeParkData type).
              */
         void SetAxis1Park(double value);
 
         /**
              * @brief SetAxis1Park Set default AZ parking position.
-             * @param value Default Axis 1 value (AZ either in angles or encoder values as specificed by the DomeParkData type).
+             * @param value Default Axis 1 value (AZ either in angles or encoder values as specified by the DomeParkData type).
              */
         void SetAxis1ParkDefault(double steps);
 
@@ -603,7 +603,7 @@ class Dome : public DefaultDevice
         ISwitchVectorProperty DomeAutoSyncSP;
         ISwitch DomeAutoSyncS[2];
 
-        // Backlash toogle
+        // Backlash toggle
         ISwitchVectorProperty DomeBacklashSP;
         ISwitch DomeBacklashS[2];
 

--- a/libs/indibase/indidriver.c
+++ b/libs/indibase/indidriver.c
@@ -294,7 +294,7 @@ int dispatch(XMLEle *root, char msg[])
         }
     }
 
-    /* check tag in surmised decreasing order of likelyhood */
+    /* check tag in surmised decreasing order of likelihood */
 
     if (!strcmp(rtag, "newNumberVector"))
     {

--- a/libs/indibase/indidriver.h
+++ b/libs/indibase/indidriver.h
@@ -41,7 +41,7 @@ extern int dispatch(XMLEle *root, char msg[]);
 //extern void clientMsgCB(int fd, void *arg);
 
 /**
- * @defgroup configFunctions Configuration Functions: Functions drivers call to save and load configuraion options.
+ * @defgroup configFunctions Configuration Functions: Functions drivers call to save and load configuration options.
  * 
  * <p>Drivers can save properties states and values in an XML configuration file. The following functions take an optional filename
  * parameter which specifies the full path of the configuration file. If the filename is set to NULL, the configuration file
@@ -57,7 +57,7 @@ extern int dispatch(XMLEle *root, char msg[]);
  * 
  * <p>If no filename is supplied, each function will try to create the configuration files in the following order:</p>
  * <ol>
- * <li>INDICONFIG environment variable: The functions checks if the envrionment variable is defined, and if so, it shall
+ * <li>INDICONFIG environment variable: The functions checks if the environment variable is defined, and if so, it shall
  * be used as the configuration filename</li>
  * <li>Generate filename: If the <i>device_name</i> is supplied, the function will attempt to set the configuration filename to ~/.indi/device_name_config.xml</li>
  * </ol>
@@ -120,7 +120,7 @@ extern int IUSaveDefaultConfig(const char *source_config, const char *dest_confi
 /** @brief Add opening or closing tag to a configuration file.
  *  A configuration file root XML element is \<INDIDriver\>. This functions add \<INDIDriver\> or \</INDIDriver\> as required.
  *  @param fp file pointer to a configuration file.
- *  @param ctag If 0, \<INDIDriver\> is appened to the configuration file, otherwise \</INDIDriver\> is appeneded and the <i>fp</i> is closed.
+ *  @param ctag If 0, \<INDIDriver\> is appended to the configuration file, otherwise \</INDIDriver\> is appended and the <i>fp</i> is closed.
  *  @param dev device name. Used only for sending notification to the driver if silent is set to 1.
  *  @param silent If silent is 1, it will suppress any output messages to the driver.
  */

--- a/libs/indibase/indidrivermain.c
+++ b/libs/indibase/indidrivermain.c
@@ -65,8 +65,8 @@ static int messageHandling = PROCEED_IMMEDIATE;
 
 
 /* callback when INDI client message arrives on stdin.
- * collect and dispatch when see outter element closure.
- * exit if OS trouble or see incompatable INDI version.
+ * collect and dispatch when see outer element closure.
+ * exit if OS trouble or see incompatible INDI version.
  * arg is not used.
  */
 static void clientMsgCB(int fd, void *arg)
@@ -122,7 +122,7 @@ typedef struct DeferredMessage
     struct DeferredMessage * prev;
 } DeferredMessage;
 
-// Messages will accumulate here until beeing processed
+// Messages will accumulate here until being processed
 static DeferredMessage * firstDeferredMessage = NULL;
 static DeferredMessage * lastDeferredMessage = NULL;
 

--- a/libs/indibase/indidustcapinterface.h
+++ b/libs/indibase/indidustcapinterface.h
@@ -27,7 +27,7 @@
  * \class DustCapInterface
    \brief Provides interface to implement remotely controlled dust cover
 
-   \e IMPORTANT: initDustCapProperties() must be called before any other function to initilize the Dust Cap properties.
+   \e IMPORTANT: initDustCapProperties() must be called before any other function to initialize the Dust Cap properties.
 
    \e IMPORTANT: processDustCapSwitch() must be called in your driver ISNewSwitch function.
 \author Jasem Mutlaq
@@ -50,17 +50,17 @@ class DustCapInterface
 
         /**
              * @brief Park dust cap (close cover). Must be implemented by child.
-             * @return If command completed immediatly, return IPS_OK. If command is in progress, return IPS_BUSY. If there is an error, return IPS_ALERT
+             * @return If command completed immediately, return IPS_OK. If command is in progress, return IPS_BUSY. If there is an error, return IPS_ALERT
              */
         virtual IPState ParkCap();
 
         /**
              * @brief unPark dust cap (open cover). Must be implemented by child.
-             * @return If command completed immediatly, return IPS_OK. If command is in progress, return IPS_BUSY. If there is an error, return IPS_ALERT
+             * @return If command completed immediately, return IPS_OK. If command is in progress, return IPS_BUSY. If there is an error, return IPS_ALERT
              */
         virtual IPState UnParkCap();
 
-        /** \brief Initilize dust cap properties. It is recommended to call this function within initProperties() of your primary device
+        /** \brief Initialize dust cap properties. It is recommended to call this function within initProperties() of your primary device
                 \param deviceName Name of the primary device
                 \param groupName Group or tab name to be used to define focuser properties.
             */

--- a/libs/indibase/indifilterinterface.h
+++ b/libs/indibase/indifilterinterface.h
@@ -31,7 +31,7 @@
    A filter wheel can be an independent device, or an embedded filter wheel within another device (e.g. CCD camera). Child class must implement all the
    pure virtual functions and call SelectFilterDone(int) when selection of a new filter position is complete in the hardware.
 
-   \e IMPORTANT: initFilterProperties() must be called before any other function to initilize the filter properties.
+   \e IMPORTANT: initFilterProperties() must be called before any other function to initialize the filter properties.
 
    \e IMPORTANT: processFilterSlot() must be called in your driver's ISNewNumber() function. processFilterSlot() will call the driver's
       SelectFilter() accordingly.
@@ -87,14 +87,14 @@ class FilterInterface
         ~FilterInterface();
 
         /**
-         * \brief Initilize filter wheel properties. It is recommended to call this function within
+         * \brief Initialize filter wheel properties. It is recommended to call this function within
          * initProperties() of your primary device
          * \param groupName Group or tab name to be used to define filter wheel properties.
          */
         void initProperties(const char *groupName);
 
         /**
-         * @brief updateProperties Defines or Delete proprties based on default device connection status
+         * @brief updateProperties Defines or Delete properties based on default device connection status
          * @return True if all is OK, false otherwise.
          */
         bool updateProperties();

--- a/libs/indibase/indifocuserinterface.h
+++ b/libs/indibase/indifocuserinterface.h
@@ -158,7 +158,7 @@ class FocuserInterface
         virtual ~FocuserInterface() = default;
 
         /**
-         * \brief Initilize focuser properties. It is recommended to call this function within
+         * \brief Initialize focuser properties. It is recommended to call this function within
          * initProperties() of your primary device
          * \param groupName Group or tab name to be used to define focuser properties.
          */
@@ -302,7 +302,7 @@ class FocuserInterface
         ISwitchVectorProperty FocusReverseSP;
         ISwitch FocusReverseS[2];
 
-        // Backlash toogle
+        // Backlash toggle
         ISwitchVectorProperty FocusBacklashSP;
         ISwitch FocusBacklashS[2];
 

--- a/libs/indibase/indigpsinterface.h
+++ b/libs/indibase/indigpsinterface.h
@@ -55,7 +55,7 @@ class GPSInterface
         virtual ~GPSInterface() = default;
 
         /**
-         * \brief Initilize focuser properties. It is recommended to call this function within
+         * \brief Initialize focuser properties. It is recommended to call this function within
          * initProperties() of your primary device
          * \param groupName Group or tab name to be used to define focuser properties.
          */

--- a/libs/indibase/indiguiderinterface.h
+++ b/libs/indibase/indiguiderinterface.h
@@ -90,7 +90,7 @@ class GuiderInterface
         ~GuiderInterface();
 
         /**
-         * @brief Initilize guider properties. It is recommended to call this function within
+         * @brief Initialize guider properties. It is recommended to call this function within
          * initProperties() of your primary device
          * @param deviceName Name of the primary device
          * @param groupName Group or tab name to be used to define guider properties.

--- a/libs/indibase/indilightboxinterface.h
+++ b/libs/indibase/indilightboxinterface.h
@@ -33,7 +33,7 @@
 
    The child class is expected to call the following functions from the INDI frameworks standard functions:
 
-   \e IMPORTANT: initLightBoxProperties() must be called before any other function to initilize the Light device properties.
+   \e IMPORTANT: initLightBoxProperties() must be called before any other function to initialize the Light device properties.
    \e IMPORTANT: isGetLightBoxProperties() must be called in your driver ISGetProperties function
    \e IMPORTANT: processLightBoxSwitch() must be called in your driver ISNewSwitch function.
    \e IMPORTANT: processLightBoxNumber() must be called in your driver ISNewNumber function.
@@ -56,7 +56,7 @@ class LightBoxInterface
         LightBoxInterface(DefaultDevice *device, bool isDimmable);
         virtual ~LightBoxInterface();
 
-        /** \brief Initilize light box properties. It is recommended to call this function within initProperties() of your primary device
+        /** \brief Initialize light box properties. It is recommended to call this function within initProperties() of your primary device
                 \param deviceName Name of the primary device
                 \param groupName Group or tab name to be used to define light box properties.
             */
@@ -82,14 +82,14 @@ class LightBoxInterface
         bool snoopLightBox(XMLEle *root);
 
         /**
-             * @brief setBrightness Set light level. Must be impelemented in the child class, if supported.
+             * @brief setBrightness Set light level. Must be implemented in the child class, if supported.
              * @param value level of light box
              * @return True if successful, false otherwise.
              */
         virtual bool SetLightBoxBrightness(uint16_t value);
 
         /**
-             * @brief EnableLightBox Turn on/off on a light box. Must be impelemented in the child class.
+             * @brief EnableLightBox Turn on/off on a light box. Must be implemented in the child class.
              * @param enable If true, turn on the light, otherwise turn off the light.
              * @return True if successful, false otherwise.
              */

--- a/libs/indibase/indirotator.h
+++ b/libs/indibase/indirotator.h
@@ -32,7 +32,7 @@ class TCP;
 
    Rotators must be able to move to a specific angle. Other capabilities including abort, syncing, homing are optional.
 
-   The angle is to be interpreted as the raw angle and not necessairly the position angle as this definition should be
+   The angle is to be interpreted as the raw angle and not necessarily the position angle as this definition should be
    handled by clients after homing and syncing.
 
    This class is designed for pure rotator devices. To utilize Rotator Interface in another type of device, inherit from RotatorInterface.

--- a/libs/indibase/indirotatorinterface.h
+++ b/libs/indibase/indirotatorinterface.h
@@ -33,9 +33,9 @@ using RI = INDI::RotatorInterface;
    pure virtual functions. Only absolute position Rotators are supported. Angle is ranged from 0 to 360 increasing clockwise when looking at the back
    of the camera.
 
-   \e IMPORTANT: initRotatorProperties() must be called before any other function to initilize the Rotator properties.
+   \e IMPORTANT: initRotatorProperties() must be called before any other function to initialize the Rotator properties.
 
-   \e IMPORTANT: processRotatorNumber() must be called in your driver's ISNewNumber() function. Similary, processRotatorSwitch() must be called in ISNewSwitch()
+   \e IMPORTANT: processRotatorNumber() must be called in your driver's ISNewNumber() function. Similarly, processRotatorSwitch() must be called in ISNewSwitch()
 
 \author Jasem Mutlaq
 */
@@ -121,7 +121,7 @@ class RotatorInterface
         explicit RotatorInterface(DefaultDevice *defaultDevice);
 
         /**
-         * \brief Initilize Rotator properties. It is recommended to call this function within
+         * \brief Initialize Rotator properties. It is recommended to call this function within
          * initProperties() of your primary device
          * \param groupName Group or tab name to be used to define Rotator properties.
          */
@@ -209,7 +209,7 @@ class RotatorInterface
         ISwitch ReverseRotatorS[2];
         ISwitchVectorProperty ReverseRotatorSP;
 
-        // Backlash toogle
+        // Backlash toggle
         ISwitchVectorProperty RotatorBacklashSP;
         ISwitch RotatorBacklashS[2];
 

--- a/libs/indibase/indisensorinterface.h
+++ b/libs/indibase/indisensorinterface.h
@@ -233,7 +233,7 @@ class SensorInterface : public DefaultDevice
         void setNAxis(int value);
 
         /**
-         * @brief setIntegrationExtension Set integration exntension
+         * @brief setIntegrationExtension Set integration extension
          * @param ext extension (fits, jpeg, raw..etc)
          */
         void setIntegrationFileExtension(const char *ext);
@@ -293,7 +293,7 @@ class SensorInterface : public DefaultDevice
         virtual bool StartIntegration(double duration);
 
         /**
-         * \brief Uploads target Device exposed buffer as FITS to the client. Dervied classes should class
+         * \brief Uploads target Device exposed buffer as FITS to the client. Derived classes should class
          * this function when an Integration is complete.
          * @param targetDevice device that contains upload integration data
          * \note This function is not implemented in Sensor, it must be implemented in the child class
@@ -322,7 +322,7 @@ class SensorInterface : public DefaultDevice
          * \brief Add FITS keywords to a fits file
          * \param fptr pointer to a valid FITS file.
          * \param buf The buffer of the fits contents.
-         * \param len The lenght of the buffer.
+         * \param len The length of the buffer.
          * \note In additional to the standard FITS keywords, this function write the following
          * keywords the FITS file:
          * <ul>

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -911,7 +911,7 @@ bool Telescope::ISNewNumber(const char *dev, const char *name, double values[], 
 
             if (TrackState == SCOPE_TRACKING && !strcmp(IUFindOnSwitch(&TrackModeSP)->name, "TRACK_CUSTOM"))
             {
-                // Check that we do not abruplty change positive tracking rates to negative ones.
+                // Check that we do not abruptly change positive tracking rates to negative ones.
                 // tracking must be stopped first.
                 // Give warning is tracking sign would cause a reverse in direction
                 if ( (preAxis1 * TrackRateN[AXIS_RA].value < 0) || (preAxis2 * TrackRateN[AXIS_DE].value < 0) )
@@ -1268,7 +1268,7 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
                 //if (TrackState != SCOPE_PARKED)
                 //TrackState = SCOPE_IDLE;
                 // For Idle, Tracking, Parked state, we do not change its status, it should remain as is.
-                // For Slewing & Parking, state should go back to last rememberd state.
+                // For Slewing & Parking, state should go back to last remembered state.
                 if (TrackState == SCOPE_SLEWING || TrackState == SCOPE_PARKING)
                 {
                     TrackState = RememberTrackState;

--- a/libs/indibase/inditelescope.h
+++ b/libs/indibase/inditelescope.h
@@ -369,7 +369,7 @@ class Telescope : public DefaultDevice
         double GetAxis2Park() const;
 
         /**
-         * @return Get defailt DEC/ALT parking position.
+         * @return Get default DEC/ALT parking position.
          */
         double GetAxis2ParkDefault() const;
 
@@ -453,7 +453,7 @@ class Telescope : public DefaultDevice
          *   <li>Update telescope status: Idle, Slewing, Parking..etc.</li>
          *   <li>Read coordinates</li>
          * </ol>
-         * \return True if reading scope status is OK, false if an error is encounterd.
+         * \return True if reading scope status is OK, false if an error is encountered.
          * \note This function is not implemented in Telescope, it must be implemented in the
          * child class
          */
@@ -716,7 +716,7 @@ class Telescope : public DefaultDevice
         ISwitchVectorProperty CoordSP;
         ISwitch CoordS[4];
 
-        // A number vector that stores lattitude and longitude
+        // A number vector that stores latitude and longitude
         INumberVectorProperty LocationNP;
         INumber LocationN[3];
 
@@ -772,7 +772,7 @@ class Telescope : public DefaultDevice
         ISwitchVectorProperty DomePolicySP;
         ISwitch DomePolicyS[2];
 
-        // Switch for choosing between motion control by 4-way joystick or two seperate axes
+        // Switch for choosing between motion control by 4-way joystick or two separate axes
         ISwitchVectorProperty MotionControlModeTP;
         ISwitch MotionControlModeT[2];
         enum
@@ -781,7 +781,7 @@ class Telescope : public DefaultDevice
             MOTION_CONTROL_AXES
         };
 
-        // Lock Joystick Axis to one direciton only
+        // Lock Joystick Axis to one direction only
         ISwitch LockAxisS[2];
         ISwitchVectorProperty LockAxisSP;
 

--- a/libs/indibase/indiweather.h
+++ b/libs/indibase/indiweather.h
@@ -122,7 +122,7 @@ class Weather : public DefaultDevice, public WeatherInterface
         /** \brief perform handshake with device to check communication */
         virtual bool Handshake();
 
-        // A number vector that stores lattitude and longitude
+        // A number vector that stores latitude and longitude
         INumberVectorProperty LocationNP;
         INumber LocationN[3];
 

--- a/libs/indibase/indiweatherinterface.h
+++ b/libs/indibase/indiweatherinterface.h
@@ -63,7 +63,7 @@ class WeatherInterface
         virtual ~WeatherInterface();
 
         /**
-         * \brief Initilize focuser properties. It is recommended to call this function within
+         * \brief Initialize focuser properties. It is recommended to call this function within
          * initProperties() of your primary device
          * \param statusGroup group for status properties
          * \param paramsGroup group for parameter properties
@@ -114,7 +114,7 @@ class WeatherInterface
          * <li>Alert: Any value outsize of Ok and Warning zone is marked as Alert.</li>
          * </ol>
          * @param name Name of parameter
-         * @param label Label of paremeter (in GUI)
+         * @param label Label of parameter (in GUI)
          * @param numMinOk minimum Ok range value.
          * @param numMaxOk maximum Ok range value.
          * @param percWarning percentage for Warning.

--- a/libs/indibase/stream/ccvt.h
+++ b/libs/indibase/stream/ccvt.h
@@ -23,7 +23,7 @@
 /*
  $Log$
  Revision 1.4  2005/04/29 16:51:20  mutlaqja
- Adding initial support for Video 4 Linux 2 drivers. This mean that KStars can probably control Meade Lunar Planetary Imager (LPI). V4L2 requires a fairly recent kernel (> 2.6.9) and many drivers don't fully support it yet. It will take sometime. KStars still supports V4L1 and will continue so until V4L1 is obselete. Please test KStars video drivers if you can. Any comments welcomed.
+ Adding initial support for Video 4 Linux 2 drivers. This mean that KStars can probably control Meade Lunar Planetary Imager (LPI). V4L2 requires a fairly recent kernel (> 2.6.9) and many drivers don't fully support it yet. It will take sometime. KStars still supports V4L1 and will continue so until V4L1 is obsolete. Please test KStars video drivers if you can. Any comments welcomed.
 
  CCMAIL: kstars-devel@kde.org
 

--- a/libs/indibase/stream/ccvt_misc.c
+++ b/libs/indibase/stream/ccvt_misc.c
@@ -27,7 +27,7 @@
 /*
  * $Log$
  * Revision 1.2  2005/04/29 16:51:20  mutlaqja
- * Adding initial support for Video 4 Linux 2 drivers. This mean that KStars can probably control Meade Lunar Planetary Imager (LPI). V4L2 requires a fairly recent kernel (> 2.6.9) and many drivers don't fully support it yet. It will take sometime. KStars still supports V4L1 and will continue so until V4L1 is obselete. Please test KStars video drivers if you can. Any comments welcomed.
+ * Adding initial support for Video 4 Linux 2 drivers. This mean that KStars can probably control Meade Lunar Planetary Imager (LPI). V4L2 requires a fairly recent kernel (> 2.6.9) and many drivers don't fully support it yet. It will take sometime. KStars still supports V4L1 and will continue so until V4L1 is obsolete. Please test KStars video drivers if you can. Any comments welcomed.
  *
  * CCMAIL: kstars-devel@kde.org
  *

--- a/libs/indibase/stream/jpegutils.c
+++ b/libs/indibase/stream/jpegutils.c
@@ -76,7 +76,7 @@ static void init_source(j_decompress_ptr cinfo)
 /*
  * Fill the input buffer --- called whenever buffer is emptied.
  *
- * Should never be called since all data should be allready provided.
+ * Should never be called since all data should be already provided.
  * Is nevertheless sometimes called - sets the input buffer to data
  * which is the JPEG EOI marker;
  *
@@ -150,7 +150,7 @@ static void jpeg_buffer_src(j_decompress_ptr cinfo, unsigned char *buffer, long 
 /*
  * jpeg_skip_ff is not a part of the source manager but it is
  * particularly useful when reading several images from the same buffer:
- * It should be called to skip padding 0xff bytes beetween images.
+ * It should be called to skip padding 0xff bytes between images.
  */
 
 static void jpeg_skip_ff(j_decompress_ptr cinfo)

--- a/libs/indibase/stream/jpegutils.h
+++ b/libs/indibase/stream/jpegutils.h
@@ -67,7 +67,7 @@ int decode_jpeg_raw(unsigned char *jpeg_data, int len, int itype, int ctype, uns
  * @param naxis 1 for mono, 3 for color
  * @param w width of image in pixels
  * @param h height image in pixels
- * @return 0 if decoding sucseeds, -1 otherwise.
+ * @return 0 if decoding succeeds, -1 otherwise.
  */
 int decode_jpeg_rgb(unsigned char *inBuffer, unsigned long inSize, uint8_t **memptr, size_t *memsize, int *naxis, int *w,
                     int *h);

--- a/libs/indibase/stream/recorder/serrecorder.cpp
+++ b/libs/indibase/stream/recorder/serrecorder.cpp
@@ -384,7 +384,7 @@ void SER_Recorder::dateTo64BitTS(int32_t year, int32_t month, int32_t day, int32
             case 11: // Novenber
                 ts += (30 * m_septaseconds_per_day);
                 break;
-            case 2: // Feburary
+            case 2: // February
                 if (is_leap_year(year))
                 {
                     ts += (29 * m_septaseconds_per_day);

--- a/libs/indibase/stream/recorder/theorarecorder.cpp
+++ b/libs/indibase/stream/recorder/theorarecorder.cpp
@@ -271,7 +271,7 @@ bool TheoraRecorder::open(const char *filename, char *errmsg)
         We make this call just to set the encoder into 2-pass mode, because
          by default enabling two-pass sets the buffer delay to the whole file
          (because there's no way to explicitly request that behavior).
-        If we waited until we were actually encoding, it would overwite our
+        If we waited until we were actually encoding, it would overwrite our
          settings.*/
         if(th_encode_ctl(td, TH_ENCCTL_2PASS_IN, nullptr, 0) < 0)
         {

--- a/libs/indibase/stream/streammanager.cpp
+++ b/libs/indibase/stream/streammanager.cpp
@@ -1037,7 +1037,7 @@ bool StreamManagerPrivate::setStream(bool enable)
             else
                 LOGF_INFO("Starting the video stream with target FPS %.f", StreamOptionsN[OPTION_TARGET_FPS].value);
 #endif
-            LOGF_INFO("Starting the video stream with target exposure %.6f s (Max theoritical FPS %.f)",
+            LOGF_INFO("Starting the video stream with target exposure %.6f s (Max theoretical FPS %.f)",
                       StreamExposureNP[0].getValue(), 1 / StreamExposureNP[0].getValue());
 
             FPSAverage.reset();

--- a/libs/indibase/stream/streammanager_p.h
+++ b/libs/indibase/stream/streammanager_p.h
@@ -208,7 +208,7 @@ class StreamManagerPrivate
         INDI::PropertySwitch EncoderSP {2};
         enum { ENCODER_RAW, ENCODER_MJPEG };
 
-        // Recorder Selector. Static but should be implmeneted as a dynamic plugin interface
+        // Recorder Selector. Static but should be implemented as a dynamic plugin interface
         INDI::PropertySwitch RecorderSP {2};
         enum { RECORDER_RAW, RECORDER_OGV };
 

--- a/libs/indibase/webcam/pwc-ioctl.h
+++ b/libs/indibase/webcam/pwc-ioctl.h
@@ -164,7 +164,7 @@ struct pwc_mpt_angles
 {
     int absolute; /* write-only */
     int pan;      /* degrees * 100 */
-    int tilt;     /* degress * 100 */
+    int tilt;     /* degrees * 100 */
 };
 
 /* Range of angles of the camera, both horizontally and vertically.

--- a/libs/indibase/webcam/v4l2_base.cpp
+++ b/libs/indibase/webcam/v4l2_base.cpp
@@ -463,7 +463,7 @@ bool V4L2_Base::isLXmodCapable()
  * verified against the buffer list. No processing is done actually, and
  * the buffer is immediately requeued.
  *
- * @param errmsg is the error messsage updated in case of error.
+ * @param errmsg is the error message updated in case of error.
  * @return 0 if frame read is processed, or -1 with error message updated.
  */
 int V4L2_Base::read_frame(char * errmsg)
@@ -713,7 +713,7 @@ int V4L2_Base::stop_capturing(char * errmsg)
             break;
 
         case IO_METHOD_MMAP:
-        /* Kernel 3.11 problem with streamoff: vb2_is_busy(queue) remains true so we can not change anything without diconnecting */
+        /* Kernel 3.11 problem with streamoff: vb2_is_busy(queue) remains true so we can not change anything without disconnecting */
         /* It seems that device should be closed/reopened to change any capture format settings. From V4L2 API Spec. (Data Negotiation) */
         /* Switching the logical stream or returning into "panel mode" is possible by closing and reopening the device. */
         /* Drivers may support a switch using VIDIOC_S_FMT. */

--- a/libs/indibase/webcam/v4l2_decode/v4l2_builtin_decoder.cpp
+++ b/libs/indibase/webcam/v4l2_decode/v4l2_builtin_decoder.cpp
@@ -27,11 +27,11 @@
     modprobe v4l2loopback video_nr=8 card_label="Indi Loopback" exclusive_caps=0,0
     gst-launch-0.10 -v videotestsrc ! 'video/x-raw-bayer, format=(string)bggr, width=640, height=480, framerate=(fraction)2/1' ! v4l2sink device=/dev/video8
 
-    For Gray16 format I use gst-launch with a videotstsrc in GRAY16 format writing in a FIFO and a C program reding the FIFO into the v4l2loopback device
+    For Gray16 format I use gst-launch with a videotstsrc in GRAY16 format writing in a FIFO and a C program reading the FIFO into the v4l2loopback device
     mkfifo /tmp/videopipe
     gst-launch-1.0  -v videotestsrc  ! video/x-raw,format=\(string\)GRAY16_LE,width=1024,height=576,framerate=\(fraction\)25/1 ! filesink location =/tmp/videopipe
     ./gray16_to_v4l2 /dev/video8 < /tmp/videopipe &
-    The C program ./gray16_to_v4l2 is adpated from https://github.com/umlaeute/v4l2loopback/blob/master/examples/yuv4mpeg_to_v4l2.c :
+    The C program ./gray16_to_v4l2 is adapated from https://github.com/umlaeute/v4l2loopback/blob/master/examples/yuv4mpeg_to_v4l2.c :
     process_header/read_header calls are suppressed (copy_frames uses a while (true) loop), frame_width and frame_height are constant
     and V4L2 pixel format is set to V4L2_PIX_FMT_Y16.
 

--- a/libs/indiclient/baseclient.cpp
+++ b/libs/indiclient/baseclient.cpp
@@ -254,7 +254,7 @@ BaseClientPrivate::BaseClientPrivate(BaseClient *parent)
 
             if (err_code < 0)
             {
-                // Silenty ignore property duplication errors
+                // Silently ignore property duplication errors
                 if (err_code != INDI_PROPERTY_DUPLICATED)
                 {
                     IDLog("Dispatch command error(%d): %s\n", err_code, msg);

--- a/libs/indiclient/baseclient.h
+++ b/libs/indiclient/baseclient.h
@@ -59,7 +59,7 @@ class INDI::BaseClient : public INDI::AbstractBaseClient
     public:
         /** @brief Connect to INDI server.
          *  @returns True if the connection is successful, false otherwise.
-         *  @note This function blocks until connection is either successull or unsuccessful.
+         *  @note This function blocks until connection is either successfull or unsuccessful.
          */
         bool connectServer() override;
 

--- a/libs/indiclientqt/baseclientqt.cpp
+++ b/libs/indiclientqt/baseclientqt.cpp
@@ -70,7 +70,7 @@ void BaseClientQtPrivate::listenINDI()
 
             if (err_code < 0)
             {
-                // Silenty ignore property duplication errors
+                // Silently ignore property duplication errors
                 if (err_code != INDI_PROPERTY_DUPLICATED)
                 {
                     IDLog("Dispatch command error(%d): %s\n", err_code, msg);

--- a/libs/indiclientqt/baseclientqt.h
+++ b/libs/indiclientqt/baseclientqt.h
@@ -56,7 +56,7 @@ class INDI::BaseClientQt : public QObject, public INDI::AbstractBaseClient
     public:
         /** @brief Connect to INDI server.
          *  @returns True if the connection is successful, false otherwise.
-         *  @note This function blocks until connection is either successull or unsuccessful.
+         *  @note This function blocks until connection is either successfull or unsuccessful.
          */
         bool connectServer() override;
 

--- a/libs/indicore/base64.h
+++ b/libs/indicore/base64.h
@@ -51,7 +51,7 @@ extern int to64frombits(unsigned char *out, const unsigned char *in, int inlen);
 /** \brief Convert base64 to bytes array.
     \param out output buffer in bytes. The buffer size must be at least (3 * size_of_in_buffer / 4) bytes long.
     \param in input base64 buffer
-    \param inlen base64 buffer lenght
+    \param inlen base64 buffer length
     \return 0 on success, -1 on failure.
  */
 

--- a/libs/indicore/indiapi.h.in
+++ b/libs/indicore/indiapi.h.in
@@ -35,10 +35,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 <p>A full description of the INDI protocol is detailed in the INDI <a href="http://www.clearskyinstitute.com/INDI/INDI.pdf">white paper</a></p>
 
 <p>Under INDI, any number of clients can connect to any number of drivers running one or more devices. It is a true N-to-N server/client architecture topology
-allowing for reliable deployments of several INDI server, client, and driver instances distrubted across different systems in different physical and logical locations.</p>
+allowing for reliable deployments of several INDI server, client, and driver instances distributed across different systems in different physical and logical locations.</p>
 
 <p>The basic premise of INDI is this: Drivers are responsible for defining their functionality in terms of <b>Properties</b>. Clients are not aware of such properties until they establish connection with the driver
-and start receiving streams of defined properties. Each property encompases some functionality or information about the device. These include number, text, switch, light, and BLOB properties.</p>
+and start receiving streams of defined properties. Each property encompasses some functionality or information about the device. These include number, text, switch, light, and BLOB properties.</p>
 
 <p>For example, all devices define the <i>CONNECTION</i> vector switch property, which is compromised of two switches:</p>
 <ol>
@@ -59,7 +59,7 @@ INDI is intended for developers seeking to add support for their devices in INDI
 
 \section Development Developing under INDI
 
-<p>Please refere to the <a href="http://www.indilib.org/develop/developer-manual">INDI Developers Manual</a> for a complete guide on INDI's driver developemnt framework.</p>
+<p>Please refer to the <a href="http://www.indilib.org/develop/developer-manual">INDI Developers Manual</a> for a complete guide on INDI's driver development framework.</p>
 
 <p>The INDI Library API is divided into the following main sections:</p>
 <ul>
@@ -105,7 +105,7 @@ Simulators provide a great framework to test drivers and equipment alike. INDI L
  The simulator snoops FWHM from the focuser simulator which affects the generated images focus. All images are generated in standard FITS format.</li>
 <li><b>@ref GuideSim "Guide Simulator"</b>: Simple dedicated Guide Simulator.
 <li><b>@ref FilterSim "Filter Wheel Simulator"</b>: Offers a simple simulator to change filter wheels and their corresponding designations.</li>
-<li><b>@ref FocusSim "Focuser Simulator"</b>: Offers a simple simualtor for an absolute position focuser. It generates a simulated FWHM value that may be used by other simulator such as the CCD simulator.</li>
+<li><b>@ref FocusSim "Focuser Simulator"</b>: Offers a simple simulator for an absolute position focuser. It generates a simulated FWHM value that may be used by other simulator such as the CCD simulator.</li>
 <li><b>@ref DomeSim "Dome Simulator"</b>: Offers a simple simulator for an absolute position dome with shutter.
 <li><b>@ref GPSSimulator "GPS Simulator"</b>: Offers a simple simulator for GPS devices that send time and location data to the client and other drivers.
 </ul>
@@ -128,7 +128,7 @@ For a full list of contributors, please check <a href="https://github.com/indili
 
 /*******************************************************************************
  * INDI wire protocol version implemented by this API.
- * N.B. this is indepedent of the API itself.
+ * N.B. this is independent of the API itself.
  */
 
 #define INDIV 1.7

--- a/libs/indicore/indicom.c
+++ b/libs/indicore/indicom.c
@@ -95,7 +95,7 @@
 #if defined(_MSC_VER)
 #define snprintf _snprintf
 #pragma warning(push)
-///@todo Introduce plattform indipendent safe functions as macros to fix this
+///@todo Introduce platform independent safe functions as macros to fix this
 #pragma warning(disable : 4996)
 #endif
 

--- a/libs/indicore/indicom.h
+++ b/libs/indicore/indicom.h
@@ -372,18 +372,18 @@ double range360(double r);
  */
 double rangeDec(double r);
 
-/** \brief get_local_sidereal_time Returns local sideral time given longitude and system clock.
+/** \brief get_local_sidereal_time Returns local sidereal time given longitude and system clock.
  *  \param longitude Longitude in INDI format (0 to 360) increasing eastward.
  *  \return Local Sidereal Time.
  */
 double get_local_sidereal_time(double longitude);
 
 /** \brief get_local_hour_angle Returns local hour angle of an object
- *  \param local_sideral_time Local Sideral Time
+ *  \param local_sidereal_time Local Sidereal Time
  *  \param ra RA of object
  *  \return Hour angle in hours (-12 to 12)
  */
-double get_local_hour_angle(double local_sideral_time, double ra);
+double get_local_hour_angle(double local_sidereal_time, double ra);
 
 
 /** \brief get_hrz_from_equ Calculate horizontal coordinates from equatorial coordinates.
@@ -416,7 +416,7 @@ void get_alt_az_coordinates(double hour_angle, double dec, double latitude, doub
 /** \brief estimate_geocentric_elevation Returns an estimation of the actual geocentric elevation
  *  \param latitude latitude in INDI format (-90 to +90)
  *  \param sea_level_elevation sea level elevation
- *  \return Aproximated geocentric elevation
+ *  \return Approximated geocentric elevation
  */
 double estimate_geocentric_elevation(double latitude, double sea_level_elevation);
 
@@ -424,14 +424,14 @@ double estimate_geocentric_elevation(double latitude, double sea_level_elevation
  *  \param Alt altitude coordinate of the object
  *  \param Az azimuth coordinate of the object
  *  \param latitude latitude in INDI format (-90 to +90)
- *  \return Aproximation of the field rotation rate
+ *  \return Approximation of the field rotation rate
  */
 double estimate_field_rotation_rate(double Alt, double Az, double latitude);
 
 /** \brief estimate_field_rotation Returns an estimation of the field rotation rate of the object
  *  \param hour_angle Hour angle in hours (-12 to 12)
  *  \param field_rotation_rate the field rotation rate
- *  \return Aproximation of the absolute field rotation
+ *  \return Approximation of the absolute field rotation
  */
 double estimate_field_rotation(double hour_angle, double field_rotation_rate);
 
@@ -468,7 +468,7 @@ double m2au(double m);
  */
 double calc_delta_magnitude(double mag_ratio, double *spectrum, double *ref_spectrum, int spectrum_size);
 
-/** \brief calc_photon_flux Returns the photon flux of the object with the given magnitude observed at a determined wavelenght using a passband filter through a steradian expressed cone
+/** \brief calc_photon_flux Returns the photon flux of the object with the given magnitude observed at a determined wavelength using a passband filter through a steradian expressed cone
  *  \param rel_magnitude Relative magnitude of the object observed
  *  \param filter_bandwidth Filter bandwidth in meters
  *  \param wavelength Wavelength in meters
@@ -477,7 +477,7 @@ double calc_delta_magnitude(double mag_ratio, double *spectrum, double *ref_spec
  */
 double calc_photon_flux(double rel_magnitude, double filter_bandwidth, double wavelength, double steradian);
 
-/** \brief calc_rel_magnitude Returns the relative magnitude of the object with the given photon flux measured at a determined wavelenght using a passband filter over an incident surface
+/** \brief calc_rel_magnitude Returns the relative magnitude of the object with the given photon flux measured at a determined wavelength using a passband filter over an incident surface
  *  \param photon_flux The photon flux in Lumen
  *  \param filter_bandwidth Filter bandwidth in meters
  *  \param wavelength Wavelength in meters
@@ -489,7 +489,7 @@ double calc_rel_magnitude(double photon_flux, double filter_bandwidth, double wa
 /** \brief estimate_absolute_magnitude Returns an estimation of the absolute magnitude of an object given its distance and the difference of its magnitude with a reference object
  *  \param dist The distance in parallax radiuses
  *  \param delta_mag The difference of magnitudes
- *  \return Aproximation of the absolute magnitude in Δmag
+ *  \return Approximation of the absolute magnitude in Δmag
  */
 double estimate_absolute_magnitude(double dist, double delta_mag);
 

--- a/libs/indicore/indidevapi.h
+++ b/libs/indicore/indidevapi.h
@@ -38,7 +38,7 @@
  *   INDI Library wrapper functions instead of calling IDxxx directly.
  *   <ul>
  *    <li>IDMessage: Use @ref INDI::Logger "INDI Logging Framework" functions (e.g. LOG_DEBUG..etc) instead.</li>
- *    <li>IDDefXXX: use @ref INDI::DefaultDevice "INDI Default Device" defXXX functions intead.</li>
+ *    <li>IDDefXXX: use @ref INDI::DefaultDevice "INDI Default Device" defXXX functions instead.</li>
  *   </ul>
  *   </li>
  *  <li>IExxx functions to implement the event driven model.</li>
@@ -294,7 +294,7 @@ extern void IDSnoopBLOBs(const char *snooped_device, const char *snooped_propert
 
 /* @{ */
 
-/* signature of a callback, timout caller and work procedure function */
+/* signature of a callback, timeout caller and work procedure function */
 
 /** @typedef IE_CBF
  *  @brief Signature of a callback.
@@ -512,7 +512,7 @@ extern int IUFindOnSwitchIndex(const ISwitchVectorProperty *sp);
 
 /** @brief Returns the name of the first ON switch it finds in the supplied arguments.
  *  @note This is only valid for ISR_1OFMANY mode. That is, when only one switch out of many is allowed to be ON. Do not use this function if you can have multiple ON switches in the same vector property.
- *  @note This is a convience function intended to be used in ISNewSwitch(...) function to find out ON switch name without having to change actual switch state via IUUpdateSwitch(..)
+ *  @note This is a convenience function intended to be used in ISNewSwitch(...) function to find out ON switch name without having to change actual switch state via IUUpdateSwitch(..)
  *  @param states list of switch states passed by ISNewSwitch()
  *  @param names list of switch names passed by ISNewSwitch()
  *  @param n number of switches passed by ISNewSwitch()

--- a/libs/indicore/lilxml.cpp
+++ b/libs/indicore/lilxml.cpp
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 #if defined(_MSC_VER)
 #define snprintf _snprintf
 #pragma warning(push)
-///@todo Introduce plattform indipendent safe functions as macros to fix this
+///@todo Introduce platform independent safe functions as macros to fix this
 #pragma warning(disable : 4996)
 #endif
 
@@ -98,7 +98,7 @@ struct LilXML_
     String endtag; /* to check for match with opening tag*/
     String entity; /* collect entity seq */
     int delim;     /* attribute value delimiter */
-    int lastc;     /* last char (just used wiht skipping)*/
+    int lastc;     /* last char (just used with skipping)*/
     int skipping;  /* in comment or declaration */
     int inblob;    /* in oneBLOB element */
 };
@@ -377,7 +377,7 @@ XMLEle **parseXMLChunk(LilXML *lp, char *buf, int size, char ynot[])
 }
 
 /* process one more character of an XML file.
- * when find closure with outter element return root of complete tree.
+ * when find closure with outer element return root of complete tree.
  * when find error return NULL with reason in ynot[].
  * when need more return NULL with ynot[0] = '\0'.
  * N.B. it is up to the caller to delete any tree returned with delXMLEle().
@@ -1173,7 +1173,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
         case ENTINATTRV: /* working on entity in attr valu */
             if (c == ';')
             {
-                /* if find a recongized esp seq, add equiv char else raw seq */
+                /* if find a recognized esp seq, add equiv char else raw seq */
                 growString(&lp->entity, c);
                 if (decodeEntity(lp->entity.s, &c))
                     growString(&lp->ce->at[lp->ce->nat - 1]->valu, c);

--- a/libs/indicore/lilxml.h
+++ b/libs/indicore/lilxml.h
@@ -28,7 +28,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 
     It only handles elements, attributes and pcdata content. <! ... > and <? ... > are silently ignored. pcdata is collected into one string, sans leading whitespace first line. \n
 
-    The following is an example of a cannonical usage for the lilxml library. Initialize a lil xml context and read an XML file in a root element.
+    The following is an example of a canonical usage for the lilxml library. Initialize a lil xml context and read an XML file in a root element.
 
     \code
 
@@ -110,7 +110,7 @@ extern XMLEle **parseXMLChunk(LilXML *lp, char *buf, int size, char errmsg[]);
 /** \brief Process an XML one char at a time.
   \param lp a pointer to a lilxml parser.
   \param c one character to process.
-  \param errmsg a buffer to store error messages if an error in parsing is encounterd.
+  \param errmsg a buffer to store error messages if an error in parsing is encountered.
   \return When the function parses a complete valid XML element, it will return a pointer to the XML element. A NULL is returned when parsing the element is still in progress, or if a parsing error occurs. Check errmsg for errors if NULL is returned.
 */
 extern XMLEle *readXMLEle(LilXML *lp, int c, char errmsg[]);
@@ -253,7 +253,7 @@ extern const char *findXMLAttValu(XMLEle *ep, const char *name);
 
 /** \brief return a surface copy of a node.
     Don't copy childs or cdata.
-    \return a new independant node
+    \return a new independent node
 */
 extern XMLEle *shallowCloneXMLEle(XMLEle * ele);
 
@@ -262,7 +262,7 @@ extern XMLEle *shallowCloneXMLEle(XMLEle * ele);
     \param ele the original tree
     \param replace function which can provide replacement. Return 1 & set replace for replacement. Optional
     \param self additional value passed to replace function
-    \return a new independant node
+    \return a new independent node
 */
 extern XMLEle * cloneXMLEle(XMLEle * ep, int (*replace)(void * self, XMLEle * source, XMLEle * * replace), void * self);
 

--- a/libs/indidevice/basedevice.h
+++ b/libs/indidevice/basedevice.h
@@ -37,7 +37,7 @@
 /** @class INDI::BaseDevice
  *  @brief Class to provide basic INDI device functionality.
  *
- *  INDI::BaseDevice is the base device for all INDI devices and contains a list of all properties defined by the device either explicity or via a skeleton file.
+ *  INDI::BaseDevice is the base device for all INDI devices and contains a list of all properties defined by the device either explicitly or via a skeleton file.
  *  You don't need to subclass INDI::BaseDevice class directly, it is inheritied by INDI::DefaultDevice which takes care of building a standard INDI device. Moreover, INDI::BaseClient
  *  maintains a list of INDI::BaseDevice objects as they get defined from the INDI server, and those objects may be accessed to retrieve information on the object properties or message log.
  *
@@ -112,12 +112,12 @@ class BaseDevice
          */
         void registerProperty(const INDI::Property &property);
         void registerProperty(const INDI::Property &property,
-                              INDI_PROPERTY_TYPE type); // backward compatiblity (PentaxCCD, PkTriggerCordCCD)
+                              INDI_PROPERTY_TYPE type); // backward compatibility (PentaxCCD, PkTriggerCordCCD)
 
         /** @brief Remove a property
          *  @param name name of property to be removed. Pass NULL to remove the whole device.
          *  @param errmsg buffer to store error message.
-         *  @return 0 if successul, -1 otherwise.
+         *  @return 0 if successful, -1 otherwise.
          */
         int removeProperty(const char *name, char *errmsg);
 
@@ -239,7 +239,7 @@ class BaseDevice
 
         /** @brief getDriverInterface returns ORed values of @ref INDI::BaseDevice::DRIVER_INTERFACE "DRIVER_INTERFACE". It presents the device classes supported by the driver.
          *  @return driver device interface descriptor.
-         *  @note For example, to know if the driver supports CCD interface, check the retruned value:
+         *  @note For example, to know if the driver supports CCD interface, check the returned value:
          *  @code{.cpp}
          *  if (device.getDriverInterface() & CCD_INTERFACE)
          *       cout << "We received a camera!" << endl;

--- a/libs/indidevice/basedevice_p.h
+++ b/libs/indidevice/basedevice_p.h
@@ -176,7 +176,7 @@ class BaseDevicePrivate
         };
 
     public:
-        BaseDevice self {make_shared_weak(this)}; // backward compatibile (for operators as pointer)
+        BaseDevice self {make_shared_weak(this)}; // backward compatible (for operators as pointer)
         std::string deviceName;
         BaseDevice::Properties pAll;
         std::map<std::string, WatchDetails> watchPropertyMap;

--- a/libs/indidevice/indibase.h
+++ b/libs/indidevice/indibase.h
@@ -19,9 +19,9 @@
  *  and reduces code overhead.
  *
  *  <ul>
- *    <li>BaseClient: Base class for INDI clients. By subclassing BaseClient, client can easily connect to INDI server and handle device communication, command, and notifcation.</li>
+ *    <li>BaseClient: Base class for INDI clients. By subclassing BaseClient, client can easily connect to INDI server and handle device communication, command, and notification.</li>
  *    <li>BaseClientQt: Qt5 based class for INDI clients. By subclassing BaseClientQt, client can easily connect to INDI server
- *    and handle device communication, command, and notifcation.</li>
+ *    and handle device communication, command, and notification.</li>
  *    <li>BaseMediator: Abstract class to provide interface for event notifications in INDI::BaseClient.</li>
  *    <li>BaseDevice: Base class for all INDI virtual devices as handled and stored in INDI::BaseClient. It is also the parent for all drivers.</li>
  *    <li>DefaultDevice: INDI::BaseDevice with extended functionality such as debug, simulation, and configuration support.

--- a/libs/indidevice/indistandardproperty.h
+++ b/libs/indidevice/indistandardproperty.h
@@ -27,7 +27,7 @@ namespace INDI
 
 /**
  * @namespace INDI::SP
-   @brief INDI Standard Properties are common properties standarized across drivers and clients alike.
+   @brief INDI Standard Properties are common properties standardized across drivers and clients alike.
 
 INDI does not place any special semantics on property names (i.e. properties are just texts, numbers, or switches that represent no physical function). While GUI clients can construct graphical representation of properties in order to permit the user to operate the device, we run into situations where clients and drivers need to agree on the exact meaning of some fundamental properties.
 What if some client need to be aware of the existence of some property in order to perform some function useful to the user? How can that client tie itself to such a property if the property can be arbitrary defined by drivers?
@@ -61,7 +61,7 @@ namespace SP
  * standard properties in the INDI library driver repository.
  *
  * As a <b>general</b> rule of the thumb, the status of properties reflects the command execution result:
- * IPS_OKAY: Command excuted successfully.
+ * IPS_OKAY: Command executed successfully.
  * IPS_BUSY: Command execution under progress.
  * IPS_ALERT: Command execution failed.
  */

--- a/libs/inicpp.h
+++ b/libs/inicpp.h
@@ -40,7 +40,7 @@ namespace ini
       * @param str string to be trimmed in place */
     inline void trim(std::string &str)
     {
-        // first erasing from end should be slighty more efficient
+        // first erasing from end should be slightly more efficient
         // because erasing from start potentially moves all chars
         // multiple indices towards the front.
 
@@ -538,7 +538,7 @@ namespace ini
         ~IniFileBase()
         {}
 
-        /** Sets the separator charactor for fields in the INI file.
+        /** Sets the separator character for fields in the INI file.
           * @param sep separator character to be used. */
         void setFieldSep(const char sep)
         {

--- a/libs/json.h
+++ b/libs/json.h
@@ -6013,7 +6013,7 @@ struct wide_string_input_helper<BaseInputAdapter, 2>
     }
 };
 
-// Wraps another input apdater to convert wide character types into individual bytes.
+// Wraps another input adapter to convert wide character types into individual bytes.
 template<typename BaseInputAdapter, typename WideCharType>
 class wide_string_input_adapter
 {
@@ -10850,7 +10850,7 @@ class binary_reader
                 }
                 if (is_ndarray) // ndarray dimensional vector can only contain integers, and can not embed another array
                 {
-                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimentional vector is not allowed", "size"), nullptr));
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimensional vector is not allowed", "size"), nullptr));
                 }
                 std::vector<size_t> dim;
                 if (JSON_HEDLEY_UNLIKELY(!get_ubjson_ndarray_size(dim)))

--- a/tools/compiler.c
+++ b/tools/compiler.c
@@ -48,7 +48,7 @@ enum
     NEG,
     NOT,
 
-    /* symantically operands, ie, constants, variables and all functions */
+    /* semantically operands, ie, constants, variables and all functions */
     CONST,
     VAR,
     ABS,
@@ -424,7 +424,7 @@ static int next_token()
     return (ERR);
 }
 
-/* return funtion token, else ERR.
+/* return function token, else ERR.
  * if find one, update cexpr too.
  */
 static int chk_funcs()
@@ -676,7 +676,7 @@ static int execute(result) double *result;
         instr = *pc++;
         switch (instr & OP_MASK)
         {
-            /* put these in numberic order so hopefully even the dumbest
+            /* put these in numeric order so hopefully even the dumbest
 	     * compiler will choose to use a jump table, not a cascade of ifs.
 	     */
             case HALT:

--- a/tools/evalINDI.c
+++ b/tools/evalINDI.c
@@ -63,7 +63,7 @@ static int directfd = -1;             /* direct filedes to server, if >= 0 */
 static int verbose;                   /* more tracing */
 static int eflag;                     /* print each updated expression value*/
 static int fflag;                     /* print final expression value */
-static int iflag;                     /* read expresion from stdin */
+static int iflag;                     /* read expression from stdin */
 static int oflag;                     /* print operands as they change */
 static int wflag;                     /* wait for expression to be true */
 static int bflag;                     /* beep when true */


### PR DESCRIPTION
Typos include user-facing and non-user-facing. Commits have been split up for the convenience of the reviewer(s). 

Typos were found via `codespell -q 3 -S "./obsolete" -L accrate,inout,pres,respons,ser,som,valu,writen` and vscode. They were not just linted and submitted, they were reviewed as best as possible. Please review closely.


If there are concerns about polluting git history please ocnside adding  a `.git-blame-ignore-revs` file that is supported by github per https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/