### PR TITLE
fix buffer overflow error found with Celestron focuser

### DIFF
--- a/drivers/focuser/celestronauxpacket.cpp
+++ b/drivers/focuser/celestronauxpacket.cpp
@@ -160,7 +160,7 @@ bool Communicator::sendPacket(int portFD, Target dest, Command cmd, buffer data)
 
 bool Communicator::readPacket(int portFD, Packet &reply)
 {
-    char rxbuf[] = {0};
+    char rxbuf[1] = {0};
     int nr = 0, ttyrc = 0;
     // look for header
     while(rxbuf[0] != Packet::AUX_HDR)


### PR DESCRIPTION
After getting back in to astrophotography I found that my Celestron focuser wasn't working on Linux, both on x86_64 and aarch64.  I could see that there was a buffer overflow error detected and traced it down to this 1 line of code. This looks like the issue raised in [INDI Forum - driver indi celestron sct](https://indilib.org/forum/focusers-filter-wheels/14833-driver-indi-celestron-sct) . The issue doesn't appear on macOS but definitely on my two different Arch (x86_64 is plain old ArchLinux, ODROID N2+ is Manjaro) based systems

I believe the compilers have been optimising away the size of the `rxbuf` and then resulted in the buffer oveflow. 

I've tested this change locally and see that it has resolved the buffer overflow.  I can now connect to the focuser and use it.  
