### PR TITLE
Fixed myFocuserPro2 Autofocus Issues in Ekos 

### DIFF
--- a/drivers/focuser/myfocuserpro2.cpp
+++ b/drivers/focuser/myfocuserpro2.cpp
@@ -737,6 +737,8 @@ bool MyFocuserPro2::isMoving()
 {
     char res[ML_RES] = {0};
 
+    readPosition(); // Fix for Ekos autofocus
+ 
     if (sendCommand(":01#", res) == false)
     {
         return false;


### PR DESCRIPTION
This small change resolves an issue with autofocus using the myFocuserPro2. It simply refreshes the driver's internal position whenever the client requests the isMoving state of the focuser. For full details of what I found please see this forum post. 
https://www.indilib.org/forum/development/14887-myfocuserpro2-driver-fix-for-ekos.html