### PR TITLE
fix issue of Celestron SCT focuser for aarch64

### DIFF
--- a/drivers/focuser/celestron.cpp
+++ b/drivers/focuser/celestron.cpp
@@ -114,8 +114,10 @@ bool CelestronSCT::initProperties()
     // Add debugging support
     addDebugControl();
 
-    // Set default baud rate to 19200
-    serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
+    // Set default baud rate to 9600
+    // On aarch64 19200 or more seems to crash the whole USB hub.
+    // stty -a says the baud rate is 9600
+    serialConnection->setDefaultBaudRate(Connection::Serial::B_9600);
 
     communicator.setDeviceName(getDeviceName());
 

--- a/drivers/focuser/celestronauxpacket.cpp
+++ b/drivers/focuser/celestronauxpacket.cpp
@@ -43,7 +43,7 @@ char * toHexStr(buffer data)
         sz = 100;
     for (int i = 0; i < sz; i++)
     {
-        snprintf(&debugStr[i * 3], 301, "%02X ", data[i]);
+        snprintf(&debugStr[i * 3], 301 - 3*i, "%02X ", data[i]);
     }
     return debugStr;
 }


### PR DESCRIPTION
This is a continuation of work done in commit 83030d454 (see https://github.com/indilib/indi/pull/2252) which fixed issue on an x86_64 but the issue stil existed on the aarch64.

I've found 2 issues that were causing issues on the aarch64
* the `toHexStr` could cause a buffer overflow in the sprintf.  Not sure why even the x86_64 architecture didn't pick it up
* the default baud rate was set to 19200 but doing `stty -a` on the serial dev said it was 9600. On my x86_64 server it would happily handle 19200 but on my ODROID N2+ it would crash the how xhci and I would have to completely power cycle my ODROID.

I've changed the `toHexStr` to avoid the buffer overflow and I've set the default baud rate to 9600.

If there is a clean way to warn users know about the baud rate, then I'm happy to make the change but would need to know where to make the changes.

I've been able to test this fix on both x86_64 and aarch64 machines so I'm confident that this should be the last issue of the Celestron SCT focuser for now.