### PR TITLE
Fix issues affecting guide simulator

### DIFF
--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -682,7 +682,9 @@ void Telescope::NewRaDec(double ra, double dec)
         TrackStateSP.apply();
     }
 
-    if (std::abs(EqNP[AXIS_RA].getValue() - ra) > EQ_NOTIFY_THRESHOLD ||
+    // RA is in hours, so change the arc-second threshold accordingly.
+    constexpr double RA_NOTIFY_THRESHOLD = EQ_NOTIFY_THRESHOLD/15.0;
+    if (std::abs(EqNP[AXIS_RA].getValue() - ra) > RA_NOTIFY_THRESHOLD ||
             std::abs(EqNP[AXIS_DE].getValue() - dec) > EQ_NOTIFY_THRESHOLD ||
             EqNP.getState() != lastEqState)
     {


### PR DESCRIPTION
Fixed two issues which prevented the guide simulator from working well.
1- The simulator snoops on the telescope simulator, which was not updating its RA coordinates often enough because the RA coordinate (in hours) was using an update threshold (meant for degrees).
2- The calculations for distance from center of a star was made more accurate using sub-pixel distances.