### PR TITLE
Adding Home support to base class

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -33,11 +33,11 @@
         </device>
         <device label="LX200 OnStep" manufacturer="OnStep">
             <driver name="LX200 OnStep">indi_lx200_OnStep</driver>
-            <version>1.22</version>
+            <version>1.23</version>
         </device>
         <device label="WARPDRIVE" manufacturer="WarpAstron">
             <driver name="LX200 OnStep">indi_lx200_OnStep</driver>
-            <version>1.22</version>
+            <version>1.23</version>
         </device>
         <device label="LX200 OpenAstroTech" manufacturer="OpenAstroTech">
             <driver name="LX200 OpenAstroTech">indi_lx200_OpenAstroTech</driver>
@@ -77,7 +77,7 @@
         </device>
         <device label="Pegasus NYX-101" manufacturer="Pegasus Astro">
             <driver name="Pegasus NYX-101">indi_lx200_pegasus_nyx101</driver>
-            <version>2.1</version>
+            <version>2.2</version>
         </device>
         <device label="ZWO AM5 WiFi" manufacturer="ZWO">
             <driver name="ZWO AM5">indi_lx200am5</driver>

--- a/drivers/telescope/ieqpro.cpp
+++ b/drivers/telescope/ieqpro.cpp
@@ -59,7 +59,9 @@ IEQPro::IEQPro()
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT |
                            TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION | TELESCOPE_HAS_TRACK_MODE | TELESCOPE_CAN_CONTROL_TRACK |
                            TELESCOPE_HAS_TRACK_RATE,
-                           9);
+                           9,
+                           HOME_FIND | HOME_GO | HOME_SET
+                          );
 }
 
 const char *IEQPro::getDefaultName()
@@ -127,13 +129,6 @@ bool IEQPro::initProperties()
     IUFillSwitchVector(&HemisphereSP, HemisphereS, 2, getDeviceName(), "HEMISPHERE", "Hemisphere", MOUNTINFO_TAB, IP_RO,
                        ISR_1OFMANY, 0, IPS_IDLE);
 
-    /* Home */
-    IUFillSwitch(&HomeS[IEQ_SET_HOME], "IEQ_SET_HOME", "Set current as Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IEQ_GOTO_HOME], "IEQ_GOTO_HOME", "Go to Home", ISS_OFF);
-    IUFillSwitch(&HomeS[IEQ_FIND_HOME], "IEQ_FIND_HOME", "Find Home", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 3, getDeviceName(), "HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 0,
-                       IPS_IDLE);
-
     /* How fast do we guide compared to sidereal rate */
     IUFillNumber(&GuideRateN[RA_AXIS], "RA_GUIDE_RATE", "RA", "%.2f", 0.01, 0.9, 0.1, 0.5);
     IUFillNumber(&GuideRateN[DEC_AXIS], "DE_GUIDE_RATE", "DE", "%.2f", 0.1, 0.99, 0.1, 0.5);
@@ -170,12 +165,6 @@ bool IEQPro::updateProperties()
 
         INDI::Telescope::updateProperties();
 
-        // Remove find home if we do not support it.
-        if (!canFindHome)
-            HomeSP.nsp = 2;
-
-        defineProperty(&HomeSP);
-
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
 
@@ -190,9 +179,6 @@ bool IEQPro::updateProperties()
     else
     {
         INDI::Telescope::updateProperties();
-
-        HomeSP.nsp = 3;
-        deleteProperty(HomeSP.name);
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
@@ -347,79 +333,9 @@ bool IEQPro::ISNewNumber(const char *dev, const char *name, double values[], cha
     return INDI::Telescope::ISNewNumber(dev, name, values, names, n);
 }
 
-bool IEQPro::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
-{
-    if (!strcmp(getDeviceName(), dev))
-    {
-        if (!strcmp(name, HomeSP.name))
-        {
-            IUUpdateSwitch(&HomeSP, states, names, n);
-
-            HomeOperation operation = static_cast<HomeOperation>(IUFindOnSwitchIndex(&HomeSP));
-
-            IUResetSwitch(&HomeSP);
-
-            switch (operation)
-            {
-                case IEQ_SET_HOME:
-                    if (driver->setCurrentHome() == false)
-                    {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
-                        return false;
-                    }
-
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
-                    LOG_INFO("Home position set to current coordinates.");
-                    return true;
-
-                case IEQ_GOTO_HOME:
-                    if (TrackState == SCOPE_PARKED)
-                    {
-                        LOG_ERROR("Please unpark the mount before issuing any motion commands.");
-                        return false;
-                    }
-
-                    if (driver->gotoHome() == false)
-                    {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
-                        return false;
-                    }
-
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
-                    LOG_INFO("Slewing to home position...");
-                    return true;
-
-                case IEQ_FIND_HOME:
-                    if (driver->findHome() == false)
-                    {
-                        HomeSP.s = IPS_ALERT;
-                        IDSetSwitch(&HomeSP, nullptr);
-                        return false;
-                    }
-
-                    HomeSP.s = IPS_OK;
-                    IDSetSwitch(&HomeSP, nullptr);
-                    LOG_INFO("Searching for home position...");
-                    return true;
-            }
-
-            return true;
-        }
-    }
-
-    return INDI::Telescope::ISNewSwitch(dev, name, states, names, n);
-}
-
 bool IEQPro::ReadScopeStatus()
 {
     iEQ::Base::Info newInfo;
-
-    //    if (isSimulation())
-    //        mountSim();
 
     bool rc = driver->getStatus(&newInfo);
 
@@ -1070,4 +986,52 @@ bool IEQPro::SetTrackEnabled(bool enabled)
     }
 
     return driver->setTrackEnabled(enabled);
+}
+
+IPState IEQPro::ExecuteHomeAction(TelescopeHomeAction action)
+{
+    switch (action)
+    {
+        case HOME_FIND:
+            if (!canFindHome && (firmwareInfo.Model.find("CEM") == std::string::npos &&
+                                 firmwareInfo.Model.find("GEM45") == std::string::npos &&
+                                 firmwareInfo.Model.find("HAE") == std::string::npos &&
+                                 firmwareInfo.Model.find("HAZ") == std::string::npos &&
+                                 firmwareInfo.Model.find("HEM") == std::string::npos))
+            {
+                LOG_WARN("Home search is not supported in this model.");
+                return IPS_ALERT;
+            }
+
+            if (driver->findHome() == false)
+            {
+                return IPS_ALERT;
+            }
+
+            LOG_INFO("Searching for home position...");
+            return IPS_BUSY;
+
+        case HOME_SET:
+            if (driver->setCurrentHome() == false)
+            {
+                return IPS_ALERT;
+            }
+
+            LOG_INFO("Home position set to current coordinates.");
+            return IPS_OK;
+
+        case HOME_GO:
+            if (driver->gotoHome() == false)
+            {
+                return IPS_ALERT;
+            }
+
+            LOG_INFO("Slewing to home position...");
+            return IPS_BUSY;
+
+        default:
+            return IPS_ALERT;
+    }
+
+    return IPS_ALERT;
 }

--- a/drivers/telescope/ieqpro.cpp
+++ b/drivers/telescope/ieqpro.cpp
@@ -58,9 +58,8 @@ IEQPro::IEQPro()
 
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT |
                            TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION | TELESCOPE_HAS_TRACK_MODE | TELESCOPE_CAN_CONTROL_TRACK |
-                           TELESCOPE_HAS_TRACK_RATE,
-                           9,
-                           HOME_FIND | HOME_GO | HOME_SET
+                           TELESCOPE_HAS_TRACK_RATE | TELESCOPE_CAN_HOME_FIND | TELESCOPE_CAN_HOME_SET | TELESCOPE_CAN_HOME_GO,
+                           9
                           );
 }
 

--- a/drivers/telescope/ieqpro.h
+++ b/drivers/telescope/ieqpro.h
@@ -32,7 +32,6 @@ class IEQPro : public INDI::Telescope, public INDI::GuiderInterface
         IEQPro();
 
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
     protected:
         virtual const char *getDefaultName() override;
@@ -78,6 +77,9 @@ class IEQPro : public INDI::Telescope, public INDI::GuiderInterface
         // Slew Rate
         virtual bool SetSlewRate(int index) override;
 
+        // Homing
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
+
         // Sim
         //void mountSim();
 
@@ -118,8 +120,8 @@ class IEQPro : public INDI::Telescope, public INDI::GuiderInterface
         ISwitchVectorProperty HemisphereSP;
 
         /* Home Control */
-        ISwitch HomeS[3];
-        ISwitchVectorProperty HomeSP;
+        // ISwitch HomeS[3];
+        // ISwitchVectorProperty HomeSP;
 
         /* Guide Rate */
         INumber GuideRateN[2];

--- a/drivers/telescope/ioptronv3.cpp
+++ b/drivers/telescope/ioptronv3.cpp
@@ -67,9 +67,11 @@ IOptronV3::IOptronV3()
                            TELESCOPE_HAS_TRACK_MODE |
                            TELESCOPE_CAN_CONTROL_TRACK |
                            TELESCOPE_HAS_TRACK_RATE |
-                           TELESCOPE_HAS_PIER_SIDE,
-                           9,
-                           HOME_FIND | HOME_SET | HOME_GO
+                           TELESCOPE_HAS_PIER_SIDE |
+                           TELESCOPE_CAN_HOME_FIND |
+                           TELESCOPE_CAN_HOME_SET |
+                           TELESCOPE_CAN_HOME_GO,
+                           9
                           );
 }
 

--- a/drivers/telescope/ioptronv3.h
+++ b/drivers/telescope/ioptronv3.h
@@ -90,6 +90,9 @@ class IOptronV3 : public INDI::Telescope, public INDI::GuiderInterface
         virtual IPState GuideEast(uint32_t ms) override;
         virtual IPState GuideWest(uint32_t ms) override;
 
+        // Homing
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
+
     private:
         /**
             * @brief getStartupData Get initial mount info on startup.
@@ -129,10 +132,6 @@ class IOptronV3 : public INDI::Telescope, public INDI::GuiderInterface
         /* Hemisphere */
         ISwitch HemisphereS[2];
         ISwitchVectorProperty HemisphereSP;
-
-        /* Home Control */
-        ISwitch HomeS[3];
-        ISwitchVectorProperty HomeSP;
 
         /* Guide Rate */
         INumber GuideRateN[2];

--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -55,7 +55,11 @@ LX200_OnStep::LX200_OnStep() : LX200Generic(), WI(this), RotatorInterface(this)
     setLX200Capability(LX200_HAS_TRACKING_FREQ | LX200_HAS_SITES | LX200_HAS_ALIGNMENT_TYPE | LX200_HAS_PULSE_GUIDING |
                        LX200_HAS_PRECISE_TRACKING_FREQ);
 
-    SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_CAN_CONTROL_TRACK | TELESCOPE_HAS_TRACK_RATE, 10, HOME_GO | HOME_SET);
+    SetTelescopeCapability(GetTelescopeCapability() |
+                           TELESCOPE_CAN_CONTROL_TRACK |
+                           TELESCOPE_HAS_TRACK_RATE |
+                           TELESCOPE_CAN_HOME_GO |
+                           TELESCOPE_CAN_HOME_SET, 10);
 
     //CAN_ABORT, CAN_GOTO ,CAN_PARK ,CAN_SYNC ,HAS_LOCATION ,HAS_TIME ,HAS_TRACK_MODE Already inherited from lx200generic,
     // 4 stands for the number of Slewrate Buttons as defined in Inditelescope.cpp

--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -50,13 +50,12 @@ LX200_OnStep::LX200_OnStep() : LX200Generic(), WI(this), RotatorInterface(this)
     currentCatalog    = LX200_STAR_C;
     currentSubCatalog = 0;
 
-    setVersion(1, 22);   // don't forget to update libindi/drivers.xml
+    setVersion(1, 23);   // don't forget to update libindi/drivers.xml
 
     setLX200Capability(LX200_HAS_TRACKING_FREQ | LX200_HAS_SITES | LX200_HAS_ALIGNMENT_TYPE | LX200_HAS_PULSE_GUIDING |
                        LX200_HAS_PRECISE_TRACKING_FREQ);
 
-    SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_CAN_CONTROL_TRACK                         |
-                           TELESCOPE_HAS_TRACK_RATE, 10 );
+    SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_CAN_CONTROL_TRACK | TELESCOPE_HAS_TRACK_RATE, 10, HOME_GO | HOME_SET);
 
     //CAN_ABORT, CAN_GOTO ,CAN_PARK ,CAN_SYNC ,HAS_LOCATION ,HAS_TIME ,HAS_TRACK_MODE Already inherited from lx200generic,
     // 4 stands for the number of Slewrate Buttons as defined in Inditelescope.cpp
@@ -210,10 +209,10 @@ bool LX200_OnStep::initProperties()
     // ============== DATETIME_TAB
 
     // ============== SITE_TAB
-    IUFillSwitch(&SetHomeS[0], "RETURN_HOME", "Return  Home", ISS_OFF);
-    IUFillSwitch(&SetHomeS[1], "AT_HOME", "At Home (Reset)", ISS_OFF);
-    IUFillSwitchVector(&SetHomeSP, SetHomeS, 2, getDeviceName(), "HOME_INIT", "Homing", SITE_TAB, IP_RW, ISR_ATMOST1, 60,
-                       IPS_IDLE);
+    // IUFillSwitch(&SetHomeS[0], "RETURN_HOME", "Return  Home", ISS_OFF);
+    // IUFillSwitch(&SetHomeS[1], "AT_HOME", "At Home (Reset)", ISS_OFF);
+    // IUFillSwitchVector(&SetHomeSP, SetHomeS, 2, getDeviceName(), "HOME_INIT", "Homing", SITE_TAB, IP_RW, ISR_ATMOST1, 60,
+    //                    IPS_IDLE);
 
     // ============== GUIDE_TAB
 
@@ -503,7 +502,7 @@ bool LX200_OnStep::updateProperties()
 
         // Site Management
         defineProperty(ParkOptionSP);
-        defineProperty(&SetHomeSP);
+        //defineProperty(&SetHomeSP);
 
         // Guide
 
@@ -733,7 +732,7 @@ bool LX200_OnStep::updateProperties()
 
         // Site Management
         deleteProperty(ParkOptionSP);
-        deleteProperty(SetHomeSP.name);
+        //deleteProperty(SetHomeSP.name);
         // Guide
 
         // Focuser
@@ -1364,31 +1363,6 @@ bool LX200_OnStep::ISNewSwitch(const char *dev, const char *name, ISState *state
             SlewRateS[index].s = ISS_ON;
             SlewRateSP.s = IPS_OK;
             IDSetSwitch(&SlewRateSP, nullptr);
-            return true;
-        }
-        // Homing, Cold and Warm Init
-        if (!strcmp(name, SetHomeSP.name))
-        {
-            IUUpdateSwitch(&SetHomeSP, states, names, n);
-            SetHomeSP.s = IPS_OK;
-
-            if (SetHomeS[0].s == ISS_ON)
-            {
-                if(!sendOnStepCommandBlind(":hC#"))
-                    return false;
-                IDSetSwitch(&SetHomeSP, "Return Home");
-                SetHomeS[0].s = ISS_OFF;
-            }
-            else
-            {
-                if(!sendOnStepCommandBlind(":hF#"))
-                    return false;
-                IDSetSwitch(&SetHomeSP, "At Home (Reset)");
-                SetHomeS[1].s = ISS_OFF;
-            }
-            IUResetSwitch(&ReticSP);
-            SetHomeSP.s = IPS_IDLE;
-            IDSetSwitch(&SetHomeSP, nullptr);
             return true;
         }
 
@@ -5458,3 +5432,24 @@ bool LX200_OnStep::setUTCOffset(double offset)
     return result;
 }
 
+IPState LX200_OnStep::ExecuteHomeAction(TelescopeHomeAction action)
+{
+    // Homing, Cold and Warm Init
+    switch (action)
+    {
+        case HOME_GO:
+            if(!sendOnStepCommandBlind(":hC#"))
+                return IPS_ALERT;
+            return IPS_BUSY;
+
+        case HOME_SET:
+            if(!sendOnStepCommandBlind(":hF#"))
+                return IPS_ALERT;
+            return IPS_OK;
+
+        default:
+            return IPS_ALERT;
+    }
+
+    return IPS_ALERT;
+}

--- a/drivers/telescope/lx200_OnStep.h
+++ b/drivers/telescope/lx200_OnStep.h
@@ -41,7 +41,7 @@
     - fixed minutes passed meridian not showing actual values
     - fixed missing slewrates defineProperty and deleteProperty causing redefinitions of overrides
     - todo focuser stops working after some time ??? could not yet reproduce
-    - fixed poll and update slew rates 
+    - fixed poll and update slew rates
     - todo poll and update maximum slew speed SmartWebServer=>Settings
     Version 1.18
     - implemented Focuser T° compensation in FOCUSER TAB
@@ -227,12 +227,13 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface, public 
         //RotatorInterface
 
         IPState MoveRotator(double angle) override;
-        //         bool SyncRotator(double angle) override;
         IPState HomeRotator() override;
-        //         bool ReverseRotator(bool enabled) override;
         bool AbortRotator() override;
         bool SetRotatorBacklash (int32_t steps) override;
         bool SetRotatorBacklashEnabled(bool enabled) override;
+
+        // Homing
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
 
         //End RotatorInterface
 
@@ -332,11 +333,11 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface, public 
         bool OSFocuser1 = false;
         ISwitchVectorProperty OSFocus1InitializeSP;
         ISwitch OSFocus1InitializeS[4];
-        
+
         // Focus T° Compensation
         INumberVectorProperty FocusTemperatureNP;
         INumber FocusTemperatureN[2];
-        
+
         ISwitchVectorProperty TFCCompensationSP;
         ISwitch TFCCompensationS[2];
         INumberVectorProperty TFCCoefficientNP;
@@ -394,8 +395,8 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface, public 
         ISwitchVectorProperty HomePauseSP;
         ISwitch HomePauseS[3];
 
-        ISwitchVectorProperty SetHomeSP;
-        ISwitch SetHomeS[2];
+        // ISwitchVectorProperty SetHomeSP;
+        // ISwitch SetHomeS[2];
 
         ISwitchVectorProperty PreferredPierSideSP;
         ISwitch PreferredPierSideS[3];

--- a/drivers/telescope/lx200_OpenAstroTech.cpp
+++ b/drivers/telescope/lx200_OpenAstroTech.cpp
@@ -39,7 +39,7 @@ LX200_OpenAstroTech::LX200_OpenAstroTech(void) : LX200GPS()
 {
     setVersion(MAJOR_VERSION, MINOR_VERSION);
 
-    SetTelescopeCapability(GetTelescopeCapability(), 4, HOME_GO);
+    SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_CAN_HOME_GO, 4);
 }
 
 bool LX200_OpenAstroTech::Handshake()

--- a/drivers/telescope/lx200_OpenAstroTech.h
+++ b/drivers/telescope/lx200_OpenAstroTech.h
@@ -27,66 +27,68 @@
 
 class LX200_OpenAstroTech : public LX200GPS
 {
-  public:
-    LX200_OpenAstroTech(void);
+    public:
+        LX200_OpenAstroTech(void);
 
-    virtual bool Handshake() override;
-    virtual const char *getDefaultName(void) override;
-    virtual bool initProperties() override;
-    virtual bool updateProperties() override;
-    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+        virtual bool Handshake() override;
+        virtual const char *getDefaultName(void) override;
+        virtual bool initProperties() override;
+        virtual bool updateProperties() override;
+        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+        virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
 
-  protected:
-//    virtual void getBasicData(void) override;
-    //FocuserInterface
+    protected:
+        //    virtual void getBasicData(void) override;
+        //FocuserInterface
 
-    IPState MoveFocuser(FocusDirection dir, int speed, uint16_t duration) override;
-    IPState MoveAbsFocuser (uint32_t targetTicks) override;
-    IPState MoveRelFocuser (FocusDirection dir, uint32_t ticks) override;
-    virtual bool SetFocuserBacklash(int32_t steps) override;
-    virtual bool AbortFocuser () override;
-    virtual bool ReadScopeStatus() override;
-    virtual bool SyncFocuser(uint32_t ticks) override;
+        IPState MoveFocuser(FocusDirection dir, int speed, uint16_t duration) override;
+        IPState MoveAbsFocuser (uint32_t targetTicks) override;
+        IPState MoveRelFocuser (FocusDirection dir, uint32_t ticks) override;
+        virtual bool SetFocuserBacklash(int32_t steps) override;
+        virtual bool AbortFocuser () override;
+        virtual bool ReadScopeStatus() override;
+        virtual bool SyncFocuser(uint32_t ticks) override;
 
-    //End FocuserInterface
+        // Home
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
 
-  private:
-    virtual char getCommandChar(int fd, const char *cmd);
-    virtual int executeMeadeCommand(const char *cmd, char *data);
-    virtual bool executeMeadeCommandBlind(const char *cmd);
-    //virtual int executeMeadeCommandNumber(const char *cmd);
-    virtual int flushIO(int fd);
-    int OATUpdateProperties();
-    int OATUpdateFocuser();
-    void initFocuserProperties(const char *);
+        //End FocuserInterface
 
-  private:
-    IText MeadeCommandT;
-    ITextVectorProperty MeadeCommandTP;
+    private:
+        virtual char getCommandChar(int fd, const char *cmd);
+        virtual int executeMeadeCommand(const char *cmd, char *data);
+        virtual bool executeMeadeCommandBlind(const char *cmd);
+        //virtual int executeMeadeCommandNumber(const char *cmd);
+        virtual int flushIO(int fd);
+        int OATUpdateProperties();
+        int OATUpdateFocuser();
+        void initFocuserProperties(const char *);
 
-    INumber PolarAlignAltN;
-    INumberVectorProperty PolarAlignAltNP;
+    private:
+        IText MeadeCommandT;
+        ITextVectorProperty MeadeCommandTP;
 
-    INumber PolarAlignAzN;
-    INumberVectorProperty PolarAlignAzNP;
+        INumber PolarAlignAltN;
+        INumberVectorProperty PolarAlignAltNP;
 
-    INumber RAHomeN;
-    INumberVectorProperty RAHomeNP;
+        INumber PolarAlignAzN;
+        INumberVectorProperty PolarAlignAzNP;
 
-    INumber RAHomeOffsetN;
-    INumberVectorProperty RAHomeOffsetNP;
+        INumber RAHomeN;
+        INumberVectorProperty RAHomeNP;
 
-    INumber DecLimitsN[2];
-    INumberVectorProperty DecLimitsNP;
+        INumber RAHomeOffsetN;
+        INumberVectorProperty RAHomeOffsetNP;
 
-    ISwitchVectorProperty HomeSP;
-    ISwitch HomeS;
+        INumber DecLimitsN[2];
+        INumberVectorProperty DecLimitsNP;
 
-    char MeadeCommandResult[1024];
-    int32_t FocuserBacklash;
-    bool PolarActive;
-    INDI::FocuserInterface::FocusDirection FocuserDirectionLast;    
+        // ISwitchVectorProperty HomeSP;
+        // ISwitch HomeS;
+
+        char MeadeCommandResult[1024];
+        int32_t FocuserBacklash;
+        bool PolarActive;
+        INDI::FocuserInterface::FocusDirection FocuserDirectionLast;
 };
 

--- a/drivers/telescope/lx200_pegasus_nyx101.cpp
+++ b/drivers/telescope/lx200_pegasus_nyx101.cpp
@@ -51,9 +51,10 @@ LX200NYX101::LX200NYX101()
                            TELESCOPE_CAN_CONTROL_TRACK |
                            TELESCOPE_HAS_TIME |
                            TELESCOPE_HAS_LOCATION |
-                           TELESCOPE_HAS_TRACK_MODE,
-                           SLEW_MODES,
-                           HOME_GO | HOME_SET
+                           TELESCOPE_HAS_TRACK_MODE |
+                           TELESCOPE_CAN_HOME_SET |
+                           TELESCOPE_CAN_HOME_GO,
+                           SLEW_MODES
                           );
 }
 

--- a/drivers/telescope/lx200_pegasus_nyx101.h
+++ b/drivers/telescope/lx200_pegasus_nyx101.h
@@ -29,104 +29,107 @@
 
 class LX200NYX101 : public LX200Generic
 {
-public:
-    LX200NYX101();
-    virtual bool updateProperties() override;
-    virtual bool initProperties() override;
-    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+    public:
+        LX200NYX101();
+        virtual bool updateProperties() override;
+        virtual bool initProperties() override;
+        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 #ifdef DEBUG_NYX
-    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+        virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
 
-    INDI::PropertyText DebugCommandTP {1};
+        INDI::PropertyText DebugCommandTP {1};
 #endif
-    
-protected:
-    virtual bool ReadScopeStatus() override;
-    virtual const char *getDefaultName() override;
-    virtual bool Park() override;
-    virtual bool UnPark() override;
-    virtual bool updateLocation(double latitude, double longitude, double elevation) override;
-    virtual bool setUTCOffset(double offset) override;
-    virtual bool setLocalDate(uint8_t days, uint8_t months, uint16_t years) override;
-    virtual bool SetTrackEnabled(bool enabled) override;
-    virtual bool SetTrackMode(uint8_t mode) override;
-    virtual bool SetSlewRate(int index) override;
 
-private:
-     static constexpr const uint8_t SLEW_MODES {10};
-     static constexpr const uint8_t DRIVER_LEN {64};
-     static const char DRIVER_STOP_CHAR { 0x23 };
-     static constexpr const uint8_t DRIVER_TIMEOUT {3};
+    protected:
+        virtual bool ReadScopeStatus() override;
+        virtual const char *getDefaultName() override;
+        virtual bool Park() override;
+        virtual bool UnPark() override;
+        virtual bool updateLocation(double latitude, double longitude, double elevation) override;
+        virtual bool setUTCOffset(double offset) override;
+        virtual bool setLocalDate(uint8_t days, uint8_t months, uint16_t years) override;
+        virtual bool SetTrackEnabled(bool enabled) override;
+        virtual bool SetTrackMode(uint8_t mode) override;
+        virtual bool SetSlewRate(int index) override;
 
-    enum RefractionState
-    {
-        REFRACT_ON,
-        REFRACT_OFF
-    };
+        // Homing
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
 
-    enum SafetyLimits
-    {
-        SET_SAFETY_LIMIT,
-        CLEAR_SAFETY_LIMIT
-    };
+    private:
+        static constexpr const uint8_t SLEW_MODES {10};
+        static constexpr const uint8_t DRIVER_LEN {64};
+        static const char DRIVER_STOP_CHAR { 0x23 };
+        static constexpr const uint8_t DRIVER_TIMEOUT {3};
 
-    enum NYXTelescopeTrackMode
-    {
-        TRACK_SIDEREAL,
-        TRACK_SOLAR,
-        TRACK_LUNAR,
-        TRACK_KING
-    };
-    
-    INDI::PropertySwitch MountTypeSP {2};
-    enum MountType
-    {
-        AltAz,
-        Equatorial
-    };
+        enum RefractionState
+        {
+            REFRACT_ON,
+            REFRACT_OFF
+        };
 
-    enum ElevationNumber
-    {
-        OVERHEAD,
-        HORIZON
-    };
+        enum SafetyLimits
+        {
+            SET_SAFETY_LIMIT,
+            CLEAR_SAFETY_LIMIT
+        };
 
-    INDI::PropertySwitch GuideRateSP {3};
-    INDI::PropertySwitch HomeSP {1};
-    INDI::PropertySwitch ResetHomeSP {1};
-    INDI::PropertyText Report {1};
-    INDI::PropertySwitch VerboseReportSP {2};
-    INDI::PropertyText IsTracking {1};
-    INDI::PropertyText IsSlewCompleted {1};
-    INDI::PropertyText IsParked {1};
-    INDI::PropertyText IsParkginInProgress {1};
-    INDI::PropertyText IsAtHomePosition {1};
-    INDI::PropertyText MountAltAz {1};
-    INDI::PropertyText MountEquatorial {1};
-    INDI::PropertyText PierNone {1};
-    INDI::PropertyText PierEast {1};
-    INDI::PropertyText PierWest {1};
-    INDI::PropertyText DoesRefractionComp {1};
-    INDI::PropertyText WaitingAtHome {1};
-    INDI::PropertyText IsHomePaused {1};
-    INDI::PropertyText ParkFailed {1};
-    INDI::PropertyText SlewingHome {1};
-    INDI::PropertySwitch FlipSP {1};
-    INDI::PropertySwitch RebootSP {1};
-    INDI::PropertySwitch RefractSP {2};
-    INDI::PropertyNumber ElevationLimitNP {2};
-    INDI::PropertyNumber MeridianLimitNP {1};
-    INDI::PropertySwitch SafetyLimitSP {2};
- 
+        enum NYXTelescopeTrackMode
+        {
+            TRACK_SIDEREAL,
+            TRACK_SOLAR,
+            TRACK_LUNAR,
+            TRACK_KING
+        };
 
-     bool sendCommand(const char * cmd, char * res = nullptr, int cmd_len = -1, int res_len = -1);
-     void hexDump(char * buf, const char * data, int size);
-     std::vector<std::string> split(const std::string &input, const std::string &regex);
-     bool goToPark();
-     bool goToUnPark();
-     bool setMountType(int type);
-     bool setGuideRate(int rate);
-     bool verboseReport = false;
-     void SetPropertyText(INDI::PropertyText propertyTxt, IPState state);
+        INDI::PropertySwitch MountTypeSP {2};
+        enum MountType
+        {
+            AltAz,
+            Equatorial
+        };
+
+        enum ElevationNumber
+        {
+            OVERHEAD,
+            HORIZON
+        };
+
+        INDI::PropertySwitch GuideRateSP {3};
+        // INDI::PropertySwitch HomeSP {1};
+        // INDI::PropertySwitch ResetHomeSP {1};
+        INDI::PropertyText Report {1};
+        INDI::PropertySwitch VerboseReportSP {2};
+        INDI::PropertyText IsTracking {1};
+        INDI::PropertyText IsSlewCompleted {1};
+        INDI::PropertyText IsParked {1};
+        INDI::PropertyText IsParkginInProgress {1};
+        INDI::PropertyText IsAtHomePosition {1};
+        INDI::PropertyText MountAltAz {1};
+        INDI::PropertyText MountEquatorial {1};
+        INDI::PropertyText PierNone {1};
+        INDI::PropertyText PierEast {1};
+        INDI::PropertyText PierWest {1};
+        INDI::PropertyText DoesRefractionComp {1};
+        INDI::PropertyText WaitingAtHome {1};
+        INDI::PropertyText IsHomePaused {1};
+        INDI::PropertyText ParkFailed {1};
+        INDI::PropertyText SlewingHome {1};
+        INDI::PropertySwitch FlipSP {1};
+        INDI::PropertySwitch RebootSP {1};
+        INDI::PropertySwitch RefractSP {2};
+        INDI::PropertyNumber ElevationLimitNP {2};
+        INDI::PropertyNumber MeridianLimitNP {1};
+        INDI::PropertySwitch SafetyLimitSP {2};
+
+
+        bool sendCommand(const char * cmd, char * res = nullptr, int cmd_len = -1, int res_len = -1);
+        void hexDump(char * buf, const char * data, int size);
+        std::vector<std::string> split(const std::string &input, const std::string &regex);
+        bool goToPark();
+        bool goToUnPark();
+        bool setMountType(int type);
+        bool setGuideRate(int rate);
+        bool verboseReport = false;
+        void SetPropertyText(INDI::PropertyText propertyTxt, IPState state);
 };

--- a/drivers/telescope/lx200am5.cpp
+++ b/drivers/telescope/lx200am5.cpp
@@ -46,9 +46,10 @@ LX200AM5::LX200AM5()
                            TELESCOPE_CAN_CONTROL_TRACK |
                            TELESCOPE_HAS_TIME |
                            TELESCOPE_HAS_LOCATION |
-                           TELESCOPE_HAS_TRACK_MODE,
-                           SLEW_MODES,
-                           HOME_GO
+                           TELESCOPE_HAS_TRACK_MODE |
+                           TELESCOPE_CAN_HOME_SET |
+                           TELESCOPE_CAN_HOME_GO,
+                           SLEW_MODES
                           );
 }
 

--- a/drivers/telescope/lx200am5.h
+++ b/drivers/telescope/lx200am5.h
@@ -34,7 +34,7 @@ class LX200AM5 : public LX200Generic
         virtual bool initProperties() override;
 
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;        
+        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
 
     protected:
         virtual const char *getDefaultName() override;
@@ -46,7 +46,7 @@ class LX200AM5 : public LX200Generic
         virtual bool ReadScopeStatus() override;
         virtual bool SetSlewRate(int index) override;
 
-        // Tracking        
+        // Tracking
         virtual bool SetTrackEnabled(bool enabled) override;
 
         // Time & Location
@@ -57,6 +57,9 @@ class LX200AM5 : public LX200Generic
         // Parking
         virtual bool Park() override;
         virtual bool UnPark() override;
+
+        // Home
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
 
     private:
 
@@ -82,14 +85,14 @@ class LX200AM5 : public LX200Generic
         /// Properties
         //////////////////////////////////////////////////////////////////////////////////
         // Go Home
-        INDI::PropertySwitch HomeSP {1};
+        //INDI::PropertySwitch HomeSP {1};
         // Mount Type
         INDI::PropertySwitch MountTypeSP {2};
         enum
         {
             Azimuth,
             Equatorial
-        };        
+        };
         // Guide Rate
         INDI::PropertyNumber GuideRateNP {1};
         // Buzzer control

--- a/drivers/telescope/lx200zeq25.cpp
+++ b/drivers/telescope/lx200zeq25.cpp
@@ -47,9 +47,9 @@ LX200ZEQ25::LX200ZEQ25()
                            TELESCOPE_HAS_TIME |
                            TELESCOPE_HAS_LOCATION |
                            TELESCOPE_HAS_TRACK_MODE |
-                           TELESCOPE_HAS_PIER_SIDE,
-                           9,
-                           HOME_GO
+                           TELESCOPE_HAS_PIER_SIDE |
+                           TELESCOPE_CAN_HOME_GO,
+                           9
                           );
 }
 

--- a/drivers/telescope/lx200zeq25.h
+++ b/drivers/telescope/lx200zeq25.h
@@ -31,7 +31,6 @@ class LX200ZEQ25 : public LX200Generic
         virtual bool updateProperties() override;
         virtual bool initProperties() override;
 
-        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
 
     protected:
@@ -63,6 +62,9 @@ class LX200ZEQ25 : public LX200Generic
 
         virtual int SendPulseCmd(int8_t direction, uint32_t duration_msec) override;
 
+        // Home
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
+
     private:
         int setZEQ25StandardProcedure(int fd, const char *data);
         int setZEQ25Latitude(double Lat);
@@ -87,9 +89,6 @@ class LX200ZEQ25 : public LX200Generic
 
         bool getMountInfo();
         void mountSim();
-
-        ISwitch HomeS[1];
-        ISwitchVectorProperty HomeSP;
 
         /* Guide Rate */
         INumber GuideRateN[1];

--- a/drivers/telescope/paramount.cpp
+++ b/drivers/telescope/paramount.cpp
@@ -76,9 +76,8 @@ Paramount::Paramount()
 
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT |
                            TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION | TELESCOPE_HAS_TRACK_MODE | TELESCOPE_HAS_TRACK_RATE |
-                           TELESCOPE_CAN_CONTROL_TRACK | TELESCOPE_HAS_PIER_SIDE,
-                           9,
-                           HOME_GO
+                           TELESCOPE_CAN_CONTROL_TRACK | TELESCOPE_HAS_PIER_SIDE | TELESCOPE_CAN_HOME_GO,
+                           9
                           );
     setTelescopeConnection(CONNECTION_TCP);
 

--- a/drivers/telescope/paramount.h
+++ b/drivers/telescope/paramount.h
@@ -39,7 +39,6 @@ class Paramount : public INDI::Telescope, public INDI::GuiderInterface
         virtual bool updateProperties() override;
 
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
     protected:
         virtual bool MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command) override;
@@ -71,6 +70,9 @@ class Paramount : public INDI::Telescope, public INDI::GuiderInterface
         // these all call these two functions
         IPState GuideNS(int32_t ms);
         IPState GuideWE(int32_t ms);
+
+        // Home
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
 
     private:
         void mountSim();
@@ -106,10 +108,6 @@ class Paramount : public INDI::Telescope, public INDI::GuiderInterface
         // Tracking Mode
         ISwitch TrackModeS[4];
         ISwitchVectorProperty TrackModeSP;
-
-        // Homing
-        ISwitchVectorProperty HomeSP;
-        ISwitch HomeS[1];
 
         // Timers
         INDI::Timer m_NSTimer;

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -43,7 +43,9 @@ Rainbow::Rainbow() : INDI::Telescope ()
                            TELESCOPE_HAS_TIME |
                            TELESCOPE_HAS_LOCATION |
                            TELESCOPE_HAS_PIER_SIDE |
-                           TELESCOPE_HAS_TRACK_MODE, 4);
+                           TELESCOPE_HAS_TRACK_MODE, 4,
+                           HOME_GO
+                          );
 }
 
 /////////////////////////////////////////////////////////////////////////////////////
@@ -66,9 +68,9 @@ bool Rainbow::initProperties()
     SetParkDataType(PARK_AZ_ALT);
 
     // Homing
-    IUFillSwitch(&HomeS[0], "GO", "Go", ISS_OFF);
-    IUFillSwitchVector(&HomeSP, HomeS, 1, getDeviceName(), "TELESCOPE_HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
-                       IPS_IDLE);
+    // IUFillSwitch(&HomeS[0], "GO", "Go", ISS_OFF);
+    // IUFillSwitchVector(&HomeSP, HomeS, 1, getDeviceName(), "TELESCOPE_HOME", "Home", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60,
+    //                    IPS_IDLE);
 
     // Star Alignment on Sync
     IUFillSwitch(&SaveAlignBeforeSyncS[STAR_ALIGNMENT_ENABLED], "STAR_ALIGNMENT_ENABLED", "Enabled", ISS_OFF);
@@ -144,7 +146,7 @@ bool Rainbow::updateProperties()
     if (isConnected())
     {
         defineProperty(&HorizontalCoordsNP);
-        defineProperty(&HomeSP);
+        //defineProperty(&HomeSP);
 
         defineProperty(&GuideNSNP);
         defineProperty(&GuideWENP);
@@ -162,7 +164,7 @@ bool Rainbow::updateProperties()
     else
     {
         deleteProperty(HorizontalCoordsNP.name);
-        deleteProperty(HomeSP.name);
+        //deleteProperty(HomeSP.name);
 
         deleteProperty(GuideNSNP.name);
         deleteProperty(GuideWENP.name);
@@ -280,29 +282,8 @@ bool Rainbow::ISNewSwitch(const char *dev, const char *name, ISState *states, ch
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
         // Homing
-        if (!strcmp(HomeSP.name, name))
-        {
-            if (HomeSP.s == IPS_BUSY)
-            {
-                LOG_WARN("Homing is already in progress.");
-                return true;
-            }
-
-            HomeSP.s = findHome() ? IPS_BUSY : IPS_ALERT;
-            if (HomeSP.s == IPS_BUSY)
-            {
-                TrackState = SCOPE_SLEWING;
-                HomeS[0].s = ISS_ON;
-                LOG_INFO("Mount is moving to home position...");
-            }
-            else
-                LOG_ERROR("Mount failed to move to home position.");
-
-            IDSetSwitch(&HomeSP, nullptr);
-            return true;
-        }
         // Star Align
-        else if (!strcmp(SaveAlignBeforeSyncSP.name, name))
+        if (!strcmp(SaveAlignBeforeSyncSP.name, name))
         {
 
             IUUpdateSwitch(&SaveAlignBeforeSyncSP, states, names, n);
@@ -677,12 +658,12 @@ bool Rainbow::ReadScopeStatus()
             HorizontalCoordsNP.s = IPS_OK;
             IDSetNumber(&HorizontalCoordsNP, nullptr);
 
-            if (HomeSP.s == IPS_BUSY)
+            if (HomeSP.getState() == IPS_BUSY)
             {
                 LOG_INFO("Homing completed successfully.");
-                HomeSP.s = IPS_OK;
-                HomeS[0].s = ISS_OFF;
-                IDSetSwitch(&HomeSP, nullptr);
+                HomeSP.reset();
+                HomeSP.setState(IPS_OK);
+                HomeSP.apply();
                 TrackState = SCOPE_IDLE;
             }
             else
@@ -701,12 +682,12 @@ bool Rainbow::ReadScopeStatus()
 
             EqNP.s = IPS_ALERT;
 
-            if (HomeSP.s == IPS_BUSY)
+            if (HomeSP.getState() == IPS_BUSY)
             {
                 TrackState = SCOPE_IDLE;
-                HomeSP.s = IPS_ALERT;
-                HomeS[0].s = ISS_OFF;
-                IDSetSwitch(&HomeSP, nullptr);
+                HomeSP.reset();
+                HomeSP.setState(IPS_ALERT);
+                HomeSP.apply();
                 LOGF_ERROR("Homing error: %s", getSlewErrorString(m_SlewErrorCode).c_str());
             }
             else
@@ -1778,4 +1759,21 @@ std::vector<std::string> Rainbow::split(const std::string &input, const std::str
     first{input.begin(), input.end(), re, -1},
           last;
     return {first, last};
+}
+
+/////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////
+// Home
+IPState Rainbow::ExecuteHomeAction(TelescopeHomeAction action)
+{
+
+    switch (action)
+    {
+        case HOME_GO:
+            return findHome() ? IPS_BUSY : IPS_ALERT;
+
+        default:
+            return IPS_ALERT;
+    }
 }

--- a/drivers/telescope/rainbow.cpp
+++ b/drivers/telescope/rainbow.cpp
@@ -43,8 +43,9 @@ Rainbow::Rainbow() : INDI::Telescope ()
                            TELESCOPE_HAS_TIME |
                            TELESCOPE_HAS_LOCATION |
                            TELESCOPE_HAS_PIER_SIDE |
-                           TELESCOPE_HAS_TRACK_MODE, 4,
-                           HOME_GO
+                           TELESCOPE_HAS_TRACK_MODE |
+                           TELESCOPE_CAN_HOME_GO,
+                           4
                           );
 }
 

--- a/drivers/telescope/rainbow.h
+++ b/drivers/telescope/rainbow.h
@@ -63,6 +63,8 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         virtual bool SetSlewRate(int index) override;
         // Syncing
         virtual bool Sync(double ra, double dec) override;
+        // Home
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
 
         // RA/DE
         bool getRA();
@@ -157,9 +159,6 @@ class Rainbow : public INDI::Telescope, public INDI::GuiderInterface
         ///////////////////////////////////////////////////////////////////////////////////
         /// Properties
         ///////////////////////////////////////////////////////////////////////////////////
-        ISwitchVectorProperty HomeSP;
-        ISwitch HomeS[1];
-
         ISwitchVectorProperty SaveAlignBeforeSyncSP;
         ISwitch SaveAlignBeforeSyncS[2];
         enum { STAR_ALIGNMENT_DISABLED, STAR_ALIGNMENT_ENABLED};

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -41,9 +41,8 @@ ScopeSim::ScopeSim()
 
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT |
                            TELESCOPE_HAS_TIME | TELESCOPE_HAS_LOCATION | TELESCOPE_HAS_TRACK_MODE | TELESCOPE_CAN_CONTROL_TRACK |
-                           TELESCOPE_HAS_TRACK_RATE,
-                           4,
-                           HOME_FIND | HOME_GO | HOME_SET
+                           TELESCOPE_HAS_TRACK_RATE | TELESCOPE_CAN_HOME_FIND | TELESCOPE_CAN_HOME_SET | TELESCOPE_CAN_HOME_GO,
+                           4
                           );
 
     /* initialize random seed: */
@@ -676,7 +675,7 @@ bool ScopeSim::updateMountAndPierSide()
     {
         cap &= ~static_cast<uint32_t>(TELESCOPE_HAS_PIER_SIDE);
     }
-    SetTelescopeCapability(cap, 4, HOME_FIND | HOME_SET | HOME_GO);
+    SetTelescopeCapability(cap, 4);
 
     return true;
 }

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -41,130 +41,126 @@
  */
 class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface
 {
-public:
-    ScopeSim();
-    virtual ~ScopeSim() = default;
+    public:
+        ScopeSim();
+        virtual ~ScopeSim() = default;
 
-    virtual const char *getDefaultName() override;
-    virtual bool Connect() override;
-    virtual bool Disconnect() override;
-    virtual bool ReadScopeStatus() override;
-    virtual bool initProperties() override;
-    virtual void ISGetProperties(const char *dev) override;
-    virtual bool updateProperties() override;
+        virtual const char *getDefaultName() override;
+        virtual bool Connect() override;
+        virtual bool Disconnect() override;
+        virtual bool ReadScopeStatus() override;
+        virtual bool initProperties() override;
+        virtual void ISGetProperties(const char *dev) override;
+        virtual bool updateProperties() override;
 
-    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
-protected:
-    // Slew Rate
-    virtual bool MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command) override;
-    virtual bool MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command) override;
-    virtual bool Abort() override;
+    protected:
+        // Slew Rate
+        virtual bool MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command) override;
+        virtual bool MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command) override;
+        virtual bool Abort() override;
 
-    virtual IPState GuideNorth(uint32_t ms) override;
-    virtual IPState GuideSouth(uint32_t ms) override;
-    virtual IPState GuideEast(uint32_t ms) override;
-    virtual IPState GuideWest(uint32_t ms) override;
+        virtual IPState GuideNorth(uint32_t ms) override;
+        virtual IPState GuideSouth(uint32_t ms) override;
+        virtual IPState GuideEast(uint32_t ms) override;
+        virtual IPState GuideWest(uint32_t ms) override;
 
-    virtual bool SetTrackMode(uint8_t mode) override;
-    virtual bool SetTrackEnabled(bool enabled) override;
-    virtual bool SetTrackRate(double raRate, double deRate) override;
+        virtual bool SetTrackMode(uint8_t mode) override;
+        virtual bool SetTrackEnabled(bool enabled) override;
+        virtual bool SetTrackRate(double raRate, double deRate) override;
 
-    virtual bool Goto(double, double) override;
-    virtual bool Park() override;
-    virtual bool UnPark() override;
-    virtual bool Sync(double ra, double dec) override;
+        virtual bool Goto(double, double) override;
+        virtual bool Park() override;
+        virtual bool UnPark() override;
+        virtual bool Sync(double ra, double dec) override;
 
-    // Parking
-    virtual bool SetCurrentPark() override;
-    virtual bool SetDefaultPark() override;
-    virtual bool updateLocation(double latitude, double longitude, double elevation) override;
+        // Parking
+        virtual bool SetCurrentPark() override;
+        virtual bool SetDefaultPark() override;
+        virtual bool updateLocation(double latitude, double longitude, double elevation) override;
 
-    virtual bool saveConfigItems(FILE *fp) override;
+        // Home
+        virtual IPState ExecuteHomeAction(TelescopeHomeAction action) override;
 
-private:
-    double currentRA { 0 };
-    double currentDEC { 90 };
-    double targetRA { 0 };
-    double targetDEC { 0 };
+        virtual bool saveConfigItems(FILE *fp) override;
 
-    /// used by GoTo and Park
-    void StartSlew(double ra, double dec, TelescopeStatus status);
+    private:
+        double currentRA { 0 };
+        double currentDEC { 90 };
+        double targetRA { 0 };
+        double targetDEC { 0 };
 
-    // bool forceMeridianFlip { false }; // #PS: unused
-    unsigned int DBG_SCOPE { 0 };
+        /// used by GoTo and Park
+        void StartSlew(double ra, double dec, TelescopeStatus status);
 
-    int mcRate = 0;
+        // bool forceMeridianFlip { false }; // #PS: unused
+        unsigned int DBG_SCOPE { 0 };
 
-    //    double guiderEWTarget[2];
-    //    double guiderNSTarget[2];
+        int mcRate = 0;
 
-    bool guidingNS = false;
-    bool guidingEW = false;
+        //    double guiderEWTarget[2];
+        //    double guiderNSTarget[2];
 
-    INDI::PropertyNumber GuideRateNP {2};
-    enum
-    {
-        GUIDE_RATE_WE,
-        GUIDE_RATE_NS
-    };
+        bool guidingNS = false;
+        bool guidingEW = false;
 
-    INDI::PropertySwitch HomeSP {3};
-    enum
-    {
-        Find,
-        Set,
-        Go
-    };
-    double m_Home[2] = {0, 0};
+        INDI::PropertyNumber GuideRateNP {2};
+        enum
+        {
+            GUIDE_RATE_WE,
+            GUIDE_RATE_NS
+        };
 
-    Axis axisPrimary { "HaAxis" };         // hour angle mount axis
-    Axis axisSecondary { "DecAxis" };       // declination mount axis
+        double m_Home[2] = {0, 0};
 
-    int m_PierSide {-1};
-    int m_MountType {-1};
+        Axis axisPrimary { "HaAxis" };         // hour angle mount axis
+        Axis axisSecondary { "DecAxis" };       // declination mount axis
 
-    Alignment alignment;
-    bool updateMountAndPierSide();
+        int m_PierSide {-1};
+        int m_MountType {-1};
+
+        Alignment alignment;
+        bool updateMountAndPierSide();
 
 #ifdef USE_SIM_TAB
-    // Simulator Tab properties
-    // Scope type and alignment
-    INDI::PropertySwitch mountTypeSP {3};
-    enum
-    {
-        ALTAZ,
-        EQ_FORK,
-        EQ_GEM
-    };
+        // Simulator Tab properties
+        // Scope type and alignment
+        INDI::PropertySwitch mountTypeSP {3};
+        enum
+        {
+            ALTAZ,
+            EQ_FORK,
+            EQ_GEM
+        };
 
-    INDI::PropertySwitch simPierSideSP {2};
-    enum
-    {
-        PS_OFF,
-        PS_ON
-    };
+        INDI::PropertySwitch simPierSideSP {2};
+        enum
+        {
+            PS_OFF,
+            PS_ON
+        };
 
-    INDI::PropertyNumber mountModelNP {6};
-    enum
-    {
-        MM_IH,
-        MM_ID,
-        MM_CH,
-        MM_NP,
-        MM_MA,
-        MM_ME
-    };
+        INDI::PropertyNumber mountModelNP {6};
+        enum
+        {
+            MM_IH,
+            MM_ID,
+            MM_CH,
+            MM_NP,
+            MM_MA,
+            MM_ME
+        };
 
-    INDI::PropertyNumber mountAxisNP {2};
-    enum
-    {
-        PRIMARY,
-        SECONDARY
-    };
+        INDI::PropertyNumber mountAxisNP {2};
+        enum
+        {
+            PRIMARY,
+            SECONDARY
+        };
 
-    INDI::PropertyNumber flipHourAngleNP {1};
+        INDI::PropertyNumber flipHourAngleNP {1};
 
 #endif
 

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -1231,7 +1231,7 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         ///////////////////////////////////
         if (HomeSP.isNameMatch(name))
         {
-            auto onSwitchName = IUFindOnSwitchName(states, names, n);
+            auto onSwitchName = std::string(IUFindOnSwitchName(states, names, n));
             auto action = HOME_FIND;
             if (onSwitchName == "SET")
                 action = HOME_SET;

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -1232,12 +1232,10 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
         if (HomeSP.isNameMatch(name))
         {
             auto onSwitchName = IUFindOnSwitchName(states, names, n);
-            TelescopeHomeAction action = HOME_NONE;
-            if (HomeSP[HOME_FIND].isNameMatch(onSwitchName))
-                action = HOME_FIND;
-            else if (HomeSP[HOME_SET].isNameMatch(onSwitchName))
+            auto action = HOME_FIND;
+            if (onSwitchName == "SET")
                 action = HOME_SET;
-            else
+            else if (onSwitchName == "GO")
                 action = HOME_GO;
 
             if (isParked())

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -321,7 +321,7 @@ bool Telescope::updateProperties()
             defineProperty(&TrackStateSP);
         if (HasTrackRate())
             defineProperty(&TrackRateNP);
-        if (CanHome() && m_HomeCapability > 0)
+        if (m_HomeCapability > 0)
             defineProperty(HomeSP);
 
         if (CanGOTO())
@@ -382,7 +382,7 @@ bool Telescope::updateProperties()
             deleteProperty(TrackRateNP.name);
         if (CanControlTrack())
             deleteProperty(TrackStateSP.name);
-        if (CanHome() && m_HomeCapability > 0)
+        if (m_HomeCapability > 0)
             deleteProperty(HomeSP);
 
         if (CanGOTO())
@@ -1251,6 +1251,8 @@ bool Telescope::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 
             auto state = ExecuteHomeAction(action);
             HomeSP.setState(state);
+            if (state == IPS_BUSY)
+                HomeSP.update(states, names, n);
             HomeSP.apply();
             return true;
         }
@@ -1768,6 +1770,12 @@ bool Telescope::updateLocation(double latitude, double longitude, double elevati
     INDI_UNUSED(longitude);
     INDI_UNUSED(elevation);
     return true;
+}
+
+IPState Telescope::ExecuteHomeAction(TelescopeHomeAction action)
+{
+    INDI_UNUSED(action);
+    return IPS_ALERT;
 }
 
 void Telescope::updateObserverLocation(double latitude, double longitude, double elevation)

--- a/libs/indibase/inditelescope.h
+++ b/libs/indibase/inditelescope.h
@@ -187,6 +187,9 @@ class Telescope : public DefaultDevice
             TELESCOPE_HAS_PIER_SIDE_SIMULATION    = 1 << 11, /** Does the telescope simulate the pier side property? */
             TELESCOPE_CAN_TRACK_SATELLITE         = 1 << 12, /** Can the telescope track satellites? */
             TELESCOPE_CAN_FLIP                    = 1 << 13, /** Does the telescope have a command for flipping? */
+            TELESCOPE_CAN_HOME_FIND               = 1 << 14, /** Can the telescope find home position? */
+            TELESCOPE_CAN_HOME_SET                = 1 << 15, /** Can the telescope set the current position as the new home position? */
+            TELESCOPE_CAN_HOME_GO                 = 1 << 16, /** Can the telescope slew to home position? */
         } TelescopeCapability;
 
         Telescope();
@@ -213,9 +216,8 @@ class Telescope : public DefaultDevice
          * no slew rate properties will be defined to the client. If >=4, the driver will construct the default
          * slew rate property TELESCOPE_SLEW_RATE with SLEW_GUIDE, SLEW_CENTERING, SLEW_FIND, and SLEW_MAX
          * members where SLEW_GUIDE is the at the lowest setting and SLEW_MAX is at the highest.
-         * @param homeCapability An ORed value of supported home actions (Find, Set, Go) if any. By default, no home actions are supported.
          */
-        void SetTelescopeCapability(uint32_t cap, uint8_t slewRateCount, uint8_t homeCapability = 0);
+        void SetTelescopeCapability(uint32_t cap, uint8_t slewRateCount);
 
         /**
          * @return True if telescope support goto operations
@@ -325,6 +327,30 @@ class Telescope : public DefaultDevice
         bool HasTrackRate()
         {
             return capability & TELESCOPE_HAS_TRACK_RATE;
+        }
+
+        /**
+         * @return True if telescope can search for home position.
+         */
+        bool CanHomeFind()
+        {
+            return capability & TELESCOPE_CAN_HOME_FIND;
+        }
+
+        /**
+         * @return True if telescope can set current position as the home position.
+         */
+        bool CanHomeSet()
+        {
+            return capability & TELESCOPE_CAN_HOME_SET;
+        }
+
+        /**
+         * @return True if telescope can go to the home position.
+         */
+        bool CanHomeGo()
+        {
+            return capability & TELESCOPE_CAN_HOME_GO;
         }
 
         /** \brief Called to initialize basic properties required all the time */
@@ -953,8 +979,6 @@ class Telescope : public DefaultDevice
 
         float motionDirNSValue {0};
         float motionDirWEValue {0};
-
-        uint8_t m_HomeCapability {0};
 
         bool m_simulatePierSide;    // use setSimulatePierSide and getSimulatePierSide for public access
 

--- a/libs/indibase/inditelescope.h
+++ b/libs/indibase/inditelescope.h
@@ -136,10 +136,9 @@ class Telescope : public DefaultDevice
 
         enum TelescopeHomeAction
         {
-            HOME_NONE = 1 << 0,     /*!< Mount does not support any form of homing */
-            HOME_FIND = 1 << 1,     /*!< Mount can search for home position  */
-            HOME_SET  = 1 << 2,     /*!< Mount can use current-position as home position */
-            HOME_GO   = 1 << 3,     /*!< Mount can slew to home position */
+            HOME_FIND,              /*!< Command mount to search for home position.  */
+            HOME_SET,               /*!< Command mount to accept current position as the home position. */
+            HOME_GO,                /*!< Command mount to slew to home position. */
         };
 
         enum TelescopePECState

--- a/libs/indibase/inditelescope.h
+++ b/libs/indibase/inditelescope.h
@@ -60,6 +60,13 @@
  * + TrackState: Engages or Disengages tracking. When engaging tracking, the child class should take the necessary steps to set the appropriate TrackMode and TrackRate
  *               properties before or after engaging tracking as governed by the mount protocol.
  *
+ * Home position is the default starting position of the mount where both axis indexes are in the zero or home position. This can be different from the parking
+ * position which can be set to avoid obstacles (e.g. roof) while in the parked state. For many mounts, the parking and home positions are identical. If homing is supported,
+ * the following operations may be supported:
+ * 1. Find: Search for the home indexes.
+ * 2. Set: Use current position as the home position
+ * 3. Go: Go to the stored home position.
+ *
  * Ideally, the child class should avoid changing property states directly within a function call from the base class as such state changes take place in the base class
  * after checking the return values of such functions.
  * \author Jasem Mutlaq, Gerry Rozema
@@ -180,7 +187,6 @@ class Telescope : public DefaultDevice
             TELESCOPE_HAS_PIER_SIDE_SIMULATION    = 1 << 11, /** Does the telescope simulate the pier side property? */
             TELESCOPE_CAN_TRACK_SATELLITE         = 1 << 12, /** Can the telescope track satellites? */
             TELESCOPE_CAN_FLIP                    = 1 << 13, /** Does the telescope have a command for flipping? */
-            TELESCOPE_CAN_HOME                    = 1 << 14, /** Does the telescope support setting and going to home index position? */
         } TelescopeCapability;
 
         Telescope();
@@ -319,14 +325,6 @@ class Telescope : public DefaultDevice
         bool HasTrackRate()
         {
             return capability & TELESCOPE_HAS_TRACK_RATE;
-        }
-
-        /**
-         * @return True if telescope supports homing.
-         */
-        bool CanHome()
-        {
-            return capability & TELESCOPE_CAN_HOME;
         }
 
         /** \brief Called to initialize basic properties required all the time */


### PR DESCRIPTION
Since several mounts support Homing controls. This PR moves the responsibility of defining available homing operations to the INDI::Telescope class. Three operations are currently supported and any combination of the three can be set by the concrete class:
* ***Find***: Command mount to search for home axis indexes.
* ***Set***: Accept current position as the new home position.
* ***Go***: Slew to home position.

Both **Find** and **Go** are transient operations so the driver must set the status of HomeSP to OK and must also reset all members of the switch property.