### PR TITLE
Feature - ZWO AM5 Buzzer setup

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -81,11 +81,11 @@
         </device>
         <device label="ZWO AM5 WiFi" manufacturer="ZWO">
             <driver name="ZWO AM5">indi_lx200am5</driver>
-            <version>1.1</version>
+            <version>1.2</version>
         </device>
         <device label="ZWO AM5 USB" manufacturer="ZWO">
             <driver name="ZWO AM5">indi_lx200am5</driver>
-            <version>1.1</version>
+            <version>1.2</version>
         </device>
         <device label="Celestron GPS" manufacturer="Celestron">
             <driver name="Celestron GPS">indi_celestron_gps</driver>

--- a/drivers/telescope/lx200am5.cpp
+++ b/drivers/telescope/lx200am5.cpp
@@ -35,7 +35,7 @@
 
 LX200AM5::LX200AM5()
 {
-    setVersion(1, 1);
+    setVersion(1, 2);
 
     setLX200Capability(LX200_HAS_PULSE_GUIDING);
 

--- a/drivers/telescope/lx200am5.cpp
+++ b/drivers/telescope/lx200am5.cpp
@@ -106,6 +106,17 @@ bool LX200AM5::initProperties()
     BuzzerSP[Low].fill("LOW", "Low", ISS_OFF);
     BuzzerSP[High].fill("HIGH", "High", ISS_ON);
     BuzzerSP.fill(getDeviceName(), "BUZZER", "Buzzer", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    BuzzerSP.onUpdate([this]{
+        if (setBuzzer(BuzzerSP.findOnSwitchIndex()))
+        {
+            BuzzerSP.setState(IPState::IPS_OK);
+        }
+        else
+        {
+            BuzzerSP.setState(IPState::IPS_ALERT);
+        }
+        BuzzerSP.apply();
+    });
 
     return true;
 }

--- a/drivers/telescope/lx200am5.cpp
+++ b/drivers/telescope/lx200am5.cpp
@@ -353,7 +353,7 @@ bool LX200AM5::getTrackMode()
 bool LX200AM5::setBuzzer(int value)
 {
     char command[DRIVER_LEN] = {0};
-    snprintf(command, DRIVER_LEN, ":SBu%d", value);
+    snprintf(command, DRIVER_LEN, ":SBu%d#", value);
     return sendCommand(command);
 }
 


### PR DESCRIPTION
Hello!

I have an AM5 mount and I noticed that the "INDI Control Panel" does not have the ability to change the buzzer volume. The property was not associated with the setBuzzer function and the command was missing the trailing sign (#).

I checked the command by intercepting the transmission from `StarGazing`.
https://github.com/pawel-soja/ZWO-AM5-Proxy