### PR TITLE
Fix Build fails with LTO

### DIFF
--- a/drivers/telescope/celestrongps.cpp
+++ b/drivers/telescope/celestrongps.cpp
@@ -729,7 +729,7 @@ bool CelestronGPS::ReadScopeStatus()
     if (HasPierSide())
     {
         // read the pier side close to reading the Radec so they should match
-        char sop;
+        char sop = '?';
         char psc = 'u';
         if (driver.get_pier_side(&sop))
         {
@@ -2077,7 +2077,7 @@ bool CelestronGPS::AbortFocuser()
 // read the focuser limits from the hardware
 bool CelestronGPS::focusReadLimits()
 {
-    int low, high;
+    int low = 0, high = 0;
     bool valid = driver.foc_limits(&low, &high);
 
     focusTrueMax = high;

--- a/integs/ConnectionMock.cpp
+++ b/integs/ConnectionMock.cpp
@@ -225,8 +225,6 @@ char ConnectionMock::peekChar(const std::string & expected) {
     return ret;
 }
 
-enum XmlStatus { PRE, TAGNAME, WAIT_ATTRIB, ATTRIB, QUOTE, WAIT_CLOSE };
-
 static std::string parseXmlFragmentFromString(const std::string &str)
 {
     ssize_t pos = 0;


### PR DESCRIPTION
Referring to https://github.com/indilib/indi/issues/2023

In short:
The `XmlStatus` type is declared differently, but not used - I removed it.
Some variables may be uninitialized. I set the default values.

These are not complicated changes. Now building the project with the flags mentioned in the issue has been successful for me.