### PR TITLE
Fix build - SWIG 4.2.0

### DIFF
--- a/.github/workflows/linux-pyindi.yml
+++ b/.github/workflows/linux-pyindi.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install test deps
         run: |
-          cd pyindi-client && pip3 install -r requirements-test.txt
+          cd pyindi-client && pip3 install --break-system-packages -r requirements-test.txt
 
       - name: Test PyIndi
         run: |

--- a/libs/indidevice/property/indiproperties.h
+++ b/libs/indidevice/property/indiproperties.h
@@ -35,8 +35,13 @@ class Properties
     public:
         using iterator        = std::deque<INDI::Property>::iterator;
         using const_iterator  = std::deque<INDI::Property>::const_iterator;
-        using reference       = std::deque<INDI::Property>::reference;
-        using const_reference = std::deque<INDI::Property>::const_reference;
+
+        // #PS 2024: workaround; SWIG 4.2.0 - SwigSmartPointer, does not create a pointer, just an uninitialized reference.
+        // using reference       = std::deque<INDI::Property>::reference;
+        // using const_reference = std::deque<INDI::Property>::const_reference;
+        using reference       = INDI::Property &;
+        using const_reference = const INDI::Property &;
+        
         using size_type       = std::deque<INDI::Property>::size_type;
 
     public:

--- a/libs/indidevice/property/indipropertyview.h
+++ b/libs/indidevice/property/indipropertyview.h
@@ -358,20 +358,20 @@ struct WidgetView<IText>: PROPERTYVIEW_BASE_ACCESS IText
         {
             memset(this, 0, sizeof(*this));
         }
-        WidgetView(const WidgetView &other): Type(other)
+        WidgetView(const WidgetView<Type> &other): Type(other)
         {
             this->text = nullptr;
             setText(other.text);
         }
-        WidgetView(WidgetView &&other): Type(other)
+        WidgetView(WidgetView<Type> &&other): Type(other)
         {
             memset(static_cast<Type*>(&other), 0, sizeof(other));
         }
-        WidgetView &operator=(const WidgetView &other)
+        WidgetView<Type> &operator=(const WidgetView<Type> &other)
         {
             return *this = WidgetView(other);
         }
-        WidgetView &operator=(WidgetView &&other)
+        WidgetView<Type> &operator=(WidgetView<Type> &&other)
         {
             std::swap(static_cast<Type &>(other), static_cast<Type &>(*this));
             return *this;
@@ -499,16 +499,16 @@ struct WidgetView<INumber>: PROPERTYVIEW_BASE_ACCESS INumber
         {
             memset(this, 0, sizeof(*this));
         }
-        WidgetView(const WidgetView &other): Type(other)       { }
-        WidgetView(WidgetView &&other): Type(other)
+        WidgetView(const WidgetView<Type> &other): Type(other)       { }
+        WidgetView(WidgetView<Type> &&other): Type(other)
         {
             memset(static_cast<Type*>(&other), 0, sizeof(other));
         }
-        WidgetView &operator=(const WidgetView &other)
+        WidgetView<Type> &operator=(const WidgetView<Type> &other)
         {
             return *this = WidgetView(other);
         }
-        WidgetView &operator=(WidgetView &&other)
+        WidgetView<Type> &operator=(WidgetView<Type> &&other)
         {
             std::swap(static_cast<Type &>(other), static_cast<Type &>(*this));
             return *this;
@@ -663,16 +663,16 @@ struct WidgetView<ISwitch>: PROPERTYVIEW_BASE_ACCESS ISwitch
         {
             memset(this, 0, sizeof(*this));
         }
-        WidgetView(const WidgetView &other): Type(other)       { }
-        WidgetView(WidgetView &&other): Type(other)
+        WidgetView(const WidgetView<Type> &other): Type(other)       { }
+        WidgetView(WidgetView<Type> &&other): Type(other)
         {
             memset(static_cast<Type*>(&other), 0, sizeof(other));
         }
-        WidgetView &operator=(const WidgetView &other)
+        WidgetView<Type> &operator=(const WidgetView<Type> &other)
         {
             return *this = WidgetView(other);
         }
-        WidgetView &operator=(WidgetView &&other)
+        WidgetView<Type> &operator=(WidgetView<Type> &&other)
         {
             std::swap(static_cast<Type &>(other), static_cast<Type &>(*this));
             return *this;
@@ -792,16 +792,16 @@ struct WidgetView<ILight>: PROPERTYVIEW_BASE_ACCESS ILight
         {
             memset(this, 0, sizeof(*this));
         }
-        WidgetView(const WidgetView &other): Type(other)       { }
-        WidgetView(WidgetView &&other): Type(other)
+        WidgetView(const WidgetView<Type> &other): Type(other)       { }
+        WidgetView(WidgetView<Type> &&other): Type(other)
         {
             memset(static_cast<Type*>(&other), 0, sizeof(other));
         }
-        WidgetView &operator=(const WidgetView &other)
+        WidgetView<Type> &operator=(const WidgetView<Type> &other)
         {
             return *this = WidgetView(other);
         }
-        WidgetView &operator=(WidgetView &&other)
+        WidgetView<Type> &operator=(WidgetView<Type> &&other)
         {
             std::swap(static_cast<Type &>(other), static_cast<Type &>(*this));
             return *this;
@@ -921,16 +921,16 @@ struct WidgetView<IBLOB>: PROPERTYVIEW_BASE_ACCESS IBLOB
         {
             memset(this, 0, sizeof(*this));
         }
-        WidgetView(const WidgetView &other): Type(other)       { }
-        WidgetView(WidgetView &&other): Type(other)
+        WidgetView(const WidgetView<Type> &other): Type(other)       { }
+        WidgetView(WidgetView<Type> &&other): Type(other)
         {
             memset(static_cast<Type*>(&other), 0, sizeof(other));
         }
-        WidgetView &operator=(const WidgetView &other)
+        WidgetView<Type> &operator=(const WidgetView<Type> &other)
         {
             return *this = WidgetView(other);
         }
-        WidgetView &operator=(WidgetView &&other)
+        WidgetView<Type> &operator=(WidgetView<Type> &&other)
         {
             std::swap(static_cast<Type &>(other), static_cast<Type &>(*this));
             return *this;


### PR DESCRIPTION
After upgrading Ubuntu from 22.04 to 24.04, there is a problem building PyIndi.
The new SWIG version 4.2.0, with the current code, can no longer deduce types correctly. The posted fixes declare types explicitly in templates, and by declaring new ones via `using`.

I also added the `break-system-packages` flag to `pip3` to install the `requirements-test.txt` packages from the `pyindi-client` repository.
