### PR TITLE
enable more Meade commands

### DIFF
--- a/drivers/telescope/lx200_OpenAstroTech.cpp
+++ b/drivers/telescope/lx200_OpenAstroTech.cpp
@@ -330,7 +330,23 @@ int LX200_OpenAstroTech::executeMeadeCommand(const char *cmd, char *data)
                 getchar = true;
             }
         }
-        else if(cmd[1] == 'M' && cmd[2] == 'A')     // MAL, MAZ
+        else if(cmd[1] == 'M' && cmd[2] == 'A') // MAL, MAZ
+        {
+            wait = false;
+        }
+        else if(cmd[1] == 'M' && cmd[2] == 'X') // MXxnnnnn#
+        {
+            getchar = true;
+        }
+        else if(cmd[1] == 'M' && (cmd[2] == 'g' || cmd[2] == 'G')) // Mgnxxxx#
+        {
+            wait = false;
+        }
+        else if(cmd[1] == 'S' && cmd[2] != 'C') // SCMM/DD/YY#
+        {
+            getchar = true;
+        }
+        else if(cmd[1] == 'X' && cmd[2] == 'S') // :XSRn.n# :XSDn.n# :XS...
         {
             wait = false;
         }
@@ -343,7 +359,18 @@ int LX200_OpenAstroTech::executeMeadeCommand(const char *cmd, char *data)
     if(getchar)
     {
         int val = getCommandChar(PortFD, cmd);
-        sprintf(data, "%c", val);
+        if(0 < val)
+        {
+            sprintf(data, "%c", val);
+        }
+        else if(0 == val)
+        {
+            sprintf(data, "%s", "null");
+        }
+        else
+        {
+            err = val;
+        }
     }
     else
     {


### PR DESCRIPTION
We have found it convenient to be able to send more Meade commands via the INDI  Control Panel
The following commands are added 

:XSRn.n# :XSDn.n# :XS...  these command do not return values:
WARNING	564.754999 sec	: Executed Meade Command error: -4 :XSD317.2# -> ''
WARNING	530.018348 sec	: Executed Meade Command error: -4 :XSR315.5# -> ''

:Mgnxxxx# these commands do not return values:
WARNING	1022.177341 sec	: Executed Meade Command error: -4 :Mgn0200# -> ''
WARNING	2372.737374 sec	: Executed Meade Command error: -4 :MGN0200# -> ''

:MXxnnnnn# these commands return a character:
WARNING	509.919341 sec	: Executed Meade Command error: -4 :MXd00100# -> '1'

:SCMM/DD/YY# these commands return a string.   Other :Sxxx# commands return a character