### PR TITLE
Add INDI_BUILD_EXAMPLES cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,7 @@ OPTION(INDI_FAST_BLOB "Build INDI with Fast BLOB support" ON)
 OPTION(INDI_BUILD_SHARED "Build shared library" ON)
 OPTION(INDI_BUILD_STATIC "Build static library" ON)
 OPTION(INDI_BUILD_XISF "Build XISF support" ON)
+OPTION(INDI_BUILD_EXAMPLES "Build INDI examples" ON)
 
 # System provided or bundled libs
 OPTION(INDI_SYSTEM_HTTPLIB "Use system provided httplib" OFF)
@@ -341,7 +342,9 @@ if(INDI_BUILD_DRIVERS)
         # ########### EXamples ###############
         # ####################################
         if(INDI_BUILD_CLIENT)
-            add_subdirectory(examples)
+            if(INDI_BUILD_EXAMPLES)
+                add_subdirectory(examples)
+            endif()
         else()
             message(WARNING "Skipping build of examples since INDI POSIX client is not built")
         endif()


### PR DESCRIPTION
Add a cmake option `INDI_BUILD_EXAMPLES` to make it possible to choose whether build the examples.

Its default value is ON for compatibility with the current behaviour.