### PR TITLE
Flip-flat: Allow handshake without ioctl on virtual serial connection

### DIFF
--- a/drivers/auxiliary/flip_flat.cpp
+++ b/drivers/auxiliary/flip_flat.cpp
@@ -144,6 +144,14 @@ bool FlipFlat::Handshake()
     }
 
     PortFD = serialConnection->getPortFD();
+    
+    /* Try handshake first in case of virtual serial port where ioctl would fail*/
+    if (ping())
+    {
+        return true;
+    } 
+
+    LOG_DEBUG("Initial handshake unsuccessful, dropping RTS");
 
     /* Drop RTS */
     int i = 0;


### PR DESCRIPTION
Try premptively pinging the flip-flat without dropping the RTS line so that the handshake succeeds in the case of a virtual serial port (pty with no ioctl).

(originally submitted as bug #1983 , but hopefully this PR will work to solve).