### PR TITLE
Fix setting ScopeInfo property

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -539,7 +539,7 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
 
     exposure_time *= (1 + sqrt(GainNP[0].getValue()));
 
-    auto targetFocalLength = ScopeInfoNP[FocalLength].getValue() > 0 ? ScopeInfoNP[FocalLength].getValue() : snoopedFocalLength;
+    auto targetFocalLength = ScopeInfoNP[FOCAL_LENGTH].getValue() > 0 ? ScopeInfoNP[FOCAL_LENGTH].getValue() : snoopedFocalLength;
 
     if (ShowStarField)
     {

--- a/drivers/ccd/guide_simulator.cpp
+++ b/drivers/ccd/guide_simulator.cpp
@@ -394,7 +394,7 @@ int GuideSim::DrawCcdFrame(INDI::CCDChip * targetChip)
 
     exposure_time *= (1 + sqrt(GainNP[0].getValue()));
 
-    auto targetFocalLength = ScopeInfoNP[FocalLength].getValue() > 0 ? ScopeInfoNP[FocalLength].getValue() : snoopedFocalLength;
+    auto targetFocalLength = ScopeInfoNP[FOCAL_LENGTH].getValue() > 0 ? ScopeInfoNP[FOCAL_LENGTH].getValue() : snoopedFocalLength;
 
     if (ShowStarField)
     {

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -353,8 +353,8 @@ bool CCD::initProperties()
     IUFillNumberVector(&CCDRotationNP, CCDRotationN, 1, getDeviceName(), "CCD_ROTATION", "CCD FOV", WCS_TAB, IP_RW, 60,
                        IPS_IDLE);
 
-    ScopeInfoNP[FocalLength].fill("FOCAL_LENGTH", "Focal Length (mm)", "%.2f", 10, 10000, 100, 0);
-    ScopeInfoNP[Aperture].fill("APERTURE", "Aperture (mm)", "%.2f", 10, 3000, 100, 0);
+    ScopeInfoNP[FOCAL_LENGTH].fill("FOCAL_LENGTH", "Focal Length (mm)", "%g", 0, 10000, 1, 0);
+    ScopeInfoNP[APERTURE].fill("APERTURE", "Aperture (mm)", "%g", 0, 3000, 1, 0);
     ScopeInfoNP.fill(getDeviceName(), "SCOPE_INFO", "Scope", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
 
     /**********************************************/
@@ -1228,10 +1228,17 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
         // Scope Information
         if (ScopeInfoNP.isNameMatch(name))
         {
-            ScopeInfoNP.update(values, names, n);
-            ScopeInfoNP.setState(IPS_OK);
-            ScopeInfoNP.apply();
-            saveConfig(true, ScopeInfoNP.getName());
+            const bool success = ScopeInfoNP.update(values, names, n);
+            if (success)
+            {
+                ScopeInfoNP.setState(IPS_OK);
+                ScopeInfoNP.apply();
+                saveConfig(true, ScopeInfoNP.getName());
+            } else
+            {
+                ScopeInfoNP.setState(IPS_ALERT);
+            }
+
             return true;
         }
 
@@ -1961,8 +1968,8 @@ void CCD::addFITSKeywords(CCDChip * targetChip, std::vector<FITSRecord> &fitsKey
 
     // Which scope is in effect
     // Prefer Scope Info over snooped property which should be deprecated.
-    effectiveFocalLength = ScopeInfoNP[FocalLength].getValue() > 0 ?  ScopeInfoNP[FocalLength].getValue() : snoopedFocalLength;
-    effectiveAperture = ScopeInfoNP[Aperture].getValue() > 0 ?  ScopeInfoNP[Aperture].getValue() : snoopedAperture;
+    effectiveFocalLength = ScopeInfoNP[FOCAL_LENGTH].getValue() > 0 ?  ScopeInfoNP[FOCAL_LENGTH].getValue() : snoopedFocalLength;
+    effectiveAperture = ScopeInfoNP[APERTURE].getValue() > 0 ?  ScopeInfoNP[APERTURE].getValue() : snoopedAperture;
 
     if (std::isnan(effectiveFocalLength))
         LOG_WARN("Telescope focal length is missing.");

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -728,8 +728,8 @@ class CCD : public DefaultDevice, GuiderInterface
         INDI::PropertyNumber ScopeInfoNP {2};
         enum
         {
-            FocalLength,
-            Aperture
+            FOCAL_LENGTH,
+            APERTURE
         };
 
         // Websocket Support


### PR DESCRIPTION
Setting Scopeinfo property with previous settings: min, max, step, val:

`ScopeInfoNP[FocalLength].fill("FOCAL_LENGTH", "Focal Length (mm)", "%.2f", 10, 10000, 100, 0); ScopeInfoNP[Aperture].fill("APERTURE", "Aperture (mm)", "%.2f", 10, 3000, 100, 0);`

resulted in error:

Error: Invalid range for Aperture (mm) (APERTURE). Valid range is from 10 to 3000. Requested value is 0 [DEBUG] Configuration successfully saved for SCOPE_INFO. Error: Invalid range for Focal Length (mm) (FOCAL_LENGTH). Valid range is from 10 to 10000. Requested value is 0 [DEBUG] Configuration successfully saved for SCOPE_INFO.

because at least one property value is 0 by default however, min values are set to 10mm, so the value cannot be set via the property settings. In addition the step size is decreased to 1mm and enum values are in uppercase letters. Moreover, the state of the property is IPS_OK only when the update is successful, otherwise IPS_ALERT.