### PR TITLE
Refactor WandererCover status update logic and add TimerHit method

### DIFF
--- a/drivers/auxiliary/wanderer_cover.cpp
+++ b/drivers/auxiliary/wanderer_cover.cpp
@@ -227,12 +227,12 @@ bool WandererCover::Handshake()
 
 void WandererCover::updateCoverStatus(char* res)
 {
-    if (strcmp(res, "0") == 0)
+    if (strcmp(res, "0") == 0 && isCoverOpen == true)
     {
         isCoverOpen = false;
         setParkCapStatusAsClosed();
     }
-    else if (strcmp(res, "1") == 0)
+    else if (strcmp(res, "1") == 0 && isCoverOpen == false)
     {
         isCoverOpen = true;
         setParkCapStatusAsOpen();
@@ -773,6 +773,11 @@ bool WandererCover::processConfigurationButtonSwitch(const char *dev, const char
 
     LOG_INFO("Configuration button processing complete");
     return false;
+}
+
+void WandererCover::TimerHit()
+{
+    SetTimer(getPollingPeriod());
 }
 
 bool WandererCover::hasWandererSentAnError(char* response)

--- a/drivers/auxiliary/wanderer_cover.h
+++ b/drivers/auxiliary/wanderer_cover.h
@@ -71,6 +71,8 @@ class WandererCover : public INDI::DefaultDevice, public INDI::LightBoxInterface
         virtual bool SetLightBoxBrightness(uint16_t value) override;
         virtual bool EnableLightBox(bool enable) override;
 
+        virtual void TimerHit() override;
+
     private:
         enum
         {


### PR DESCRIPTION
- Updated updateCoverStatus to check isCoverOpen state before changing status.
- Introduced TimerHit method to set the polling timer. This seems required for the capture to trigger while using the scheduler. This seems required to start the capture while using the scheduler.