### PR TITLE
Bugfix: update focuser temperature in alluna tcs2 driver

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <driversList>
- 	<devGroup group="Spectrographs">
+    <devGroup group="Spectrographs">
         <device label="Shelyak Usis" manufacturer="Shelyak">
             <driver name="Shelyak Usis">shelyak_usis</driver>
             <version>1.2</version>
         </device>
-	</devGroup>
+    </devGroup>
     <devGroup group="Telescopes">
-		<device label="Shelyak Usis" manufacturer="Shelyak">
+        <device label="Shelyak Usis" manufacturer="Shelyak">
             <driver name="Shelyak Usis">shelyak_usis</driver>
             <version>1.2</version>
         </device>
@@ -70,7 +70,7 @@
         <device label="EQ500X" manufacturer="Omegon">
             <driver name="EQ500X">indi_eq500x_telescope</driver>
             <version>1.0</version>
-        </device>        
+        </device>
         <device label="AstroPhysics V2" manufacturer="Astrophysics">
             <driver name="AstroPhysics V2">indi_lx200ap_v2</driver>
             <version>1.1</version>
@@ -321,7 +321,7 @@
             <driver name="RoboFocus">indi_robo_focus</driver>
             <version>1.0</version>
         </device>
-	<device label="iEAFFocus" manufacturer="iOptron">
+        <device label="iEAFFocus" manufacturer="iOptron">
             <driver name="iEAFFocus">indi_ieaf_focus</driver>
             <version>1.0</version>
         </device>
@@ -409,7 +409,7 @@
             <driver name="Pegasus DMFC">indi_dmfc_focus</driver>
             <version>1.1</version>
         </device>
-	    <device label="Pegasus Prodigy MF" manufacturer="Pegasus Astro">
+        <device label="Pegasus Prodigy MF" manufacturer="Pegasus Astro">
             <driver name="Pegasus DMFC">indi_dmfc_focus</driver>
             <version>1.1</version>
         </device>
@@ -417,11 +417,11 @@
             <driver name="Pegasus FocusCube">indi_pegasus_focuscube</driver>
             <version>1.0</version>
         </device>
-          <device label="Pegasus FocusCube3" manufacturer="Pegasus Astro">
+        <device label="Pegasus FocusCube3" manufacturer="Pegasus Astro">
             <driver name="Pegasus FocusCube3">indi_pegasus_focuscube3</driver>
             <version>1.0</version>
         </device>
-         <device label="Pegasus ProdigyMF" manufacturer="Pegasus Astro">
+        <device label="Pegasus ProdigyMF" manufacturer="Pegasus Astro">
             <driver name="Pegasus MMC-7000AH">indi_pegasus_prodigyMF</driver>
             <version>1.0</version>
         </device>
@@ -437,21 +437,25 @@
             <driver name="Pegasus Falcon">indi_falcon_rotator</driver>
             <version>1.0</version>
         </device>
+        <device label="Integra 85" manufacturer="Gemini Telescope">
+            <driver name="Integra85">indi_integra_focus</driver>
+            <version>1.1</version>
+        </device>
         <device label="Rotator Simulator" manufacturer="Simulator">
             <driver name="Rotator Simulator">indi_simulator_rotator</driver>
             <version>1.0</version>
         </device>
         <device label="Rotator Lite" manufacturer="Wanderer Astro">
-               <driver name="Wanderer Rotator Lite">indi_wanderer_lite_rotator</driver>
-               <version>1.0</version>
+            <driver name="Wanderer Rotator Lite">indi_wanderer_lite_rotator</driver>
+            <version>1.0</version>
         </device>
-                <device label="Rotator Mini V1-2" manufacturer="Wanderer Astro">
-               <driver name="Wanderer Rotator Mini">indi_wanderer_rotator_mini</driver>
-        <version>1.1</version>
-                </device>
-                <device label="Rotator Lite V2" manufacturer="Wanderer Astro">
-               <driver name="Wanderer Rotator Lite V2">indi_wanderer_rotator_lite_v2</driver>
-        <version>1.0</version>
+        <device label="Rotator Mini V1-2" manufacturer="Wanderer Astro">
+            <driver name="Wanderer Rotator Mini">indi_wanderer_rotator_mini</driver>
+            <version>1.1</version>
+        </device>
+        <device label="Rotator Lite V2" manufacturer="Wanderer Astro">
+            <driver name="Wanderer Rotator Lite V2">indi_wanderer_rotator_lite_v2</driver>
+            <version>1.0</version>
         </device>
         <device label="Microtouch" manufacturer="Starizona">
             <driver name="Microtouch">indi_microtouch_focus</driver>
@@ -521,7 +525,7 @@
             <driver name="Lacerta MFOC FMC">indi_lacerta_mfoc_fmc_focus</driver>
             <version>0.1</version>
         </device>
-	<device label="ActiveFocuser" manufacturer="Optique Unterlinden">
+        <device label="ActiveFocuser" manufacturer="Optique Unterlinden">
             <driver name="ActiveFocuser">indi_activefocuser_focus</driver>
             <version>1.0</version>
         </device>
@@ -669,7 +673,7 @@
             <driver name="Pegasus UCH">indi_pegasus_uch</driver>
             <version>1.6</version>
         </device>
-         <device label="Pegasus FlatMaster" manufacturer="Pegasus Astro">
+        <device label="Pegasus FlatMaster" manufacturer="Pegasus Astro">
             <driver name="Pegasus FlatMaster">indi_pegasus_flatmaster</driver>
             <version>1.2</version>
         </device>
@@ -753,11 +757,11 @@
             <driver name="MyDCP4ESP32">indi_mydcp4esp32</driver>
             <version>1.0</version>
         </device>
-		<device label="DeepSkyDad FP1" manufacturer="DeepSkyDad">
+        <device label="DeepSkyDad FP1" manufacturer="DeepSkyDad">
             <driver name="DeepSkyDad FP1">indi_deepskydad_fp1</driver>
             <version>1.0</version>
         </device>
-		<device label="DeepSkyDad FR1" manufacturer="DeepSkyDad">
+        <device label="DeepSkyDad FR1" manufacturer="DeepSkyDad">
             <driver name="DeepSkyDad FR1">indi_deepskydad_fr1</driver>
             <version>1.0</version>
         </device>

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -171,7 +171,7 @@ bool CCDSim::initProperties()
                   ISR_1OFMANY, 0, IPS_IDLE);
 
     // Gain
-    GainNP[0].fill("GAIN", "value", "%.f", 0, 100, 10, 90);
+    GainNP[0].fill("GAIN", "value", "%.f", 0, 300, 10, 90);
     GainNP.fill(getDeviceName(), "CCD_GAIN", "Gain", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     // Offset

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -730,8 +730,6 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
             if (pp != nullptr)
             {
                 char line[256];
-                int stars = 0;
-                int lines = 0;
 
                 while (fgets(line, 256, pp) != nullptr)
                 {
@@ -753,9 +751,6 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
                                     &band, &c, plate, ob, &dist, &dir);
                     if (rc == 12)
                     {
-                        lines++;
-                        stars++;
-
                         //  Convert the ra/dec to standard co-ordinates
                         double sx;    //  standard co-ords
                         double sy;    //
@@ -931,14 +926,13 @@ int CCDSim::DrawImageStar(INDI::CCDChip * targetChip, float mag, float x, float 
     //  scale up linearly for exposure time
     flux = flux * exposure_time;
 
-    float qx;
     //  we need a box size that gives a radius at least 3 times fwhm
-    qx       = seeing / ImageScalex;
-    qx       = qx * 3;
+    //qx       = seeing / ImageScalex;
+    //qx       = qx * 3;
     //boxsizex = (int)qx;
     //boxsizex++;
-    qx       = seeing / ImageScaley;
-    qx       = qx * 3;
+    auto qx = seeing / ImageScaley;
+    qx = qx * 3;
     boxsizey = static_cast<int>(qx);
     boxsizey++;
 

--- a/drivers/focuser/alluna_tcs2.cpp
+++ b/drivers/focuser/alluna_tcs2.cpp
@@ -739,7 +739,7 @@ bool AllunaTCS2::getTemperature()
     // d#{ambient-humidity}<CR><LF>
 
     std::chrono::duration<double> seconds = std::chrono::system_clock::now() - last_temp_update;
-    if ( !first_run && seconds.count() < 300 ) // update every 300 seconds
+    if ( !first_run && seconds.count() < 10 ) // update every 10 seconds
     {
         if (tcs.try_lock()) {
             tcs.unlock(); // we need to get lock, to make TimerHit behave the same when we block reading temperature
@@ -978,7 +978,7 @@ bool AllunaTCS2::getFanPower()
     char res[DRIVER_LEN] = {0};
 
     std::chrono::duration<double> seconds = std::chrono::system_clock::now() - last_temp_update;
-    if ( !first_run && seconds.count() < 3 ) // update every 3 seconds
+    if ( !first_run && seconds.count() < 30 ) // update every 30 seconds
     {
         if (tcs.try_lock()) {
             tcs.unlock(); // we need to get lock, to make TimerHit behave the same when we block reading temperature

--- a/drivers/focuser/alluna_tcs2.cpp
+++ b/drivers/focuser/alluna_tcs2.cpp
@@ -594,7 +594,7 @@ bool AllunaTCS2::AbortFocuser()
 
 void AllunaTCS2::TimerHit()
 {
-    //LOG_INFO("TimerHit");
+    LOG_INFO("TimerHit");
     if (!isConnected())
         return; // No need to reset timer if we are not connected anymore
 
@@ -866,7 +866,7 @@ bool AllunaTCS2::setStepping(SteppingMode mode)
     char cmd[DRIVER_LEN] = {0};
     steppingMode=mode;
     value = (mode == SPEED) ? 0 : 1;
-    LOGF_INFO("Setting stepping mde to: %s", (mode==SPEED)?"SPEED":"micro");
+    LOGF_INFO("Setting stepping mode to: %s", (mode==SPEED)?"SPEED":"micro");
     LOGF_INFO("Setting stepping mode to: %d", value);
     snprintf(cmd, DRIVER_LEN, "SetFocuserMode %d\n", value);
     return sendCommand(cmd);

--- a/drivers/focuser/alluna_tcs2.cpp
+++ b/drivers/focuser/alluna_tcs2.cpp
@@ -780,6 +780,7 @@ bool AllunaTCS2::getTemperature()
                 receiveDone();
                 isGetTemperature=false;
                 TemperatureNP.setState(IPS_OK);
+                TemperatureNP.apply(); // update clients
                 break;
             default: // unexpected output
                 LOGF_ERROR("GetTemperatures: unexpected response (%s)", res);

--- a/drivers/focuser/alluna_tcs2.h
+++ b/drivers/focuser/alluna_tcs2.h
@@ -1,14 +1,8 @@
 /*
-  Skeleton Focuser Driver
+  Alluna TCS2 Focus, Dust Cover, Climate, Rotator, and Settings
+  (Dust Cover and Rotator are not implemented)
 
-  Modify this driver when developing new absolute position
-  based focusers. This driver uses serial communication by default
-  but it can be changed to use networked TCP/UDP connection as well.
-
-  Copyright(c) 2019 Jasem Mutlaq. All rights reserved.
-
-  Thanks to Rigel Systems, especially Gene Nolan and Leon Palmer,
-  for their support in writing this driver.
+  Copyright(c) 2022 Peter Englmaier. All rights reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public

--- a/libs/alignment/InMemoryDatabase.cpp
+++ b/libs/alignment/InMemoryDatabase.cpp
@@ -28,7 +28,7 @@ InMemoryDatabase::InMemoryDatabase() : DatabaseReferencePositionIsValid(false),
 bool InMemoryDatabase::CheckForDuplicateSyncPoint(const AlignmentDatabaseEntry &CandidateEntry,
         double Tolerance) const
 {
-    return std::any_of(MySyncPoints.begin(), MySyncPoints.end(), [CandidateEntry, Tolerance](const auto & point)
+    return std::any_of(MySyncPoints.begin(), MySyncPoints.end(), [&CandidateEntry, Tolerance](const auto & point)
     {
         return (((std::abs(point.RightAscension - CandidateEntry.RightAscension) < 24.0 * Tolerance / 100.0) &&
                  (std::abs(point.Declination - CandidateEntry.Declination) < 180.0 * Tolerance / 100.0)) ||
@@ -42,7 +42,7 @@ void InMemoryDatabase::RemoveSyncPoint(const AlignmentDatabaseEntry &CandidateEn
                                        double Tolerance)
 {
     MySyncPoints.erase(std::remove_if(MySyncPoints.begin(), MySyncPoints.end(),
-                                      [CandidateEntry, Tolerance](const auto & point)
+                                      [&CandidateEntry, Tolerance](const auto & point)
     {
         return (((std::abs(point.RightAscension - CandidateEntry.RightAscension) < 24.0 * Tolerance / 100.0) &&
                  (std::abs(point.Declination - CandidateEntry.Declination) < 180.0 * Tolerance / 100.0)) ||

--- a/libs/dsp/stream.c
+++ b/libs/dsp/stream.c
@@ -129,8 +129,8 @@ dsp_stream_p dsp_stream_new()
 {
     dsp_stream_p stream = (dsp_stream_p)malloc(sizeof(dsp_stream) * 1);
     stream->is_copy = 0;
-    stream->buf = (dsp_t*)malloc(sizeof(dsp_t) * 0);
-    stream->dft.buf = (double*)malloc(sizeof(dsp_t) * 0);
+    stream->buf = 0;
+    stream->dft.buf = 0;
     stream->magnitude = NULL;
     stream->phase = NULL;
     stream->sizes = (int*)malloc(sizeof(int) * 1);

--- a/tools/compiler.c
+++ b/tools/compiler.c
@@ -490,7 +490,7 @@ static void skip_double()
  * "look-ahead" token.
  * if error, fill in a message in err_msg[] and return ERR.
  */
-static int compile(prec) int prec;
+static int compile(int prec)
 {
     int expect_binop = 0; /* set after we have seen any operand.
 				 * used by SUB so it can tell if it really 

--- a/tools/compiler.c
+++ b/tools/compiler.c
@@ -667,7 +667,7 @@ static int compile(prec) int prec;
  * if ok, return 0 and the final result,
  * else return -1 with a reason why not message in err_msg.
  */
-static int execute(result) double *result;
+static int execute(double *result)
 {
     int instr;
 
@@ -826,8 +826,7 @@ static int execute(result) double *result;
  * the only sanity check is the string contains two dots.
  * when return, leave lcexpr alone but move cexpr to just after the second '"'.
  */
-static int parse_fieldname(name, len) char name[];
-int len;
+static int parse_fieldname(char name[], int len)
 {
     char c    = '\0';
     int ndots = 0;

--- a/tools/getINDIproperty.c
+++ b/tools/getINDIproperty.c
@@ -57,8 +57,8 @@ typedef struct
     char *d;    /* device to seek */
     char *p;    /* property to seek */
     char *e;    /* element to seek */
-    int wc : 1; /* whether pattern uses wild cards */
-    int ok : 1; /* something matched this query */
+    char wc; /* whether pattern uses wild cards */
+    char ok; /* something matched this query */
 } SearchDef;
 static SearchDef *srchs; /* properties to look for */
 static int nsrchs;

--- a/tools/getINDIproperty.c
+++ b/tools/getINDIproperty.c
@@ -57,8 +57,8 @@ typedef struct
     char *d;    /* device to seek */
     char *p;    /* property to seek */
     char *e;    /* element to seek */
-    char wc; /* whether pattern uses wild cards */
-    char ok; /* something matched this query */
+    unsigned int wc : 1; /* whether pattern uses wild cards */
+    unsigned int ok : 1; /* something matched this query */
 } SearchDef;
 static SearchDef *srchs; /* properties to look for */
 static int nsrchs;


### PR DESCRIPTION
I noticed, that the focuser temperature was not updated in kstars and other clients. The reason was, that the  .apply() method was not called when reading new values from the device.

Other (minor) changes:
- update temperature more often (every 10 seconds instead of once every 5 minutes)
- update fan speed less frequently (very 30 seconds instead of every 3 seconds)
- corrected the copyright message in the header file to reflect my authorship (getting it in sync with the source file).
