### PR TITLE
Respond to FLIP command (do not merge yet as code is not tested)

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -13,7 +13,7 @@
         </device>
         <device label="LX200 10micron" manufacturer="10 Micron">
             <driver name="LX200 10micron">indi_lx200_10micron</driver>
-            <version>1.2</version>
+            <version>1.3</version>
         </device>
         <device label="LX200 Basic" manufacturer="Meade">
             <driver name="LX200 Basic">indi_lx200basic</driver>

--- a/drivers/telescope/lx200_10micron.cpp
+++ b/drivers/telescope/lx200_10micron.cpp
@@ -654,6 +654,8 @@ bool LX200_10MICRON::setUnattendedFlipSetting(bool setting)
 
 bool LX200_10MICRON::Flip(double ra, double dec)
 {
+    INDI_UNUSED(ra);
+    INDI_UNUSED(dec);
     return flip();
 }
 

--- a/drivers/telescope/lx200_10micron.cpp
+++ b/drivers/telescope/lx200_10micron.cpp
@@ -3,7 +3,7 @@
     GM1000HPS GM2000QCI GM2000HPS GM3000HPS GM4000QCI GM4000HPS AZ2000
     Mount Command Protocol 2.14.11
 
-    Copyright (C) 2017-2023 Hans Lambermont
+    Copyright (C) 2017-2025 Hans Lambermont
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -67,6 +67,7 @@ LX200_10MICRON::LX200_10MICRON() : LX200Generic()
         TELESCOPE_CAN_GOTO |
         TELESCOPE_CAN_SYNC |
         TELESCOPE_CAN_PARK |
+        TELESCOPE_CAN_FLIP |
         TELESCOPE_CAN_ABORT |
         TELESCOPE_HAS_TIME |
         TELESCOPE_HAS_LOCATION |
@@ -78,7 +79,7 @@ LX200_10MICRON::LX200_10MICRON() : LX200Generic()
         4
     );
 
-    setVersion(1, 2); // don't forget to update drivers.xml
+    setVersion(1, 3); // don't forget to update drivers.xml
 }
 
 // Called by INDI::DefaultDevice::ISGetProperties
@@ -649,6 +650,11 @@ bool LX200_10MICRON::setUnattendedFlipSetting(bool setting)
         return true;
     }
     return false;
+}
+
+bool LX200_10MICRON::Flip(double ra, double dec)
+{
+    return flip();
 }
 
 bool LX200_10MICRON::flip()

--- a/drivers/telescope/lx200_10micron.h
+++ b/drivers/telescope/lx200_10micron.h
@@ -113,7 +113,7 @@ class LX200_10MICRON : public LX200Generic
         bool Park() override;
         bool UnPark() override;
         bool SetTrackEnabled(bool enabled) override;
-        bool flip();
+        bool Flip(double ra, double dec) override;
         bool getUnattendedFlipSetting();
         bool setUnattendedFlipSetting(bool setting);
         bool SyncConfigBehaviour(bool cmcfg);
@@ -180,6 +180,7 @@ class LX200_10MICRON : public LX200Generic
     private:
         int fd = -1; // short notation for PortFD/sockfd
         bool getMountInfo();
+        bool flip();
 
         int OldGstat = GSTAT_UNSET;
         struct _Ginfo


### PR DESCRIPTION
The flip() function existed but was never called from inditelescope.cpp . This PR should fix that.
I have to wait for clear skies to test the code.