### PR TITLE
Add debhelper package - fix package build

### DIFF
--- a/.github/docker/Dockerfile.ubuntu
+++ b/.github/docker/Dockerfile.ubuntu
@@ -30,4 +30,4 @@ RUN apt-get install -y \
 
 # Install deb package tools
 RUN apt-get install -y \
-    cdbs
+    cdbs debhelper


### PR DESCRIPTION
Hi Jasem,

I noticed that *.deb packages are not being built in GitHub Actions. Probably something changed on Ubuntu and I added the 'debhelper' package.
For everything to work fully, after accepting the pull request, you need to rebuild the docker images used by the build system.

I can also take care of it, and if there are any problems, I can fix the problems directly in the repository.

