### PR TITLE
Add workaround for OnStepX failing connection

### DIFF
--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -5457,3 +5457,28 @@ IPState LX200_OnStep::ExecuteHomeAction(TelescopeHomeAction action)
 
     return IPS_ALERT;
 }
+
+bool LX200_OnStep::Handshake()
+{
+    if (checkConnection())
+    {
+        return true;
+    }
+
+    /* OnStepX has a tendency to start up in an unresponsive state
+     * due to grabage in the serial buffer. Try to reset it by sending
+     * the :GVP# command repeatedly.
+     *
+     * First sending should result in a '0' response, the second in
+     * 'OnStep' so the 2nd sending should return with a failure.
+     */
+    if(sendOnStepCommand(":GVP#"))
+    {
+        if(!sendOnStepCommand(":GVP#"))
+        {
+            return checkConnection();
+        }
+    }
+
+    return false;
+}

--- a/drivers/telescope/lx200_OnStep.h
+++ b/drivers/telescope/lx200_OnStep.h
@@ -180,6 +180,7 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface, public 
         virtual bool updateProperties() override;
         virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
         virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+        virtual bool Handshake() override;
 
     protected:
         virtual void getBasicData() override;
@@ -506,7 +507,4 @@ class LX200_OnStep : public LX200Generic, public INDI::WeatherInterface, public 
     private:
         int currentCatalog;
         int currentSubCatalog;
-
-
-
 };


### PR DESCRIPTION
OnStepX controllers have a tendency to come up with a serial buffer blocked by garbage. As a result of this handshake with the mount will consistently fail, until that garbage is cleared.
To work around this issue the :GVP# command is sent to the mount twice.