### PR TITLE
Fix build warning - Removing clang-extensions for variable length arrays

### DIFF
--- a/drivers/dome/scopedome_usb21.cpp
+++ b/drivers/dome/scopedome_usb21.cpp
@@ -27,6 +27,7 @@
 
 #include <termios.h>
 #include <unistd.h>
+#include <vector>
 
 #define SCOPEDOME_TIMEOUT 2
 
@@ -267,7 +268,7 @@ int ScopeDomeUSB21::writeBuf(Command cmd, uint8_t len, uint8_t *buff)
     int nbytes_written = 0, rc = -1;
     char errstr[MAXRBUF];
 
-    uint8_t cbuf[BytesToWrite];
+    std::vector<uint8_t> cbuf(BytesToWrite, 0);
     cbuf[0] = header;
     cbuf[3] = CRC(0, cbuf[0]);
     cbuf[1] = len;
@@ -287,7 +288,7 @@ int ScopeDomeUSB21::writeBuf(Command cmd, uint8_t len, uint8_t *buff)
 
     // Write buffer
     LOGF_DEBUG("write buf: %x %x %x %x %x", cbuf[0], cbuf[1], cbuf[2], cbuf[3], cbuf[4]);
-    if ((rc = tty_write(PortFD, (const char *)cbuf, sizeof(cbuf), &nbytes_written)) != TTY_OK)
+    if ((rc = tty_write(PortFD, (const char *)cbuf.data(), sizeof(cbuf), &nbytes_written)) != TTY_OK)
     {
         tty_error_msg(rc, errstr, MAXRBUF);
         LOGF_ERROR("Error writing command: %s. Cmd %s (%d)", errstr, cmdToString(cmd), cmd);
@@ -326,12 +327,11 @@ int ScopeDomeUSB21::readBuf(Command &cmd, uint8_t len, uint8_t *buff)
 {
     int nbytes_read = 0, rc = -1;
     int BytesToRead = len + 4;
-    uint8_t cbuf[BytesToRead];
-    memset(cbuf, 0, BytesToRead);
+    std::vector<uint8_t> cbuf(BytesToRead, 0);
     char errstr[MAXRBUF];
 
     // Read buffer
-    if ((rc = tty_read(PortFD, (char *)cbuf, sizeof(cbuf), SCOPEDOME_TIMEOUT, &nbytes_read)) != TTY_OK)
+    if ((rc = tty_read(PortFD, (char *)cbuf.data(), sizeof(cbuf), SCOPEDOME_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(rc, errstr, MAXRBUF);
         LOGF_ERROR("Error reading: %s. Cmd: %s (%d)", errstr, cmdToString(prevcmd), prevcmd);

--- a/drivers/dome/scopedome_usb21.cpp
+++ b/drivers/dome/scopedome_usb21.cpp
@@ -288,7 +288,7 @@ int ScopeDomeUSB21::writeBuf(Command cmd, uint8_t len, uint8_t *buff)
 
     // Write buffer
     LOGF_DEBUG("write buf: %x %x %x %x %x", cbuf[0], cbuf[1], cbuf[2], cbuf[3], cbuf[4]);
-    if ((rc = tty_write(PortFD, (const char *)cbuf.data(), sizeof(cbuf), &nbytes_written)) != TTY_OK)
+    if ((rc = tty_write(PortFD, (const char *)cbuf.data(), cbuf.size() * sizeof(cbuf[0]), &nbytes_written)) != TTY_OK)
     {
         tty_error_msg(rc, errstr, MAXRBUF);
         LOGF_ERROR("Error writing command: %s. Cmd %s (%d)", errstr, cmdToString(cmd), cmd);
@@ -331,7 +331,7 @@ int ScopeDomeUSB21::readBuf(Command &cmd, uint8_t len, uint8_t *buff)
     char errstr[MAXRBUF];
 
     // Read buffer
-    if ((rc = tty_read(PortFD, (char *)cbuf.data(), sizeof(cbuf), SCOPEDOME_TIMEOUT, &nbytes_read)) != TTY_OK)
+    if ((rc = tty_read(PortFD, (char *)cbuf.data(), cbuf.size() * sizeof(cbuf[0]), SCOPEDOME_TIMEOUT, &nbytes_read)) != TTY_OK)
     {
         tty_error_msg(rc, errstr, MAXRBUF);
         LOGF_ERROR("Error reading: %s. Cmd: %s (%d)", errstr, cmdToString(prevcmd), prevcmd);

--- a/integs/ConnectionMock.cpp
+++ b/integs/ConnectionMock.cpp
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <vector>
 
 #include "ConnectionMock.h"
 #include "SharedBuffer.h"
@@ -166,9 +167,9 @@ void ConnectionMock::expectBuffer(SharedBuffer &sb)
 void ConnectionMock::expect(const std::string &str)
 {
     ssize_t l = str.size();
-    char buff[l];
+    std::vector<char> buff(l);
 
-    char * in = buff;
+    char * in = buff.data();
     ssize_t left = l;
     while(left)
     {
@@ -186,9 +187,9 @@ void ConnectionMock::expect(const std::string &str)
         left -= rd;
         in += rd;
     }
-    if (strncmp(str.c_str(), buff, l))
+    if (strncmp(str.c_str(), buff.data(), l))
     {
-        throw std::runtime_error("Received unexpected content while expecting " + str + ": " + std::string(buff, l));
+        throw std::runtime_error("Received unexpected content while expecting " + str + ": " + std::string(buff.data(), l));
     }
 }
 

--- a/integs/ProcessController.cpp
+++ b/integs/ProcessController.cpp
@@ -71,7 +71,7 @@ void ProcessController::start(const std::string & path, const std::vector<std::s
 
     int argCount = 0;
     argCount = args.size();
-    const char * fullArgs[argCount + 2];
+    std::vector<const char *> fullArgs(argCount + 2);
     fullArgs[0] = path.c_str();
     for(int i = 0; i < argCount ; i++) {
         fullArgs[i + 1] = args[i].c_str();
@@ -90,7 +90,7 @@ void ProcessController::start(const std::string & path, const std::vector<std::s
     if (pid == 0) {
         std::string error = "exec " + path;
         // TODO : Close all file descriptor
-        execv(fullArgs[0], (char * const *) fullArgs);
+        execv(fullArgs[0], (char * const *) fullArgs.data());
 
         // Child goes here....
         perror(error.c_str());


### PR DESCRIPTION
This PR addresses warnings regarding clang extensions for dynamic arrays. 
`warning: variable length arrays in C++ are a Clang extension [-Wvla-cxx-extension]`
I replaced these locations with `std::vector` so we don't have to deal with new/delete.

Some of the `uint8_t` seem like they would be better off as a `std::byte`, but I'll leave that unless someone says otherwise. 