### PR TITLE
Needed to change libs/indibase/indiweatherinterface.* to allow alerts…

### DIFF
--- a/drivers/weather/weatherwatcher.cpp
+++ b/drivers/weather/weatherwatcher.cpp
@@ -138,7 +138,7 @@ bool WeatherWatcher::createProperties()
             IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "MAX_OK", &maxOK);
             IUGetConfigNumber(getDeviceName(), "WEATHER_CLOUDS", "PERC_WARN", &percWarn);
 
-            addParameter("WEATHER_CLOUDS",  labelTP[WEATHER_CLOUD].text, minOK, maxOK, percWarn);
+            addParameter("WEATHER_CLOUDS",  labelTP[WEATHER_CLOUD].text, minOK, maxOK, percWarn, true);
             if (criticalSP[WEATHER_CLOUD].getState())
                 setCriticalParameter("WEATHER_CLOUDS");
         }

--- a/libs/indibase/indiweatherinterface.h
+++ b/libs/indibase/indiweatherinterface.h
@@ -120,8 +120,9 @@ class WeatherInterface
          * @param numMinOk minimum Ok range value.
          * @param numMaxOk maximum Ok range value.
          * @param percWarning percentage for Warning.
+         * @param flipWarning boolean indicating if range warning should be flipped to in-bounds, rather than out-of-bounds
          */
-        void addParameter(std::string name, std::string label, double numMinOk, double numMaxOk, double percWarning);
+        void addParameter(std::string name, std::string label, double numMinOk, double numMaxOk, double percWarning, bool flipWarning = false);
 
         /**
          * @brief setCriticalParameter Set parameter that is considered critical to the operation of the
@@ -165,6 +166,7 @@ class WeatherInterface
             MIN_OK,
             MAX_OK,
             PERCENT_WARNING,
+	    FLIP_RANGE_TEST,
         };
 
         // Weather status
@@ -180,7 +182,7 @@ class WeatherInterface
 
 
     private:
-        void createParameterRange(std::string name, std::string label, double numMinOk, double numMaxOk, double percWarning);
+        void createParameterRange(std::string name, std::string label, double numMinOk, double numMaxOk, double percWarning, bool flipWarning);
         DefaultDevice *m_defaultDevice { nullptr };
         std::string m_ParametersGroup;
         INDI::Timer m_UpdateTimer;


### PR DESCRIPTION
… for negative values (e.g., sky temperature).

```
Current percent warning model was like this:
    min--+         +-low-%    high-%-+        +--max
         |         |                 |        |
         v         v                 v        v
         [         (                 )        ]
danger     warning       good         warning   danger

For case where values below minimum value is actually good, needed to flip comparison to:
    min--+         +-low-%    high-%-+        +--max
         |         |                 |        |
         v         v                 v        v
         [         (                 )        ]
good       warning      danger        warning   good

```
Change I did will add extra line to EVERY parameter widget set to allow user to decide if alert behavior should be flipped or not (1/0). Probably some better way to make the developer decide when flipping option is desired, but I was not sure that could always always be known in advance. Default might be known, but user might need to change.

The added widget line appears below the widget line that sets the warning percentage.