### PR TITLE
Link against httplib if using system libraries

### DIFF
--- a/drivers/auxiliary/CMakeLists.txt
+++ b/drivers/auxiliary/CMakeLists.txt
@@ -313,5 +313,5 @@ SET(dragonlight_SRC
     dragonlight.cpp)
 
 add_executable(indi_dragon_light ${dragonlight_SRC})
-target_link_libraries(indi_dragon_light indidriver)
+target_link_libraries(indi_dragon_light indidriver ${HTTPLIB_LIBRARY})
 install(TARGETS indi_dragon_light RUNTIME DESTINATION bin)

--- a/drivers/dome/CMakeLists.txt
+++ b/drivers/dome/CMakeLists.txt
@@ -80,5 +80,5 @@ SET(dragonlair_SRC
     dragonlair.cpp)
 
 add_executable(indi_dragonlair_dome ${dragonlair_SRC})
-target_link_libraries(indi_dragonlair_dome indidriver)
+target_link_libraries(indi_dragonlair_dome indidriver ${HTTPLIB_LIBRARY})
 install(TARGETS indi_dragonlair_dome RUNTIME DESTINATION bin)


### PR DESCRIPTION
This patch fixes the following build error if system provided httplib is used.

```
[392/503] : && /usr/bin/x86_64-pc-linux-gnu-g++ -march=native -O2 -pipe -D_FORTIFY_SOURCE=2 -O1 -Wa,--noexecstack  -Wall -Wextra -Wno-format-truncation -g -DHAVE_MREMAP -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs  -Wl,-z,nodump -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now drivers/dome/CMakeFiles/indi_dragonlair_dome.dir/dragonlair.cpp.o -o drivers/dome/indi_dragonlair_dome  -Wl,-rpath,/var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7_build/libs/indibase:  libs/indibase/libindidriver.so.2.0.7  -lusb-1.0  /usr/lib64/libnova.so  /usr/lib64/libcfitsio.so  /usr/lib64/libz.so  /usr/lib64/libjpeg.so  /usr/lib64/libfftw3.so  -lm  /usr/lib64/libtheoraenc.so  /usr/lib64/libtheoradec.so  /usr/lib64/libogg.so && :
FAILED: drivers/dome/indi_dragonlair_dome 
: && /usr/bin/x86_64-pc-linux-gnu-g++ -march=native -O2 -pipe -D_FORTIFY_SOURCE=2 -O1 -Wa,--noexecstack  -Wall -Wextra -Wno-format-truncation -g -DHAVE_MREMAP -Wl,-O1 -Wl,--as-needed -Wl,-z,pack-relative-relocs  -Wl,-z,nodump -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now drivers/dome/CMakeFiles/indi_dragonlair_dome.dir/dragonlair.cpp.o -o drivers/dome/indi_dragonlair_dome  -Wl,-rpath,/var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7_build/libs/indibase:  libs/indibase/libindidriver.so.2.0.7  -lusb-1.0  /usr/lib64/libnova.so  /usr/lib64/libcfitsio.so  /usr/lib64/libz.so  /usr/lib64/libjpeg.so  /usr/lib64/libfftw3.so  -lm  /usr/lib64/libtheoraenc.so  /usr/lib64/libtheoradec.so  /usr/lib64/libogg.so && :
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/dome/CMakeFiles/indi_dragonlair_dome.dir/dragonlair.cpp.o: in function `DragonLAIR::stopRoof()':
/var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:462:(.text+0x372): undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:464:(.text+0x3aa): undefined reference to `httplib::Client::Post(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:479:(.text+0x43c): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:479:(.text+0x596): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:479:(.text+0x63a): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/dome/CMakeFiles/indi_dragonlair_dome.dir/dragonlair.cpp.o: in function `DragonLAIR::closeRoof()':
/var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:428:(.text+0x86a): undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:430:(.text+0x8a2): undefined reference to `httplib::Client::Post(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:445:(.text+0x934): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:445:(.text+0xa8e): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:445:(.text+0xb32): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/dome/CMakeFiles/indi_dragonlair_dome.dir/dragonlair.cpp.o: in function `DragonLAIR::openRoof()':
/var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:394:(.text+0xd62): undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:396:(.text+0xd9a): undefined reference to `httplib::Client::Post(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:411:(.text+0xe2c): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:411:(.text+0xf86): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:411:(.text+0x102a): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: drivers/dome/CMakeFiles/indi_dragonlair_dome.dir/dragonlair.cpp.o: in function `DragonLAIR::updateStatus()':
/var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:283:(.text+0x2656): undefined reference to `httplib::Client::Client(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:287:(.text+0x26e7): undefined reference to `httplib::Client::Get(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:382:(.text+0x2779): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:382:(.text+0x300f): undefined reference to `httplib::Client::~Client()'
/usr/lib/gcc/x86_64-pc-linux-gnu/13/../../../../x86_64-pc-linux-gnu/bin/ld: /var/tmp/portage/sci-libs/indilib-2.0.7/work/indi-2.0.7/drivers/dome/dragonlair.cpp:382:(.text+0x30b8): undefined reference to `httplib::Client::~Client()'
collect2: error: ld returned 1 exit status
```