### PR TITLE
Flip-flat: Allow handshake without ioctl on virtual serial connection

### DIFF
--- a/drivers/auxiliary/flip_flat.cpp
+++ b/drivers/auxiliary/flip_flat.cpp
@@ -150,6 +150,12 @@ bool FlipFlat::Handshake()
     i |= TIOCM_RTS;
     if (ioctl(PortFD, TIOCMBIC, &i) != 0)
     {
+        /* Try ping anyway, to allow flip-flat implementations using virtual serial ports to proceed */
+        if(ping())
+        {
+          LOG_DEBUG("Successfully connected to flip-flat without hardware IOCTL");
+          return true;
+        }
         LOGF_ERROR("IOCTL error %s.", strerror(errno));
         return false;
     }


### PR DESCRIPTION
… (revised)

If initial IOCTL call fails, try premptively pinging the flip-flat anyway,  so that the handshake can succeed in the case of a virtual serial port (e.g. a pty with no IOCTL).

This shouldn't impact flip-flat driver users with 'real' or clone hardware, but will allow hardware implementations that use a virtual serial port (e.g. in my case, using stepper/relay hats via gpio on a rpi with a small python daemon)