### PR TITLE
Fix iguider issues

### DIFF
--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -296,17 +296,6 @@ void V4L2_Driver::ISGetProperties(const char * dev)
         defineProperty(&CaptureColorSpaceTP);
 #endif
 
-        // iOptron cameras take an excessively long time to start if started with a longer exposure time (eg 8 seconds to
-        // start with a 1s exposure, 28 seconds to start with a 3.5s exposure). Here we start the camera up with a small duration
-        // to get the camera going. Changing the exposure after it has started does not cause a delay.
-        if (!v4l_capture_started && isIOptron() )
-        {
-            char errmsg[ERRMSGSIZ];
-            v4l_base->setINTControl(IOPTRON_ABS_EXPOSURE_CTRL_ID, 1, errmsg);
-            v4l_base->setOPTControl(IOPTRON_AUTO_EXPOSURE_CTRL_ID, 1, errmsg); // Manual
-            v4l_base->start_capturing(errmsg);
-            v4l_capture_started = true;
-        }
     }
 }
 

--- a/drivers/video/v4l2driver.h
+++ b/drivers/video/v4l2driver.h
@@ -233,4 +233,5 @@ public:
 
         char defaultVideoPort[256] = {"/dev/video0"};
         char configPort[256] = {0};
+        bool waiting_for_iguider_to_start;
 };

--- a/drivers/video/v4l2driver.h
+++ b/drivers/video/v4l2driver.h
@@ -186,12 +186,17 @@ public:
         bool startlongexposure(double timeinsec);
         static void lxtimerCallback(void *userpointer);
         static void stdtimerCallback(void *userpointer);
+        static void iOptronWatchdogCallback(void *userpointer);
 
         /* start/stop functions */
         bool start_capturing(bool do_stream);
         bool stop_capturing();
 
         virtual void updateV4L2Controls();
+
+        bool isIOptron();
+
+        void resetDevice(int bus_num, int dev_num);
 
         /* Variables */
         INDI::V4L2_Base *v4l_base;
@@ -222,16 +227,17 @@ public:
         bool v4l_capture_started;
         bool is_capturing;
         bool is_exposing;
+        bool valid_frame_has_arrived;
 
         //Long Exposure
         Lx *lx;
         int lxtimer;
         int stdtimer;
+        int iOptronWatchdogTimer;
 
         short lxstate;
         PixelSizeInfo * m_Info {nullptr};
 
         char defaultVideoPort[256] = {"/dev/video0"};
         char configPort[256] = {0};
-        bool waiting_for_iguider_to_start;
 };

--- a/drivers/video/v4l2driver.h
+++ b/drivers/video/v4l2driver.h
@@ -186,7 +186,7 @@ public:
         bool startlongexposure(double timeinsec);
         static void lxtimerCallback(void *userpointer);
         static void stdtimerCallback(void *userpointer);
-        static void iOptronWatchdogCallback(void *userpointer);
+        void iOptronWatchdogCallback();
 
         /* start/stop functions */
         bool start_capturing(bool do_stream);
@@ -233,7 +233,7 @@ public:
         Lx *lx;
         int lxtimer;
         int stdtimer;
-        int iOptronWatchdogTimer;
+        INDI::Timer ioptron_watchdog_timer;
 
         short lxstate;
         PixelSizeInfo * m_Info {nullptr};


### PR DESCRIPTION
I've resolved the exposure issue https://github.com/indilib/indi/issues/1722 with the iOptron iGuider/iPolar cameras. 

Unfortunately fixing this has brought up another problem with excessively slow capture startup times. I've partially resolved this, however there's still a reliability issue where the camera sometimes refuses to start after being stopped, or ignores exposure commands. 

Any suggestions on dealing with this last issue would be appreciated!



### Notes on Exposure Issue
The iGuider manual and ASCOM dialogs give the impression that negative values need to be used to set the Absolute Exposure time on the camera. This turns out to be not true. Sniffing the USB bus while changing exposure settings in ASCOM shows the negative values do not get sent to the USB Absolute Exposure Controls. Instead _somewhat_ conventional ticks are sent. See the table below:

|    Duration (s) |  Value from USB sniff |
|-|-|
|    0.01  |         1 |
 |   0.02   |        2   |
 |   0.05   |        5     |
 |   0.1     |       10      |
 |   0.2     |       20        |
 |   0.5     |       39        |
 |   1        |      78          |
 |   1.5     |       156       |
 |   2        |      312        |
 |   2.5     |       625        |
 |   3        |      1250       |
|    3.5     |       2500      |

By 'somewhat', I mean that the ticks are not linear with respect to duration. It appears they are linear until 0.2 seconds, then exponential afterwards. Presumably this is done to give more resolution at lower exposure times.  We can recover the formula for the exponential equation by assuming 4 seconds corresponds to 5000 ticks (the max). This gives us:
```
        ticks <= 0.2 ? duration * 100 : 19.53 * pow(4, duration)
```
Where the constant 19.53 is  5000 / 4^4. This matches the values in the table exactly when rounded.

Plugging in this conversion factor works, and the resulting frame timings in the debug logs are correct.

See https://github.com/indilib/indi/commit/ddce625ee8c502503ec6d3509e55bf5378618b95


### Notes on the slow capture start up issue

This brought up another issue. If you attempt to start the capture with a multi-second exposure time, the camera takes many, many seconds before delivering the first frame. For example:

| Initial exposure time (s) | Delay before first frame delivered (s) |
|-|-|
| 1.0 | 4.0 |
| 2.0 | 8.0 |
| 3.0 | 12 |
|4.0 | 27 |

This looks exponential-ish, as if there's a delay somewhere in the driver or camera based on the tick count.

ASCOM seems to deal with this by rarely shutting down the stream. As soon as the ASCOM driver is activated, the camera immediately begins sending frames over USB, which presumably the driver just discards. Clicking stop/start in PHD doesn't result in any USB commands being sent to the camera - this must just affect whether the driver forwards the frames to PHD or discards them. Even after disconnecting the camera in PHD, the frames continue to be sent over USB. A little wasteful perhaps, but it seems to work.

A dirty hack to get around this is to set the initial exposure to 0.01s (1 tick), start the capture, wait for the first frame to be delivered, then set the exposure to the desired value (earlier doesn't work). This works, and results in a delay of about 150ms, which is acceptable. As long as the stream is shutdown lazily, rather than immediately after a frame is delivered, PHDs frequent frame requests don't incur this delay and everything works well.

See https://github.com/indilib/indi/commit/e0b86fef13a3e9aee0005d1385eb8249c7efbbaf


*** Ongoing issues

Well, almost. I can get some reasonable runs with PHD where everything works: I can stop and start the capture, set different exposure rates and gains successfully, however at some point something fails and the capture won't restart.

Occasionally when this happens, I can issue repeated IOCTLs to abort the capture, or re-set the values of USB controls, and this will restart it, however many times this does not work. When attempting to change the 'Capture Size' I get an 'Resource busy' error, suggesting the driver/camera wasn't correctly shutdown.

Occasionally, it will restart but run at 9 or 20fps, and ignore attempts to change the exposure, again as if the driver/camera is stuck in some other mode.

This doesn't occur on windows. One difference is that when ASCOM needs to stop the capture or change a control it issues an ABORT_PIPE URB followed by a SYNC_RESET_PIPE_AND_CLEAR_STALL URB. Linux/libuvc/v4l2 doesn't do this and just issues the ABORT_PIPE URB. 

There's an interesting comment around this in the libuvc source: https://github.com/torvalds/linux/blob/87adedeba51a822533649b143232418b9e26d08b/drivers/media/usb/uvc/uvc_video.c#L2254. In our case the interface alt_setting is changed after the ABORT_PIPE, so alt_setting is still set to 6, so the branch in the code above isn't taken, and the  `usb_clear_halt` isn't called. 

I could try tweaking this function in the kernel to see if it fixes our problem, but even if it did, I imagine it's hard to get a patch applied to the kernel - I can't imagine linus risking breaking a bunch of UVC cameras for our iGuider.

Any thoughts/suggestions very welcome!

