### PR TITLE
Feature for ZWO AM5 - Heavy Duty Mode and Fix slew rate

### DIFF
--- a/drivers/telescope/lx200am5.cpp
+++ b/drivers/telescope/lx200am5.cpp
@@ -123,22 +123,12 @@ bool LX200AM5::initProperties()
     });
 
     // Heavy Duty Mode
-    HeavyDutyModeSP[HeavyDutyModeOff].fill("OFF", "Off", ISS_OFF);
-    HeavyDutyModeSP[HeavyDutyModeOn].fill("ON", "On", ISS_OFF);
+    HeavyDutyModeSP[INDI_ENABLED].fill("INDI_ENABLED", "Enabled", ISS_OFF);
+    HeavyDutyModeSP[INDI_DISABLED].fill("INDI_DISABLED", "Disabled", ISS_OFF);
     HeavyDutyModeSP.fill(getDeviceName(), "HEAVY_DUTY_MODE", "Heavy Duty Mode", MOTION_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
     HeavyDutyModeSP.onUpdate([this]{
-        IPState state = IPS_BUSY;
-
-        if (HeavyDutyModeSP[HeavyDutyModeOff].getState() == ISS_ON)
-        {
-            state = setHeavyDutyMode(false) ? IPS_OK : IPS_ALERT;
-        }
-
-        if (HeavyDutyModeSP[HeavyDutyModeOn].getState() == ISS_ON)
-        {
-            state = setHeavyDutyMode(true) ? IPS_OK : IPS_ALERT;
-        }
-
+        bool enabled = HeavyDutyModeSP[INDI_ENABLED].getState() == ISS_ON;
+        IPState state = setHeavyDutyMode(enabled) ? IPS_OK : IPS_ALERT;
         HeavyDutyModeSP.setState(state);
         HeavyDutyModeSP.apply();
     });
@@ -473,12 +463,12 @@ bool LX200AM5::getHeavyDutyMode()
 
         if (strcmp(response, "1440#") == 0)
         {
-            HeavyDutyModeSP[HeavyDutyModeOff].setState(ISS_ON);
+            HeavyDutyModeSP[INDI_DISABLED].setState(ISS_ON);
         }
 
         if (strcmp(response, "720#") == 0)
         {
-            HeavyDutyModeSP[HeavyDutyModeOn].setState(ISS_ON);
+            HeavyDutyModeSP[INDI_ENABLED].setState(ISS_ON);
         }
 
         HeavyDutyModeSP.setState(IPS_OK);

--- a/drivers/telescope/lx200am5.cpp
+++ b/drivers/telescope/lx200am5.cpp
@@ -83,7 +83,7 @@ bool LX200AM5::initProperties()
 
     // Slew Rates
 
-    SlewRateSP[0].setLabel("0.25x");
+    SlewRateSP[0].setLabel("0.5x");
     SlewRateSP[1].setLabel("1x");
     SlewRateSP[2].setLabel("2x");
     SlewRateSP[3].setLabel("4x");
@@ -94,7 +94,7 @@ bool LX200AM5::initProperties()
     SlewRateSP[8].setLabel("1440x");
     SlewRateSP.reset();
     // 1440x is the default
-    SlewRateSP[9].setState(ISS_ON);
+    SlewRateSP[8].setState(ISS_ON);
 
     // Home/Zero position
     // HomeSP[0].fill("GO", "Go", ISS_OFF);
@@ -373,7 +373,7 @@ bool LX200AM5::getMountType()
 bool LX200AM5::SetSlewRate(int index)
 {
     char command[DRIVER_LEN] = {0};
-    snprintf(command, DRIVER_LEN, ":R%d#", index);
+    snprintf(command, DRIVER_LEN, ":R%d#", index + 1);
     return sendCommand(command);
 }
 

--- a/drivers/telescope/lx200am5.h
+++ b/drivers/telescope/lx200am5.h
@@ -106,11 +106,6 @@ class LX200AM5 : public LX200Generic
 
         // Heavy duty control
         INDI::PropertySwitch HeavyDutyModeSP {2};
-        enum
-        {
-            HeavyDutyModeOff = 0,
-            HeavyDutyModeOn  = 1,
-        };
 
         // Meridian Flip Control
         INDI::PropertySwitch MeridianFlipSP {2};

--- a/drivers/telescope/lx200am5.h
+++ b/drivers/telescope/lx200am5.h
@@ -171,6 +171,6 @@ class LX200AM5 : public LX200Generic
         // Maximum buffer for sending/receiving.
         static constexpr const uint8_t DRIVER_LEN {64};
         // Slew Modes
-        static constexpr const uint8_t SLEW_MODES {10};
+        static constexpr const uint8_t SLEW_MODES {9};
         static constexpr const char * MERIDIAN_FLIP_TAB {"Meridian Flip"};
 };

--- a/drivers/telescope/lx200am5.h
+++ b/drivers/telescope/lx200am5.h
@@ -104,6 +104,14 @@ class LX200AM5 : public LX200Generic
             High
         };
 
+        // Heavy duty control
+        INDI::PropertySwitch HeavyDutyModeSP {2};
+        enum
+        {
+            HeavyDutyModeOff = 0,
+            HeavyDutyModeOn  = 1,
+        };
+
         // Meridian Flip Control
         INDI::PropertySwitch MeridianFlipSP {2};
 
@@ -135,6 +143,10 @@ class LX200AM5 : public LX200Generic
         // Buzzer
         bool getBuzzer();
         bool setBuzzer(int value);
+
+        // Heavy Duty Mode
+        bool getHeavyDutyMode();
+        bool setHeavyDutyMode(bool enable);
 
         // Mount type
         bool setMountType(int type);


### PR DESCRIPTION
Hi

I often use a light and heavy tube on the ZWO AM5 mount.
With a heavier load, e.g. Celestron EdgeHD 800, or at low temperatures, the mount stops when aiming at the target or parking. For this reason, I propose a similar feature which is in the "SkyAtlas" program.
![image](https://github.com/user-attachments/assets/a34ae164-acb6-408a-bdab-9cac2b0cb95e)

The mode enable/disable is now located in `INDI Control Panel -> ZWO AM5 USB -> Motion Control -> Heavy Duty Mode`
![image](https://github.com/user-attachments/assets/13df738c-29a6-4c7c-9d44-10e0a137ebca)

AM5 has a special command `:SRl720#` (720x speed) and `:SRl1440#` (1440x speed) which sets the maximum speed limit, regardless of other settings. To read, use the command `:GRl#`, which has also been implemented. The mount remembers the settings, so after a restart of the mount they are remembered.

I also added a fix for the slew rate selection, because the mount has 9 modes, not 10 as declared in the `SLEW_MODES` constant, as well as the `:Rx#` command where x takes values ​​from 1 to 9.

![image](https://github.com/user-attachments/assets/1dc5f092-b4e9-4592-bf69-0da546ef710c)
