### PR TITLE
added support for the :GC# command for Moonlite focuser

### DIFF
--- a/drivers/focuser/moonlite.cpp
+++ b/drivers/focuser/moonlite.cpp
@@ -205,6 +205,27 @@ bool MoonLite::readTemperature()
     return true;
 }
 
+bool MoonLite::readTemperatureCoefficient()
+{
+    char res[ML_RES] = {0};
+
+    if (sendCommand(":GC#", res) == false)
+        return false;
+
+    uint8_t coefficient = 0;
+    int rc = sscanf(res, "%hhX", &coefficient);
+    if (rc > 0)
+        // Signed HEX two digits
+        TemperatureSettingNP[1].setValue(static_cast<int8_t>(coefficient) / 2.0);
+    else
+    {
+        LOGF_ERROR("Unknown error: focuser temperature coefficient value (%s)", res);
+        return false;
+    }
+
+    return true;
+}
+
 bool MoonLite::readPosition()
 {
     char res[ML_RES] = {0};
@@ -424,6 +445,9 @@ void MoonLite::GetFocusParams()
 
     if (readTemperature())
         TemperatureNP.apply();
+
+    if (readTemperatureCoefficient())
+        TemperatureSettingNP.apply();
 
     if (readSpeed())
         IDSetNumber(&FocusSpeedNP, nullptr);

--- a/drivers/focuser/moonlite.cpp
+++ b/drivers/focuser/moonlite.cpp
@@ -215,7 +215,7 @@ bool MoonLite::readTemperatureCoefficient()
     uint8_t coefficient = 0;
     int rc = sscanf(res, "%hhX", &coefficient);
     if (rc > 0)
-        // Signed HEX two digits
+        // Signed HEX of two digits
         TemperatureSettingNP[1].setValue(static_cast<int8_t>(coefficient) / 2.0);
     else
     {

--- a/drivers/focuser/moonlite.h
+++ b/drivers/focuser/moonlite.h
@@ -102,6 +102,8 @@ class MoonLite : public INDI::Focuser
         bool readStepMode();
         // Read and update Temperature
         bool readTemperature();
+        // Read and update Temperature Coefficient
+		bool readTemperatureCoefficient();
         // Read and update Position
         bool readPosition();
         // Read and update speed


### PR DESCRIPTION
My focusser runs via the Moonlite protocol and stores the temperature compensation coefficient in the flash memory of the focuser. Moonlite protocol supports this by the GC (get coefficient) command.