### PR TITLE
Add USB ports parameter to initProperties comment

### DIFF
--- a/libs/indibase/indipowerinterface.h
+++ b/libs/indibase/indipowerinterface.h
@@ -152,6 +152,7 @@ class PowerInterface
          * \param nDewPorts Number of DEW/Dew heater ports
          * \param nVariablePorts Number of variable voltage ports
          * \param nAutoDewPorts Number of Auto Dew ports
+         * \param nUSBPorts Number of USB ports
          */
         void initProperties(const char *groupName, size_t nPowerPorts = 0, size_t nDewPorts = 0, size_t nVariablePorts = 0,
                             size_t nAutoDewPorts = 0, size_t nUSBPorts = 0);


### PR DESCRIPTION
The USBPorts parameter was missing from the comment brief