### PR TITLE
Bugfix: update focuser temperature in alluna tcs2 driver

### DIFF
--- a/drivers/focuser/alluna_tcs2.cpp
+++ b/drivers/focuser/alluna_tcs2.cpp
@@ -739,7 +739,7 @@ bool AllunaTCS2::getTemperature()
     // d#{ambient-humidity}<CR><LF>
 
     std::chrono::duration<double> seconds = std::chrono::system_clock::now() - last_temp_update;
-    if ( !first_run && seconds.count() < 300 ) // update every 300 seconds
+    if ( !first_run && seconds.count() < 10 ) // update every 10 seconds
     {
         if (tcs.try_lock()) {
             tcs.unlock(); // we need to get lock, to make TimerHit behave the same when we block reading temperature
@@ -978,7 +978,7 @@ bool AllunaTCS2::getFanPower()
     char res[DRIVER_LEN] = {0};
 
     std::chrono::duration<double> seconds = std::chrono::system_clock::now() - last_temp_update;
-    if ( !first_run && seconds.count() < 3 ) // update every 3 seconds
+    if ( !first_run && seconds.count() < 30 ) // update every 30 seconds
     {
         if (tcs.try_lock()) {
             tcs.unlock(); // we need to get lock, to make TimerHit behave the same when we block reading temperature

--- a/drivers/focuser/alluna_tcs2.cpp
+++ b/drivers/focuser/alluna_tcs2.cpp
@@ -594,7 +594,7 @@ bool AllunaTCS2::AbortFocuser()
 
 void AllunaTCS2::TimerHit()
 {
-    //LOG_INFO("TimerHit");
+    LOG_INFO("TimerHit");
     if (!isConnected())
         return; // No need to reset timer if we are not connected anymore
 
@@ -866,7 +866,7 @@ bool AllunaTCS2::setStepping(SteppingMode mode)
     char cmd[DRIVER_LEN] = {0};
     steppingMode=mode;
     value = (mode == SPEED) ? 0 : 1;
-    LOGF_INFO("Setting stepping mde to: %s", (mode==SPEED)?"SPEED":"micro");
+    LOGF_INFO("Setting stepping mode to: %s", (mode==SPEED)?"SPEED":"micro");
     LOGF_INFO("Setting stepping mode to: %d", value);
     snprintf(cmd, DRIVER_LEN, "SetFocuserMode %d\n", value);
     return sendCommand(cmd);

--- a/drivers/focuser/alluna_tcs2.cpp
+++ b/drivers/focuser/alluna_tcs2.cpp
@@ -780,6 +780,7 @@ bool AllunaTCS2::getTemperature()
                 receiveDone();
                 isGetTemperature=false;
                 TemperatureNP.setState(IPS_OK);
+                TemperatureNP.apply(); // update clients
                 break;
             default: // unexpected output
                 LOGF_ERROR("GetTemperatures: unexpected response (%s)", res);

--- a/drivers/focuser/alluna_tcs2.h
+++ b/drivers/focuser/alluna_tcs2.h
@@ -1,14 +1,8 @@
 /*
-  Skeleton Focuser Driver
+  Alluna TCS2 Focus, Dust Cover, Climate, Rotator, and Settings
+  (Dust Cover and Rotator are not implemented)
 
-  Modify this driver when developing new absolute position
-  based focusers. This driver uses serial communication by default
-  but it can be changed to use networked TCP/UDP connection as well.
-
-  Copyright(c) 2019 Jasem Mutlaq. All rights reserved.
-
-  Thanks to Rigel Systems, especially Gene Nolan and Leon Palmer,
-  for their support in writing this driver.
+  Copyright(c) 2022 Peter Englmaier. All rights reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
I noticed, that the focuser temperature was not updated in kstars and other clients. The reason was, that the  .apply() method was not called when reading new values from the device.

Other (minor) changes:
- update temperature more often (every 10 seconds instead of once every 5 minutes)
- update fan speed less frequently (very 30 seconds instead of every 3 seconds)
- corrected the copyright message in the header file to reflect my authorship (getting it in sync with the source file).
