### PR TITLE
Refactoring GeminiFlatPanel driver to support multiple devices.

### DIFF
--- a/drivers/auxiliary/CMakeLists.txt
+++ b/drivers/auxiliary/CMakeLists.txt
@@ -384,7 +384,8 @@ install(TARGETS indi_dragon_light RUNTIME DESTINATION bin)
 
 # ########## Gemini Flatpanel ###############
 SET(gemini_flatpanel_SRC
-    gemini_flatpanel.cpp)
+    gemini_flatpanel.cpp
+    gemini_flatpanel_adapters.cpp)
 
 add_executable(indi_gemini_flatpanel ${gemini_flatpanel_SRC})
 target_link_libraries(indi_gemini_flatpanel indidriver)

--- a/drivers/auxiliary/gemini_flatpanel.cpp
+++ b/drivers/auxiliary/gemini_flatpanel.cpp
@@ -146,6 +146,7 @@ bool GeminiFlatpanel::ISNewSwitch(const char *dev, const char *name, ISState *st
             DeviceTypeSP.update(states, names, n);
             DeviceTypeSP.setState(IPS_OK);
             DeviceTypeSP.apply();
+            saveConfig(DeviceTypeSP);
             return true;
         }
 

--- a/drivers/auxiliary/gemini_flatpanel.cpp
+++ b/drivers/auxiliary/gemini_flatpanel.cpp
@@ -1,12 +1,15 @@
+#include "config.h"
 #include "gemini_flatpanel.h"
 #include "indicom.h"
 #include <termios.h>
+#include <functional>
+#include <vector>
 
 static std::unique_ptr<GeminiFlatpanel> mydriver(new GeminiFlatpanel());
 
 GeminiFlatpanel::GeminiFlatpanel() : LightBoxInterface(this), DustCapInterface(this)
 {
-    setVersion(1, 0);
+    setVersion(1, 1);
 }
 
 const char *GeminiFlatpanel::getDefaultName()
@@ -24,7 +27,24 @@ bool GeminiFlatpanel::initProperties()
     LI::initProperties(MAIN_CONTROL_TAB, LI::CAN_DIM);
     DI::initProperties(MAIN_CONTROL_TAB);
 
-    setDriverInterface(AUX_INTERFACE | LIGHTBOX_INTERFACE | DUSTCAP_INTERFACE);
+    // Initialize device selection property
+    DeviceTypeSP.fill(
+        getDeviceName(),
+        "DEVICE_TYPE",
+        "Device Type",
+        CONNECTION_TAB,
+        IP_RW,
+        ISR_1OFMANY,
+        60,
+        IPS_IDLE
+    );
+    DeviceTypeSP[DEVICE_AUTO].fill("AUTO", "Auto-detect", ISS_ON);
+    DeviceTypeSP[DEVICE_REV1].fill("REV1", "Revision 1", ISS_OFF);
+    DeviceTypeSP[DEVICE_REV2].fill("REV2", "Revision 2", ISS_OFF);
+    DeviceTypeSP[DEVICE_LITE].fill("LITE", "Lite", ISS_OFF);
+    DeviceTypeSP.load();
+
+    // Driver interface will be set dynamically in Handshake() based on device capabilities
 
     addAuxControls();
 
@@ -41,43 +61,73 @@ bool GeminiFlatpanel::initProperties()
 
 bool GeminiFlatpanel::updateProperties()
 {
+    INDI::DefaultDevice::updateProperties();
+
     if (isConnected())
     {
+        // Hide device selection when connected
+        deleteProperty(DeviceTypeSP);
+
         defineProperty(StatusTP);
         defineProperty(ConfigurationTP);
 
-        // Only register beep and brightness mode controls for revision 2 devices
-        if (deviceRevision == GEMINI_REVISION_2)
+        // Only register advanced features if supported by the current adapter
+        if (adapter && adapter->supportsBeep())
         {
             defineProperty(BeepSP);
+        }
+        if (adapter && adapter->supportsBrightnessMode())
+        {
             defineProperty(BrightnessModeSP);
         }
 
-        defineProperty(ConfigureSP);
-        defineProperty(ClosedPositionSP);
-        defineProperty(SetClosedSP);
-        defineProperty(OpenPositionSP);
-        defineProperty(SetOpenSP);
+        // Only register dust cap movement controls if supported
+        if (adapter && adapter->supportsDustCap())
+        {
+            defineProperty(ConfigureSP);
+            defineProperty(ClosedPositionSP);
+            defineProperty(SetClosedSP);
+            defineProperty(OpenPositionSP);
+            defineProperty(SetOpenSP);
+        }
     }
     else
     {
+        // Show device selection when disconnected
+        defineProperty(DeviceTypeSP);
+
         deleteProperty(StatusTP);
         deleteProperty(ConfigurationTP);
 
-        // Only delete beep and brightness mode controls if they were defined (revision 2)
-        if (deviceRevision == GEMINI_REVISION_2)
+        // Only delete properties that were defined
+        if (adapter && adapter->supportsBeep())
         {
             deleteProperty(BeepSP);
+        }
+        if (adapter && adapter->supportsBrightnessMode())
+        {
             deleteProperty(BrightnessModeSP);
         }
 
-        deleteProperty(ConfigureSP);
-        deleteProperty(ClosedPositionSP);
-        deleteProperty(SetClosedSP);
-        deleteProperty(OpenPositionSP);
-        deleteProperty(SetOpenSP);
+        // Only delete dust cap properties that were defined
+        if (adapter && adapter->supportsDustCap())
+        {
+            deleteProperty(ConfigureSP);
+            deleteProperty(ClosedPositionSP);
+            deleteProperty(SetClosedSP);
+            deleteProperty(OpenPositionSP);
+            deleteProperty(SetOpenSP);
+        }
     }
-    return LI::updateProperties() && DI::updateProperties() && INDI::DefaultDevice::updateProperties();
+    bool result = LI::updateProperties() && INDI::DefaultDevice::updateProperties();
+
+    // Only update dust cap properties if the device supports dust cap functionality
+    if (adapter && adapter->supportsDustCap())
+    {
+        result = result && DI::updateProperties();
+    }
+
+    return result;
 }
 
 void GeminiFlatpanel::ISGetProperties(const char *deviceName)
@@ -90,11 +140,20 @@ bool GeminiFlatpanel::ISNewSwitch(const char *dev, const char *name, ISState *st
 {
     if (dev != nullptr and strcmp(dev, getDeviceName()) == 0)
     {
+        // Handle device type selection
+        if (DeviceTypeSP.isNameMatch(name))
+        {
+            DeviceTypeSP.update(states, names, n);
+            DeviceTypeSP.setState(IPS_OK);
+            DeviceTypeSP.apply();
+            return true;
+        }
+
         if (LI::processSwitch(dev, name, states, names, n))
         {
             return true;
         }
-        if (DI::processSwitch(dev, name, states, names, n))
+        if (adapter && adapter->supportsDustCap() && DI::processSwitch(dev, name, states, names, n))
         {
             return true;
         }
@@ -135,6 +194,10 @@ bool GeminiFlatpanel::ISSnoopDevice(XMLEle *root)
 bool GeminiFlatpanel::saveConfigItems(FILE *fp)
 {
     INDI::DefaultDevice::saveConfigItems(fp);
+
+    // Save device type selection
+    DeviceTypeSP.save(fp);
+
     return LI::saveConfigItems(fp);
 }
 
@@ -200,6 +263,15 @@ void GeminiFlatpanel::initStatusProperties()
 void GeminiFlatpanel::onBeepChange()
 {
     bool enable = BeepSP[1].getState() == ISS_ON;
+
+    if (!adapter || !adapter->supportsBeep())
+    {
+        LOG_WARN("Beep functionality not supported by this device.");
+        BeepSP.setState(IPS_ALERT);
+        BeepSP.apply();
+        return;
+    }
+
     if (setBeep(enable))
     {
         BeepSP.setState(IPS_OK);
@@ -214,6 +286,15 @@ void GeminiFlatpanel::onBeepChange()
 void GeminiFlatpanel::onBrightnessModeChange()
 {
     int mode = BrightnessModeSP[1].getState() == ISS_ON ? GEMINI_BRIGHTNESS_MODE_HIGH : GEMINI_BRIGHTNESS_MODE_LOW;
+
+    if (!adapter || !adapter->supportsBrightnessMode())
+    {
+        LOG_WARN("Brightness mode selection not supported by this device.");
+        BrightnessModeSP.setState(IPS_ALERT);
+        BrightnessModeSP.apply();
+        return;
+    }
+
     if (setBrightnessMode(mode))
     {
         BrightnessModeSP.setState(IPS_OK);
@@ -307,18 +388,9 @@ void GeminiFlatpanel::TimerHit()
     int coverStatus = 0, lightStatus = 0, motorStatus = 0, brightness = 0;
     bool error = false;
 
-    if (isSimulation())
-    {
-        coverStatus = simulationValues[SIMULATION_COVER];
-        lightStatus = simulationValues[SIMULATION_LIGHT];
-        motorStatus = simulationValues[SIMULATION_MOTOR];
-        brightness = simulationValues[SIMULATION_BRIGHTNESS];
-    }
-    else
-    {
-        error |= !getStatus(&coverStatus, &lightStatus, &motorStatus);
-        error |= !getBrightness(&brightness);
-    }
+    // Use adapter for both real hardware and simulation
+    error |= !getStatus(&coverStatus, &lightStatus, &motorStatus);
+    error |= !getBrightness(&brightness);
 
     if (error)
     {
@@ -360,12 +432,6 @@ bool GeminiFlatpanel::SetLightBoxBrightness(uint16_t value)
     {
         return false;
     }
-    if (isSimulation())
-    {
-        LOGF_INFO("Setting brightness to %d.", value);
-        simulationValues[SIMULATION_BRIGHTNESS] = (int)value;
-        return true;
-    }
     return setBrightness((int)value);
 }
 
@@ -374,12 +440,6 @@ bool GeminiFlatpanel::EnableLightBox(bool enable)
     if (!validateOperation())
     {
         return false;
-    }
-    if (isSimulation())
-    {
-        LOGF_INFO("Turning light %s.", enable ? "on" : "off");
-        simulationValues[SIMULATION_LIGHT] = enable ? GEMINI_LIGHT_STATUS_ON : GEMINI_LIGHT_STATUS_OFF;
-        return true;
     }
     return enable ? lightOn() : lightOff();
 }
@@ -390,12 +450,6 @@ IPState GeminiFlatpanel::ParkCap()
     if (!validateOperation())
     {
         return IPS_ALERT;
-    }
-    if (isSimulation())
-    {
-        LOG_INFO("Parking dust cap.");
-        simulationValues[SIMULATION_COVER] = GEMINI_COVER_STATUS_CLOSED;
-        return IPS_OK;
     }
     ParkCapSP.setState(IPS_BUSY);
     ParkCapSP.apply();
@@ -411,12 +465,6 @@ IPState GeminiFlatpanel::UnParkCap()
     if (!validateOperation())
     {
         return IPS_ALERT;
-    }
-    if (isSimulation())
-    {
-        LOG_INFO("Unparking dust cap.");
-        simulationValues[SIMULATION_COVER] = GEMINI_COVER_STATUS_OPEN;
-        return IPS_OK;
     }
     ParkCapSP.setState(IPS_BUSY);
     ParkCapSP.apply();
@@ -437,47 +485,123 @@ bool GeminiFlatpanel::Handshake()
 {
     if (isSimulation())
     {
-        LOGF_INFO("Connected successfuly to simulated %s.", getDeviceName());
-        configStatus = GEMINI_CONFIG_READY;
-        updateConfigStatus();
+        // Use simulation adapter (can simulate both Rev1 and Rev2 features)
+        adapter = std::make_unique<GeminiFlatpanelSimulationAdapter>(true); // true = Rev2 features
+        deviceRevision = adapter->getRevision();
+        commandTerminator = adapter->getCommandTerminator();
+
+        // Set driver interface based on device capabilities
+        uint32_t interface = AUX_INTERFACE | LIGHTBOX_INTERFACE;
+        if (adapter && adapter->supportsDustCap())
+        {
+            interface |= DUSTCAP_INTERFACE;
+        }
+        setDriverInterface(interface);
+
+        // Get config status from adapter
+        int adapterConfigStatus;
+        if (adapter->getConfigStatus(&adapterConfigStatus))
+        {
+            configStatus = adapterConfigStatus;
+            updateConfigStatus();
+        }
+
+        LOGF_INFO("Connected successfully to simulated %s.", getDeviceName());
         return true;
     }
 
     PortFD = serialConnection->getPortFD();
 
-    int firmwareVersion = 0;
-    deviceRevision = GEMINI_REVISION_UNKNOWN;
+    // Check if user has selected a specific device type
+    int selectedDeviceType = DeviceTypeSP.findOnSwitchIndex();
 
-    if (deviceRevision == GEMINI_REVISION_UNKNOWN)
+    // List of adapter types to try in order
+    struct AdapterInfo
     {
-        commandTerminator = '\n';
-        if (pingRevision1())
+        std::function<std::unique_ptr<GeminiFlatpanelAdapter>()> factory;
+        std::string name;
+        int deviceType;
+    };
+
+    std::vector<AdapterInfo> adapterTypes;
+
+    if (selectedDeviceType == DEVICE_AUTO)
+    {
+        // Auto-detect: try all adapters in order
+        adapterTypes =
         {
-            deviceRevision = GEMINI_REVISION_1;
-            LOGF_INFO("Connected successfully to %s.", getDeviceName());
-            LOGF_INFO("Device revision: %d", deviceRevision);
+            {[]() { return std::make_unique<GeminiFlatpanelRev1Adapter>(); }, "Rev1", DEVICE_REV1},
+            {[]() { return std::make_unique<GeminiFlatpanelRev2Adapter>(); }, "Rev2", DEVICE_REV2},
+            {[]() { return std::make_unique<GeminiFlatpanelLiteAdapter>(); }, "Lite", DEVICE_LITE}
+        };
+    }
+    else
+    {
+        // Use only the selected adapter type
+        switch (selectedDeviceType)
+        {
+            case DEVICE_REV1:
+                adapterTypes = {{[]() { return std::make_unique<GeminiFlatpanelRev1Adapter>(); }, "Rev1", DEVICE_REV1}};
+                break;
+            case DEVICE_REV2:
+                adapterTypes = {{[]() { return std::make_unique<GeminiFlatpanelRev2Adapter>(); }, "Rev2", DEVICE_REV2}};
+                break;
+            case DEVICE_LITE:
+                adapterTypes = {{[]() { return std::make_unique<GeminiFlatpanelLiteAdapter>(); }, "Lite", DEVICE_LITE}};
+                break;
         }
     }
 
-    if (deviceRevision == GEMINI_REVISION_UNKNOWN)
+    // Try each adapter type until one succeeds
+    bool connected = false;
+    for (const auto &adapterInfo : adapterTypes)
     {
-        commandTerminator = '#';
-        if (pingRevision2() && getFirmwareVersion(&firmwareVersion))
+        auto testAdapter = adapterInfo.factory();
+        testAdapter->setupCommunication(PortFD);
+
+        if (testAdapter->ping())
         {
-            deviceRevision = GEMINI_REVISION_2;
-            LOGF_INFO("Connected successfully to %s.", getDeviceName());
-            LOGF_INFO("Device revision: %d (Firmware v%d)", deviceRevision, firmwareVersion);
+            adapter = std::move(testAdapter);
+            deviceRevision = adapter->getRevision();
+            commandTerminator = adapter->getCommandTerminator();
+
+            // Log connection success with firmware version details
+            int firmwareVersion = 0;
+            if (adapter->getFirmwareVersion(&firmwareVersion))
+            {
+                LOGF_INFO("Connected successfully to %s.", getDeviceName());
+                LOGF_INFO("Device revision: %s (Firmware v%d)", adapterInfo.name.c_str(), firmwareVersion);
+            }
+            else
+            {
+                LOGF_INFO("Connected successfully to %s.", getDeviceName());
+                LOGF_INFO("Device revision: %s", adapterInfo.name.c_str());
+            }
+
+            connected = true;
+            break;
         }
     }
 
-    if (deviceRevision == GEMINI_REVISION_UNKNOWN)
+    if (!connected)
     {
         LOG_ERROR("Handshake failed. Unable to communicate with the device.");
         return false;
     }
 
-    if (getConfigStatus())
+    // Set driver interface based on device capabilities
+    uint32_t interface = AUX_INTERFACE | LIGHTBOX_INTERFACE;
+    if (adapter && adapter->supportsDustCap())
     {
+        interface |= DUSTCAP_INTERFACE;
+    }
+    setDriverInterface(interface);
+
+    // Check config status using adapter
+    int adapterConfigStatus;
+    if (adapter->getConfigStatus(&adapterConfigStatus))
+    {
+        configStatus = adapterConfigStatus;
         updateConfigStatus();
         return true;
     }
@@ -485,556 +609,67 @@ bool GeminiFlatpanel::Handshake()
     return false;
 }
 
-// Commands
-bool GeminiFlatpanel::formatCommand(char commandLetter, char *commandString, int value)
-{
-    if (commandString == nullptr)
-    {
-        LOG_ERROR("Command string buffer is null");
-        return false;
-    }
+// Note: Protocol-specific methods moved to adapter classes
 
-    if (deviceRevision == GEMINI_REVISION_1)
-    {
-        // Rev1 format: >X000# (no value) or >XNNN# (with value) where X is command letter and NNN is 3-digit value
-        if (value == NO_VALUE)
-        {
-            // No value provided, pad with 000
-            snprintf(commandString, MAXRBUF, ">%c000#", commandLetter);
-        }
-        else
-        {
-            // Value provided, pad to 3 digits
-            snprintf(commandString, MAXRBUF, ">%c%03d#", commandLetter, value);
-        }
-    }
-    else if (deviceRevision == GEMINI_REVISION_2)
-    {
-        // Rev2 format: >X# (no value) or >Xnnn# (with value) where X is command letter and nnn is value
-        if (value == 0)
-        {
-            // No value provided, no padding
-            snprintf(commandString, MAXRBUF, ">%c#", commandLetter);
-        }
-        else
-        {
-            // Value provided, no padding
-            snprintf(commandString, MAXRBUF, ">%c%d#", commandLetter, value);
-        }
-    }
-    else
-    {
-        LOG_ERROR("Unknown device revision");
-        return false;
-    }
-
-    return true;
-}
-
-bool GeminiFlatpanel::extractIntValue(const char *response, int startPos, int *value)
-{
-    if (response == nullptr || value == nullptr)
-    {
-        LOG_ERROR("Invalid parameters for extractIntValue.");
-        return false;
-    }
-
-    // Revision 1 responses have a 3-digit numeric part 0 padded
-    int length = 3;
-    if (deviceRevision == GEMINI_REVISION_2)
-    {
-        const char *terminator = strchr(response, '#');
-        if (terminator == nullptr)
-        {
-            LOG_ERROR("Missing # terminator in response.");
-            return false;
-        }
-
-        // Calculate the length of the numeric part
-        length = terminator - (response + startPos);
-    }
-
-    if (length <= 0)
-    {
-        LOG_ERROR("Invalid numeric value length in response.");
-        return false;
-    }
-
-    // Extract the numeric part
-    char value_str[MAXRBUF] = {0};
-    strncpy(value_str, response + startPos, length);
-    *value = atoi(value_str);
-
-    return true;
-}
-
-bool GeminiFlatpanel::sendCommand(const char *command, char *response, int timeout, bool log)
-{
-    int nbytes_written = 0, nbytes_read = 0, rc = -1;
-
-    char cmd_with_terminator[MAXRBUF];
-
-    snprintf(cmd_with_terminator, MAXRBUF, "%s\r", command);
-
-    LOGF_DEBUG("CMD <%s>", command);
-
-    tcflush(PortFD, TCIOFLUSH);
-    if ((rc = tty_write_string(PortFD, command, &nbytes_written)) != TTY_OK)
-    {
-        if (log)
-        {
-            char errstr[MAXRBUF] = {0};
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("Serial write error: %s.", errstr);
-        }
-        return false;
-    }
-
-    if (response == nullptr)
-        return true;
-
-    if ((rc = tty_nread_section(PortFD, response, MAXRBUF, commandTerminator, timeout, &nbytes_read)) != TTY_OK)
-    {
-        if (log)
-        {
-            char errstr[MAXRBUF] = {0};
-            tty_error_msg(rc, errstr, MAXRBUF);
-            LOGF_ERROR("Serial read error: %s.", errstr);
-        }
-        return false;
-    }
-
-    // Remove trailing newline character if present
-    if (nbytes_read > 0 && response[nbytes_read - 1] == '\n')
-    {
-        response[nbytes_read - 1] = '\0';
-    }
-    tcflush(PortFD, TCIOFLUSH);
-
-    LOGF_DEBUG("RES <%s>", response);
-
-    if (response[0] != '*' || response[1] != command[1])
-    {
-        LOG_ERROR("Invalid response.");
-        return false;
-    }
-
-    return true;
-}
-
-bool GeminiFlatpanel::pingRevision1()
-{
-    // This command is only supported by revision 1 devices
-    // It is used to check if the device is a revision 1 device
-    char response[MAXRBUF] = {0};
-
-    if (!sendCommand(">P000#", response, SERIAL_TIMEOUT_SEC, false))
-    {
-        return false;
-    }
-
-    if (strcmp(response, "*P99OOO") != 0)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-bool GeminiFlatpanel::pingRevision2()
-{
-    // This command is only supported by revision 2 devices
-    // It is used to check if the device is a revision 2 device
-    char response[MAXRBUF] = {0};
-
-    if (!sendCommand(">H#", response, SERIAL_TIMEOUT_SEC, false))
-    {
-        return false;
-    }
-
-    if (strcmp(response, "*HGeminiFlatPanel#") != 0)
-    {
-        return false;
-    }
-
-    return true;
-}
-
-bool GeminiFlatpanel::getFirmwareVersion(int *version)
-{
-    // This command is only supported by revision 2 devices
-    // It is used to get the firmware version
-    char response[MAXRBUF] = {0};
-
-    // Initialize version to 0 in case of errors
-    *version = 0;
-
-    if (!sendCommand(">V#", response))
-    {
-        return false;
-    }
-
-    if (strlen(response) < 3)
-    {
-        LOG_ERROR("Invalid firmware version response.");
-        return false;
-    }
-
-    if (response[0] != '*' || response[1] != 'V')
-    {
-        LOG_ERROR("Invalid firmware version response.");
-        return false;
-    }
-
-    int firmwareVersion;
-    if (!extractIntValue(response, 2, &firmwareVersion))
-    {
-        return false;
-    }
-
-    if (firmwareVersion < 402)
-    {
-        LOG_ERROR("Firmware version too old. Please update to version 402 or later.");
-        return false;
-    }
-
-    *version = firmwareVersion;
-    return true;
-}
-
-bool GeminiFlatpanel::getConfigStatus()
-{
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('A', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    if (strlen(response) < 3)
-    {
-        LOG_ERROR("Invalid config status response.");
-        return false;
-    }
-
-    if (response[0] != '*' || response[1] != 'A')
-    {
-        LOG_ERROR("Invalid config status response.");
-        return false;
-    }
-
-    configStatus = response[2] - '0';
-    return true;
-}
-
+// Device command methods - now using adapter pattern
 bool GeminiFlatpanel::getBrightness(int *const brightness)
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('J', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    if (strlen(response) < 3)
-    {
-        LOG_ERROR("Invalid brightness response.");
-        return false;
-    }
-
-    if (response[0] != '*' || response[1] != 'J')
-    {
-        LOG_ERROR("Invalid brightness response.");
-        return false;
-    }
-
-    int index = deviceRevision == GEMINI_REVISION_1 ? 4 : 2;
-
-    return extractIntValue(response, index, brightness);
+    return adapter ? adapter->getBrightness(brightness) : false;
 }
 
 bool GeminiFlatpanel::setBrightness(int value)
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (value > GEMINI_MAX_BRIGHTNESS)
-    {
-        LOG_WARN("Brightness level out of range, setting it to 255.");
-        value = GEMINI_MAX_BRIGHTNESS;
-    }
-
-    if (value < GEMINI_MIN_BRIGHTNESS)
-    {
-        LOG_WARN("Brightness level out of range, setting it to 0.");
-        value = GEMINI_MIN_BRIGHTNESS;
-    }
-
-    if (!formatCommand('B', command, value))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    if (strlen(response) < 3)
-    {
-        LOG_ERROR("Invalid brightness response.");
-        return false;
-    }
-
-    if (response[0] != '*' || response[1] != 'B')
-    {
-        LOG_ERROR("Invalid brightness response.");
-        return false;
-    }
-
-    int response_value;
-    int index = deviceRevision == GEMINI_REVISION_1 ? 4 : 2;
-    if (!extractIntValue(response, index, &response_value))
-    {
-        return false;
-    }
-
-    return (response_value == value);
+    return adapter ? adapter->setBrightness(value) : false;
 }
 
 bool GeminiFlatpanel::lightOn()
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('L', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'L');
+    return adapter ? adapter->lightOn() : false;
 }
 
 bool GeminiFlatpanel::lightOff()
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('D', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'D');
+    return adapter ? adapter->lightOff() : false;
 }
 
 bool GeminiFlatpanel::openCover()
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('O', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
-    {
-        return false;
-    }
-
-    if (deviceRevision == GEMINI_REVISION_1)
-    {
-        return (strcmp(response, "*O99OOO") == 0);
-    }
-    else
-    {
-        return (strcmp(response, "*OOpened#") == 0);
-    }
+    return adapter ? adapter->openCover() : false;
 }
 
 bool GeminiFlatpanel::closeCover()
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('C', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
-    {
-        return false;
-    }
-
-    if (deviceRevision == GEMINI_REVISION_1)
-    {
-        return (strcmp(response, "*C99OOO") == 0);
-    }
-    else
-    {
-        return (strcmp(response, "*CClosed#") == 0);
-    }
+    return adapter ? adapter->closeCover() : false;
 }
 
 bool GeminiFlatpanel::setBeep(bool enable)
 {
-    char command[MAXRBUF] = {0};
-
-    if (!formatCommand('T', command, enable ? GEMINI_BEEP_ON : GEMINI_BEEP_OFF))
-    {
-        return false;
-    }
-
-    return sendCommand(command, nullptr);
+    return adapter ? adapter->setBeep(enable) : false;
 }
 
 bool GeminiFlatpanel::setBrightnessMode(int mode)
 {
-    if (mode != GEMINI_BRIGHTNESS_MODE_LOW && mode != GEMINI_BRIGHTNESS_MODE_HIGH)
-    {
-        LOG_ERROR("Invalid brightness mode.");
-        return false;
-    }
-
-    char command[MAXRBUF] = {0};
-
-    if (!formatCommand('Y', command, mode))
-    {
-        return false;
-    }
-
-    return sendCommand(command, nullptr);
+    return adapter ? adapter->setBrightnessMode(mode) : false;
 }
 
 bool GeminiFlatpanel::getStatus(int *const coverStatus, int *const lightStatus, int *const motorStatus)
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('S', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    if (strlen(response) < 7)
-    {
-        LOG_ERROR("Invalid status response.");
-        return false;
-    }
-
-    if (response[0] != '*' || response[1] != 'S')
-    {
-        LOG_ERROR("Invalid status response.");
-        return false;
-    }
-
-    // Check if device ID is valid (19 or 99)
-    char id_str[3] = {response[2], response[3], '\0'};
-    int id = atoi(id_str);
-    if (id != 19 && id != 99)
-    {
-        LOG_ERROR("Invalid device ID in status response.");
-        return false;
-    }
-
-    *motorStatus = response[4] - '0';
-    *lightStatus = response[5] - '0';
-    *coverStatus = response[6] - '0';
-
-    return true;
+    return adapter ? adapter->getStatus(coverStatus, lightStatus, motorStatus) : false;
 }
 
 bool GeminiFlatpanel::move(uint16_t value, int direction)
 {
-    char command[MAXRBUF] = {0};
-
-    if (direction == -1)
-    {
-        snprintf(command, sizeof(command), ">M-%02d#", value);
-    }
-    else
-    {
-        snprintf(command, sizeof(command), ">M%03d#", value);
-    }
-
-    char response[MAXRBUF] = {0};
-
-    if (!sendCommand(command, response, 30))
-    {
-        return false;
-    }
-
-    LOGF_INFO("Move response: %s", response);
-    return true;
+    return adapter ? adapter->move(value, direction) : false;
 }
 
 bool GeminiFlatpanel::setClosePosition()
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('F', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    LOGF_INFO("Close position: %s", response);
-
-    return true;
+    return adapter ? adapter->setClosePosition() : false;
 }
 
 bool GeminiFlatpanel::setOpenPosition()
 {
-    char command[MAXRBUF] = {0};
-    char response[MAXRBUF] = {0};
-
-    if (!formatCommand('E', command))
-    {
-        return false;
-    }
-
-    if (!sendCommand(command, response))
-    {
-        return false;
-    }
-
-    LOGF_INFO("Open position: %s", response);
-
-    return true;
+    return adapter ? adapter->setOpenPosition() : false;
 }
 
 // Status update and transitions
@@ -1191,14 +826,10 @@ void GeminiFlatpanel::startConfiguration()
 
 void GeminiFlatpanel::endConfiguration()
 {
-    if (isSimulation())
+    int adapterConfigStatus;
+    if (adapter && adapter->getConfigStatus(&adapterConfigStatus))
     {
-        LOG_INFO("Configuration completed successfully.");
-        configStatus = GEMINI_CONFIG_READY;
-    }
-    else
-    {
-        getConfigStatus();
+        configStatus = adapterConfigStatus;
         if (configStatus == GEMINI_CONFIG_READY)
         {
             LOG_INFO("Configuration completed successfully.");
@@ -1210,6 +841,12 @@ void GeminiFlatpanel::endConfiguration()
             configStatus = GEMINI_CONFIG_NOTREADY;
         }
     }
+    else
+    {
+        LOG_WARN("Failed to get configuration status.");
+        configStatus = GEMINI_CONFIG_NOTREADY;
+    }
+
     ConfigureSP.reset();
     ConfigureSP[0].setState(ISS_OFF);
     ConfigureSP.setState(IPS_IDLE);
@@ -1255,6 +892,13 @@ void GeminiFlatpanel::cleanupSwitch(INDI::PropertySwitch &currentSwitch, int swi
 
 void GeminiFlatpanel::onMove(int direction)
 {
+    // Check if dust cap functionality is supported
+    if (!adapter || !adapter->supportsDustCap())
+    {
+        LOG_WARN("Dust cap movement not supported by this device.");
+        return;
+    }
+
     // Determine the switch based solely on the direction.
     auto &currentSwitch = (direction == GEMINI_DIRECTION_CLOSE) ? ClosedPositionSP : OpenPositionSP;
     int switchIndex = currentSwitch.findOnSwitchIndex();
@@ -1280,20 +924,21 @@ void GeminiFlatpanel::onMove(int direction)
             break;
     }
 
-    if (isSimulation())
-    {
-        LOGF_INFO("Moving %d steps in %s direction.", steps, direction == GEMINI_DIRECTION_CLOSE ? "close" : "open");
-    }
-    else
-    {
-        move(steps, direction);
-    }
+    // Use adapter for both real hardware and simulation
+    move(steps, direction);
 
     cleanupSwitch(currentSwitch, switchIndex);
 }
 
 void GeminiFlatpanel::onSetPosition(int direction)
 {
+    // Check if dust cap functionality is supported
+    if (!adapter || !adapter->supportsDustCap())
+    {
+        LOG_WARN("Dust cap position setting not supported by this device.");
+        return;
+    }
+
     auto currentSwitch = (direction == GEMINI_DIRECTION_CLOSE) ? SetClosedSP : SetOpenSP;
     auto switchIndex = currentSwitch.findOnSwitchIndex();
 
@@ -1308,18 +953,12 @@ void GeminiFlatpanel::onSetPosition(int direction)
     {
         case GEMINI_DIRECTION_CLOSE:
             LOG_INFO("Close position set.");
-            if (!isSimulation())
-            {
-                setClosePosition();
-            }
+            setClosePosition();
             configStatus = GEMINI_CONFIG_OPEN;
             break;
         case GEMINI_DIRECTION_OPEN:
             LOG_INFO("Setting open position.");
-            if (!isSimulation())
-            {
-                setOpenPosition();
-            }
+            setOpenPosition();
             endConfiguration();
             break;
     }

--- a/drivers/auxiliary/gemini_flatpanel.h
+++ b/drivers/auxiliary/gemini_flatpanel.h
@@ -4,191 +4,149 @@
 #include "connectionplugins/connectionserial.h"
 #include "indilightboxinterface.h"
 #include "indidustcapinterface.h"
+#include "gemini_flatpanel_adapters.h"
+#include <memory>
 
 #define GEMINI_DEVICE_ID 99
-#define GEMINI_MIN_BRIGHTNESS 0
-#define GEMINI_MAX_BRIGHTNESS 255
-#define SERIAL_TIMEOUT_SEC 10
-#define SERIAL_TIMEOUT_SEC_LONG 120
-#define NO_VALUE 1000 // Used to indicate that no value is provided
 
 namespace Connection
 {
-    class Serial;
+class Serial;
 }
+
+// Forward declaration for the adapter
+class GeminiFlatpanelAdapter;
 
 class GeminiFlatpanel : public INDI::DefaultDevice, public INDI::LightBoxInterface, public INDI::DustCapInterface
 {
-public:
-    GeminiFlatpanel();
-    virtual ~GeminiFlatpanel() = default;
-    virtual const char *getDefaultName() override;
+    public:
+        GeminiFlatpanel();
+        virtual ~GeminiFlatpanel() = default;
+        virtual const char *getDefaultName() override;
 
-    void ISGetProperties(const char *deviceName) override;
-    virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-    virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
-    virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
-    virtual bool ISSnoopDevice(XMLEle *root) override;
+        void ISGetProperties(const char *deviceName) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
+        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+        virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+        virtual bool ISSnoopDevice(XMLEle *root) override;
 
-protected:
-    bool initProperties() override;
-    bool updateProperties() override;
-    bool saveConfigItems(FILE *fp) override;
-    void initStatusProperties();
-    void initLimitsProperties();
+    protected:
+        bool initProperties() override;
+        bool updateProperties() override;
+        bool saveConfigItems(FILE *fp) override;
+        void initStatusProperties();
+        void initLimitsProperties();
 
-    void TimerHit() override;
+        void TimerHit() override;
 
-    // From LightBoxInterface
-    bool SetLightBoxBrightness(uint16_t value) override;
-    bool EnableLightBox(bool enable) override;
+        // From LightBoxInterface
+        bool SetLightBoxBrightness(uint16_t value) override;
+        bool EnableLightBox(bool enable) override;
 
-    // From DustCapInterface
-    virtual IPState ParkCap() override;
-    virtual IPState UnParkCap() override;
-    virtual IPState AbortCap() override;
+        // From DustCapInterface
+        virtual IPState ParkCap() override;
+        virtual IPState UnParkCap() override;
+        virtual IPState AbortCap() override;
 
-    // UI interactions
-    void startConfiguration();
-    void endConfiguration();
-    bool validateOperation();
-    bool validateCalibrationOperation(int direction);
-    void onMove(int direction);
-    void onSetPosition(int direction);
-    void cleanupSwitch(INDI::PropertySwitch &currentSwitch, int switchIndex);
-    void onBeepChange();
-    void onBrightnessModeChange();
+        // UI interactions
+        void startConfiguration();
+        void endConfiguration();
+        bool validateOperation();
+        bool validateCalibrationOperation(int direction);
+        void onMove(int direction);
+        void onSetPosition(int direction);
+        void cleanupSwitch(INDI::PropertySwitch &currentSwitch, int switchIndex);
+        void onBeepChange();
+        void onBrightnessModeChange();
 
-private:
-    // Serial connection
-    bool Handshake();
-    int PortFD{-1};
+    private:
+        // Serial connection
+        bool Handshake();
+        int PortFD{-1};
 
-    Connection::Serial *serialConnection{nullptr};
+        Connection::Serial *serialConnection{nullptr};
 
-    // Simulation values
-    enum
-    {
-        SIMULATION_MOTOR,
-        SIMULATION_LIGHT,
-        SIMULATION_COVER,
-        SIMULATION_BRIGHTNESS,
-        SIMULATION_N
-    };
-    int simulationValues[SIMULATION_N]{GEMINI_MOTOR_STATUS_STOPPED, GEMINI_LIGHT_STATUS_OFF, GEMINI_COVER_STATUS_CLOSED, 128};
+        // Adapter for firmware-specific functionality
+        std::unique_ptr<GeminiFlatpanelAdapter> adapter;
 
-    // Device revision
-    int deviceRevision{-1};
-    char commandTerminator{'\n'};
+        // Note: Simulation state now managed by GeminiFlatpanelSimulationAdapter
 
-    // State variables
-    int prevCoverStatus{-1};
-    int prevLightStatus{-1};
-    int prevMotorStatus{-1};
-    int prevBrightness{-1};
-    int configStatus{GEMINI_CONFIG_NOTREADY};
+        // Device revision
+        int deviceRevision{-1};
+        char commandTerminator{'\n'};
 
-    // State update methods
-    bool updateCoverStatus(char coverStatus);
-    bool updateLightStatus(char lightStatus);
-    bool updateMotorStatus(char motorStatus);
-    bool updateBrightness(int brightness);
-    void updateConfigStatus();
+        // State variables
+        int prevCoverStatus{-1};
+        int prevLightStatus{-1};
+        int prevMotorStatus{-1};
+        int prevBrightness{-1};
+        int configStatus{GEMINI_CONFIG_NOTREADY};
 
-    // Commands
-    bool sendCommand(const char *command, char *response, int timeout = SERIAL_TIMEOUT_SEC, bool log = true);
-    bool pingRevision1();
-    bool pingRevision2();
-    bool getFirmwareVersion(int *version);
-    bool getConfigStatus();
-    bool getBrightness(int *const brightness);
-    bool setBrightness(int value);
-    bool lightOn();
-    bool lightOff();
-    bool openCover();
-    bool closeCover();
-    bool getStatus(int *const coverStatus, int *const lightStatus, int *const motorStatus);
-    bool move(uint16_t value, int direction);
-    bool setClosePosition();
-    bool setOpenPosition();
-    bool setBeep(bool enable);
-    bool setBrightnessMode(int mode);
+        // State update methods
+        bool updateCoverStatus(char coverStatus);
+        bool updateLightStatus(char lightStatus);
+        bool updateMotorStatus(char motorStatus);
+        bool updateBrightness(int brightness);
+        void updateConfigStatus();
 
-    // Helper functions
-    bool extractIntValue(const char *response, int startPos, int *value);
-    bool formatCommand(char commandLetter, char *commandString, int value = NO_VALUE);
-    
-    // Status properties
-    enum
-    {
-        STATUS_COVER,
-        STATUS_LIGHT,
-        STATUS_MOTOR,
-        STATUS_N
-    };
-    INDI::PropertyText StatusTP{STATUS_N};
-    INDI::PropertyText ConfigurationTP{1};
-    INDI::PropertySwitch BeepSP{2};
-    INDI::PropertySwitch BrightnessModeSP{2};
+        // Commands
+        bool sendCommand(const char *command, char *response, int timeout = SERIAL_TIMEOUT_SEC);
+        bool pingRevision1();
+        bool pingRevision2();
+        bool getFirmwareVersion(int *version);
+        bool getConfigStatus();
+        bool getBrightness(int *const brightness);
+        bool setBrightness(int value);
+        bool lightOn();
+        bool lightOff();
+        bool openCover();
+        bool closeCover();
+        bool getStatus(int *const coverStatus, int *const lightStatus, int *const motorStatus);
+        bool move(uint16_t value, int direction);
+        bool setClosePosition();
+        bool setOpenPosition();
+        bool setBeep(bool enable);
+        bool setBrightnessMode(int mode);
 
-    // Limit properties
-    enum
-    {
-        MOVEMENT_LIMITS_45,
-        MOVEMENT_LIMITS_10,
-        MOVEMENT_LIMITS_01,
-        MOVEMENT_LIMITS_N
-    };
-    INDI::PropertySwitch ClosedPositionSP{MOVEMENT_LIMITS_N};
-    INDI::PropertySwitch SetClosedSP{1};
-    INDI::PropertySwitch OpenPositionSP{MOVEMENT_LIMITS_N};
-    INDI::PropertySwitch SetOpenSP{1};
-    INDI::PropertySwitch ConfigureSP{1};
+        // Helper functions
+        bool extractIntValue(const char *response, int startPos, int *value);
+        bool formatCommand(char commandLetter, char *commandString, int value = NO_VALUE);
 
-    // Gemini light panel constants
-    enum
-    {
-        GEMINI_REVISION_UNKNOWN = 0,
-        GEMINI_REVISION_1 = 1,
-        GEMINI_REVISION_2 = 2
-    };
-    enum
-    {
-        GEMINI_COVER_STATUS_MOVING = 0,
-        GEMINI_COVER_STATUS_CLOSED = 1,
-        GEMINI_COVER_STATUS_OPEN = 2,
-        GEMINI_COVER_STATUS_TIMED_OUT = 3
-    };
-    enum
-    {
-        GEMINI_LIGHT_STATUS_OFF = 0,
-        GEMINI_LIGHT_STATUS_ON = 1
-    };
-    enum
-    {
-        GEMINI_MOTOR_STATUS_STOPPED = 0,
-        GEMINI_MOTOR_STATUS_RUNNING = 1
-    };
-    enum
-    {
-        GEMINI_DIRECTION_CLOSE = -1,
-        GEMINI_DIRECTION_OPEN = 1
-    };
-    enum
-    {
-        GEMINI_CONFIG_NOTREADY = 0,
-        GEMINI_CONFIG_READY = 1,
-        GEMINI_CONFIG_CLOSED = 2,
-        GEMINI_CONFIG_OPEN = 3,
-    };
-    enum
-    {
-        GEMINI_BEEP_OFF = 0,
-        GEMINI_BEEP_ON = 1
-    };
-    enum
-    {
-        GEMINI_BRIGHTNESS_MODE_LOW = 0,
-        GEMINI_BRIGHTNESS_MODE_HIGH = 1
-    };
+        // Status properties
+        enum
+        {
+            STATUS_COVER,
+            STATUS_LIGHT,
+            STATUS_MOTOR,
+            STATUS_N
+        };
+        INDI::PropertyText StatusTP{STATUS_N};
+        INDI::PropertyText ConfigurationTP{1};
+        INDI::PropertySwitch BeepSP{2};
+        INDI::PropertySwitch BrightnessModeSP{2};
+
+        // Limit properties
+        enum
+        {
+            MOVEMENT_LIMITS_45,
+            MOVEMENT_LIMITS_10,
+            MOVEMENT_LIMITS_01,
+            MOVEMENT_LIMITS_N
+        };
+        INDI::PropertySwitch ClosedPositionSP{MOVEMENT_LIMITS_N};
+        INDI::PropertySwitch SetClosedSP{1};
+        INDI::PropertySwitch OpenPositionSP{MOVEMENT_LIMITS_N};
+        INDI::PropertySwitch SetOpenSP{1};
+        INDI::PropertySwitch ConfigureSP{1};
+
+        // Device selection property
+        enum
+        {
+            DEVICE_AUTO,
+            DEVICE_REV1,
+            DEVICE_REV2,
+            DEVICE_LITE,
+            DEVICE_N
+        };
+        INDI::PropertySwitch DeviceTypeSP{DEVICE_N};
 };

--- a/drivers/auxiliary/gemini_flatpanel_adapters.cpp
+++ b/drivers/auxiliary/gemini_flatpanel_adapters.cpp
@@ -1,0 +1,1388 @@
+#include "gemini_flatpanel_adapters.h"
+#include "indicom.h"
+#include "indibase.h"
+#include <termios.h>
+#include <cstring>
+#include <cstdio>
+
+//////////////////////////////////////////////////////////////////////////////
+// GeminiFlatpanelRev1Adapter Implementation
+//////////////////////////////////////////////////////////////////////////////
+
+// Device detection and identification
+bool GeminiFlatpanelRev1Adapter::ping()
+{
+    // This command is only supported by revision 1 devices
+    // It is used to check if the device is a revision 1 device
+    char response[MAXRBUF] = {0};
+
+    if (!sendCommand(">P000#", response, SERIAL_TIMEOUT_SEC, false))
+    {
+        return false;
+    }
+
+    if (strcmp(response, "*P99OOO") != 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelRev1Adapter::getFirmwareVersion(int *version)
+{
+    // Rev1 doesn't support firmware version reporting command
+    // Always return 0 to indicate no firmware version available
+    *version = 0;
+    return true;
+}
+
+// Basic device commands
+bool GeminiFlatpanelRev1Adapter::getConfigStatus(int *status)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('A', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'A')
+    {
+        return false;
+    }
+
+    *status = response[2] - '0';
+    return true;
+}
+
+bool GeminiFlatpanelRev1Adapter::getBrightness(int *brightness)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('J', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'J')
+    {
+        return false;
+    }
+
+    // Rev1 brightness response index is at position 4
+    return extractIntValue(response, 4, brightness);
+}
+
+bool GeminiFlatpanelRev1Adapter::setBrightness(int value)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (value > GEMINI_MAX_BRIGHTNESS)
+    {
+        value = GEMINI_MAX_BRIGHTNESS;
+    }
+
+    if (value < GEMINI_MIN_BRIGHTNESS)
+    {
+        value = GEMINI_MIN_BRIGHTNESS;
+    }
+
+    if (!formatCommand('B', command, value))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'B')
+    {
+        return false;
+    }
+
+    int response_value;
+    if (!extractIntValue(response, 4, &response_value))
+    {
+        return false;
+    }
+
+    return (response_value == value);
+}
+
+bool GeminiFlatpanelRev1Adapter::lightOn()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('L', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'L');
+}
+
+bool GeminiFlatpanelRev1Adapter::lightOff()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('D', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'D');
+}
+
+bool GeminiFlatpanelRev1Adapter::openCover()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('O', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
+    {
+        return false;
+    }
+
+    return (strcmp(response, "*O99OOO") == 0);
+}
+
+bool GeminiFlatpanelRev1Adapter::closeCover()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('C', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
+    {
+        return false;
+    }
+
+    return (strcmp(response, "*C99OOO") == 0);
+}
+
+bool GeminiFlatpanelRev1Adapter::getStatus(int *coverStatus, int *lightStatus, int *motorStatus)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('S', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 7)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'S')
+    {
+        return false;
+    }
+
+    // Check if device ID is valid (19 or 99)
+    char id_str[3] = {response[2], response[3], '\0'};
+    int id = atoi(id_str);
+    if (id != 19 && id != 99)
+    {
+        return false;
+    }
+
+    *motorStatus = response[4] - '0';
+    *lightStatus = response[5] - '0';
+    *coverStatus = response[6] - '0';
+
+    return true;
+}
+
+// Motion/calibration commands
+bool GeminiFlatpanelRev1Adapter::move(uint16_t value, int direction)
+{
+    char command[MAXRBUF] = {0};
+
+    if (direction == -1)
+    {
+        snprintf(command, sizeof(command), ">M-%02d#", value);
+    }
+    else
+    {
+        snprintf(command, sizeof(command), ">M%03d#", value);
+    }
+
+    char response[MAXRBUF] = {0};
+
+    return sendCommand(command, response, 30);
+}
+
+bool GeminiFlatpanelRev1Adapter::setClosePosition()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('F', command))
+    {
+        return false;
+    }
+
+    return sendCommand(command, response);
+}
+
+bool GeminiFlatpanelRev1Adapter::setOpenPosition()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('E', command))
+    {
+        return false;
+    }
+
+    return sendCommand(command, response);
+}
+
+// Helper methods for Rev1
+bool GeminiFlatpanelRev1Adapter::formatCommand(char commandLetter, char *commandString, int value)
+{
+    if (commandString == nullptr)
+    {
+        return false;
+    }
+
+    // Rev1 format: >X000# (no value) or >XNNN# (with value) where X is command letter and NNN is 3-digit value
+    if (value == NO_VALUE)
+    {
+        // No value provided, pad with 000
+        snprintf(commandString, MAXRBUF, ">%c000#", commandLetter);
+    }
+    else
+    {
+        // Value provided, pad to 3 digits
+        snprintf(commandString, MAXRBUF, ">%c%03d#", commandLetter, value);
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelRev1Adapter::extractIntValue(const char *response, int startPos, int *value)
+{
+    if (response == nullptr || value == nullptr)
+    {
+        return false;
+    }
+
+    // Revision 1 responses have a 3-digit numeric part 0 padded
+    int length = 3;
+
+    if (length <= 0)
+    {
+        return false;
+    }
+
+    // Extract the numeric part
+    char value_str[MAXRBUF] = {0};
+    strncpy(value_str, response + startPos, length);
+    *value = atoi(value_str);
+
+    return true;
+}
+
+bool GeminiFlatpanelRev1Adapter::sendCommand(const char *command, char *response, int timeout, bool log)
+{
+    int nbytes_written = 0, nbytes_read = 0, rc = -1;
+
+    tcflush(portFD, TCIOFLUSH);
+    if ((rc = tty_write_string(portFD, command, &nbytes_written)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+            // The main driver should handle logging of errors
+        }
+        return false;
+    }
+
+    if (response == nullptr)
+        return true;
+
+    if ((rc = tty_nread_section(portFD, response, MAXRBUF, getCommandTerminator(), timeout, &nbytes_read)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+        }
+        return false;
+    }
+
+    // Remove trailing newline character if present
+    if (nbytes_read > 0 && response[nbytes_read - 1] == '\n')
+    {
+        response[nbytes_read - 1] = '\0';
+    }
+    tcflush(portFD, TCIOFLUSH);
+
+    if (response[0] != '*' || response[1] != command[1])
+    {
+        return false;
+    }
+
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// GeminiFlatpanelRev2Adapter Implementation
+//////////////////////////////////////////////////////////////////////////////
+
+// Device detection and identification
+bool GeminiFlatpanelRev2Adapter::ping()
+{
+    // This command is only supported by revision 2 devices
+    // It is used to check if the device is a revision 2 device
+    char response[MAXRBUF] = {0};
+
+    if (!sendCommand(">H#", response, SERIAL_TIMEOUT_SEC, false))
+    {
+        return false;
+    }
+
+    if (strcmp(response, "*HGeminiFlatPanel#") != 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelRev2Adapter::getFirmwareVersion(int *version)
+{
+    // This command is only supported by revision 2 devices
+    // It is used to get the firmware version
+    char response[MAXRBUF] = {0};
+
+    // Initialize version to 0 in case of errors
+    *version = 0;
+
+    if (!sendCommand(">V#", response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'V')
+    {
+        return false;
+    }
+
+    int firmwareVersion;
+    if (!extractIntValue(response, 2, &firmwareVersion))
+    {
+        return false;
+    }
+
+    if (firmwareVersion < 402)
+    {
+        // Firmware version too old. Should be 402 or later.
+        return false;
+    }
+
+    *version = firmwareVersion;
+    return true;
+}
+
+// Basic device commands
+bool GeminiFlatpanelRev2Adapter::getConfigStatus(int *status)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('A', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'A')
+    {
+        return false;
+    }
+
+    *status = response[2] - '0';
+    return true;
+}
+
+bool GeminiFlatpanelRev2Adapter::getBrightness(int *brightness)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('J', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'J')
+    {
+        return false;
+    }
+
+    // Rev2 brightness response index is at position 2
+    return extractIntValue(response, 2, brightness);
+}
+
+bool GeminiFlatpanelRev2Adapter::setBrightness(int value)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (value > GEMINI_MAX_BRIGHTNESS)
+    {
+        value = GEMINI_MAX_BRIGHTNESS;
+    }
+
+    if (value < GEMINI_MIN_BRIGHTNESS)
+    {
+        value = GEMINI_MIN_BRIGHTNESS;
+    }
+
+    if (!formatCommand('B', command, value))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'B')
+    {
+        return false;
+    }
+
+    int response_value;
+    if (!extractIntValue(response, 2, &response_value))
+    {
+        return false;
+    }
+
+    return (response_value == value);
+}
+
+bool GeminiFlatpanelRev2Adapter::lightOn()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('L', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'L');
+}
+
+bool GeminiFlatpanelRev2Adapter::lightOff()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('D', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'D');
+}
+
+bool GeminiFlatpanelRev2Adapter::openCover()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('O', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
+    {
+        return false;
+    }
+
+    return (strcmp(response, "*OOpened#") == 0);
+}
+
+bool GeminiFlatpanelRev2Adapter::closeCover()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('C', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
+    {
+        return false;
+    }
+
+    return (strcmp(response, "*CClosed#") == 0);
+}
+
+bool GeminiFlatpanelRev2Adapter::getStatus(int *coverStatus, int *lightStatus, int *motorStatus)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('S', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 7)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'S')
+    {
+        return false;
+    }
+
+    // Check if device ID is valid (19 or 99)
+    char id_str[3] = {response[2], response[3], '\0'};
+    int id = atoi(id_str);
+    if (id != 19 && id != 99)
+    {
+        return false;
+    }
+
+    *motorStatus = response[4] - '0';
+    *lightStatus = response[5] - '0';
+    *coverStatus = response[6] - '0';
+
+    return true;
+}
+
+// Motion/calibration commands
+bool GeminiFlatpanelRev2Adapter::move(uint16_t value, int direction)
+{
+    char command[MAXRBUF] = {0};
+
+    if (direction == -1)
+    {
+        snprintf(command, sizeof(command), ">M-%02d#", value);
+    }
+    else
+    {
+        snprintf(command, sizeof(command), ">M%03d#", value);
+    }
+
+    char response[MAXRBUF] = {0};
+
+    return sendCommand(command, response, 30);
+}
+
+bool GeminiFlatpanelRev2Adapter::setClosePosition()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('F', command))
+    {
+        return false;
+    }
+
+    return sendCommand(command, response);
+}
+
+bool GeminiFlatpanelRev2Adapter::setOpenPosition()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('E', command))
+    {
+        return false;
+    }
+
+    return sendCommand(command, response);
+}
+
+// Advanced commands
+bool GeminiFlatpanelRev2Adapter::setBeep(bool enable)
+{
+    char command[MAXRBUF] = {0};
+
+    if (!formatCommand('T', command, enable ? GEMINI_BEEP_ON : GEMINI_BEEP_OFF))
+    {
+        return false;
+    }
+
+    return sendCommand(command, nullptr);
+}
+
+bool GeminiFlatpanelRev2Adapter::setBrightnessMode(int mode)
+{
+    if (mode != GEMINI_BRIGHTNESS_MODE_LOW && mode != GEMINI_BRIGHTNESS_MODE_HIGH)
+    {
+        return false;
+    }
+
+    char command[MAXRBUF] = {0};
+
+    if (!formatCommand('Y', command, mode))
+    {
+        return false;
+    }
+
+    return sendCommand(command, nullptr);
+}
+
+// Helper methods for Rev2
+bool GeminiFlatpanelRev2Adapter::formatCommand(char commandLetter, char *commandString, int value)
+{
+    if (commandString == nullptr)
+    {
+        return false;
+    }
+
+    // Rev2 format: >X# (no value) or >Xnnn# (with value) where X is command letter and nnn is value
+    if (value == NO_VALUE)
+    {
+        // No value provided, no padding
+        snprintf(commandString, MAXRBUF, ">%c#", commandLetter);
+    }
+    else
+    {
+        // Value provided, no padding
+        snprintf(commandString, MAXRBUF, ">%c%d#", commandLetter, value);
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelRev2Adapter::extractIntValue(const char *response, int startPos, int *value)
+{
+    if (response == nullptr || value == nullptr)
+    {
+        return false;
+    }
+
+    const char *terminator = strchr(response, '#');
+    if (terminator == nullptr)
+    {
+        return false;
+    }
+
+    // Calculate the length of the numeric part
+    int length = terminator - (response + startPos);
+
+    if (length <= 0)
+    {
+        return false;
+    }
+
+    // Extract the numeric part
+    char value_str[MAXRBUF] = {0};
+    strncpy(value_str, response + startPos, length);
+    *value = atoi(value_str);
+
+    return true;
+}
+
+bool GeminiFlatpanelRev2Adapter::sendCommand(const char *command, char *response, int timeout, bool log)
+{
+    int nbytes_written = 0, nbytes_read = 0, rc = -1;
+
+    tcflush(portFD, TCIOFLUSH);
+    if ((rc = tty_write_string(portFD, command, &nbytes_written)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+            // The main driver should handle logging of errors
+        }
+        return false;
+    }
+
+    if (response == nullptr)
+        return true;
+
+    if ((rc = tty_nread_section(portFD, response, MAXRBUF, getCommandTerminator(), timeout, &nbytes_read)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+        }
+        return false;
+    }
+
+    // Remove trailing newline character if present
+    if (nbytes_read > 0 && response[nbytes_read - 1] == '\n')
+    {
+        response[nbytes_read - 1] = '\0';
+    }
+    tcflush(portFD, TCIOFLUSH);
+
+    if (response[0] != '*' || response[1] != command[1])
+    {
+        return false;
+    }
+
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// GeminiFlatpanelLiteAdapter Implementation
+//////////////////////////////////////////////////////////////////////////////
+
+// Device detection and identification
+bool GeminiFlatpanelLiteAdapter::ping()
+{
+    // This command is only supported by Lite devices
+    // It is used to check if the device is a Lite device
+    char response[MAXRBUF] = {0};
+
+    if (!sendCommand(">H#", response, SERIAL_TIMEOUT_SEC, false))
+    {
+        return false;
+    }
+
+    if (strcmp(response, "*HGeminiFlatPanelLite#") != 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelLiteAdapter::getFirmwareVersion(int *version)
+{
+    // This command is supported by Lite devices
+    // It is used to get the firmware version
+    char response[MAXRBUF] = {0};
+
+    // Initialize version to 0 in case of errors
+    *version = 0;
+
+    if (!sendCommand(">V#", response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'V')
+    {
+        return false;
+    }
+
+    int firmwareVersion;
+    if (!extractIntValue(response, 2, &firmwareVersion))
+    {
+        return false;
+    }
+
+    if (firmwareVersion < 205)
+    {
+        // Firmware version too old. Should be 205 or later for Lite.
+        return false;
+    }
+
+    *version = firmwareVersion;
+    return true;
+}
+
+// Basic device commands
+bool GeminiFlatpanelLiteAdapter::getConfigStatus(int *status)
+{
+    // Lite devices don't have a separate config status command
+    // We'll assume they're always ready since they don't have motorized parts
+    *status = GEMINI_CONFIG_READY;
+    return true;
+}
+
+bool GeminiFlatpanelLiteAdapter::getBrightness(int *brightness)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('J', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'J')
+    {
+        return false;
+    }
+
+    // Lite brightness response index is at position 2
+    return extractIntValue(response, 2, brightness);
+}
+
+bool GeminiFlatpanelLiteAdapter::setBrightness(int value)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (value > GEMINI_MAX_BRIGHTNESS)
+    {
+        value = GEMINI_MAX_BRIGHTNESS;
+    }
+
+    if (value < GEMINI_MIN_BRIGHTNESS)
+    {
+        value = GEMINI_MIN_BRIGHTNESS;
+    }
+
+    if (!formatCommand('B', command, value))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'B')
+    {
+        return false;
+    }
+
+    int response_value;
+    if (!extractIntValue(response, 2, &response_value))
+    {
+        return false;
+    }
+
+    return (response_value == value);
+}
+
+bool GeminiFlatpanelLiteAdapter::lightOn()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('L', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'L');
+}
+
+bool GeminiFlatpanelLiteAdapter::lightOff()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('D', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'D');
+}
+
+bool GeminiFlatpanelLiteAdapter::openCover()
+{
+    // Lite devices don't have motorized covers
+    return false;
+}
+
+bool GeminiFlatpanelLiteAdapter::closeCover()
+{
+    // Lite devices don't have motorized covers
+    return false;
+}
+
+bool GeminiFlatpanelLiteAdapter::getStatus(int *coverStatus, int *lightStatus, int *motorStatus)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('S', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 5)  // "*SLMB#" minimum
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'S')
+    {
+        return false;
+    }
+
+    // Lite status format: "*SLMB#" where:
+    // L = light status (0 off, 1 on)
+    // M = brightness Mode (0 Low, 1 High)
+    // B = Beep on/off (0 off, 1 on)
+
+    *lightStatus = response[2] - '0';
+    // For Lite devices, cover is always "open" since there's no physical cover
+    *coverStatus = GEMINI_COVER_STATUS_OPEN;
+    // Motor is always stopped since there's no motor
+    *motorStatus = GEMINI_MOTOR_STATUS_STOPPED;
+
+    return true;
+}
+
+// Advanced commands
+bool GeminiFlatpanelLiteAdapter::setBeep(bool enable)
+{
+    char command[MAXRBUF] = {0};
+
+    if (!formatCommand('T', command, enable ? GEMINI_BEEP_ON : GEMINI_BEEP_OFF))
+    {
+        return false;
+    }
+
+    return sendCommand(command, nullptr);
+}
+
+bool GeminiFlatpanelLiteAdapter::setBrightnessMode(int mode)
+{
+    if (mode != GEMINI_BRIGHTNESS_MODE_LOW && mode != GEMINI_BRIGHTNESS_MODE_HIGH)
+    {
+        return false;
+    }
+
+    char command[MAXRBUF] = {0};
+
+    if (!formatCommand('Y', command, mode))
+    {
+        return false;
+    }
+
+    return sendCommand(command, nullptr);
+}
+
+// Helper methods for Lite
+bool GeminiFlatpanelLiteAdapter::formatCommand(char commandLetter, char *commandString, int value)
+{
+    if (commandString == nullptr)
+    {
+        return false;
+    }
+
+    // Lite format: >X# (no value) or >Xnnn# (with value) where X is command letter and nnn is value
+    if (value == NO_VALUE)
+    {
+        // No value provided
+        snprintf(commandString, MAXRBUF, ">%c#", commandLetter);
+    }
+    else
+    {
+        // Value provided
+        snprintf(commandString, MAXRBUF, ">%c%d#", commandLetter, value);
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelLiteAdapter::extractIntValue(const char *response, int startPos, int *value)
+{
+    if (response == nullptr || value == nullptr)
+    {
+        return false;
+    }
+
+    const char *terminator = strchr(response, '#');
+    if (terminator == nullptr)
+    {
+        return false;
+    }
+
+    // Calculate the length of the numeric part
+    int length = terminator - (response + startPos);
+
+    if (length <= 0)
+    {
+        return false;
+    }
+
+    // Extract the numeric part
+    char value_str[MAXRBUF] = {0};
+    strncpy(value_str, response + startPos, length);
+    *value = atoi(value_str);
+
+    return true;
+}
+
+bool GeminiFlatpanelLiteAdapter::sendCommand(const char *command, char *response, int timeout, bool log)
+{
+    int nbytes_written = 0, nbytes_read = 0, rc = -1;
+
+    tcflush(portFD, TCIOFLUSH);
+    if ((rc = tty_write_string(portFD, command, &nbytes_written)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+            // The main driver should handle logging of errors
+        }
+        return false;
+    }
+
+    if (response == nullptr)
+        return true;
+
+    if ((rc = tty_nread_section(portFD, response, MAXRBUF, getCommandTerminator(), timeout, &nbytes_read)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+        }
+        return false;
+    }
+
+    // Remove trailing newline character if present
+    if (nbytes_read > 0 && response[nbytes_read - 1] == '\n')
+    {
+        response[nbytes_read - 1] = '\0';
+    }
+    tcflush(portFD, TCIOFLUSH);
+
+    if (response[0] != '*' || response[1] != command[1])
+    {
+        return false;
+    }
+
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// GeminiFlatpanelSimulationAdapter Implementation
+//////////////////////////////////////////////////////////////////////////////
+
+GeminiFlatpanelSimulationAdapter::GeminiFlatpanelSimulationAdapter(bool simulateRev2Features)
+    : simulateRev2Features(simulateRev2Features)
+{
+    // Initialize simulation state
+    simulationValues[SIM_MOTOR] = GEMINI_MOTOR_STATUS_STOPPED;
+    simulationValues[SIM_LIGHT] = GEMINI_LIGHT_STATUS_OFF;
+    simulationValues[SIM_COVER] = GEMINI_COVER_STATUS_CLOSED;
+    simulationValues[SIM_BRIGHTNESS] = 128;
+    simulationValues[SIM_CONFIG_STATUS] = GEMINI_CONFIG_READY;
+    simulationValues[SIM_BEEP_ENABLED] = 0; // Beep off by default
+    simulationValues[SIM_BRIGHTNESS_MODE] = GEMINI_BRIGHTNESS_MODE_LOW;
+
+    // Set simulated revision and firmware version
+    if (simulateRev2Features)
+    {
+        simulatedRevision = GEMINI_REVISION_2;
+        simulatedFirmwareVersion = 450; // A version >= 402
+    }
+    else
+    {
+        simulatedRevision = GEMINI_REVISION_1;
+        simulatedFirmwareVersion = 0; // Rev1 doesn't report version
+    }
+}
+
+bool GeminiFlatpanelSimulationAdapter::ping()
+{
+    // Simulation always responds to ping
+    return true;
+}
+
+int GeminiFlatpanelSimulationAdapter::getRevision() const
+{
+    return simulatedRevision;
+}
+
+bool GeminiFlatpanelSimulationAdapter::getFirmwareVersion(int *version)
+{
+    if (!simulateRev2Features)
+    {
+        // Rev1 doesn't report firmware version
+        return false;
+    }
+
+    *version = simulatedFirmwareVersion;
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::supportsBeep() const
+{
+    return simulateRev2Features;
+}
+
+bool GeminiFlatpanelSimulationAdapter::supportsDustCap() const
+{
+    return true; // Both revisions support dust cap
+}
+
+bool GeminiFlatpanelSimulationAdapter::supportsBrightnessMode() const
+{
+    return simulateRev2Features;
+}
+
+bool GeminiFlatpanelSimulationAdapter::getConfigStatus(int *status)
+{
+    *status = simulationValues[SIM_CONFIG_STATUS];
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::getBrightness(int *brightness)
+{
+    *brightness = simulationValues[SIM_BRIGHTNESS];
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::setBrightness(int value)
+{
+    if (value < GEMINI_MIN_BRIGHTNESS || value > GEMINI_MAX_BRIGHTNESS)
+    {
+        return false;
+    }
+
+    simulationValues[SIM_BRIGHTNESS] = value;
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::lightOn()
+{
+    simulationValues[SIM_LIGHT] = GEMINI_LIGHT_STATUS_ON;
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::lightOff()
+{
+    simulationValues[SIM_LIGHT] = GEMINI_LIGHT_STATUS_OFF;
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::openCover()
+{
+    simulationValues[SIM_COVER] = GEMINI_COVER_STATUS_OPEN;
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::closeCover()
+{
+    simulationValues[SIM_COVER] = GEMINI_COVER_STATUS_CLOSED;
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::getStatus(int *coverStatus, int *lightStatus, int *motorStatus)
+{
+    *coverStatus = simulationValues[SIM_COVER];
+    *lightStatus = simulationValues[SIM_LIGHT];
+    *motorStatus = simulationValues[SIM_MOTOR];
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::move(uint16_t value, int direction)
+{
+    // Simulate brief motor activity
+    simulationValues[SIM_MOTOR] = GEMINI_MOTOR_STATUS_RUNNING;
+    // In real implementation, motor would stop after movement
+    // For simulation, we immediately set it back to stopped
+    simulationValues[SIM_MOTOR] = GEMINI_MOTOR_STATUS_STOPPED;
+
+    // Unused parameters
+    (void)value;
+    (void)direction;
+
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::setClosePosition()
+{
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::setOpenPosition()
+{
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::setBeep(bool enable)
+{
+    if (!supportsBeep())
+    {
+        return false;
+    }
+
+    simulationValues[SIM_BEEP_ENABLED] = enable ? 1 : 0;
+    return true;
+}
+
+bool GeminiFlatpanelSimulationAdapter::setBrightnessMode(int mode)
+{
+    if (!supportsBrightnessMode())
+    {
+        return false;
+    }
+
+    if (mode != GEMINI_BRIGHTNESS_MODE_LOW && mode != GEMINI_BRIGHTNESS_MODE_HIGH)
+    {
+        return false;
+    }
+
+    simulationValues[SIM_BRIGHTNESS_MODE] = mode;
+    return true;
+}
+
+char GeminiFlatpanelSimulationAdapter::getCommandTerminator() const
+{
+    // Use Rev2 terminator for consistency (most features)
+    return simulateRev2Features ? '#' : '\n';
+}
+
+void GeminiFlatpanelSimulationAdapter::setupCommunication(int /*portFD*/)
+{
+    // No actual communication setup needed for simulation
+}

--- a/drivers/auxiliary/gemini_flatpanel_adapters.h
+++ b/drivers/auxiliary/gemini_flatpanel_adapters.h
@@ -1,0 +1,613 @@
+#pragma once
+
+#include <cstdint>
+
+// Forward declaration to avoid circular dependencies
+class GeminiFlatpanel;
+
+// Constants that may be needed by adapters
+#define GEMINI_MIN_BRIGHTNESS 0
+#define GEMINI_MAX_BRIGHTNESS 255
+#define SERIAL_TIMEOUT_SEC 10
+#define SERIAL_TIMEOUT_SEC_LONG 120
+#define NO_VALUE 1000 // Used to indicate that no value is provided
+// Note: MAXRBUF is already defined in INDI headers
+
+// Gemini device constants
+enum GeminiRevision
+{
+    GEMINI_REVISION_UNKNOWN = 0,
+    GEMINI_REVISION_1 = 1,
+    GEMINI_REVISION_2 = 2,
+    GEMINI_REVISION_LITE = 3
+};
+
+enum GeminiConfigStatus
+{
+    GEMINI_CONFIG_NOTREADY = 0,
+    GEMINI_CONFIG_READY = 1,
+    GEMINI_CONFIG_CLOSED = 2,
+    GEMINI_CONFIG_OPEN = 3,
+};
+
+enum GeminiBrightnessMode
+{
+    GEMINI_BRIGHTNESS_MODE_LOW = 0,
+    GEMINI_BRIGHTNESS_MODE_HIGH = 1
+};
+
+// Status constants used by all adapters
+enum GeminiCoverStatus
+{
+    GEMINI_COVER_STATUS_MOVING = 0,
+    GEMINI_COVER_STATUS_CLOSED = 1,
+    GEMINI_COVER_STATUS_OPEN = 2,
+    GEMINI_COVER_STATUS_TIMED_OUT = 3
+};
+
+enum GeminiLightStatus
+{
+    GEMINI_LIGHT_STATUS_OFF = 0,
+    GEMINI_LIGHT_STATUS_ON = 1
+};
+
+enum GeminiMotorStatus
+{
+    GEMINI_MOTOR_STATUS_STOPPED = 0,
+    GEMINI_MOTOR_STATUS_RUNNING = 1
+};
+
+enum GeminiDirection
+{
+    GEMINI_DIRECTION_CLOSE = -1,
+    GEMINI_DIRECTION_OPEN = 1
+};
+
+enum GeminiBeepStatus
+{
+    GEMINI_BEEP_OFF = 0,
+    GEMINI_BEEP_ON = 1
+};
+
+/**
+ * @brief Abstract adapter interface for Gemini Flatpanel firmware versions
+ *
+ * This interface abstracts the differences between firmware revisions,
+ * providing a uniform command-oriented API for the main driver to use.
+ */
+class GeminiFlatpanelAdapter
+{
+    public:
+        virtual ~GeminiFlatpanelAdapter() = default;
+
+        // Device detection and identification
+
+        /**
+         * @brief Ping the device to check if it responds to this adapter's protocol
+         * @return true if device responds correctly, false otherwise
+         */
+        virtual bool ping() = 0;
+
+        /**
+         * @brief Get the firmware revision this adapter supports
+         * @return revision number (1, 2, etc.)
+         */
+        virtual int getRevision() const = 0;
+
+        /**
+         * @brief Get the firmware version from the device
+         * @param version pointer to store the firmware version
+         * @return true if successful, false otherwise
+         */
+        virtual bool getFirmwareVersion(int *version) = 0;
+
+        // Capability checks
+
+        /**
+         * @brief Check if device supports beep functionality
+         * @return true if beep is supported
+         */
+        virtual bool supportsBeep() const = 0;
+
+        /**
+         * @brief Check if device supports dust cap functionality
+         * @return true if dust cap is supported
+         */
+        virtual bool supportsDustCap() const = 0;
+
+        /**
+         * @brief Check if device supports brightness mode selection (high/low)
+         * @return true if brightness modes are supported
+         */
+        virtual bool supportsBrightnessMode() const = 0;
+
+        // Basic device commands (supported by all revisions)
+
+        /**
+         * @brief Get the current configuration status
+         * @param status pointer to store the configuration status
+         * @return true if successful, false otherwise
+         */
+        virtual bool getConfigStatus(int *status) = 0;
+
+        /**
+         * @brief Get the current brightness level
+         * @param brightness pointer to store the brightness value (0-255)
+         * @return true if successful, false otherwise
+         */
+        virtual bool getBrightness(int *brightness) = 0;
+
+        /**
+         * @brief Set the brightness level
+         * @param value brightness value (0-255)
+         * @return true if successful, false otherwise
+         */
+        virtual bool setBrightness(int value) = 0;
+
+        /**
+         * @brief Turn the light on
+         * @return true if successful, false otherwise
+         */
+        virtual bool lightOn() = 0;
+
+        /**
+         * @brief Turn the light off
+         * @return true if successful, false otherwise
+         */
+        virtual bool lightOff() = 0;
+
+        /**
+         * @brief Open the dust cover
+         * @return true if successful, false otherwise
+         */
+        virtual bool openCover() = 0;
+
+        /**
+         * @brief Close the dust cover
+         * @return true if successful, false otherwise
+         */
+        virtual bool closeCover() = 0;
+
+        /**
+         * @brief Get the current device status
+         * @param coverStatus pointer to store cover status
+         * @param lightStatus pointer to store light status
+         * @param motorStatus pointer to store motor status
+         * @return true if successful, false otherwise
+         */
+        virtual bool getStatus(int *coverStatus, int *lightStatus, int *motorStatus) = 0;
+
+        // Motion/calibration commands
+
+        /**
+         * @brief Move the cover by a specified amount
+         * @param value number of steps to move
+         * @param direction direction of movement (1 for open, -1 for close)
+         * @return true if successful, false otherwise
+         */
+        virtual bool move(uint16_t value, int direction) = 0;
+
+        /**
+         * @brief Set the current position as the closed position
+         * @return true if successful, false otherwise
+         */
+        virtual bool setClosePosition() = 0;
+
+        /**
+         * @brief Set the current position as the open position
+         * @return true if successful, false otherwise
+         */
+        virtual bool setOpenPosition() = 0;
+
+        // Advanced commands (may not be supported by all revisions)
+
+        /**
+         * @brief Enable or disable beep functionality
+         * @param enable true to enable beep, false to disable
+         * @return true if successful, false if not supported or failed
+         */
+        virtual bool setBeep(bool enable) = 0;
+
+        /**
+         * @brief Set the brightness mode (high/low)
+         * @param mode brightness mode (GEMINI_BRIGHTNESS_MODE_LOW or GEMINI_BRIGHTNESS_MODE_HIGH)
+         * @return true if successful, false if not supported or failed
+         */
+        virtual bool setBrightnessMode(int mode) = 0;
+
+        // Communication setup
+
+        /**
+         * @brief Get the command terminator character for this revision
+         * @return terminator character ('\n' for rev1, '#' for rev2)
+         */
+        virtual char getCommandTerminator() const = 0;
+
+        /**
+         * @brief Set up communication parameters for this revision
+         * @param portFD file descriptor for the serial port
+         */
+        virtual void setupCommunication(int portFD) = 0;
+};
+
+/**
+ * @brief Concrete adapter implementation for Gemini Flatpanel Revision 1 firmware
+ *
+ * This adapter handles the specific protocol and commands for revision 1 devices:
+ * - Command format: >X000# (no value) or >XNNN# (3-digit padded value)
+ * - Command terminator: '\n'
+ * - Response format: *Xnnn with 3-digit zero-padded numeric values
+ * - Limited features: no beep, no brightness mode selection
+ */
+class GeminiFlatpanelRev1Adapter : public GeminiFlatpanelAdapter
+{
+    private:
+        int portFD;
+
+        // Internal helper methods for Rev1 protocol
+
+        /**
+         * @brief Format a command according to Rev1 protocol
+         * @param commandLetter the command character (B, L, D, etc.)
+         * @param commandString buffer to store the formatted command
+         * @param value optional value to include (NO_VALUE if not needed)
+         * @return true if successful, false otherwise
+         */
+        bool formatCommand(char commandLetter, char *commandString, int value = NO_VALUE);
+
+        /**
+         * @brief Send a command to the device and receive response
+         * @param command command string to send
+         * @param response buffer to store response (can be nullptr if no response expected)
+         * @param timeout timeout in seconds
+         * @param log whether to log errors
+         * @return true if successful, false otherwise
+         */
+        bool sendCommand(const char *command, char *response, int timeout = SERIAL_TIMEOUT_SEC, bool log = true);
+
+        /**
+         * @brief Extract integer value from Rev1 response format
+         * @param response response string from device
+         * @param startPos position to start extracting from
+         * @param value pointer to store extracted value
+         * @return true if successful, false otherwise
+         */
+        bool extractIntValue(const char *response, int startPos, int *value);
+
+    public:
+        GeminiFlatpanelRev1Adapter() : portFD(-1) {}
+
+        // Device detection and identification
+        bool ping() override;
+        int getRevision() const override
+        {
+            return GEMINI_REVISION_1;
+        }
+        bool getFirmwareVersion(int *version) override;
+
+        // Capability checks
+        bool supportsBeep() const override
+        {
+            return false;
+        }
+        bool supportsDustCap() const override
+        {
+            return true;
+        }
+        bool supportsBrightnessMode() const override
+        {
+            return false;
+        }
+
+        // Basic device commands
+        bool getConfigStatus(int *status) override;
+        bool getBrightness(int *brightness) override;
+        bool setBrightness(int value) override;
+        bool lightOn() override;
+        bool lightOff() override;
+        bool openCover() override;
+        bool closeCover() override;
+        bool getStatus(int *coverStatus, int *lightStatus, int *motorStatus) override;
+
+        // Motion/calibration commands
+        bool move(uint16_t value, int direction) override;
+        bool setClosePosition() override;
+        bool setOpenPosition() override;
+
+        // Advanced commands (not supported by Rev1)
+        bool setBeep(bool enable) override
+        {
+            (void)enable;    // Not supported
+            return false;
+        }
+        bool setBrightnessMode(int mode) override
+        {
+            (void)mode;    // Not supported
+            return false;
+        }
+
+        // Communication setup
+        char getCommandTerminator() const override
+        {
+            return '\n';
+        }
+        void setupCommunication(int portFD) override
+        {
+            this->portFD = portFD;
+        }
+};
+
+/**
+ * @brief Concrete adapter implementation for Gemini Flatpanel Revision 2 firmware
+ *
+ * This adapter handles the specific protocol and commands for revision 2 devices:
+ * - Command format: >X# (no value) or >Xnnn# (with value, no padding)
+ * - Command terminator: '#'
+ * - Response format: *X<variable_length_number># or *X<text>#
+ * - Enhanced features: beep control, brightness mode selection
+ * - Firmware version reporting
+ */
+class GeminiFlatpanelRev2Adapter : public GeminiFlatpanelAdapter
+{
+    private:
+        int portFD;
+
+        // Internal helper methods for Rev2 protocol
+
+        /**
+         * @brief Format a command according to Rev2 protocol
+         * @param commandLetter the command character (B, L, D, etc.)
+         * @param commandString buffer to store the formatted command
+         * @param value optional value to include (NO_VALUE if not needed)
+         * @return true if successful, false otherwise
+         */
+        bool formatCommand(char commandLetter, char *commandString, int value = NO_VALUE);
+
+        /**
+         * @brief Send a command to the device and receive response
+         * @param command command string to send
+         * @param response buffer to store response (can be nullptr if no response expected)
+         * @param timeout timeout in seconds
+         * @param log whether to log errors
+         * @return true if successful, false otherwise
+         */
+        bool sendCommand(const char *command, char *response, int timeout = SERIAL_TIMEOUT_SEC, bool log = true);
+
+        /**
+         * @brief Extract integer value from Rev2 response format
+         * @param response response string from device
+         * @param startPos position to start extracting from
+         * @param value pointer to store extracted value
+         * @return true if successful, false otherwise
+         */
+        bool extractIntValue(const char *response, int startPos, int *value);
+
+    public:
+        GeminiFlatpanelRev2Adapter() : portFD(-1) {}
+
+        // Device detection and identification
+        bool ping() override;
+        int getRevision() const override
+        {
+            return GEMINI_REVISION_2;
+        }
+        bool getFirmwareVersion(int *version) override;
+
+        // Capability checks
+        bool supportsBeep() const override
+        {
+            return true;
+        }
+        bool supportsDustCap() const override
+        {
+            return true;
+        }
+        bool supportsBrightnessMode() const override
+        {
+            return true;
+        }
+
+        // Basic device commands
+        bool getConfigStatus(int *status) override;
+        bool getBrightness(int *brightness) override;
+        bool setBrightness(int value) override;
+        bool lightOn() override;
+        bool lightOff() override;
+        bool openCover() override;
+        bool closeCover() override;
+        bool getStatus(int *coverStatus, int *lightStatus, int *motorStatus) override;
+
+        // Motion/calibration commands
+        bool move(uint16_t value, int direction) override;
+        bool setClosePosition() override;
+        bool setOpenPosition() override;
+
+        // Advanced commands (fully supported by Rev2)
+        bool setBeep(bool enable) override;
+        bool setBrightnessMode(int mode) override;
+
+        // Communication setup
+        char getCommandTerminator() const override
+        {
+            return '#';
+        }
+        void setupCommunication(int portFD) override
+        {
+            this->portFD = portFD;
+        }
+};
+
+/**
+ * @brief Concrete adapter implementation for Gemini Flatpanel Lite firmware
+ *
+ * This adapter handles the specific protocol and commands for Lite devices:
+ * - Command format: >X# (no value) or >Xnnn# (with value)
+ * - Command terminator: '#'
+ * - Response format: *X<variable_length_number># or *X<text>#
+ * - Features: light control, beep control, brightness mode selection
+ * - No dust cap/motor support (lite version is not motorized)
+ */
+class GeminiFlatpanelLiteAdapter : public GeminiFlatpanelAdapter
+{
+    private:
+        int portFD;
+
+        // Internal helper methods for Lite protocol
+
+        /**
+         * @brief Format a command according to Lite protocol
+         * @param commandLetter the command character (B, L, D, etc.)
+         * @param commandString buffer to store the formatted command
+         * @param value optional value to include (NO_VALUE if not needed)
+         * @return true if successful, false otherwise
+         */
+        bool formatCommand(char commandLetter, char *commandString, int value = NO_VALUE);
+
+        /**
+         * @brief Send a command to the device and receive response
+         * @param command command string to send
+         * @param response buffer to store response (can be nullptr if no response expected)
+         * @param timeout timeout in seconds
+         * @param log whether to log errors
+         * @return true if successful, false otherwise
+         */
+        bool sendCommand(const char *command, char *response, int timeout = SERIAL_TIMEOUT_SEC, bool log = true);
+
+        /**
+         * @brief Extract integer value from Lite response format
+         * @param response response string from device
+         * @param startPos position to start extracting from
+         * @param value pointer to store extracted value
+         * @return true if successful, false otherwise
+         */
+        bool extractIntValue(const char *response, int startPos, int *value);
+
+    public:
+        GeminiFlatpanelLiteAdapter() : portFD(-1) {}
+
+        // Device detection and identification
+        bool ping() override;
+        int getRevision() const override
+        {
+            return GEMINI_REVISION_LITE;
+        }
+        bool getFirmwareVersion(int *version) override;
+
+        // Capability checks
+        bool supportsBeep() const override
+        {
+            return true;
+        }
+        bool supportsDustCap() const override
+        {
+            return false;    // Lite version is not motorized
+        }
+        bool supportsBrightnessMode() const override
+        {
+            return true;
+        }
+
+        // Basic device commands
+        bool getConfigStatus(int *status) override;
+        bool getBrightness(int *brightness) override;
+        bool setBrightness(int value) override;
+        bool lightOn() override;
+        bool lightOff() override;
+        bool openCover() override;   // Not supported, always returns false
+        bool closeCover() override;  // Not supported, always returns false
+        bool getStatus(int *coverStatus, int *lightStatus, int *motorStatus) override;
+
+        // Motion/calibration commands (not supported by Lite)
+        bool move(uint16_t value, int direction) override
+        {
+            (void)value;
+            (void)direction;
+            return false;
+        }
+        bool setClosePosition() override
+        {
+            return false;
+        }
+        bool setOpenPosition() override
+        {
+            return false;
+        }
+
+        // Advanced commands (fully supported by Lite)
+        bool setBeep(bool enable) override;
+        bool setBrightnessMode(int mode) override;
+
+        // Communication setup
+        char getCommandTerminator() const override
+        {
+            return '#';
+        }
+        void setupCommunication(int portFD) override
+        {
+            this->portFD = portFD;
+        }
+};
+
+/**
+ * @brief Simulation adapter for testing and development
+ *
+ * This adapter simulates device behavior without requiring actual hardware.
+ * It can simulate either Rev1 or Rev2 features based on configuration.
+ */
+class GeminiFlatpanelSimulationAdapter : public GeminiFlatpanelAdapter
+{
+    public:
+        GeminiFlatpanelSimulationAdapter(bool simulateRev2Features = true);
+
+        // Device detection and identification
+        bool ping() override;
+        int getRevision() const override;
+        bool getFirmwareVersion(int *version) override;
+
+        // Capability checks
+        bool supportsBeep() const override;
+        bool supportsDustCap() const override;
+        bool supportsBrightnessMode() const override;
+
+        // Basic device commands
+        bool getConfigStatus(int *status) override;
+        bool getBrightness(int *brightness) override;
+        bool setBrightness(int value) override;
+        bool lightOn() override;
+        bool lightOff() override;
+        bool openCover() override;
+        bool closeCover() override;
+        bool getStatus(int *coverStatus, int *lightStatus, int *motorStatus) override;
+
+        // Motion/calibration commands
+        bool move(uint16_t value, int direction) override;
+        bool setClosePosition() override;
+        bool setOpenPosition() override;
+
+        // Advanced commands
+        bool setBeep(bool enable) override;
+        bool setBrightnessMode(int mode) override;
+
+        // Communication setup
+        char getCommandTerminator() const override;
+        void setupCommunication(int portFD) override;
+
+    private:
+        // Simulation state
+        enum SimulationIndex
+        {
+            SIM_MOTOR = 0,
+            SIM_LIGHT,
+            SIM_COVER,
+            SIM_BRIGHTNESS,
+            SIM_CONFIG_STATUS,
+            SIM_BEEP_ENABLED,
+            SIM_BRIGHTNESS_MODE,
+            SIM_N
+        };
+
+        int simulationValues[SIM_N];
+        bool simulateRev2Features;
+        int simulatedRevision;
+        int simulatedFirmwareVersion;
+};


### PR DESCRIPTION
# Refactor Gemini Flatpanel driver

## Summary
Complete refactor of the Gemini Flatpanel driver using an adapter pattern to support multiple firmware revisions while maintaining backward compatibility.
- Fully backward compatible with existing Rev1 and Rev2 devices
- Forward compatible for future firmware revisions
- Preserves user configurations and settings

## Key Changes

**Architecture**
- Implemented adapter pattern with `GeminiFlatpanelAdapter` base class
- Separated device communication from UI logic
- Clean protocol abstraction for different firmware revisions

**Multi-Device Support** 
- Rev1 adapter: Original firmware (`>X000#` format, `\n` terminator)
- Rev2 adapter: Enhanced firmware (`>X#` format, `#` terminator) 
- Lite adapter: Non-motorized variant with light control only
- Auto-detection with manual override option in Connection tab

**Testing**
- Comprehensive simulation adapter supporting Rev1/Rev2 features
- Hardware-independent testing capabilities

## Files Changed
- **Modified**: `gemini_flatpanel.cpp`, `gemini_flatpanel.h`, `CMakeLists.txt`
- **Added**: `gemini_flatpanel_adapters.h`, `gemini_flatpanel_adapters.cpp`

This refactor improves maintainability while adding support for new device variants and enhanced functionality.