### PR TITLE
fix(actions): upgrade actions versions.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
       - name: Login to Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           file: ./.github/docker/Dockerfile.${{ matrix.container }}
           push: true

--- a/.github/workflows/linux-i386.yml
+++ b/.github/workflows/linux-i386.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Get INDI Sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@v1 # Only v1 is compatible because of the different arch
 
       - name: Build INDI Core
         run: |

--- a/.github/workflows/linux-packages.yml
+++ b/.github/workflows/linux-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Get INDI Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'indi'
 

--- a/.github/workflows/linux-pyindi.yml
+++ b/.github/workflows/linux-pyindi.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Get INDI Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'indi'
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Get INDI Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'indi'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Get INDI Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'indi'
 


### PR DESCRIPTION
This upgrades GitHub actions just in case the deprecations are the reason some docker images don't get picked by CI.

Plus, it just runs the Docker workflow once more. Perhaps this time the image identifiers will be correct.