### PR TITLE
TeenAstro pulse behaviour #1977

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -41,7 +41,7 @@
         </device>
         <device label="LX200 TeenAstro" manufacturer="TeenAstro">
             <driver name="LX200 TeenAstro">indi_lx200_TeenAstro</driver>
-            <version>1.3</version>
+            <version>1.4</version>
         </device>
         <device label="LX200 16" manufacturer="Meade">
             <driver name="LX200 16">indi_lx200_16</driver>

--- a/drivers/telescope/lx200_TeenAstro.cpp
+++ b/drivers/telescope/lx200_TeenAstro.cpp
@@ -1152,25 +1152,25 @@ bool LX200_TeenAstro::SetGuideRate(float guideRate)
 IPState LX200_TeenAstro::GuideNorth(uint32_t ms)
 {
     SendPulseCmd(LX200_NORTH, ms);
-    return IPS_OK;
+    return IPS_BUSY;
 }
 
 IPState LX200_TeenAstro::GuideSouth(uint32_t ms)
 {
     SendPulseCmd(LX200_SOUTH, ms);
-    return IPS_OK;
+    return IPS_BUSY;
 }
 
 IPState LX200_TeenAstro::GuideEast(uint32_t ms)
 {
     SendPulseCmd(LX200_EAST, ms);
-    return IPS_OK;
+    return IPS_BUSY;
 }
 
 IPState LX200_TeenAstro::GuideWest(uint32_t ms)
 {
     SendPulseCmd(LX200_WEST, ms);
-    return IPS_OK;
+    return IPS_BUSY;
 }
 
 void LX200_TeenAstro::SendPulseCmd(int8_t direction, uint32_t duration_msec)

--- a/drivers/telescope/lx200_TeenAstro.cpp
+++ b/drivers/telescope/lx200_TeenAstro.cpp
@@ -58,7 +58,7 @@ extern std::mutex lx200CommsLock;
  */
 LX200_TeenAstro::LX200_TeenAstro()
 {
-    setVersion(1, 3);           // don't forget to update drivers.xml
+    setVersion(1, 4);           // don't forget to update drivers.xml
 
     DBG_SCOPE = INDI::Logger::getInstance().addDebugLevel("Scope Verbose", "SCOPE");
 

--- a/drivers/telescope/lx200_TeenAstro.cpp
+++ b/drivers/telescope/lx200_TeenAstro.cpp
@@ -1152,24 +1152,64 @@ bool LX200_TeenAstro::SetGuideRate(float guideRate)
 IPState LX200_TeenAstro::GuideNorth(uint32_t ms)
 {
     SendPulseCmd(LX200_NORTH, ms);
+    if(MovementNSSP.s == IPS_BUSY)
+        return IPS_ALERT;
+
+    if (GuideNSTID)
+    {
+        IERmTimer(GuideNSTID);
+        GuideNSTID = 0;
+    }
+
+    GuideNSTID = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperNS, this);
     return IPS_BUSY;
 }
 
 IPState LX200_TeenAstro::GuideSouth(uint32_t ms)
 {
     SendPulseCmd(LX200_SOUTH, ms);
+    if(MovementNSSP.s == IPS_BUSY)
+        return IPS_ALERT;
+
+    if (GuideNSTID)
+    {
+        IERmTimer(GuideNSTID);
+        GuideNSTID = 0;
+    }
+
+    GuideNSTID = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperNS, this);
     return IPS_BUSY;
 }
 
 IPState LX200_TeenAstro::GuideEast(uint32_t ms)
 {
     SendPulseCmd(LX200_EAST, ms);
+    if(MovementWESP.s == IPS_BUSY)
+        return IPS_ALERT;
+
+    if (GuideWETID)
+    {
+        IERmTimer(GuideWETID);
+        GuideWETID = 0;
+    }
+
+    GuideWETID = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperWE, this);
     return IPS_BUSY;
 }
 
 IPState LX200_TeenAstro::GuideWest(uint32_t ms)
 {
     SendPulseCmd(LX200_WEST, ms);
+    if(MovementWESP.s == IPS_BUSY)
+        return IPS_ALERT;
+
+    if (GuideWETID)
+    {
+        IERmTimer(GuideWETID);
+        GuideWETID = 0;
+    }
+
+    GuideWETID = IEAddTimer(static_cast<int>(ms), guideTimeoutHelperWE, this);
     return IPS_BUSY;
 }
 
@@ -1371,5 +1411,30 @@ void LX200_TeenAstro::sendCommand(const char *cmd)
     INDI_UNUSED(rc);
 }
 
+void LX200_TeenAstro::guideTimeoutHelperNS(void * p)
+{
+    static_cast<LX200_TeenAstro *>(p)->guideTimeoutNS();
+}
 
+void LX200_TeenAstro::guideTimeoutHelperWE(void * p)
+{
+    static_cast<LX200_TeenAstro *>(p)->guideTimeoutWE();
+}
 
+void LX200_TeenAstro::guideTimeoutNS()
+{
+    GuideNSNP.np[0].value = 0;
+    GuideNSNP.np[1].value = 0;
+    GuideNSNP.s           = IPS_IDLE;
+    GuideNSTID            = 0;
+    IDSetNumber(&GuideNSNP, nullptr);
+}
+
+void LX200_TeenAstro::guideTimeoutWE()
+{
+    GuideWENP.np[0].value = 0;
+    GuideWENP.np[1].value = 0;
+    GuideWENP.s           = IPS_IDLE;
+    GuideWETID            = 0;
+    IDSetNumber(&GuideWENP, nullptr);
+}

--- a/drivers/telescope/lx200_TeenAstro.h
+++ b/drivers/telescope/lx200_TeenAstro.h
@@ -108,6 +108,12 @@ class LX200_TeenAstro : public INDI::Telescope, public INDI::GuiderInterface
         bool sendScopeTime();
         bool sendScopeLocation();
 
+        void guideTimeoutNS();
+        void guideTimeoutWE();
+
+        static void guideTimeoutHelperNS(void * p);
+        static void guideTimeoutHelperWE(void * p);
+
         // User interface
 
         INumber SlewAccuracyN[2];
@@ -151,5 +157,8 @@ class LX200_TeenAstro : public INDI::Telescope, public INDI::GuiderInterface
         char OldOSStat[RB_MAX_LEN];
         const char *statusCommand;           // :GU# for version 1.1, :GXI# for 1.2 and later
         const char *guideSpeedCommand;       // :SXR0
+
+        int GuideNSTID { -1 };
+        int GuideWETID { -1 };
 
 };


### PR DESCRIPTION
as of #1977 :
Guide property state sets now to "busy" first, and "idle" when pulse is finished.
Guide property value sets now to 0 when pulse is finished.