### PR TITLE
Added check for lightbox capabilities in LI::updateProperties()

### DIFF
--- a/libs/indibase/indilightboxinterface.cpp
+++ b/libs/indibase/indilightboxinterface.cpp
@@ -89,7 +89,7 @@ bool LightBoxInterface::updateProperties()
     if (m_DefaultDevice->isConnected())
     {
         m_DefaultDevice->defineProperty(LightSP);
-        if (m_Capabilities & 0b1)
+        if (m_Capabilities & CAN_DIM)
             m_DefaultDevice->defineProperty(LightIntensityNP);
         if (!FilterIntensityNP.isEmpty())
             m_DefaultDevice->defineProperty(FilterIntensityNP);
@@ -97,7 +97,7 @@ bool LightBoxInterface::updateProperties()
     else
     {
         m_DefaultDevice->deleteProperty(LightSP);
-        if (m_Capabilities & 0b1)
+        if (m_Capabilities & CAN_DIM)
             m_DefaultDevice->deleteProperty(LightIntensityNP);
 
         if (!FilterIntensityNP.isEmpty())


### PR DESCRIPTION
Added a check whether the lightbox has the CAN_DIM capability set to 1, since before all lightboxes (even those that couldn't dim) had the Brightness property in the driver.