### PR TITLE
Remove obsolete Avalon Legacy driver

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -111,10 +111,6 @@
             <driver name="Astro-Electronic FS-2">indi_lx200fs2</driver>
             <version>2.3</version>
         </device>
-        <device label="Avalon Legacy" manufacturer="Avalon">
-            <driver name="LX200 Basic">indi_lx200basic</driver>
-            <version>2.1</version>
-        </device>
         <device label="Paramount" manufacturer="Software Bisque">
             <driver name="Paramount">indi_paramount_telescope</driver>
             <version>1.1</version>


### PR DESCRIPTION
There is an obsolete driver entry linking Avalon Legacy to Indi_lx200basic. Since there exists a dedicated and fully featured StarGO implementation, this driver is no longer necessary.