### PR TITLE
Fixing linux pyindi-client build

### DIFF
--- a/.github/workflows/linux-pyindi.yml
+++ b/.github/workflows/linux-pyindi.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build PyIndi
         run: |
-          cd pyindi-client && python3 ./setup.py install
+          cd pyindi-client && python3 -m pip install .
 
       - name: Install test deps
         run: |


### PR DESCRIPTION
After moving the packate to pyproject.toml the workflow was not updated.