### PR TITLE
Link alpaca drivers with httplib

### DIFF
--- a/drivers/dome/CMakeLists.txt
+++ b/drivers/dome/CMakeLists.txt
@@ -99,5 +99,5 @@ SET(alpaca_dome_SRC
     )
 
 add_executable(indi_alpaca_dome ${alpaca_dome_SRC})
-target_link_libraries(indi_alpaca_dome indidriver indiclient)
+target_link_libraries(indi_alpaca_dome indidriver indiclient ${HTTPLIB_LIBRARY})
 install(TARGETS indi_alpaca_dome RUNTIME DESTINATION bin)

--- a/drivers/weather/CMakeLists.txt
+++ b/drivers/weather/CMakeLists.txt
@@ -79,5 +79,5 @@ SET(WeatherSafetyAlpaca_SRC
     weather_safety_alpaca.cpp)
 
 add_executable(indi_weather_safety_alpaca ${WeatherSafetyAlpaca_SRC})
-target_link_libraries(indi_weather_safety_alpaca indidriver indiclient)
+target_link_libraries(indi_weather_safety_alpaca indidriver indiclient ${HTTPLIB_LIBRARY})
 install(TARGETS indi_weather_safety_alpaca RUNTIME DESTINATION bin)


### PR DESCRIPTION
They explicitly use httplib, so make sure to link against it.