### PR TITLE
Add button for custom resolution in simulator CCD

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -196,7 +196,10 @@ bool CCDSim::initProperties()
     for (uint8_t i = 0; i < Resolutions.size(); i++)
     {
         std::ostringstream ss;
-        ss << Resolutions[i].first << " x " << Resolutions[i].second;
+        if (Resolutions[i].first > 0)
+            ss << Resolutions[i].first << " x " << Resolutions[i].second;
+        else
+            ss << "Custom";
         ResolutionSP[i].fill(ss.str().c_str(), ss.str().c_str(), i == 0 ? ISS_ON : ISS_OFF);
     }
     ResolutionSP.fill(getDeviceName(), "CCD_RESOLUTION", "Resolution", SIMULATOR_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
@@ -1220,7 +1223,7 @@ bool CCDSim::ISNewSwitch(const char * dev, const char * name, ISState * states, 
             ResolutionSP.apply();
 
             int index = ResolutionSP.findOnSwitchIndex();
-            if (index >= 0 && index < static_cast<int>(Resolutions.size()))
+            if (index >= 0 && index < static_cast<int>(Resolutions.size() - 1))
             {
                 SimulatorSettingsNP[SIM_XRES].setValue(Resolutions[index].first);
                 SimulatorSettingsNP[SIM_YRES].setValue(Resolutions[index].second);

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -242,11 +242,12 @@ protected:
 
     INDI::PropertySwitch CrashSP {1};
 
-    INDI::PropertySwitch ResolutionSP {2};
+    INDI::PropertySwitch ResolutionSP {3};
     inline static const std::vector<std::pair<uint32_t, uint32_t>> Resolutions =
         {
             {1280, 1024},
-            {6000, 4000}
+            {6000, 4000},
+            {0, 0} // Custom
         };
 
     static const constexpr char* SIMULATOR_TAB = "Simulator Config";


### PR DESCRIPTION
Add button for custom resolution to reestablish the possibility to work with the resolution defined in simulator config.