### PR TITLE
Fix version reporting on older Celestron NexStar mounts

### DIFF
--- a/drivers/telescope/celestrondriver.cpp
+++ b/drivers/telescope/celestrondriver.cpp
@@ -354,7 +354,11 @@ bool CelestronDriver::get_version(char *version, size_t size)
     if (!send_command("V", 1, response, 3, true, false))
         return false;
 
-    snprintf(version, size, "%d.%02d", static_cast<uint8_t>(response[0]), static_cast<uint8_t>(response[1]));
+    // Versions up to 2.2 have a single-digit minor version
+    if (static_cast<uint8_t>(response[0]) > 2)
+        snprintf(version, size, "%d.%02d", static_cast<uint8_t>(response[0]), static_cast<uint8_t>(response[1]));
+    else
+        snprintf(version, size, "%d.%d", static_cast<uint8_t>(response[0]), static_cast<uint8_t>(response[1]));
 
     LOGF_INFO("Controller version: %s", version);
     return true;


### PR DESCRIPTION
Celestron NexStar mount hand controllers have been introduced with a number of firmware versions over the years.  Starting with the 4.xx NexStar controllers, the minor version is a 2-digit value (currently 4.22).  The older hand controllers (while sporting fewer features) still will talk to INDI since the basic serial communication protocol has not changed.

For these older controllers (v1.2, v1.6, and v2.2), the minor version is a single-digit value.  The current code in `CelestronDriver::get_version()` forces a two-digit minor version, so, for instance, the v2.2 controller is recorded as "2.02".  When the version is checked against device capabilities, `2.02 < 2.2`, so it is incorrectly rejected.

This PR checks the major version of the hand controller, and uses a 2-digit minor version for more recent models, and a 1-digit minor version for earlier models.