### PR TITLE
Disable guiding and meridian flip properties on iOptron Azimuth mounts

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -181,35 +181,35 @@
         </device>
         <device label="iOptron iMate" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron CEM26" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron GEM28" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron HEM27" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron HAE29" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron SkyHunter" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron CEM40" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron GEM45" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron iEQ45 Pro" manufacturer="iOptron">
             <driver name="iEQ">indi_ieq_telescope</driver>
@@ -249,19 +249,19 @@
         </device>
         <device label="iOptron v3" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron CEM120" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron CEM70" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="iOptron AZ Pro" manufacturer="iOptron">
             <driver name="iOptronV3">indi_ioptronv3_telescope</driver>
-            <version>1.7</version>
+            <version>1.8</version>
         </device>
         <device label="Pulsar2" manufacturer="GTD">
             <driver name="Pulsar2">indi_lx200pulsar2</driver>

--- a/drivers/telescope/ioptronv3.h
+++ b/drivers/telescope/ioptronv3.h
@@ -103,6 +103,17 @@ class IOptronV3 : public INDI::Telescope, public INDI::GuiderInterface
             */
         bool GetPECDataStatus(bool enabled);
 
+        typedef enum
+        {
+            Azimuth,
+            EquatorialEncoders,
+            EquatorialNoEncoders,
+            Unknown
+        } MountType;
+
+
+        MountType m_MountType {Unknown};
+
         /* Mod v3.0 Adding PEC Recording Switches  */
         ISwitch PECTrainingS[2];
         ISwitchVectorProperty PECTrainingSP;


### PR DESCRIPTION
According to iOptron documentations, these operations are not supported on azimuth mounts.