### PR TITLE
Enable Astrotrac 360 driver guide pulse

### DIFF
--- a/drivers/telescope/astrotrac.h
+++ b/drivers/telescope/astrotrac.h
@@ -109,6 +109,7 @@ class AstroTrac :
         /// Velocity
         ///////////////////////////////////////////////////////////////////////////////////////////////
         bool getVelocity(INDI_EQ_AXIS axis);
+        bool getVelocity(INDI_EQ_AXIS axis, double &value);
 
         /**
          * @brief setVelocity set motor velocity
@@ -193,6 +194,7 @@ class AstroTrac :
 
         /// Mount internal coordinates
         INDI::IEquatorialCoordinates m_MountInternalCoordinates;
+
         ///////////////////////////////////////////////////////////////////////////////////////////////
         /// Static Constants
         ///////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Unguided dithering in Ekos does not work with the Astrotrac 360 when Astrotrac is selected with "Guide via" in the Kstars optical train. List of changes to potentially enable this feature and some possibly bug fixes:

- initialize the GuideRate property (currently not initialized). The new default is set to 0.1x, which is the default rate for the mount according to the author of the X2 plugin. However, users might need to set a longer guide pulse to see movement at the default rate. Note, I'm not sure if the missing initialization is a bug or was omitted by design.

- check if the mount is tracking before issuing a guide pulse

- Added new function to return current tracking rate

- use the current tracking rates rather than custom rates to calculate the mount movement in arcseconds. The custom rates will only be used if the track mode is set to "Custom".

- if the DEC tracking rate is 0, which is the normal case, then the velocity for a south guide pulse is set to negative. This ensures that DEC guide pulses are not always in the same direction as RA when the DEC rate is 0.

- reset tracking when the guide pulse is finished

I have tested the changes with my mount but the test coverage is very limited. I don't use a guide camera (hence unguided dithering) so I don't know what effects, if any, these changes might have on guided dithering or guiding in general.
