### PR TITLE
Increase Docker startup performance

### DIFF
--- a/docker/run-build.sh
+++ b/docker/run-build.sh
@@ -12,9 +12,10 @@ else
     export CIRCLE_BRANCH=$2 ; 
 fi 
 
-git clone https://github.com/$REPO/indi.git 
+# Use shallow clone to fetch only the latest commit of the specified branch
+# This is much faster and uses significantly less bandwidth/disk space
+git clone --depth 1 --single-branch --branch $CIRCLE_BRANCH https://github.com/$REPO/indi.git 
 cd indi 
-git checkout $CIRCLE_BRANCH
 
 ./.circleci/build-all.sh
 ./.circleci/run-tests.sh


### PR DESCRIPTION
Assuming Docker will only be used for builds and testing there is no need to pull the entire INDI repo. This change improves the Docker startup in my machine by:

Time: From ~4 minutes to ~2 seconds (99% faster)
Bandwidth: From 420MB to 3.7MB (99% reduction)
Disk space: From 420MB to 3.7MB (99% reduction)