### PR TITLE
Major Fixes in skywatcherAltAz driver:

### DIFF
--- a/drivers/telescope/skywatcherAPI.cpp
+++ b/drivers/telescope/skywatcherAPI.cpp
@@ -915,7 +915,7 @@ bool SkywatcherAPI::TalkWithAxis(AXISID Axis, SkywatcherCommand Command, std::st
         {
             memset(response, '\0', SKYWATCHER_MAX_CMD);
             // If we get less than 2 bytes then it must be an error (=\r is a valid response).
-            if ( (errorCode = tty_read_section(MyPortFD, response, 0x0D, SKYWATCHER_TIMEOUT, &bytesRead)) != TTY_OK
+            if ( (errorCode = tty_read_section_expanded(MyPortFD, response, 0x0D, SKYWATCHER_TIMEOUT_S, SKYWATCHER_TIMEOUT_US, &bytesRead)) != TTY_OK
                     || bytesRead < 2)
             {
                 if (retries == SKYWATCHER_MAX_RETRTY - 1)

--- a/drivers/telescope/skywatcherAPI.h
+++ b/drivers/telescope/skywatcherAPI.h
@@ -409,9 +409,10 @@ class SkywatcherAPI
 
     private:
         int MyPortFD { 0 };
-        // In seconds.
-        static constexpr uint8_t SKYWATCHER_MAX_RETRTY {3};
-        static constexpr uint8_t SKYWATCHER_TIMEOUT {5};
+        /// default timeout in synscan app os 200ms and 2 retransmissions, so put there little bit more
+        static constexpr uint8_t SKYWATCHER_MAX_RETRTY {5};
+        static constexpr uint8_t SKYWATCHER_TIMEOUT_S  {0};
+        static constexpr long    SKYWATCHER_TIMEOUT_US {300000}; 
         static constexpr uint8_t SKYWATCHER_MAX_CMD {16};
 
         static const std::map<int, std::string> errorCodes;

--- a/drivers/telescope/skywatcherAPIMount.h
+++ b/drivers/telescope/skywatcherAPIMount.h
@@ -286,6 +286,9 @@ class SkywatcherAPIMount :
         // Maximum delta to track. If drift is above 5 degrees, we abort tracking.
         static constexpr double MAX_TRACKING_DELTA {5};
         static constexpr const char *TRACKING_TAB = "Tracking";
+        static constexpr double ALT_BACKLASH_DEG {0.5};
+        static constexpr double AZ_BACKLASH_DEG {0.5};
+        static constexpr double MIN_TRACK_RATE_FACTOR {0.1};
 
         INDI::ElapsedTimer m_TrackingRateTimer;
         int32_t m_LastTrackRate[2] = {-1, -1};


### PR DESCRIPTION
1. Fixed incorrect tracking behavior - prevent negative trackRate and make sure it stays somewhat positive to prevent status change during tracking and makeing stacking smooth
2. Changed timeout to 300ms instead of 5s to prevent mount running away in case of UDP packet loss
3. Added movement to same direction after goto or for alignment - as synscan app does