### PR TITLE
drivers/dome: rigel_dome shutter parking

### DIFF
--- a/drivers/dome/rigel_dome.cpp
+++ b/drivers/dome/rigel_dome.cpp
@@ -345,6 +345,16 @@ bool RigelDome::Sync(double az)
 /////////////////////////////////////////////////////////////////////////////
 IPState RigelDome::Park()
 {
+    if (readShutterStatus() && ShutterParkPolicySP[SHUTTER_CLOSE_ON_PARK].getState() == ISS_ON)
+    {
+        if(ControlShutter(SHUTTER_CLOSE))
+        {
+            LOG_INFO("Shutter close on park");
+        }
+        else
+            return IPS_ALERT;
+    }
+
     targetAz = GetAxis1Park();
     if (setParkAz(targetAz))
     {
@@ -400,6 +410,16 @@ bool RigelDome::setHome(double az)
 /////////////////////////////////////////////////////////////////////////////
 IPState RigelDome::UnPark()
 {
+    if (readShutterStatus() && ShutterParkPolicySP[SHUTTER_OPEN_ON_UNPARK].getState() == ISS_ON)
+    {
+        if(ControlShutter(SHUTTER_OPEN))
+        {
+            LOG_INFO("Shutter open on unpark");
+        }
+        else
+            return IPS_ALERT;
+    }
+
     return IPS_OK;
 }
 


### PR DESCRIPTION
Implements the `Close On Park` and `Open On Unpark` shutter options for the Pulsar (Rigel) dome.