### PR TITLE
Separate build of drivers base classes from drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,9 @@ set(PKG_CONFIG_LIBDIR ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 # ####################################  Build Options  ##############################################
 # Select which components to build and what options to apply
 OPTION(INDI_BUILD_SERVER "Build INDI Server" ON)
-OPTION(INDI_BUILD_DRIVERS "Build INDI Drivers, Tools, and Examples" ON)
 OPTION(INDI_BUILD_CLIENT "Build INDI POSIX Client" ON)
+OPTION(INDI_BUILD_DRIVERS "Build INDI Drivers, Tools, and Examples" ON)
+OPTION(INDI_BUILD_COMMON "Build base classes for INDI 3rd Party Drivers" ON)
 OPTION(INDI_BUILD_QT5_CLIENT "Build INDI Qt5 Client" OFF)
 OPTION(INDI_BUILD_UNITTESTS "Build INDI tests" OFF)
 OPTION(INDI_BUILD_INTEGTESTS "Build INDI integration tests" OFF)
@@ -274,7 +275,10 @@ endif(INDI_BUILD_QT5_CLIENT)
 # N.B. Webcam drivers only supported under Linux (Video4Linux2). Joystick support only under Linux
 #
 # ##################################################################################################
-if(INDI_BUILD_DRIVERS)
+
+
+if(INDI_BUILD_DRIVERS OR INDI_BUILD_COMMON)
+    # part required for both drivers supplied by INDI and for 3rd party drivers
     if(WIN32 OR ANDROID)
         message(WARNING "INDI drivers are only supported under Linux, BSD, MacOS, and Cygwin while current system is " ${CMAKE_SYSTEM_NAME})
     else(WIN32 OR ANDROID)
@@ -313,7 +317,6 @@ if(INDI_BUILD_DRIVERS)
         include_directories(libs/indidevice/property)
         include_directories(${CMAKE_CURRENT_BINARY_DIR}/libs/indicore)
 
-
         configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config-usb.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/config-usb.h)
 
         add_subdirectory(libs/eventloop)
@@ -331,11 +334,14 @@ if(INDI_BUILD_DRIVERS)
         # #################################################
         add_subdirectory(libs/alignment)
 
-        # #################################################
-        # ########## INDI Drivers #########################
-        # #################################################
-        add_subdirectory(drivers)
-        install(FILES drivers.xml ${CMAKE_CURRENT_SOURCE_DIR}/drivers/focuser/indi_tcfs_sk.xml DESTINATION ${DATA_INSTALL_DIR})
+        # drivers directly supplied by INDI
+        if(INDI_BUILD_DRIVERS)
+            # #################################################
+            # ########## INDI Drivers #########################
+            # #################################################
+            add_subdirectory(drivers)
+            install(FILES drivers.xml ${CMAKE_CURRENT_SOURCE_DIR}/drivers/focuser/indi_tcfs_sk.xml DESTINATION ${DATA_INSTALL_DIR})
+        endif()
 
         # ####################################
         # ########### INDI TOOLS #############
@@ -392,7 +398,7 @@ if(INDI_BUILD_DRIVERS)
             message(STATUS "GTEST not found, not building tests")
         endif(GTEST_FOUND AND BUILD_TESTING)
     endif(WIN32 OR ANDROID)
-endif(INDI_BUILD_DRIVERS)
+endif(INDI_BUILD_DRIVERS OR INDI_BUILD_COMMON)
 
 # ##################################################################################################
 # ######################################  config.h  ################################################


### PR DESCRIPTION
A new build switch INDI_BUILD_COMMON is introduced so that base classes required for 3rd party drivers could be compiled and deployed separately and are not longer part of INDI_BUILD_DRIVERS.