### PR TITLE
Make openweathermap show rain and snow data

### DIFF
--- a/drivers/weather/openweathermap.cpp
+++ b/drivers/weather/openweathermap.cpp
@@ -253,15 +253,30 @@ IPState OpenWeatherMap::updateWeather()
         weatherReport["wind"]["speed"].get_to(wind);
         // Cloud
         weatherReport["clouds"]["all"].get_to(clouds);
-        try
+        // Rain (does not exist in all reports)
+        if (weatherReport.contains("rain"))
         {
-            // Rain
-            weatherReport["rain"]["h"].get_to(rain);
-            // Snow
-            weatherReport["snow"]["h"].get_to(snow);
+            if (weatherReport["rain"].contains("h"))
+            {
+                weatherReport["rain"]["h"].get_to(rain);
+            }
+            else if (weatherReport["rain"].contains("1h"))
+            {
+                weatherReport["rain"]["1h"].get_to(rain);
+            }
         }
-        // Ignore error since these values do not exist in all reports.
-        catch (json::exception &e) {}
+        // Snow (does not exist in all reports)
+        if (weatherReport.contains("snow"))
+        {
+            if (weatherReport["snow"].contains("h"))
+            {
+                weatherReport["snow"]["h"].get_to(snow);
+            }
+            else if (weatherReport["snow"].contains("1h"))
+            {
+                weatherReport["snow"]["1h"].get_to(snow);
+            }
+        }
 
     }
     catch (json::exception &e)


### PR DESCRIPTION
I noticed that openweathmap reports rain, but it does not show up in the driver panel. The API reports the rain like this:
```
  "rain": {
    "1h": 0.4
  },
```

But, apparently indi driver expects this:
```
  "rain": {
    "h": 0.4
  },
```

I could not figure out, if the format has changed or if this just is not the right data.
Should this PR change be made?
