### PR TITLE
Weather watcher dynamic labels

### DIFF
--- a/drivers/weather/weatherwatcher.cpp
+++ b/drivers/weather/weatherwatcher.cpp
@@ -30,6 +30,9 @@
 #include <memory>
 #include <cstring>
 
+const char *LABELS_TAB  = "Labels";
+const char *PARAMETERS_TAB = "Parameters";
+
 // We declare an auto pointer to WeatherWatcher.
 static std::unique_ptr<WeatherWatcher> weatherWatcher(new WeatherWatcher());
 
@@ -41,8 +44,7 @@ static size_t write_data(void *contents, size_t size, size_t nmemb, void *userp)
 
 WeatherWatcher::WeatherWatcher()
 {
-    setVersion(1, 2);
-
+    setVersion(2, 1);
     setWeatherConnection(CONNECTION_NONE);
 }
 
@@ -58,8 +60,8 @@ bool WeatherWatcher::Connect()
         LOG_ERROR("Watch file must be specified first in options.");
         return false;
     }
-
-    return createPropertiesFromMap();
+    else
+        return true;
 }
 
 bool WeatherWatcher::Disconnect()
@@ -67,167 +69,228 @@ bool WeatherWatcher::Disconnect()
     return true;
 }
 
-bool WeatherWatcher::createPropertiesFromMap()
+bool WeatherWatcher::createProperties()
 {
-    // already parsed
-    if (initialParse)
-        return true;
-
     if (readWatchFile() == false)
         return false;
-
     double minOK = 0, maxOK = 0, percWarn = 15;
     for (auto const &x : weatherMap)
     {
-        if (x.first == keywordTP[RAIN].getText())
+        if (x.first == keywordTP[0].getText())
         {
-            minOK = 0;
+            // Caution: If both OK=0 the parameter never (re)appears in UI! (-> WeatherInterface::addParameter())
+            minOK = -1;
             maxOK = 0;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_RAIN_HOUR", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_RAIN_HOUR", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_RAIN_HOUR", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_1", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_1", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_1", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_RAIN_HOUR", "Rain (mm)", minOK, maxOK, percWarn);
-            setCriticalParameter("WEATHER_RAIN_HOUR");
+            addParameter("PARAMETER_1",  labelTP[0].text, minOK, maxOK, percWarn);
+            if (criticalSP[0].getState())
+                setCriticalParameter("PARAMETER_1");
         }
-        else if (x.first == keywordTP[TEMP].getText())
+        else if (x.first == keywordTP[1].getText())
         {
             minOK = -10;
             maxOK = 30;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_TEMPERATURE", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_TEMPERATURE", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_TEMPERATURE", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_2", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_2", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_2", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_TEMPERATURE", "Temperature (C)", minOK, maxOK, percWarn);
-            setCriticalParameter("WEATHER_TEMPERATURE");
+            addParameter("PARAMETER_2", labelTP[1].text, minOK, maxOK, percWarn);
+            if (criticalSP[1].getState())
+                setCriticalParameter("PARAMETER_2");
         }
-        else if (x.first == keywordTP[WIND].getText())
+        else if (x.first == keywordTP[2].getText())
         {
             minOK = 0;
             maxOK = 20;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_SPEED", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_SPEED", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_SPEED", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_3", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_3", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_3", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_WIND_SPEED", "Wind (kph)", minOK, maxOK, percWarn);
-            setCriticalParameter("WEATHER_WIND_SPEED");
+            addParameter("PARAMETER_3", labelTP[2].text, minOK, maxOK, percWarn);
+            if (criticalSP[2].getState())
+                setCriticalParameter("PARAMETER_3");
         }
-        else if (x.first == keywordTP[GUST].getText())
+        else if (x.first == keywordTP[3].getText())
         {
             minOK = 0;
             maxOK = 20;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_GUST", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_GUST", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_GUST", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_4", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_4", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_4", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_WIND_GUST", "Gust (kph)", minOK, maxOK, percWarn);
+            addParameter("PARAMETER_4", labelTP[3].text, minOK, maxOK, percWarn);
+            if (criticalSP[3].getState())
+               setCriticalParameter("PARAMETER_4");
         }
-        else if (x.first == keywordTP[CLOUDS].getText())
+        else if (x.first == keywordTP[4].getText())
         {
             minOK = 0;
             maxOK = 20;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_5", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_5", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_5", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_CLOUDS", "Clouds (%)", minOK, maxOK, percWarn);
-            setCriticalParameter("WEATHER_CLOUDS");
+            addParameter("PARAMETER_5",  labelTP[4].text, minOK, maxOK, percWarn);
+            if (criticalSP[4].getState())
+              setCriticalParameter("PARAMETER_5");
         }
-        else if (x.first == keywordTP[HUMIDITY].getText())
+        else if (x.first == keywordTP[5].getText())
         {
             minOK = 0;
             maxOK = 100;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_HUMIDITY", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_HUMIDITY", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_HUMIDITY", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_6", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_6", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_6", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_HUMIDITY", "Humidity (%)", minOK, maxOK, percWarn);
-            setCriticalParameter("WEATHER_HUMIDITY");
+            addParameter("PARAMETER_6", labelTP[5].text, minOK, maxOK, percWarn);
+            if (criticalSP[5].getState())
+                setCriticalParameter("PARAMETER_6");
         }
-        else if (x.first == keywordTP[PRESSURE].getText())
+        else if (x.first == keywordTP[6].getText())
         {
             minOK = 983;
             maxOK = 1043;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_PRESSURE", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_PRESSURE", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_PRESSURE", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_7", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_7", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_7", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_PRESSURE", "Pressure (hPa)", minOK, maxOK, percWarn);
-            setCriticalParameter("WEATHER_PRESSURE");
+            addParameter("PARAMETER_7", labelTP[6].text, minOK, maxOK, percWarn);
+            if (criticalSP[6].getState())
+              setCriticalParameter("PARAMETER_7");
         }
-        else if (x.first == keywordTP[FORECAST].getText())
+        else if (x.first == keywordTP[7].getText())
         {
-            minOK = 0;
+            minOK = -1;
             maxOK = 0;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "WEATHER_FORECAST", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_FORECAST", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "WEATHER_FORECAST", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_8", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_8", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "PARAMETER_8", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_FORECAST", "Weather", minOK, maxOK, percWarn);
-            setCriticalParameter("WEATHER_FORECAST");
+            addParameter("PARAMETER_8", labelTP[7].text, minOK, maxOK, percWarn);
+            if (criticalSP[7].getState())
+              setCriticalParameter("PARAMETER_8");
         }
     }
-
-    initialParse = true;
-
     return true;
 }
 
+// initialize properties on launching indiserver
 bool WeatherWatcher::initProperties()
 {
     INDI::Weather::initProperties();
-
-    keywordTP[RAIN].fill("RAIN", "Rain", "precip");
-    keywordTP[TEMP].fill("TEMP", "Temperature", "temperature");
-    keywordTP[WIND].fill("WIND", "Wind", "wind");
-    keywordTP[GUST].fill( "GUST", "Gust", "gust");
-    keywordTP[CLOUDS].fill( "CLOUDS", "Clouds", "clouds");
-    keywordTP[HUMIDITY].fill( "HUMIDITY", "Humidity", "humidity");
-    keywordTP[PRESSURE].fill("PRESSURE", "Pressure", "pressure");
-    keywordTP[FORECAST].fill( "FORECAST", "Forecast", "forecast");
-    keywordTP.fill(getDeviceName(), "KEYWORD", "Keywords", OPTIONS_TAB, IP_RW,
-                     60, IPS_IDLE);
-
-    watchFileTP[0].fill("URL", "File", nullptr);
-    watchFileTP.fill(getDeviceName(), "WATCH_SOURCE", "Source", OPTIONS_TAB, IP_RW,
-                     60, IPS_IDLE);
-
-    separatorTP[0].fill("SEPARATOR", "Separator", "=");
-    separatorTP.fill(getDeviceName(), "SEPARATOR_KEYWORD", "Separator", OPTIONS_TAB, IP_RW,
-                     60, IPS_IDLE);
-
     addDebugControl();
+    return true;
+}
+
+// initialize properties after connection/disconnection
+bool WeatherWatcher::updateProperties()
+{
+    if (isConnected())
+    {
+        getProperties();
+        createProperties();
+        INDI::Weather::updateProperties(); // define inherited properties
+    }
+    else
+    {
+        deleteProperty(keywordTP);
+        deleteProperty(criticalSP);
+        // call deliberatly here to prevent reorder of fields in indicontrol interface
+        INDI::Weather::updateProperties(); // delete inherited properties
+        // deleteProperty() does not reset widgets array to 0!! So we do it manually:
+        INDI::Weather::critialParametersLP.resize(0);
+        for (auto  &oneProperty : INDI::Weather::ParametersRangeNP )
+            oneProperty.resize(0);
+        INDI::Weather::ParametersNP.resize(0);
+        // clear array of "ParametersRangeNP"
+        INDI::Weather::ParametersRangeNP.clear();
+    }
 
     return true;
 }
 
+// get dynamic properties
+bool WeatherWatcher::getProperties()
+{
+    // Labels for Parameters-------------------------------------------------------------------------------------
+    labelTP[0].fill("LABEL_1", "Measure 1", "Rain");
+    labelTP[1].fill("LABEL_2", "Measure 2", "Temperature");
+    labelTP[2].fill("LABEL_3", "Measure 3", "Wind");
+    labelTP[3].fill("LABEL_4", "Measure 4", "Gust");
+    labelTP[4].fill("LABEL_5", "Measure 5", "Clouds");
+    labelTP[5].fill("LABEL_6", "Measure 6", "Humidity");
+    labelTP[6].fill("lABEL_7", "Measure 7", "Pressure");
+    labelTP[7].fill("LABEL_8", "Measure 8", "Forecast");
+    labelTP.fill(getDeviceName(), "LABELS", "Labels", LABELS_TAB, IP_RW, 60, IPS_IDLE);
+    defineProperty(labelTP);
+    loadConfig(true, "LABELS");
+
+    // Keywords for Parameters with dynamic labels ----------------------------------------------------------------
+    keywordTP[0].fill("KEY_1", labelTP[0].text, "precip");
+    keywordTP[1].fill("KEY_2", labelTP[1].text, "temperature");
+    keywordTP[2].fill("KEY_3", labelTP[2].text, "wind");
+    keywordTP[3].fill("KEY_4", labelTP[3].text, "gust");
+    keywordTP[4].fill("KEY_5", labelTP[4].text, "clouds");
+    keywordTP[5].fill("KEY_6", labelTP[5].text, "humidity");
+    keywordTP[6].fill("KEY_7", labelTP[6].text, "pressure");
+    keywordTP[7].fill("KEY_8", labelTP[7].text, "forecast");
+    keywordTP.fill(getDeviceName(), "KEYWORDS", "Keywords", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
+    defineProperty(keywordTP);
+    loadConfig(true, "KEYWORDS");
+
+    // Critical Parameters with dynamic labels --------------------------------------------------------------------
+    criticalSP[0].fill("CRITICAL_1", labelTP[0].text, ISS_OFF);
+    criticalSP[1].fill("CRITICAL_2", labelTP[1].text, ISS_OFF);
+    criticalSP[2].fill("CRITICAL_3", labelTP[2].text, ISS_OFF);
+    criticalSP[3].fill("CRITICAL_4", labelTP[3].text, ISS_OFF);
+    criticalSP[4].fill("CRITICAL_5", labelTP[4].text, ISS_OFF);
+    criticalSP[5].fill("CRITICAL_6", labelTP[5].text, ISS_OFF);
+    criticalSP[6].fill("CRITICAL_7", labelTP[6].text, ISS_OFF);
+    criticalSP[7].fill("CRITICAL_8", labelTP[7].text, ISS_OFF);
+    criticalSP.fill(getDeviceName(), "CRITICALS", "Criticals", PARAMETERS_TAB, IP_RW, ISR_NOFMANY, 0, IPS_IDLE);
+    defineProperty(criticalSP);
+    loadConfig(true, "CRITICALS");
+
+    return true;
+}
+// get properties from configuation
 void WeatherWatcher::ISGetProperties(const char *dev)
 {
     INDI::Weather::ISGetProperties(dev);
 
+    watchFileTP[0].fill("URL", "URL", nullptr);
+    watchFileTP.fill(getDeviceName(), "WATCH_SOURCE", "Source", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
     defineProperty(watchFileTP);
     loadConfig(true, "WATCH_SOURCE");
 
-    defineProperty(keywordTP);
-    loadConfig(true, "KEYWORD");
-
+    separatorTP[0].fill("SEPARATOR", "Separator", "=");
+    separatorTP.fill(getDeviceName(), "SEPARATOR_KEYWORD", "Separator", OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
     defineProperty(separatorTP);
     loadConfig(true, "SEPARATOR_KEYWORD");
-
 }
 
 bool WeatherWatcher::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
+        if (labelTP.isNameMatch(name))
+        {
+            labelTP.update(texts, names, n);
+            labelTP.setState(IPS_OK);
+            labelTP.apply();
+            return true;
+        }
         if (watchFileTP.isNameMatch(name))
         {
             watchFileTP.update(texts, names, n);
@@ -251,8 +314,24 @@ bool WeatherWatcher::ISNewText(const char *dev, const char *name, char *texts[],
             return true;
         }
     }
-
     return INDI::Weather::ISNewText(dev, name, texts, names, n);
+}
+
+bool WeatherWatcher::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
+{
+    if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
+    {
+        if (criticalSP.isNameMatch(name))
+        {
+            // pthread_mutex_lock(&lock);
+            criticalSP.update(states, names, n);
+            criticalSP.setState(IPS_OK);
+            criticalSP.apply();
+            // pthread_mutex_unlock(&lock);
+            return true;
+        }
+    }
+    return INDI::Weather::ISNewSwitch(dev, name, states, names, n);
 }
 
 IPState WeatherWatcher::updateWeather()
@@ -263,40 +342,39 @@ IPState WeatherWatcher::updateWeather()
 
     for (auto const &x : weatherMap)
     {
-        if (x.first == keywordTP[RAIN].getText())
+        if (x.first == keywordTP[0].getText())
         {
-            setParameterValue("WEATHER_RAIN_HOUR", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_1", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordTP[TEMP].getText())
+        else if (x.first == keywordTP[1].getText())
         {
-            setParameterValue("WEATHER_TEMPERATURE", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_2", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordTP[WIND].getText())
+        else if (x.first == keywordTP[2].getText())
         {
-            setParameterValue("WEATHER_WIND_SPEED", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_3", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordTP[GUST].getText())
+        else if (x.first == keywordTP[3].getText())
         {
-            setParameterValue("WEATHER_WIND_GUST", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_4", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordTP[CLOUDS].getText())
+        else if (x.first == keywordTP[4].getText())
         {
-            setParameterValue("WEATHER_CLOUDS", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_5", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordTP[HUMIDITY].getText())
+        else if (x.first == keywordTP[5].getText())
         {
-            setParameterValue("WEATHER_HUMIDITY", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_6", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordTP[PRESSURE].getText())
+        else if (x.first == keywordTP[6].getText())
         {
-            setParameterValue("WEATHER_PRESSURE", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_7", std::strtod(x.second.c_str(), nullptr));
         }
-        else if (x.first == keywordTP[FORECAST].getText())
+        else if (x.first == keywordTP[8].getText())
         {
-            setParameterValue("WEATHER_FORECAST", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("PARAMETER_8", std::strtod(x.second.c_str(), nullptr));
         }
     }
-
     return IPS_OK;
 }
 
@@ -319,6 +397,7 @@ bool WeatherWatcher::readWatchFile()
     if (curl)
     {
         curl_easy_setopt(curl, CURLOPT_URL, requestURL);
+        curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, &readBuffer);
         res = curl_easy_perform(curl);
@@ -330,7 +409,6 @@ bool WeatherWatcher::readWatchFile()
         }
         curl_easy_cleanup(curl);
     }
-
     return rc;
 }
 
@@ -338,6 +416,8 @@ bool WeatherWatcher::saveConfigItems(FILE *fp)
 {
     INDI::Weather::saveConfigItems(fp);
 
+    labelTP.save(fp);
+    criticalSP.save(fp);
     watchFileTP.save(fp);
     keywordTP.save(fp);
     separatorTP.apply();
@@ -357,3 +437,4 @@ std::map<std::string, std::string> WeatherWatcher::createMap(std::string const &
 
     return m;
 }
+

--- a/drivers/weather/weatherwatcher.cpp
+++ b/drivers/weather/weatherwatcher.cpp
@@ -82,104 +82,104 @@ bool WeatherWatcher::createProperties()
             minOK = -1;
             maxOK = 0;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_1", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_1", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_1", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_RAIN_HOUR", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_RAIN_HOUR", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_RAIN_HOUR", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_1",  labelTP[0].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_RAIN_HOUR",  labelTP[0].text, minOK, maxOK, percWarn);
             if (criticalSP[0].getState())
-                setCriticalParameter("PARAMETER_1");
+                setCriticalParameter("WEATHER_RAIN_HOUR");
         }
         else if (x.first == keywordTP[1].getText())
         {
             minOK = -10;
             maxOK = 30;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_2", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_2", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_2", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_TEMPERATURE", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_TEMPERATURE", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_TEMPERATURE", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_2", labelTP[1].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_TEMPERATURE", labelTP[1].text, minOK, maxOK, percWarn);
             if (criticalSP[1].getState())
-                setCriticalParameter("PARAMETER_2");
+                setCriticalParameter("WEATHER_TEMPERATURE");
         }
         else if (x.first == keywordTP[2].getText())
         {
             minOK = 0;
             maxOK = 20;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_3", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_3", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_3", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_SPEED", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_SPEED", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_SPEED", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_3", labelTP[2].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_WIND_SPEED", labelTP[2].text, minOK, maxOK, percWarn);
             if (criticalSP[2].getState())
-                setCriticalParameter("PARAMETER_3");
+                setCriticalParameter("WEATHER_WIND_SPEED");
         }
         else if (x.first == keywordTP[3].getText())
         {
             minOK = 0;
             maxOK = 20;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_4", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_4", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_4", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_GUST", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_GUST", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_WIND_GUST", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_4", labelTP[3].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_WIND_GUST", labelTP[3].text, minOK, maxOK, percWarn);
             if (criticalSP[3].getState())
-               setCriticalParameter("PARAMETER_4");
+               setCriticalParameter("WEATHER_WIND_GUST");
         }
         else if (x.first == keywordTP[4].getText())
         {
             minOK = 0;
             maxOK = 20;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_5", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_5", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_5", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_5",  labelTP[4].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_CLOUDS",  labelTP[4].text, minOK, maxOK, percWarn);
             if (criticalSP[4].getState())
-              setCriticalParameter("PARAMETER_5");
+              setCriticalParameter("WEATHER_CLOUDS");
         }
         else if (x.first == keywordTP[5].getText())
         {
             minOK = 0;
             maxOK = 100;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_6", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_6", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_6", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_HUMIDITY", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_HUMIDITY", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_HUMIDITY", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_6", labelTP[5].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_HUMIDITY", labelTP[5].text, minOK, maxOK, percWarn);
             if (criticalSP[5].getState())
-                setCriticalParameter("PARAMETER_6");
+                setCriticalParameter("WEATHER_HUMIDITY");
         }
         else if (x.first == keywordTP[6].getText())
         {
             minOK = 983;
             maxOK = 1043;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_7", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_7", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_7", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_PRESSURE", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_PRESSURE", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_PRESSURE", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_7", labelTP[6].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_PRESSURE", labelTP[6].text, minOK, maxOK, percWarn);
             if (criticalSP[6].getState())
-              setCriticalParameter("PARAMETER_7");
+              setCriticalParameter("WEATHER_PRESSURE");
         }
         else if (x.first == keywordTP[7].getText())
         {
             minOK = -1;
             maxOK = 0;
             percWarn = 15;
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_8", "MIN_OK", &minOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_8", "MAX_OK", &maxOK);
-            IUGetConfigNumber(getDeviceName(), "PARAMETER_8", "PERC_WARN", &percWarn);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_FORECAST", "MIN_OK", &minOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_FORECAST", "MAX_OK", &maxOK);
+            IUGetConfigNumber(getDeviceName(), "WEATHER_FORECAST", "PERC_WARN", &percWarn);
 
-            addParameter("PARAMETER_8", labelTP[7].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_FORECAST", labelTP[7].text, minOK, maxOK, percWarn);
             if (criticalSP[7].getState())
-              setCriticalParameter("PARAMETER_8");
+              setCriticalParameter("WEATHER_FORECAST");
         }
     }
     return true;
@@ -224,15 +224,15 @@ bool WeatherWatcher::updateProperties()
 bool WeatherWatcher::getProperties()
 {
     // Labels for Parameters-------------------------------------------------------------------------------------
-    labelTP[0].fill("LABEL_1", "Measure 1", "Rain");
-    labelTP[1].fill("LABEL_2", "Measure 2", "Temperature");
-    labelTP[2].fill("LABEL_3", "Measure 3", "Wind");
-    labelTP[3].fill("LABEL_4", "Measure 4", "Gust");
-    labelTP[4].fill("LABEL_5", "Measure 5", "Clouds");
-    labelTP[5].fill("LABEL_6", "Measure 6", "Humidity");
-    labelTP[6].fill("lABEL_7", "Measure 7", "Pressure");
-    labelTP[7].fill("LABEL_8", "Measure 8", "Forecast");
-    labelTP.fill(getDeviceName(), "LABELS", "Labels", LABELS_TAB, IP_RW, 60, IPS_IDLE);
+    labelTP[0].fill("LABEL_1", "WEATHER_RAIN_HOUR", "Rain");
+    labelTP[1].fill("LABEL_2", "WEATHER_TEMPERATURE", "Temperature");
+    labelTP[2].fill("LABEL_3", "WEATHER_WIND_SPEED", "Wind");
+    labelTP[3].fill("LABEL_4", "WEATHER_WIND_GUST", "Gust");
+    labelTP[4].fill("LABEL_5", "WEATHER_CLOUDS", "Clouds");
+    labelTP[5].fill("LABEL_6", "WEATHER_HUMIDITY", "Humidity");
+    labelTP[6].fill("lABEL_7", "WEATHER_PRESSURE", "Pressure");
+    labelTP[7].fill("LABEL_8", "WEATHER_FORECAST", "Forecast");
+    labelTP.fill(getDeviceName(), "LABELS", "Property Label", LABELS_TAB, IP_RW, 60, IPS_IDLE);
     defineProperty(labelTP);
     loadConfig(true, "LABELS");
 
@@ -344,35 +344,35 @@ IPState WeatherWatcher::updateWeather()
     {
         if (x.first == keywordTP[0].getText())
         {
-            setParameterValue("PARAMETER_1", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_RAIN_HOUR", std::strtod(x.second.c_str(), nullptr));
         }
         else if (x.first == keywordTP[1].getText())
         {
-            setParameterValue("PARAMETER_2", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_TEMPERATURE", std::strtod(x.second.c_str(), nullptr));
         }
         else if (x.first == keywordTP[2].getText())
         {
-            setParameterValue("PARAMETER_3", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_WIND_SPEED", std::strtod(x.second.c_str(), nullptr));
         }
         else if (x.first == keywordTP[3].getText())
         {
-            setParameterValue("PARAMETER_4", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_WIND_GUST", std::strtod(x.second.c_str(), nullptr));
         }
         else if (x.first == keywordTP[4].getText())
         {
-            setParameterValue("PARAMETER_5", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_CLOUDS", std::strtod(x.second.c_str(), nullptr));
         }
         else if (x.first == keywordTP[5].getText())
         {
-            setParameterValue("PARAMETER_6", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_HUMIDITY", std::strtod(x.second.c_str(), nullptr));
         }
         else if (x.first == keywordTP[6].getText())
         {
-            setParameterValue("PARAMETER_7", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_PRESSURE", std::strtod(x.second.c_str(), nullptr));
         }
         else if (x.first == keywordTP[8].getText())
         {
-            setParameterValue("PARAMETER_8", std::strtod(x.second.c_str(), nullptr));
+            setParameterValue("WEATHER_FORECAST", std::strtod(x.second.c_str(), nullptr));
         }
     }
     return IPS_OK;

--- a/drivers/weather/weatherwatcher.h
+++ b/drivers/weather/weatherwatcher.h
@@ -39,32 +39,25 @@ class WeatherWatcher : public INDI::Weather
         const char *getDefaultName() override;
 
         virtual bool initProperties() override;
+        virtual bool updateProperties() override;
         virtual void ISGetProperties(const char *dev) override;
         virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
     protected:
         virtual IPState updateWeather() override;
         virtual bool saveConfigItems(FILE *fp) override;
 
         INDI::PropertyText keywordTP {8};
-        enum
-        {
-            RAIN,
-            TEMP,
-            WIND,
-            GUST,
-            CLOUDS,
-            HUMIDITY,
-            PRESSURE,
-            FORECAST
-        };
-
         INDI::PropertyText separatorTP {1};
+        INDI::PropertyText labelTP {8};
+        INDI::PropertySwitch criticalSP {8};
 
     private:
         std::map<std::string, std::string> createMap(std::string const &s);
         bool readWatchFile();
-        bool createPropertiesFromMap();
+        bool createProperties();
+        bool getProperties();
 
         INDI::PropertyText watchFileTP {1};
 


### PR DESCRIPTION
This PR adds dynamic (user definable) labels for the weather parameters. While the default ones are still the same as before, a user can now name the labels at will. Even the critical parameters are selectable! This increases the usability and comprehensibility of the driver in a wide range.
The storing procedure is as simple a possible: Enter the desired names in the "Labels" tab, save the configuration in"Options", disconnect and reconnect the driver and the new labels are active. After that one can now check the critical parameters and repeat the above procedure.

There is a small drawback in that not all special characters are allowed. But normally one can find easily a possible transcription.

Example:
Default labels: "Rain", "Temperature", "Wind", "Gust", "Clouds", "Humidity", "Pressure" "Forecast"
New labels: "Precipitation [%]", "Ambienttemp [C]", "Windspeed [km/h]", "Cloudcover [%]", "", "", "", ""

![WeatherWatcherMain](https://github.com/indilib/indi/assets/28783957/198d2baa-bdcd-4dbc-b21b-1c485161a5d6)
![WeatherWatcherLabels](https://github.com/indilib/indi/assets/28783957/1d7d9df8-3ed6-4861-80e7-f9729b89ae57)
![WeatherWatcherParameters](https://github.com/indilib/indi/assets/28783957/5875a04d-77f8-4faa-a225-d937c1c0bebb)
