### PR TITLE
Fix "Unknown argument: -v" and %include for swig

### DIFF
--- a/libs/indidevice/indibase.h
+++ b/libs/indidevice/indibase.h
@@ -7,7 +7,7 @@
 
 #ifdef SWIG
 // api version for swig
-% include "indiapi.h"
+%include "indiapi.h"
 #endif
 
 #define MAXRBUF 2048

--- a/scripts/indi-core-test.sh
+++ b/scripts/indi-core-test.sh
@@ -3,7 +3,7 @@
 set -e
 
 pushd build/indi-core/integs
-ctest -v --output-on-failure
+ctest -V --output-on-failure
 popd
 
 pushd build/indi-core/test


### PR DESCRIPTION
I found a similar problem in another repository: https://github.com/pytorch/torchrec/pull/2208/files

Jasem, probably automatic code formatting, inserts space `% include`
```cpp
#ifdef SWIG
// api version for swig
% include "indiapi.h" // wrong!
#endif
```