### PR TITLE
fixing buffer overflow in OnStep driver

### DIFF
--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -3500,7 +3500,7 @@ int LX200_OnStep::flushIO(int fd)
     do
     {
         char discard_data[RB_MAX_LEN] = {0};
-        error_type = tty_read_section_expanded(fd, discard_data, '#', 0, 1000, &nbytes_read);
+        error_type = tty_nread_section_expanded(fd, discard_data, sizeof(discard_data), '#', 0, 1000, &nbytes_read);
         if (error_type >= 0)
         {
             LOGF_DEBUG("flushIO: Information in buffer: Bytes: %u, string: %s", nbytes_read, discard_data);
@@ -3527,7 +3527,7 @@ int LX200_OnStep::getCommandDoubleResponse(int fd, double *value, char *data, co
     if ((error_type = tty_write_string(fd, cmd, &nbytes_write)) != TTY_OK)
         return error_type;
 
-    error_type = tty_read_section_expanded(fd, data, '#', OSTimeoutSeconds, OSTimeoutMicroSeconds, &nbytes_read);
+    error_type = tty_nread_section_expanded(fd, data, RB_MAX_LEN, '#', OSTimeoutSeconds, OSTimeoutMicroSeconds, &nbytes_read);
     tcflush(fd, TCIFLUSH);
 
     term = strchr(data, '#');
@@ -3582,7 +3582,7 @@ int LX200_OnStep::getCommandIntResponse(int fd, int *value, char *data, const ch
     if ((error_type = tty_write_string(fd, cmd, &nbytes_write)) != TTY_OK)
         return error_type;
 
-    error_type = tty_read_section_expanded(fd, data, '#', OSTimeoutSeconds, OSTimeoutMicroSeconds, &nbytes_read);
+    error_type = tty_nread_section_expanded(fd, data, RB_MAX_LEN, '#', OSTimeoutSeconds, OSTimeoutMicroSeconds, &nbytes_read);
     tcflush(fd, TCIFLUSH);
 
     term = strchr(data, '#');
@@ -3631,7 +3631,7 @@ int LX200_OnStep::getCommandSingleCharErrorOrLongResponse(int fd, char *data, co
     if ((error_type = tty_write_string(fd, cmd, &nbytes_write)) != TTY_OK)
         return error_type;
 
-    error_type = tty_read_section_expanded(fd, data, '#', OSTimeoutSeconds, OSTimeoutMicroSeconds, &nbytes_read);
+    error_type = tty_nread_section_expanded(fd, data, RB_MAX_LEN, '#', OSTimeoutSeconds, OSTimeoutMicroSeconds, &nbytes_read);
     tcflush(fd, TCIFLUSH);
 
     term = strchr(data, '#');

--- a/libs/indicore/indicom.h
+++ b/libs/indicore/indicom.h
@@ -232,6 +232,22 @@ int tty_read_section_expanded(int fd, char *buf, char stop_char, long timeout_se
  */
 int tty_nread_section(int fd, char *buf, int nsize, char stop_char, int timeout, int *nbytes_read);
 
+/** \brief read buffer from terminal with a delimiter
+ *  \param fd file descriptor
+ *  \param buf pointer to store data. Must be initialized and big enough to hold data.
+ *  \param stop_char if the function encounters \e stop_char then it stops reading and returns the buffer.
+ *  \param nsize size of buf. If stop character is not encountered before nsize, the function aborts.
+ *  \param timeout number of seconds to wait for terminal before a timeout error is issued.
+ *
+ *  (Total Timeout is timeout_seconds + timeout_microseconds)
+ *  \param timeout_microseconds number of microseconds to wait for terminal before a timeout error is issued.
+ *
+ *  \param nbytes_read the number of bytes read.
+ *  \return On success, it returns TTY_OK, otherwise, a TTY_ERROR code.
+ */
+int tty_nread_section_expanded(int fd, char *buf, int nsize, char stop_char, long timeout_seconds, long timeout_microseconds,
+                               int *nbytes_read);
+
 /** \brief Writes a buffer to fd.
  *  \param fd file descriptor
  *  \param buffer a null-terminated buffer to write to fd.


### PR DESCRIPTION
There is a serious bug in the LX200 OnStep driver (and all the others which uses the tty_read_section_expanded function).
The tty_read_section_expanded() function (included from libs/indicore/indicom.h) doesn't care with the read buffer size, and sometimes it can overflow and the driver crashes. The problem occurs when garbage gets on the serial line. 