### PR TITLE
Refactoring more indiserver components

### DIFF
--- a/indiserver/CMakeLists.txt
+++ b/indiserver/CMakeLists.txt
@@ -19,6 +19,7 @@ else()
                                    SerializedMsg.cpp
                                    SerializedMsgWithoutSharedBuffer.cpp
                                    SerializedMsgWithSharedBuffer.cpp
+                                   SerializationRequirement.cpp
                                    MsgChunck.cpp
                                    Msg.cpp
                                    Utils.cpp)

--- a/indiserver/ClInfo.cpp
+++ b/indiserver/ClInfo.cpp
@@ -22,6 +22,7 @@
 #include "Constants.hpp"
 #include "Utils.hpp"
 #include "Property.hpp"
+#include "CommandLineArgs.hpp"
 
 ConcurrentSet<ClInfo> ClInfo::clients;
 
@@ -94,7 +95,7 @@ void ClInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
 
 void ClInfo::close()
 {
-    if (verbose > 0)
+    if (updatedArgs->verbosity > 0)
         log("shut down complete - bye!\n");
 
     delete(this);
@@ -146,7 +147,7 @@ void ClInfo::q2Clients(ClInfo *notme, int isblob, const std::string &dev, const 
 
         /* shut down this client if its q is already too large */
         unsigned long ql = cp->msgQSize();
-        if (isblob && maxstreamsiz > 0 && ql > maxstreamsiz)
+        if (isblob && updatedArgs->maxStreamSizeMB > 0 && ql > updatedArgs->maxStreamSizeMB)
         {
             // Drop frames for streaming blobs
             /* pull out each name/BLOB pair, decode */
@@ -167,20 +168,20 @@ void ClInfo::q2Clients(ClInfo *notme, int isblob, const std::string &dev, const 
             }
             if (streamFound)
             {
-                if (verbose > 1)
+                if (updatedArgs->verbosity > 1)
                     cp->log(fmt("%ld bytes behind. Dropping stream BLOB...\n", ql));
                 continue;
             }
         }
-        if (ql > maxqsiz)
+        if (ql > updatedArgs->maxQueueSizeMB)
         {
-            if (verbose)
+            if (updatedArgs->verbosity)
                 cp->log(fmt("%ld bytes behind, shutting down\n", ql));
             cp->close();
             continue;
         }
 
-        if (verbose > 1)
+        if (updatedArgs->verbosity > 1)
             cp->log(fmt("queuing <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
 
@@ -231,16 +232,16 @@ void ClInfo::q2Servers(DvrInfo *me, Msg *mp, XMLEle *root)
 
         /* shut down this client if its q is already too large */
         unsigned long ql = cp->msgQSize();
-        if (ql > maxqsiz)
+        if (ql > updatedArgs->maxQueueSizeMB)
         {
-            if (verbose)
+            if (updatedArgs->verbosity)
                 cp->log(fmt("%ld bytes behind, shutting down\n", ql));
             cp->close();
             continue;
         }
 
         /* ok: queue message to this client */
-        if (verbose > 1)
+        if (updatedArgs->verbosity > 1)
             cp->log(fmt("queuing <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
 

--- a/indiserver/ClInfo.cpp
+++ b/indiserver/ClInfo.cpp
@@ -95,7 +95,7 @@ void ClInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
 
 void ClInfo::close()
 {
-    if (updatedArgs->verbosity > 0)
+    if (userConfigurableArguments->verbosity > 0)
         log("shut down complete - bye!\n");
 
     delete(this);
@@ -147,7 +147,7 @@ void ClInfo::q2Clients(ClInfo *notme, int isblob, const std::string &dev, const 
 
         /* shut down this client if its q is already too large */
         unsigned long ql = cp->msgQSize();
-        if (isblob && updatedArgs->maxStreamSizeMB > 0 && ql > updatedArgs->maxStreamSizeMB)
+        if (isblob && userConfigurableArguments->maxStreamSizeMB > 0 && ql > userConfigurableArguments->maxStreamSizeMB)
         {
             // Drop frames for streaming blobs
             /* pull out each name/BLOB pair, decode */
@@ -168,20 +168,20 @@ void ClInfo::q2Clients(ClInfo *notme, int isblob, const std::string &dev, const 
             }
             if (streamFound)
             {
-                if (updatedArgs->verbosity > 1)
+                if (userConfigurableArguments->verbosity > 1)
                     cp->log(fmt("%ld bytes behind. Dropping stream BLOB...\n", ql));
                 continue;
             }
         }
-        if (ql > updatedArgs->maxQueueSizeMB)
+        if (ql > userConfigurableArguments->maxQueueSizeMB)
         {
-            if (updatedArgs->verbosity)
+            if (userConfigurableArguments->verbosity)
                 cp->log(fmt("%ld bytes behind, shutting down\n", ql));
             cp->close();
             continue;
         }
 
-        if (updatedArgs->verbosity > 1)
+        if (userConfigurableArguments->verbosity > 1)
             cp->log(fmt("queuing <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
 
@@ -232,16 +232,16 @@ void ClInfo::q2Servers(DvrInfo *me, Msg *mp, XMLEle *root)
 
         /* shut down this client if its q is already too large */
         unsigned long ql = cp->msgQSize();
-        if (ql > updatedArgs->maxQueueSizeMB)
+        if (ql > userConfigurableArguments->maxQueueSizeMB)
         {
-            if (updatedArgs->verbosity)
+            if (userConfigurableArguments->verbosity)
                 cp->log(fmt("%ld bytes behind, shutting down\n", ql));
             cp->close();
             continue;
         }
 
         /* ok: queue message to this client */
-        if (updatedArgs->verbosity > 1)
+        if (userConfigurableArguments->verbosity > 1)
             cp->log(fmt("queuing <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
 

--- a/indiserver/CommandLineArgs.hpp
+++ b/indiserver/CommandLineArgs.hpp
@@ -17,17 +17,21 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #pragma once
-#include <string_view>
-namespace indiserver::constants
-{
-constexpr unsigned indiPortDefault {7624};
-constexpr unsigned maxStringBufferLength {512};
-constexpr unsigned defaultMaxQueueSizeMB {128 * 1024 * 1024};
-constexpr unsigned defaultMaxStreamSizeMB {5 * 1024 * 1024};
-constexpr unsigned defaultMaximumRestarts {10};
+#include "Constants.hpp" 
 
-#ifdef OSX_EMBEDED_MODE
-constexpr std::string_view logNamePattern {"/Users/%s/Library/Logs/indiserver.log"};
-constexpr std::string_view fifoName {"/tmp/indiserverFIFO"}
-#endif
-} // namespace indiserver
+#include <string>
+
+class Fifo;
+
+struct CommandLineArgs {
+    size_t verbosity{0};
+    unsigned int maxStreamSizeMB{indiserver::constants::defaultMaxStreamSizeMB};
+    unsigned int maxQueueSizeMB{indiserver::constants::defaultMaxQueueSizeMB};
+    char *loggingDir{nullptr};
+    int maxRestartAttempts{indiserver::constants::defaultMaximumRestarts};
+    Fifo* fifoHandle{nullptr};
+    std::string binaryName{};
+    int port{indiserver::constants::indiPortDefault};
+};
+
+extern CommandLineArgs* updatedArgs;

--- a/indiserver/CommandLineArgs.hpp
+++ b/indiserver/CommandLineArgs.hpp
@@ -34,4 +34,4 @@ struct CommandLineArgs {
     int port{indiserver::constants::indiPortDefault};
 };
 
-extern CommandLineArgs* updatedArgs;
+extern CommandLineArgs* userConfigurableArguments;

--- a/indiserver/CommandLineArgs.hpp
+++ b/indiserver/CommandLineArgs.hpp
@@ -17,13 +17,14 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #pragma once
-#include "Constants.hpp" 
+#include "Constants.hpp"
 
 #include <string>
 
 class Fifo;
 
-struct CommandLineArgs {
+struct CommandLineArgs
+{
     size_t verbosity{0};
     unsigned int maxStreamSizeMB{indiserver::constants::defaultMaxStreamSizeMB};
     unsigned int maxQueueSizeMB{indiserver::constants::defaultMaxQueueSizeMB};

--- a/indiserver/Constants.hpp
+++ b/indiserver/Constants.hpp
@@ -17,20 +17,24 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #pragma once
+#include <string_view>
+namespace indiserver::constants
+{
+constexpr unsigned indiPort {7624};
+constexpr unsigned maxStringBufferLength {512};
+constexpr unsigned maxReadBufferLength {49152};
+constexpr unsigned maxWriteBufferLength {49152};
+constexpr unsigned defaultMaxQueueSizeMB {128 * 1024 * 1024};
+constexpr unsigned defaultMaxStreamSizeMB {5 * 1024 * 1024};
+constexpr unsigned defaultMaximumRestarts {10};
+constexpr unsigned maxFDPerMessage {16}; /* No more than 16 buffer attached to a message */
 
-#define INDIPORT      7624    /* default TCP/IP port to listen */
-#define MAXSBUF       512
-#define MAXRBUF       49152 /* max read buffering here */
-#define MAXWSIZ       49152 /* max bytes/write */
-#define SHORTMSGSIZ   2048  /* buf size for most messages */
-#define DEFMAXQSIZ    128   /* default max q behind, MB */
-#define DEFMAXSSIZ    5     /* default max stream behind, MB */
-#define DEFMAXRESTART 10    /* default max restarts */
-#define MAXFD_PER_MESSAGE 16 /* No more than 16 buffer attached to a message */
 #ifdef OSX_EMBEDED_MODE
-#define LOGNAME  "/Users/%s/Library/Logs/indiserver.log"
-#define FIFONAME "/tmp/indiserverFIFO"
+constexpr std::string_view logNamePattern {"/Users/%s/Library/Logs/indiserver.log"};
+constexpr std::string_view fifoName {"/tmp/indiserverFIFO"}
 #endif
+} // namespace indiserver
+
 
 extern int verbose;
 extern unsigned int maxstreamsiz;

--- a/indiserver/Constants.hpp
+++ b/indiserver/Constants.hpp
@@ -22,12 +22,9 @@ namespace indiserver::constants
 {
 constexpr unsigned indiPort {7624};
 constexpr unsigned maxStringBufferLength {512};
-constexpr unsigned maxReadBufferLength {49152};
-constexpr unsigned maxWriteBufferLength {49152};
 constexpr unsigned defaultMaxQueueSizeMB {128 * 1024 * 1024};
 constexpr unsigned defaultMaxStreamSizeMB {5 * 1024 * 1024};
 constexpr unsigned defaultMaximumRestarts {10};
-constexpr unsigned maxFDPerMessage {16}; /* No more than 16 buffer attached to a message */
 
 #ifdef OSX_EMBEDED_MODE
 constexpr std::string_view logNamePattern {"/Users/%s/Library/Logs/indiserver.log"};
@@ -39,7 +36,7 @@ constexpr std::string_view fifoName {"/tmp/indiserverFIFO"}
 extern int verbose;
 extern unsigned int maxstreamsiz;
 extern unsigned int maxqsiz;
-extern char *ldir;
+extern char *loggingDir;
 extern int maxrestarts;
 
 class Fifo;

--- a/indiserver/DvrInfo.cpp
+++ b/indiserver/DvrInfo.cpp
@@ -22,6 +22,7 @@
 #include "Msg.hpp"
 #include "ClInfo.hpp"
 #include "Property.hpp"
+#include "CommandLineArgs.hpp"
 
 ConcurrentSet<DvrInfo> DvrInfo::drivers;
 
@@ -32,9 +33,9 @@ void DvrInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
     const char *name = findXMLAttValu(root, "name");
     int isblob       = !strcmp(tagXMLEle(root), "setBLOBVector");
 
-    if (verbose > 2)
+    if (updatedArgs->verbosity > 2)
         traceMsg("read ", root);
-    else if (verbose > 1)
+    else if (updatedArgs->verbosity > 1)
     {
         log(fmt("read <%s device='%s' name='%s'>\n",
                 tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
@@ -80,7 +81,7 @@ void DvrInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
     }
 
     /* log messages if any and wanted */
-    if (loggingDir)
+    if (updatedArgs->loggingDir)
         logDMsg(root, dev);
 
     if (!strcmp(roottag, "pingRequest"))
@@ -142,7 +143,7 @@ void DvrInfo::close()
     }
     else
     {
-        if (restarts >= maxrestarts)
+        if (restarts >= updatedArgs->maxRestartAttempts)
         {
             log(fmt("Terminated after #%d restarts.\n", restarts));
             terminate = true;
@@ -164,7 +165,7 @@ void DvrInfo::close()
     if (terminate)
     {
         delete(this);
-        if ((!fifo) && (drivers.ids().empty()))
+        if ((!updatedArgs->fifoHandle) && (drivers.ids().empty()))
             Bye();
         return;
     }
@@ -214,7 +215,7 @@ void DvrInfo::q2RDrivers(const std::string &dev, Msg *mp, XMLEle *root)
             continue;
 
         /* ok: queue message to this driver */
-        if (verbose > 1)
+        if (updatedArgs->verbosity > 1)
         {
             dp->log(fmt("queuing responsible for <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
@@ -247,7 +248,7 @@ void DvrInfo::q2SDrivers(DvrInfo *me, int isblob, const std::string &dev, const 
             continue;
 
         /* ok: queue message to this device */
-        if (verbose > 1)
+        if (updatedArgs->verbosity > 1)
         {
             dp->log(fmt("queuing snooped <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
@@ -272,7 +273,7 @@ void DvrInfo::addSDevice(const std::string &dev, const std::string &name)
     sp->blob = B_NEVER;
     sprops.push_back(sp);
 
-    if (verbose)
+    if (updatedArgs->verbosity)
         log(fmt("snooping on %s.%s\n", dev.c_str(), name.c_str()));
 }
 

--- a/indiserver/DvrInfo.cpp
+++ b/indiserver/DvrInfo.cpp
@@ -33,9 +33,9 @@ void DvrInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
     const char *name = findXMLAttValu(root, "name");
     int isblob       = !strcmp(tagXMLEle(root), "setBLOBVector");
 
-    if (updatedArgs->verbosity > 2)
+    if (userConfigurableArguments->verbosity > 2)
         traceMsg("read ", root);
-    else if (updatedArgs->verbosity > 1)
+    else if (userConfigurableArguments->verbosity > 1)
     {
         log(fmt("read <%s device='%s' name='%s'>\n",
                 tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
@@ -81,7 +81,7 @@ void DvrInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
     }
 
     /* log messages if any and wanted */
-    if (updatedArgs->loggingDir)
+    if (userConfigurableArguments->loggingDir)
         logDMsg(root, dev);
 
     if (!strcmp(roottag, "pingRequest"))
@@ -143,7 +143,7 @@ void DvrInfo::close()
     }
     else
     {
-        if (restarts >= updatedArgs->maxRestartAttempts)
+        if (restarts >= userConfigurableArguments->maxRestartAttempts)
         {
             log(fmt("Terminated after #%d restarts.\n", restarts));
             terminate = true;
@@ -165,7 +165,7 @@ void DvrInfo::close()
     if (terminate)
     {
         delete(this);
-        if ((!updatedArgs->fifoHandle) && (drivers.ids().empty()))
+        if ((!userConfigurableArguments->fifoHandle) && (drivers.ids().empty()))
             Bye();
         return;
     }
@@ -215,7 +215,7 @@ void DvrInfo::q2RDrivers(const std::string &dev, Msg *mp, XMLEle *root)
             continue;
 
         /* ok: queue message to this driver */
-        if (updatedArgs->verbosity > 1)
+        if (userConfigurableArguments->verbosity > 1)
         {
             dp->log(fmt("queuing responsible for <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
@@ -248,7 +248,7 @@ void DvrInfo::q2SDrivers(DvrInfo *me, int isblob, const std::string &dev, const 
             continue;
 
         /* ok: queue message to this device */
-        if (updatedArgs->verbosity > 1)
+        if (userConfigurableArguments->verbosity > 1)
         {
             dp->log(fmt("queuing snooped <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));
@@ -273,7 +273,7 @@ void DvrInfo::addSDevice(const std::string &dev, const std::string &name)
     sp->blob = B_NEVER;
     sprops.push_back(sp);
 
-    if (updatedArgs->verbosity)
+    if (userConfigurableArguments->verbosity)
         log(fmt("snooping on %s.%s\n", dev.c_str(), name.c_str()));
 }
 

--- a/indiserver/DvrInfo.cpp
+++ b/indiserver/DvrInfo.cpp
@@ -80,7 +80,7 @@ void DvrInfo::onMessage(XMLEle * root, std::list<int> &sharedBuffers)
     }
 
     /* log messages if any and wanted */
-    if (ldir)
+    if (loggingDir)
         logDMsg(root, dev);
 
     if (!strcmp(roottag, "pingRequest"))

--- a/indiserver/DvrInfo.hpp
+++ b/indiserver/DvrInfo.hpp
@@ -44,10 +44,10 @@ class DvrInfo: public MsgQueue
     protected:
         /* send message to each interested client
          */
-        virtual void onMessage(XMLEle *root, std::list<int> &sharedBuffers);
+        void onMessage(XMLEle *root, std::list<int> &sharedBuffers) override;
 
         /* override to kill driver that are not reachable anymore */
-        virtual void closeWritePart();
+        void closeWritePart() override;
 
 
         /* Construct an instance that will start the same driver */
@@ -72,12 +72,12 @@ class DvrInfo: public MsgQueue
         virtual void start() = 0;
 
         /* close down the given driver and restart if set*/
-        virtual void close();
+        void close() override;
 
         /* Allocate an instance that will start the same driver */
         virtual DvrInfo * clone() const = 0;
 
-        virtual void log(const std::string &log) const;
+        void log(const std::string &log) const override;
 
         virtual const std::string remoteServerUid() const = 0;
 
@@ -95,7 +95,7 @@ class DvrInfo: public MsgQueue
         static ConcurrentSet<DvrInfo> drivers;
 
         // decoding of attached blobs from driver is not supported ATM. Be conservative here
-        virtual bool acceptSharedBuffers() const
+        bool acceptSharedBuffers() const override
         {
             return false;
         }

--- a/indiserver/Fifo.cpp
+++ b/indiserver/Fifo.cpp
@@ -26,6 +26,8 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+using namespace indiserver::constants;
+
 Fifo::Fifo(const std::string &name) : name(name)
 {
     fdev.set<Fifo, &Fifo::ioCb>(this);
@@ -65,14 +67,25 @@ void Fifo::processLine(const char * line)
     if (verbose)
         log(fmt("FIFO: %s\n", line));
 
-    char cmd[MAXSBUF], arg[4][1], var[4][MAXSBUF], tDriver[MAXSBUF], tName[MAXSBUF], envConfig[MAXSBUF],
-         envSkel[MAXSBUF], envPrefix[MAXSBUF];
+    char cmd[maxStringBufferLength];
+    char arg[4][1];
+    char var[4][maxStringBufferLength];
 
-    memset(&tDriver[0], 0, sizeof(char) * MAXSBUF);
-    memset(&tName[0], 0, sizeof(char) * MAXSBUF);
-    memset(&envConfig[0], 0, sizeof(char) * MAXSBUF);
-    memset(&envSkel[0], 0, sizeof(char) * MAXSBUF);
-    memset(&envPrefix[0], 0, sizeof(char) * MAXSBUF);
+    char tDriver[maxStringBufferLength];
+    memset(&tDriver[0], 0, sizeof(char) * maxStringBufferLength);
+
+    char tName[maxStringBufferLength];
+    memset(&tName[0], 0, sizeof(char) * maxStringBufferLength);
+
+    char envConfig[maxStringBufferLength];
+    memset(&envConfig[0], 0, sizeof(char) * maxStringBufferLength);
+
+    char envSkel[maxStringBufferLength];
+    memset(&envSkel[0], 0, sizeof(char) * maxStringBufferLength);
+
+    char envPrefix[maxStringBufferLength];
+    memset(&envPrefix[0], 0, sizeof(char) * maxStringBufferLength);
+
 
     int n = 0;
 
@@ -106,32 +119,32 @@ void Fifo::processLine(const char * line)
     {
         if (arg[j][0] == 'n')
         {
-            strncpy(tName, var[j], MAXSBUF - 1);
-            tName[MAXSBUF - 1] = '\0';
+            strncpy(tName, var[j], maxStringBufferLength - 1);
+            tName[maxStringBufferLength - 1] = '\0';
 
             if (verbose)
                 log(fmt("With name: %s\n", tName));
         }
         else if (arg[j][0] == 'c')
         {
-            strncpy(envConfig, var[j], MAXSBUF - 1);
-            envConfig[MAXSBUF - 1] = '\0';
+            strncpy(envConfig, var[j], maxStringBufferLength - 1);
+            envConfig[maxStringBufferLength - 1] = '\0';
 
             if (verbose)
                 log(fmt("With config: %s\n", envConfig));
         }
         else if (arg[j][0] == 's')
         {
-            strncpy(envSkel, var[j], MAXSBUF - 1);
-            envSkel[MAXSBUF - 1] = '\0';
+            strncpy(envSkel, var[j], maxStringBufferLength - 1);
+            envSkel[maxStringBufferLength - 1] = '\0';
 
             if (verbose)
                 log(fmt("With skeketon: %s\n", envSkel));
         }
         else if (arg[j][0] == 'p')
         {
-            strncpy(envPrefix, var[j], MAXSBUF - 1);
-            envPrefix[MAXSBUF - 1] = '\0';
+            strncpy(envPrefix, var[j], maxStringBufferLength - 1);
+            envPrefix[maxStringBufferLength - 1] = '\0';
 
             if (verbose)
                 log(fmt("With prefix: %s\n", envPrefix));

--- a/indiserver/Fifo.cpp
+++ b/indiserver/Fifo.cpp
@@ -65,7 +65,7 @@ void Fifo::open()
 void Fifo::processLine(const char * line)
 {
 
-    if (updatedArgs->verbosity)
+    if (userConfigurableArguments->verbosity)
         log(fmt("FIFO: %s\n", line));
 
     char cmd[maxStringBufferLength];
@@ -123,7 +123,7 @@ void Fifo::processLine(const char * line)
             strncpy(tName, var[j], maxStringBufferLength - 1);
             tName[maxStringBufferLength - 1] = '\0';
 
-            if (updatedArgs->verbosity)
+            if (userConfigurableArguments->verbosity)
                 log(fmt("With name: %s\n", tName));
         }
         else if (arg[j][0] == 'c')
@@ -131,7 +131,7 @@ void Fifo::processLine(const char * line)
             strncpy(envConfig, var[j], maxStringBufferLength - 1);
             envConfig[maxStringBufferLength - 1] = '\0';
 
-            if (updatedArgs->verbosity)
+            if (userConfigurableArguments->verbosity)
                 log(fmt("With config: %s\n", envConfig));
         }
         else if (arg[j][0] == 's')
@@ -139,7 +139,7 @@ void Fifo::processLine(const char * line)
             strncpy(envSkel, var[j], maxStringBufferLength - 1);
             envSkel[maxStringBufferLength - 1] = '\0';
 
-            if (updatedArgs->verbosity)
+            if (userConfigurableArguments->verbosity)
                 log(fmt("With skeketon: %s\n", envSkel));
         }
         else if (arg[j][0] == 'p')
@@ -147,7 +147,7 @@ void Fifo::processLine(const char * line)
             strncpy(envPrefix, var[j], maxStringBufferLength - 1);
             envPrefix[maxStringBufferLength - 1] = '\0';
 
-            if (updatedArgs->verbosity)
+            if (userConfigurableArguments->verbosity)
                 log(fmt("With prefix: %s\n", envPrefix));
         }
     }
@@ -160,7 +160,7 @@ void Fifo::processLine(const char * line)
 
     if (startCmd)
     {
-        if (updatedArgs->verbosity)
+        if (userConfigurableArguments->verbosity)
             log(fmt("FIFO: Starting driver %s\n", tDriver));
 
         DvrInfo * dp;
@@ -192,7 +192,7 @@ void Fifo::processLine(const char * line)
                 /* If device name is given, check against it before shutting down */
                 if (tName[0] && !dp->isHandlingDevice(tName))
                     continue;
-                if (updatedArgs->verbosity)
+                if (userConfigurableArguments->verbosity)
                     log(fmt("FIFO: Shutting down driver: %s\n", tDriver));
 
                 dp->restart = false;

--- a/indiserver/Fifo.cpp
+++ b/indiserver/Fifo.cpp
@@ -22,6 +22,7 @@
 #include "DvrInfo.hpp"
 #include "LocalDrvInfo.hpp"
 #include "RemoteDvrInfo.hpp"
+#include "CommandLineArgs.hpp"
 
 #include <fcntl.h>
 #include <unistd.h>
@@ -64,7 +65,7 @@ void Fifo::open()
 void Fifo::processLine(const char * line)
 {
 
-    if (verbose)
+    if (updatedArgs->verbosity)
         log(fmt("FIFO: %s\n", line));
 
     char cmd[maxStringBufferLength];
@@ -122,7 +123,7 @@ void Fifo::processLine(const char * line)
             strncpy(tName, var[j], maxStringBufferLength - 1);
             tName[maxStringBufferLength - 1] = '\0';
 
-            if (verbose)
+            if (updatedArgs->verbosity)
                 log(fmt("With name: %s\n", tName));
         }
         else if (arg[j][0] == 'c')
@@ -130,7 +131,7 @@ void Fifo::processLine(const char * line)
             strncpy(envConfig, var[j], maxStringBufferLength - 1);
             envConfig[maxStringBufferLength - 1] = '\0';
 
-            if (verbose)
+            if (updatedArgs->verbosity)
                 log(fmt("With config: %s\n", envConfig));
         }
         else if (arg[j][0] == 's')
@@ -138,7 +139,7 @@ void Fifo::processLine(const char * line)
             strncpy(envSkel, var[j], maxStringBufferLength - 1);
             envSkel[maxStringBufferLength - 1] = '\0';
 
-            if (verbose)
+            if (updatedArgs->verbosity)
                 log(fmt("With skeketon: %s\n", envSkel));
         }
         else if (arg[j][0] == 'p')
@@ -146,7 +147,7 @@ void Fifo::processLine(const char * line)
             strncpy(envPrefix, var[j], maxStringBufferLength - 1);
             envPrefix[maxStringBufferLength - 1] = '\0';
 
-            if (verbose)
+            if (updatedArgs->verbosity)
                 log(fmt("With prefix: %s\n", envPrefix));
         }
     }
@@ -159,7 +160,7 @@ void Fifo::processLine(const char * line)
 
     if (startCmd)
     {
-        if (verbose)
+        if (updatedArgs->verbosity)
             log(fmt("FIFO: Starting driver %s\n", tDriver));
 
         DvrInfo * dp;
@@ -191,7 +192,7 @@ void Fifo::processLine(const char * line)
                 /* If device name is given, check against it before shutting down */
                 if (tName[0] && !dp->isHandlingDevice(tName))
                     continue;
-                if (verbose)
+                if (updatedArgs->verbosity)
                     log(fmt("FIFO: Shutting down driver: %s\n", tDriver));
 
                 dp->restart = false;

--- a/indiserver/LocalDrvInfo.hpp
+++ b/indiserver/LocalDrvInfo.hpp
@@ -49,11 +49,11 @@ class LocalDvrInfo: public DvrInfo
         LocalDvrInfo();
         virtual ~LocalDvrInfo();
 
-        virtual void start();
+        void start() override;
 
-        virtual LocalDvrInfo * clone() const;
+        LocalDvrInfo * clone() const override;
 
-        virtual const std::string remoteServerUid() const
+        const std::string remoteServerUid() const override
         {
             return "";
         }

--- a/indiserver/LocalDvrInfo.cpp
+++ b/indiserver/LocalDvrInfo.cpp
@@ -21,16 +21,13 @@
 #include "Utils.hpp"
 #include "Msg.hpp"
 #include "Constants.hpp"
+#include "CommandLineArgs.hpp"
 
 #include "Fifo.hpp"
 #include <sys/socket.h>
 #include <fcntl.h>
 #include <libgen.h>
 #include <unistd.h>
-
-// these externs need to go
-extern Fifo * fifo;
-extern const char *me;
 
 /* start the given local INDI driver process.
  * exit if trouble.
@@ -112,7 +109,7 @@ void LocalDvrInfo::start()
             setenv("INDIDEV", envDev.c_str(), 1);
         }
         /* Only reset environment variable in case of FIFO */
-        else if (fifo)
+        else if (updatedArgs->fifoHandle)
         {
             unsetenv("INDIDEV");
         }
@@ -120,7 +117,7 @@ void LocalDvrInfo::start()
         {
             setenv("INDICONFIG", envConfig.c_str(), 1);
         }
-        else if (fifo)
+        else if (updatedArgs->fifoHandle)
         {
             unsetenv("INDICONFIG");
         }
@@ -128,7 +125,7 @@ void LocalDvrInfo::start()
         {
             setenv("INDISKEL", envSkel.c_str(), 1);
         }
-        else if (fifo)
+        else if (updatedArgs->fifoHandle)
         {
             unsetenv("INDISKEL");
         }
@@ -152,7 +149,7 @@ void LocalDvrInfo::start()
         {
             if (name[0] == '.')
             {
-                executable = std::string(dirname((char*)me)) + "/" + name;
+                executable = updatedArgs->binaryName + "/" + name;
                 execlp(executable.c_str(), name.c_str(), NULL);
             }
             else
@@ -204,7 +201,7 @@ void LocalDvrInfo::start()
     /* first message primes driver to report its properties -- dev known
      * if restarting
      */
-    if (verbose > 0)
+    if (updatedArgs->verbosity > 0)
         log(fmt("pid=%d rfd=%d wfd=%d efd=%d\n", pid, rp[0], wp[1], ep[0]));
 
     XMLEle *root = addXMLEle(NULL, "getProperties");

--- a/indiserver/LocalDvrInfo.cpp
+++ b/indiserver/LocalDvrInfo.cpp
@@ -104,21 +104,34 @@ void LocalDvrInfo::start()
         }
         dup2(ep[1], 2); /* driver stderr writes to e[]1] */
         for (fd = 3; fd < 100; fd++)
+        {
             (void)::close(fd);
-
+        }
         if (!envDev.empty())
+        {
             setenv("INDIDEV", envDev.c_str(), 1);
+        }
         /* Only reset environment variable in case of FIFO */
         else if (fifo)
+        {
             unsetenv("INDIDEV");
+        }
         if (!envConfig.empty())
+        {
             setenv("INDICONFIG", envConfig.c_str(), 1);
+        }
         else if (fifo)
+        {
             unsetenv("INDICONFIG");
+        }
         if (!envSkel.empty())
+        {
             setenv("INDISKEL", envSkel.c_str(), 1);
+        }
         else if (fifo)
+        {
             unsetenv("INDISKEL");
+        }
         std::string executable;
         if (!envPrefix.empty())
         {

--- a/indiserver/LocalDvrInfo.cpp
+++ b/indiserver/LocalDvrInfo.cpp
@@ -109,7 +109,7 @@ void LocalDvrInfo::start()
             setenv("INDIDEV", envDev.c_str(), 1);
         }
         /* Only reset environment variable in case of FIFO */
-        else if (updatedArgs->fifoHandle)
+        else if (userConfigurableArguments->fifoHandle)
         {
             unsetenv("INDIDEV");
         }
@@ -117,7 +117,7 @@ void LocalDvrInfo::start()
         {
             setenv("INDICONFIG", envConfig.c_str(), 1);
         }
-        else if (updatedArgs->fifoHandle)
+        else if (userConfigurableArguments->fifoHandle)
         {
             unsetenv("INDICONFIG");
         }
@@ -125,7 +125,7 @@ void LocalDvrInfo::start()
         {
             setenv("INDISKEL", envSkel.c_str(), 1);
         }
-        else if (updatedArgs->fifoHandle)
+        else if (userConfigurableArguments->fifoHandle)
         {
             unsetenv("INDISKEL");
         }
@@ -149,7 +149,7 @@ void LocalDvrInfo::start()
         {
             if (name[0] == '.')
             {
-                executable = updatedArgs->binaryName + "/" + name;
+                executable = userConfigurableArguments->binaryName + "/" + name;
                 execlp(executable.c_str(), name.c_str(), NULL);
             }
             else
@@ -201,7 +201,7 @@ void LocalDvrInfo::start()
     /* first message primes driver to report its properties -- dev known
      * if restarting
      */
-    if (updatedArgs->verbosity > 0)
+    if (userConfigurableArguments->verbosity > 0)
         log(fmt("pid=%d rfd=%d wfd=%d efd=%d\n", pid, rp[0], wp[1], ep[0]));
 
     XMLEle *root = addXMLEle(NULL, "getProperties");

--- a/indiserver/Msg.cpp
+++ b/indiserver/Msg.cpp
@@ -90,7 +90,7 @@ void Msg::releaseXmlContent()
 
 void Msg::releaseSharedBuffers(const std::set<int> &keep)
 {
-    for(std::size_t i = 0; i < sharedBuffers.size(); ++i)
+    for(size_t i = 0; i < sharedBuffers.size(); ++i)
     {
         auto fd = sharedBuffers[i];
         if (fd != -1 && keep.find(fd) == keep.end())

--- a/indiserver/MsgChunckIterator.hpp
+++ b/indiserver/MsgChunckIterator.hpp
@@ -17,12 +17,11 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #pragma once
-#include <cctype> // remove this, why are they using std::size_t
 
 class MsgChunckIterator
 {
         friend class SerializedMsg;
-        std::size_t chunckId;
+        size_t chunckId;
         unsigned long chunckOffset;
         bool endReached;
     public:

--- a/indiserver/MsgQueue.cpp
+++ b/indiserver/MsgQueue.cpp
@@ -21,6 +21,8 @@
 #include "Constants.hpp"
 #include "SerializedMsg.hpp"
 #include "Msg.hpp"
+#include "CommandLineArgs.hpp"
+
 #include <sys/socket.h>
 #include <fcntl.h>
 #include <unistd.h>
@@ -140,12 +142,12 @@ void MsgQueue::writeToFd()
     }
 
     /* trace */
-    if (verbose > 2)
+    if (updatedArgs->verbosity > 2)
     {
         log(fmt("sending msg nq %ld:\n%.*s\n",
                 msgq.size(), (int)nw, data));
     }
-    else if (verbose > 1)
+    else if (updatedArgs->verbosity > 1)
     {
         log(fmt("sending %.*s\n", (int)nw, data));
     }
@@ -513,7 +515,7 @@ void MsgQueue::readFromFd()
 
         if (nr < 0)
             log(fmt("read: %s\n", strerror(errno)));
-        else if (verbose > 0)
+        else if (updatedArgs->verbosity > 0)
             log(fmt("read EOF\n"));
         close();
         return;
@@ -539,9 +541,9 @@ void MsgQueue::readFromFd()
     {
         if (hb.alive())
         {
-            if (verbose > 2)
+            if (updatedArgs->verbosity > 2)
                 traceMsg("read ", root);
-            else if (verbose > 1)
+            else if (updatedArgs->verbosity > 1)
             {
                 log(fmt("read <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));

--- a/indiserver/MsgQueue.cpp
+++ b/indiserver/MsgQueue.cpp
@@ -142,12 +142,12 @@ void MsgQueue::writeToFd()
     }
 
     /* trace */
-    if (updatedArgs->verbosity > 2)
+    if (userConfigurableArguments->verbosity > 2)
     {
         log(fmt("sending msg nq %ld:\n%.*s\n",
                 msgq.size(), (int)nw, data));
     }
-    else if (updatedArgs->verbosity > 1)
+    else if (userConfigurableArguments->verbosity > 1)
     {
         log(fmt("sending %.*s\n", (int)nw, data));
     }
@@ -515,7 +515,7 @@ void MsgQueue::readFromFd()
 
         if (nr < 0)
             log(fmt("read: %s\n", strerror(errno)));
-        else if (updatedArgs->verbosity > 0)
+        else if (userConfigurableArguments->verbosity > 0)
             log(fmt("read EOF\n"));
         close();
         return;
@@ -541,9 +541,9 @@ void MsgQueue::readFromFd()
     {
         if (hb.alive())
         {
-            if (updatedArgs->verbosity > 2)
+            if (userConfigurableArguments->verbosity > 2)
                 traceMsg("read ", root);
-            else if (updatedArgs->verbosity > 1)
+            else if (userConfigurableArguments->verbosity > 1)
             {
                 log(fmt("read <%s device='%s' name='%s'>\n",
                         tagXMLEle(root), findXMLAttValu(root, "device"), findXMLAttValu(root, "name")));

--- a/indiserver/MsgQueue.hpp
+++ b/indiserver/MsgQueue.hpp
@@ -32,6 +32,10 @@ class Msg;
 
 class MsgQueue: public Collectable
 {
+        static constexpr unsigned maxFDPerMessage {16}; /* No more than 16 buffer attached to a message */
+        static constexpr unsigned maxReadBufferLength {49152};
+        static constexpr unsigned maxWriteBufferLength {49152};
+
         int rFd, wFd;
         LilXML * lp;         /* XML parsing context */
         ev::io   rio, wio;   /* Event loop io events */

--- a/indiserver/RemoteDvrInfo.cpp
+++ b/indiserver/RemoteDvrInfo.cpp
@@ -25,13 +25,15 @@
 #include <netinet/in.h>
 #include <netdb.h>
 
+using namespace indiserver::constants;
+
 void RemoteDvrInfo::extractRemoteId(const std::string &name, std::string &o_host, int &o_port, std::string &o_dev) const
 {
     char dev[MAXINDIDEVICE] = {0};
-    char host[MAXSBUF] = {0};
+    char host[maxStringBufferLength] = {0};
 
     /* extract host and port from name*/
-    int indi_port = INDIPORT;
+    int indi_port = indiPort;
     if (sscanf(name.c_str(), "%[^@]@%[^:]:%d", dev, host, &indi_port) < 2)
     {
         // Device missing? Try a different syntax for all devices

--- a/indiserver/RemoteDvrInfo.cpp
+++ b/indiserver/RemoteDvrInfo.cpp
@@ -20,6 +20,7 @@
 #include "Utils.hpp"
 #include "Constants.hpp"
 #include "Msg.hpp"
+#include "CommandLineArgs.hpp"
 
 #include <cstdio>
 #include <netinet/in.h>
@@ -33,7 +34,7 @@ void RemoteDvrInfo::extractRemoteId(const std::string &name, std::string &o_host
     char host[maxStringBufferLength] = {0};
 
     /* extract host and port from name*/
-    int indi_port = indiPort;
+    int indi_port = updatedArgs->port;
     if (sscanf(name.c_str(), "%[^@]@%[^:]:%d", dev, host, &indi_port) < 2)
     {
         // Device missing? Try a different syntax for all devices
@@ -65,7 +66,7 @@ void RemoteDvrInfo::start()
 
     this->setFds(sockfd, sockfd);
 
-    if (verbose > 0)
+    if (updatedArgs->verbosity > 0)
         log(fmt("socket=%d\n", sockfd));
 
     /* N.B. storing name now is key to limiting outbound traffic to this

--- a/indiserver/RemoteDvrInfo.cpp
+++ b/indiserver/RemoteDvrInfo.cpp
@@ -34,7 +34,7 @@ void RemoteDvrInfo::extractRemoteId(const std::string &name, std::string &o_host
     char host[maxStringBufferLength] = {0};
 
     /* extract host and port from name*/
-    int indi_port = updatedArgs->port;
+    int indi_port = userConfigurableArguments->port;
     if (sscanf(name.c_str(), "%[^@]@%[^:]:%d", dev, host, &indi_port) < 2)
     {
         // Device missing? Try a different syntax for all devices
@@ -66,7 +66,7 @@ void RemoteDvrInfo::start()
 
     this->setFds(sockfd, sockfd);
 
-    if (updatedArgs->verbosity > 0)
+    if (userConfigurableArguments->verbosity > 0)
         log(fmt("socket=%d\n", sockfd));
 
     /* N.B. storing name now is key to limiting outbound traffic to this

--- a/indiserver/RemoteDvrInfo.hpp
+++ b/indiserver/RemoteDvrInfo.hpp
@@ -41,11 +41,11 @@ class RemoteDvrInfo: public DvrInfo
         RemoteDvrInfo();
         virtual ~RemoteDvrInfo();
 
-        virtual void start();
+        void start() override;
 
-        virtual RemoteDvrInfo * clone() const;
+        RemoteDvrInfo * clone() const override;
 
-        virtual const std::string remoteServerUid() const
+        const std::string remoteServerUid() const override
         {
             return std::string(host) + ":" + std::to_string(port);
         }

--- a/indiserver/SerializationRequirement.cpp
+++ b/indiserver/SerializationRequirement.cpp
@@ -16,24 +16,18 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
-#pragma once
-#include <set>
-class Msg;
-class SerializedMsg;
+#include "SerializationRequirement.hpp"
 
-class SerializationRequirement
+void SerializationRequirement::add(const SerializationRequirement &from)
 {
-        friend class Msg;
-        friend class SerializedMsg;
+    xml |= from.xml;
+    for(auto fd : from.sharedBuffers)
+    {
+        sharedBuffers.insert(fd);
+    }
+}
 
-        // If the xml is still required
-        bool xml{false};
-        // Set of sharedBuffer that are still required
-        std::set<int> sharedBuffers{};
-
-        SerializationRequirement() noexcept = default;
-
-        void add(const SerializationRequirement &from);
-
-        bool operator==(const SerializationRequirement   &sr) const;
-};
+bool SerializationRequirement::operator==(const SerializationRequirement   &sr) const
+{
+    return (xml == sr.xml) && (sharedBuffers == sr.sharedBuffers);
+}

--- a/indiserver/SerializedMsgWithoutSharedBuffer.cpp
+++ b/indiserver/SerializedMsgWithoutSharedBuffer.cpp
@@ -122,7 +122,7 @@ void SerializedMsgWithoutSharedBuffer::generateContent()
         ownBuffers.push_back(model);
 
         // Get the element offset
-        for(std::size_t i = 0; i < cdata.size(); ++i)
+        for(size_t i = 0; i < cdata.size(); ++i)
         {
             modelCdataOffset[i] = sprXMLCDataOffset(xmlContent, cdata[i], 0);
         }
@@ -134,7 +134,7 @@ void SerializedMsgWithoutSharedBuffer::generateContent()
         std::vector<size_t> attachedSizes(cdata.size());
 
         // Attach all blobs
-        for(std::size_t i = 0; i < cdata.size(); ++i)
+        for(size_t i = 0; i < cdata.size(); ++i)
         {
             if (sharedBuffers[i] != -1)
             {
@@ -160,7 +160,7 @@ void SerializedMsgWithoutSharedBuffer::generateContent()
 
         // Copy from model or blob (streaming base64 encode)
         int modelOffset = 0;
-        for(std::size_t i = 0; i < cdata.size(); ++i)
+        for(size_t i = 0; i < cdata.size(); ++i)
         {
             int cdataOffset = modelCdataOffset[i];
             if (cdataOffset > modelOffset)

--- a/indiserver/TcpServer.cpp
+++ b/indiserver/TcpServer.cpp
@@ -20,6 +20,7 @@
 #include "Constants.hpp"
 #include "Utils.hpp"
 #include "ClInfo.hpp"
+#include "CommandLineArgs.hpp"
 
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -90,7 +91,7 @@ void TcpServer::listen()
     sfdev.start(sfd, EV_READ);
 
     /* ok */
-    if (verbose > 0)
+    if (updatedArgs->verbosity > 0)
         log(fmt("listening to port %d on fd %d\n", port, sfd));
 }
 
@@ -116,7 +117,7 @@ void TcpServer::accept()
     /* rig up new clinfo entry */
     cp->setFds(cli_fd, cli_fd);
 
-    if (verbose > 0)
+    if (updatedArgs->verbosity > 0)
     {
         cp->log(fmt("new arrival from %s:%d - welcome!\n",
                     inet_ntoa(cli_socket.sin_addr), ntohs(cli_socket.sin_port)));

--- a/indiserver/TcpServer.cpp
+++ b/indiserver/TcpServer.cpp
@@ -91,7 +91,7 @@ void TcpServer::listen()
     sfdev.start(sfd, EV_READ);
 
     /* ok */
-    if (updatedArgs->verbosity > 0)
+    if (userConfigurableArguments->verbosity > 0)
         log(fmt("listening to port %d on fd %d\n", port, sfd));
 }
 
@@ -117,7 +117,7 @@ void TcpServer::accept()
     /* rig up new clinfo entry */
     cp->setFds(cli_fd, cli_fd);
 
-    if (updatedArgs->verbosity > 0)
+    if (userConfigurableArguments->verbosity > 0)
     {
         cp->log(fmt("new arrival from %s:%d - welcome!\n",
                     inet_ntoa(cli_socket.sin_addr), ntohs(cli_socket.sin_port)));

--- a/indiserver/UnixServer.cpp
+++ b/indiserver/UnixServer.cpp
@@ -125,7 +125,7 @@ void UnixServer::listen()
     sfdev.start(sfd, EV_READ);
 
     /* ok */
-    if (updatedArgs->verbosity > 0)
+    if (userConfigurableArguments->verbosity > 0)
         log(fmt("listening on local domain at: @%s\n", path.c_str()));
 }
 
@@ -148,7 +148,7 @@ void UnixServer::accept()
     /* rig up new clinfo entry */
     cp->setFds(cli_fd, cli_fd);
 
-    if (updatedArgs->verbosity > 0)
+    if (userConfigurableArguments->verbosity > 0)
     {
 #ifdef SO_PEERCRED
 #ifdef __OpenBSD__

--- a/indiserver/UnixServer.cpp
+++ b/indiserver/UnixServer.cpp
@@ -20,6 +20,7 @@
 #include "Utils.hpp"
 #include "Constants.hpp"
 #include "ClInfo.hpp"
+#include "CommandLineArgs.hpp"
 
 #include <sys/un.h>
 #include <sys/socket.h>
@@ -124,7 +125,7 @@ void UnixServer::listen()
     sfdev.start(sfd, EV_READ);
 
     /* ok */
-    if (verbose > 0)
+    if (updatedArgs->verbosity > 0)
         log(fmt("listening on local domain at: @%s\n", path.c_str()));
 }
 
@@ -147,7 +148,7 @@ void UnixServer::accept()
     /* rig up new clinfo entry */
     cp->setFds(cli_fd, cli_fd);
 
-    if (verbose > 0)
+    if (updatedArgs->verbosity > 0)
     {
 #ifdef SO_PEERCRED
 #ifdef __OpenBSD__

--- a/indiserver/UnixServer.hpp
+++ b/indiserver/UnixServer.hpp
@@ -33,7 +33,7 @@ class UnixServer
         void accept();
         void ioCb(ev::io &watcher, int revents);
 
-        virtual void log(const std::string &log) const;
+        void log(const std::string &log) const;
     public:
         UnixServer(const std::string &path);
 

--- a/indiserver/Utils.cpp
+++ b/indiserver/Utils.cpp
@@ -117,7 +117,7 @@ bool parseBlobSize(XMLEle * blobWithAttachedBuffer, ssize_t &size)
     {
         return false;
     }
-    std::size_t pos;
+    size_t pos;
     size = std::stoll(sizeStr, &pos, 10);
     if (pos != sizeStr.size())
     {

--- a/indiserver/Utils.cpp
+++ b/indiserver/Utils.cpp
@@ -96,7 +96,7 @@ void logDMsg(XMLEle *root, const char *dev)
     }
 
     /* append to log file, name is date portion of time stamp */
-    sprintf(logfn, "%s/%.10s.islog", updatedArgs->loggingDir, ts);
+    sprintf(logfn, "%s/%.10s.islog", userConfigurableArguments->loggingDir, ts);
     fp = fopen(logfn, "a");
     if (!fp)
         return; /* oh well */

--- a/indiserver/Utils.cpp
+++ b/indiserver/Utils.cpp
@@ -19,6 +19,7 @@
 
 #include "Utils.hpp"
 #include "Constants.hpp"
+#include "CommandLineArgs.hpp"
 
 #include <cstring>
 #include <csignal>
@@ -95,7 +96,7 @@ void logDMsg(XMLEle *root, const char *dev)
     }
 
     /* append to log file, name is date portion of time stamp */
-    sprintf(logfn, "%s/%.10s.islog", loggingDir, ts);
+    sprintf(logfn, "%s/%.10s.islog", updatedArgs->loggingDir, ts);
     fp = fopen(logfn, "a");
     if (!fp)
         return; /* oh well */

--- a/indiserver/Utils.cpp
+++ b/indiserver/Utils.cpp
@@ -72,7 +72,7 @@ char *indi_tstamp(char *s)
     return (s);
 }
 
-/* log message in root known to be from device dev to ldir, if any.
+/* log message in root known to be from device dev to loggingDir, if any.
 */
 void logDMsg(XMLEle *root, const char *dev)
 {
@@ -95,7 +95,7 @@ void logDMsg(XMLEle *root, const char *dev)
     }
 
     /* append to log file, name is date portion of time stamp */
-    sprintf(logfn, "%s/%.10s.islog", ldir, ts);
+    sprintf(logfn, "%s/%.10s.islog", loggingDir, ts);
     fp = fopen(logfn, "a");
     if (!fp)
         return; /* oh well */

--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -212,7 +212,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-f requires fifo node\n");
                         usage();
                     }
-
+                    assert(!fifoHandle);
                     fifoHandle = std::make_unique<Fifo>(*++av);
                     userConfigurableArguments->fifoHandle = fifoHandle.get();
                     ac--;

--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -94,15 +94,14 @@ using namespace indiserver::constants;
 
 static ev::default_loop loop;
 
-const char *me; 
+const char *me;
 int port = indiPort;                          /* public INDI port */
 
-/* our name */
 // these were static, i made them extern so they could be used in the component files
 int verbose;                                    /* chattiness */
 unsigned int maxstreamsiz  = defaultMaxStreamSizeMB; /* drop blobs if these bytes behind while streaming*/
 unsigned int maxqsiz  = defaultMaxQueueSizeMB;       /* kill if these bytes behind */
-char *ldir;                                          /* where to log driver messages */
+char *loggingDir;                                          /* where to log driver messages */
 int maxrestarts   = defaultMaximumRestarts;
 Fifo * fifo = nullptr;
 
@@ -167,7 +166,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-l requires log directory\n");
                         usage();
                     }
-                    ldir = *++av;
+                    loggingDir = *++av;
                     ac--;
                     break;
                 case 'm':

--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -57,6 +57,7 @@
 #include "UnixServer.hpp"
 #include "Utils.hpp"
 #include "Constants.hpp"
+#include "CommandLineArgs.hpp"
 
 #include "config.h"
 #include <string>
@@ -65,6 +66,7 @@
 
 #include "indiapi.h"
 
+#include <memory>
 #include <fcntl.h>
 #include <libgen.h>
 #include <netdb.h>
@@ -94,21 +96,12 @@ using namespace indiserver::constants;
 
 static ev::default_loop loop;
 
-const char *me;
-int port = indiPort;                          /* public INDI port */
-
-// these were static, i made them extern so they could be used in the component files
-int verbose;                                    /* chattiness */
-unsigned int maxstreamsiz  = defaultMaxStreamSizeMB; /* drop blobs if these bytes behind while streaming*/
-unsigned int maxqsiz  = defaultMaxQueueSizeMB;       /* kill if these bytes behind */
-char *loggingDir;                                          /* where to log driver messages */
-int maxrestarts   = defaultMaximumRestarts;
-Fifo * fifo = nullptr;
+CommandLineArgs* updatedArgs{nullptr};
 
 /* print usage message and exit (2) */
 void usage(void)
 {
-    fprintf(stderr, "Usage: %s [options] driver [driver ...]\n", me);
+    fprintf(stderr, "Usage: %s [options] driver [driver ...]\n", updatedArgs->binaryName.c_str());
     fprintf(stderr, "Purpose: server for local and remote INDI drivers\n");
     fprintf(stderr, "INDI Library: %s\nCode %s. Protocol %g.\n", CMAKE_INDI_VERSION_STRING, GIT_TAG_STRING, INDIV);
     fprintf(stderr, "Options:\n");
@@ -120,7 +113,7 @@ void usage(void)
 #ifdef ENABLE_INDI_SHARED_MEMORY
     fprintf(stderr, " -u path  : Path for the local connection socket (abstract), default %s\n", INDIUNIXSOCK);
 #endif
-    fprintf(stderr, " -p p     : alternate IP port, default %d\n", indiPort);
+    fprintf(stderr, " -p p     : alternate IP port, default %d\n", indiPortDefault);
     fprintf(stderr, " -r r     : maximum driver restarts on error, default %d\n", defaultMaximumRestarts);
     fprintf(stderr, " -f path  : Path to fifo for dynamic startup and shutdown of drivers.\n");
     fprintf(stderr, " -v       : show key events, no traffic\n");
@@ -136,8 +129,13 @@ int main(int ac, char *av[])
     /* log startup */
     logStartup(ac, av);
 
+    std::unique_ptr<CommandLineArgs> argValues = std::make_unique<CommandLineArgs>();
+    updatedArgs = argValues.get();
+
+    std::unique_ptr<Fifo> fifoHandle{};
+    
     /* save our name */
-    me = av[0];
+    argValues->binaryName = av[0];
 
 #ifdef OSX_EMBEDED_MODE
 
@@ -146,9 +144,10 @@ int main(int ac, char *av[])
     fprintf(stderr, "switching stderr to %s", logname);
     freopen(logname, "w", stderr);
 
-    fifo = new Fifo();
-    fifo->name = fifoName;
-    verbose   = 1;
+    fifoHandle = std::make_unique<Fifo>();
+    updatedArgs->fifoHandle = fifoHandle.get();
+    updatedArgs->fifoHandle->name = fifoName;
+    updatedArgs->verbosity   = 1;
     ac        = 0;
 
 #else
@@ -166,7 +165,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-l requires log directory\n");
                         usage();
                     }
-                    loggingDir = *++av;
+                    updatedArgs->loggingDir = *++av;
                     ac--;
                     break;
                 case 'm':
@@ -175,7 +174,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-m requires max MB behind\n");
                         usage();
                     }
-                    maxqsiz = 1024 * 1024 * atoi(*++av);
+                    updatedArgs->maxQueueSizeMB = 1024 * 1024 * atoi(*++av);
                     ac--;
                     break;
                 case 'p':
@@ -184,7 +183,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-p requires port value\n");
                         usage();
                     }
-                    port = atoi(*++av);
+                    updatedArgs->port = atoi(*++av);
                     ac--;
                     break;
                 case 'd':
@@ -193,7 +192,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-d requires max stream MB behind\n");
                         usage();
                     }
-                    maxstreamsiz = 1024 * 1024 * atoi(*++av);
+                    updatedArgs->maxStreamSizeMB = 1024 * 1024 * atoi(*++av);
                     ac--;
                     break;
 #ifdef ENABLE_INDI_SHARED_MEMORY
@@ -213,7 +212,9 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-f requires fifo node\n");
                         usage();
                     }
-                    fifo = new Fifo(*++av);
+
+                    fifoHandle = std::make_unique<Fifo>(*++av);
+                    updatedArgs->fifoHandle = fifoHandle.get();
                     ac--;
                     break;
                 case 'r':
@@ -222,13 +223,13 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-r requires number of restarts\n");
                         usage();
                     }
-                    maxrestarts = atoi(*++av);
-                    if (maxrestarts < 0)
-                        maxrestarts = 0;
+                    updatedArgs->maxRestartAttempts = atoi(*++av);
+                    if (updatedArgs->maxRestartAttempts < 0)
+                        updatedArgs->maxRestartAttempts = 0;
                     ac--;
                     break;
                 case 'v':
-                    verbose++;
+                    updatedArgs->verbosity++;
                     break;
                 default:
                     usage();
@@ -237,7 +238,7 @@ int main(int ac, char *av[])
 #endif
 
     /* at this point there are ac args in av[] to name our drivers */
-    if (ac == 0 && !fifo)
+    if (ac == 0 && !updatedArgs->fifoHandle)
         usage();
 
     /* take care of some unixisms */
@@ -261,20 +262,20 @@ int main(int ac, char *av[])
     }
 
     /* announce we are online */
-    (new TcpServer(port))->listen();
+    (new TcpServer(updatedArgs->port))->listen();
 
 #ifdef ENABLE_INDI_SHARED_MEMORY
     /* create a new unix server */
     (new UnixServer(UnixServer::unixSocketPath))->listen();
 #endif
     /* Load up FIFO, if available */
-    if (fifo)
+    if (updatedArgs->fifoHandle)
     {
         // New started drivers will not inherit server's prefix anymore
 
         // JM 2022.07.23: This causes an issue on MacOS. Disabled for now until investigated further.
         //unsetenv("INDIPREFIX");
-        fifo->listen();
+        updatedArgs->fifoHandle->listen();
     }
 
     /* handle new clients and all io */

--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -96,12 +96,12 @@ using namespace indiserver::constants;
 
 static ev::default_loop loop;
 
-CommandLineArgs* updatedArgs{nullptr};
+CommandLineArgs* userConfigurableArguments{nullptr};
 
 /* print usage message and exit (2) */
 void usage(void)
 {
-    fprintf(stderr, "Usage: %s [options] driver [driver ...]\n", updatedArgs->binaryName.c_str());
+    fprintf(stderr, "Usage: %s [options] driver [driver ...]\n", userConfigurableArguments->binaryName.c_str());
     fprintf(stderr, "Purpose: server for local and remote INDI drivers\n");
     fprintf(stderr, "INDI Library: %s\nCode %s. Protocol %g.\n", CMAKE_INDI_VERSION_STRING, GIT_TAG_STRING, INDIV);
     fprintf(stderr, "Options:\n");
@@ -130,7 +130,7 @@ int main(int ac, char *av[])
     logStartup(ac, av);
 
     std::unique_ptr<CommandLineArgs> argValues = std::make_unique<CommandLineArgs>();
-    updatedArgs = argValues.get();
+    userConfigurableArguments = argValues.get();
 
     std::unique_ptr<Fifo> fifoHandle{};
     
@@ -165,7 +165,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-l requires log directory\n");
                         usage();
                     }
-                    updatedArgs->loggingDir = *++av;
+                    userConfigurableArguments->loggingDir = *++av;
                     ac--;
                     break;
                 case 'm':
@@ -174,7 +174,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-m requires max MB behind\n");
                         usage();
                     }
-                    updatedArgs->maxQueueSizeMB = 1024 * 1024 * atoi(*++av);
+                    userConfigurableArguments->maxQueueSizeMB = 1024 * 1024 * atoi(*++av);
                     ac--;
                     break;
                 case 'p':
@@ -183,7 +183,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-p requires port value\n");
                         usage();
                     }
-                    updatedArgs->port = atoi(*++av);
+                    userConfigurableArguments->port = atoi(*++av);
                     ac--;
                     break;
                 case 'd':
@@ -192,7 +192,7 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-d requires max stream MB behind\n");
                         usage();
                     }
-                    updatedArgs->maxStreamSizeMB = 1024 * 1024 * atoi(*++av);
+                    userConfigurableArguments->maxStreamSizeMB = 1024 * 1024 * atoi(*++av);
                     ac--;
                     break;
 #ifdef ENABLE_INDI_SHARED_MEMORY
@@ -214,7 +214,7 @@ int main(int ac, char *av[])
                     }
 
                     fifoHandle = std::make_unique<Fifo>(*++av);
-                    updatedArgs->fifoHandle = fifoHandle.get();
+                    userConfigurableArguments->fifoHandle = fifoHandle.get();
                     ac--;
                     break;
                 case 'r':
@@ -223,13 +223,13 @@ int main(int ac, char *av[])
                         fprintf(stderr, "-r requires number of restarts\n");
                         usage();
                     }
-                    updatedArgs->maxRestartAttempts = atoi(*++av);
-                    if (updatedArgs->maxRestartAttempts < 0)
-                        updatedArgs->maxRestartAttempts = 0;
+                    userConfigurableArguments->maxRestartAttempts = atoi(*++av);
+                    if (userConfigurableArguments->maxRestartAttempts < 0)
+                        userConfigurableArguments->maxRestartAttempts = 0;
                     ac--;
                     break;
                 case 'v':
-                    updatedArgs->verbosity++;
+                    userConfigurableArguments->verbosity++;
                     break;
                 default:
                     usage();
@@ -238,7 +238,7 @@ int main(int ac, char *av[])
 #endif
 
     /* at this point there are ac args in av[] to name our drivers */
-    if (ac == 0 && !updatedArgs->fifoHandle)
+    if (ac == 0 && !userConfigurableArguments->fifoHandle)
         usage();
 
     /* take care of some unixisms */
@@ -263,7 +263,7 @@ int main(int ac, char *av[])
     }
 
     /* announce we are online */
-    const auto tcpServer = std::make_unique<TcpServer>(updatedArgs->port);
+    const auto tcpServer = std::make_unique<TcpServer>(userConfigurableArguments->port);
     tcpServer->listen();
 
 #ifdef ENABLE_INDI_SHARED_MEMORY
@@ -272,13 +272,13 @@ int main(int ac, char *av[])
     unixServer->listen();
 #endif
     /* Load up FIFO, if available */
-    if (updatedArgs->fifoHandle)
+    if (userConfigurableArguments->fifoHandle)
     {
         // New started drivers will not inherit server's prefix anymore
 
         // JM 2022.07.23: This causes an issue on MacOS. Disabled for now until investigated further.
         //unsetenv("INDIPREFIX");
-        updatedArgs->fifoHandle->listen();
+        userConfigurableArguments->fifoHandle->listen();
     }
 
     /* handle new clients and all io */

--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -90,19 +90,21 @@
 #endif
 
 #include <ev++.h>
+using namespace indiserver::constants;
 
 static ev::default_loop loop;
 
-// these were static, i made them extern so they could be used in the component files
-Fifo * fifo = nullptr;
-const char *me;                                 /* our name */
-int verbose;                                    /* chattiness */
+const char *me; 
+int port = indiPort;                          /* public INDI port */
 
-static int port = INDIPORT;                            /* public INDI port */
-char *ldir;                                     /* where to log driver messages */
-unsigned int maxqsiz  = (DEFMAXQSIZ * 1024 * 1024); /* kill if these bytes behind */
-unsigned int maxstreamsiz  = (DEFMAXSSIZ * 1024 * 1024); /* drop blobs if these bytes behind while streaming*/
-int maxrestarts   = DEFMAXRESTART;
+/* our name */
+// these were static, i made them extern so they could be used in the component files
+int verbose;                                    /* chattiness */
+unsigned int maxstreamsiz  = defaultMaxStreamSizeMB; /* drop blobs if these bytes behind while streaming*/
+unsigned int maxqsiz  = defaultMaxQueueSizeMB;       /* kill if these bytes behind */
+char *ldir;                                          /* where to log driver messages */
+int maxrestarts   = defaultMaximumRestarts;
+Fifo * fifo = nullptr;
 
 /* print usage message and exit (2) */
 void usage(void)
@@ -112,15 +114,15 @@ void usage(void)
     fprintf(stderr, "INDI Library: %s\nCode %s. Protocol %g.\n", CMAKE_INDI_VERSION_STRING, GIT_TAG_STRING, INDIV);
     fprintf(stderr, "Options:\n");
     fprintf(stderr, " -l d     : log driver messages to <d>/YYYY-MM-DD.islog\n");
-    fprintf(stderr, " -m m     : kill client if gets more than this many MB behind, default %d\n", DEFMAXQSIZ);
+    fprintf(stderr, " -m m     : kill client if gets more than this many MB behind, default %d\n", defaultMaxQueueSizeMB);
     fprintf(stderr,
             " -d m     : drop streaming blobs if client gets more than this many MB behind, default %d. 0 to disable\n",
-            DEFMAXSSIZ);
+            defaultMaxStreamSizeMB);
 #ifdef ENABLE_INDI_SHARED_MEMORY
     fprintf(stderr, " -u path  : Path for the local connection socket (abstract), default %s\n", INDIUNIXSOCK);
 #endif
-    fprintf(stderr, " -p p     : alternate IP port, default %d\n", INDIPORT);
-    fprintf(stderr, " -r r     : maximum driver restarts on error, default %d\n", DEFMAXRESTART);
+    fprintf(stderr, " -p p     : alternate IP port, default %d\n", indiPort);
+    fprintf(stderr, " -r r     : maximum driver restarts on error, default %d\n", defaultMaximumRestarts);
     fprintf(stderr, " -f path  : Path to fifo for dynamic startup and shutdown of drivers.\n");
     fprintf(stderr, " -v       : show key events, no traffic\n");
     fprintf(stderr, " -vv      : -v + key message content\n");
@@ -141,12 +143,12 @@ int main(int ac, char *av[])
 #ifdef OSX_EMBEDED_MODE
 
     char logname[128];
-    snprintf(logname, 128, LOGNAME, getlogin());
+    snprintf(logname, 128, logNamePattern, getlogin());
     fprintf(stderr, "switching stderr to %s", logname);
     freopen(logname, "w", stderr);
 
     fifo = new Fifo();
-    fifo->name = FIFONAME;
+    fifo->name = fifoName;
     verbose   = 1;
     ac        = 0;
 

--- a/indiserver/indiserver.cpp
+++ b/indiserver/indiserver.cpp
@@ -133,7 +133,7 @@ int main(int ac, char *av[])
     userConfigurableArguments = argValues.get();
 
     std::unique_ptr<Fifo> fifoHandle{};
-    
+
     /* save our name */
     argValues->binaryName = av[0];
 


### PR DESCRIPTION
The largest refactor here has to do with the constants.hpp file. I removed all of the `#define` values and moved them into their own namespace as `constexpr`s. I then took all of the externs and moved them into a `CommandLineArgs` structure and made a single extern called `userConfigurableArguments` so the values can be accessed through that. 

In the IndiServer.cpp file, I removed all of the explicit calls to new and replaced them with make_unique, storing the results in the main function scope to ensure proper cleanup of the resources at program exit. 

I replaced some virtual labels with override instead and changed `std::size_t` references to just `size_t`. 
