### PR TITLE
Sim crash fix - looks like found root cause

### DIFF
--- a/drivers/telescope/scopesim_helper.cpp
+++ b/drivers/telescope/scopesim_helper.cpp
@@ -190,16 +190,20 @@ void Axis::update()         // called about once a second to update the position
         //LOGF_DEBUG("move %s: change %f, position %f", b, change, position.Degrees());
     }
 
+    int rate = std::max(-4,std::min(4,mcRate));
+    if(rate != mcRate)
+        fprintf(stderr,"Invalid mcRate Detected = %d\n",mcRate);
+
     // handle the motion control
-    if (mcRate < 0)
+    if (rate < 0)
     {
-        change = -mcRates[-mcRate].Degrees() * interval;
+        change = -mcRates[-rate].Degrees() * interval;
         //LOGF_DEBUG("mcRate %d, rate %f, change %f", mcRate, mcRates[-mcRate].Degrees(), change);
         position += change;
     }
-    else if (mcRate > 0)
+    else if (rate > 0)
     {
-        change = mcRates[mcRate].Degrees() * interval;
+        change = mcRates[rate].Degrees() * interval;
         //LOGF_DEBUG("mcRate %d, rate %f, change %f", mcRate, mcRates[mcRate].Degrees(), change);
         position += change;
     }

--- a/drivers/telescope/scopesim_helper.cpp
+++ b/drivers/telescope/scopesim_helper.cpp
@@ -191,8 +191,9 @@ void Axis::update()         // called about once a second to update the position
     }
 
     int rate = std::max(-4,std::min(4,mcRate));
-    if(rate != mcRate)
-        fprintf(stderr,"Invalid mcRate Detected = %d\n",mcRate);
+    if(rate != mcRate) {
+        LOGF_ERROR("Invalid mcRate Detected = %d",mcRate);
+    }
 
     // handle the motion control
     if (rate < 0)

--- a/drivers/telescope/scopesim_helper.h
+++ b/drivers/telescope/scopesim_helper.h
@@ -288,7 +288,7 @@ class Axis
             guideDuration = 0;
         }
 
-        bool isSlewing;
+        bool isSlewing = false;
 
         bool isTracking()
         {
@@ -328,7 +328,7 @@ class Axis
             return guideDuration > 0;
         }
 
-        int mcRate;             // int -4 to 4 sets move rate, zero is stopped
+        int mcRate = 0;             // int -4 to 4 sets move rate, zero is stopped
 
         void update();         // called about once a second to update the position and mode
 
@@ -346,13 +346,13 @@ class Axis
             0, 0
         };
 
-        bool tracking;      // this allows the tracking state and rate to be set independently
+        bool tracking = false;      // this allows the tracking state and rate to be set independently
 
         AXIS_TRACK_RATE trackingRate { AXIS_TRACK_RATE::OFF };
 
         Angle rotateCentre { 90.0 };
 
-        double guideDuration;
+        double guideDuration = 0;
         Angle guideRateDegSec;
 
         // rates are angles in degrees per second derived from the values in indicom.h

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -492,6 +492,7 @@ bool ScopeSim::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
         return false;
     }
     mcRate = static_cast<int>(SlewRateSP.findOnSwitchIndex()) + 1;
+    mcRate = std::max(1,std::min(4,mcRate));
 
     int rate = (dir == INDI_DIR_NS::DIRECTION_NORTH) ? mcRate : -mcRate;
     LOGF_DEBUG("MoveNS dir %s, motion %s, rate %d", dir == DIRECTION_NORTH ? "N" : "S", command == 0 ? "start" : "stop", rate);
@@ -510,6 +511,8 @@ bool ScopeSim::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
     }
 
     mcRate = static_cast<int>(SlewRateSP.findOnSwitchIndex()) + 1;
+    mcRate = std::max(1,std::min(4,mcRate));
+
     int rate = (dir == INDI_DIR_WE::DIRECTION_EAST) ? -mcRate : mcRate;
     LOGF_DEBUG("MoveWE dir %d, motion %s, rate %d", dir == DIRECTION_EAST ? "E" : "W", command == 0 ? "start" : "stop", rate);
 


### PR DESCRIPTION
It was uninitialised value of mcRate
I added initialisation boundary checking and print in case something goes wrong

But seems to be root cause was missing initialization since I saw invalid values reported and after checking in Valgrind it complained at these spots.
