### PR TITLE
Bugfix: lx200zeq25 RA, Dec, Lat, Long incorrectly formatted

### DIFF
--- a/drivers/telescope/lx200zeq25.h
+++ b/drivers/telescope/lx200zeq25.h
@@ -71,6 +71,8 @@ class LX200ZEQ25 : public LX200Generic
         int setZEQ25Longitude(double Long);
         int setZEQ25UTCOffset(double hours);
         int setZEQ25Date(int days, int months, int years);
+        int setZEQ25ObjectRA(int fd, double ra);
+        int setZEQ25ObjectDEC(int fd, double dec);
         bool slewZEQ25();
         int moveZEQ25To(int direction);
         int haltZEQ25Movement();


### PR DESCRIPTION
Lat and Long were formatted as "DD:mm:SS", instead of "DD*mm:SS" as stated in documentation;
RA and Dec were set using the short format, instead of long format. Implemented correct format for both cases, Lat/Long and now correctly set and Gotos are now precise.

Tested on iOptron ieq45 with HC8407.