### PR TITLE
Add Weather Interface support to WandererBoxPlusV3 and WandererBoxProV3

### DIFF
--- a/drivers/auxiliary/wandererbox_plus_v3.h
+++ b/drivers/auxiliary/wandererbox_plus_v3.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "defaultdevice.h"
+#include "indiweatherinterface.h"
 #include <vector>
 #include <stdint.h>
 
@@ -33,7 +34,7 @@ namespace Connection
 class Serial;
 }
 
-class WandererBoxPlusV3 : public INDI::DefaultDevice
+class WandererBoxPlusV3 : public INDI::DefaultDevice, public INDI::WeatherInterface
 {
 public:
     WandererBoxPlusV3();
@@ -50,6 +51,7 @@ protected:
     const char *getDefaultName() override;
     virtual bool saveConfigItems(FILE *fp) override;
     virtual void TimerHit() override;
+    virtual IPState updateWeather() override;
 
 
 private:
@@ -59,7 +61,8 @@ private:
     bool DC3DIFFMODE=false;
     bool DC3CONSTMODE=false;
     bool getData();
-    static constexpr const char *ENVIRONMENT_TAB {"Sensors"};
+    static constexpr const char *ENVIRONMENT_TAB {"Environment"};
+    static constexpr const char *SENSORS_TAB {"Sensors"};
     static constexpr const char *DC3_TAB {"DC3"};
     //Current Calibrate
     INDI::PropertySwitch CalibrateSP{1};

--- a/drivers/auxiliary/wandererbox_pro_v3.h
+++ b/drivers/auxiliary/wandererbox_pro_v3.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "defaultdevice.h"
+#include "indiweatherinterface.h"
 #include <vector>
 #include <stdint.h>
 
@@ -33,7 +34,7 @@ namespace Connection
 class Serial;
 }
 
-class WandererBoxProV3 : public INDI::DefaultDevice
+class WandererBoxProV3 : public INDI::DefaultDevice, public INDI::WeatherInterface
 {
 public:
     WandererBoxProV3();
@@ -50,6 +51,7 @@ protected:
     const char *getDefaultName() override;
     virtual bool saveConfigItems(FILE *fp) override;
     virtual void TimerHit() override;
+    virtual IPState updateWeather() override;
 
 
 private:
@@ -63,7 +65,8 @@ private:
     bool DC7DIFFMODE=false;
     bool DC7CONSTMODE=false;
     bool getData();
-    static constexpr const char *ENVIRONMENT_TAB {"Sensors"};
+    static constexpr const char *ENVIRONMENT_TAB {"Environment"};
+    static constexpr const char *SENSORS_TAB {"Sensors"};
     static constexpr const char *DC5_TAB {"DC5"};
     static constexpr const char *DC6_TAB {"DC6"};
     static constexpr const char *DC7_TAB {"DC7"};


### PR DESCRIPTION
- Implemented INDI::WeatherInterface in both WandererBoxPlusV3 and WandererBoxProV3 classes.
- Updated initProperties to include weather parameters: temperature, humidity, and dew point.
- Enhanced updateENV method to calculate and set weather parameters.
- Modified property management to handle weather interface updates.
- Refactored code for clarity and consistency in handling environment and weather data.