### PR TITLE
Avoid copying over build ...

### DIFF
--- a/scripts/indi-core-deb.sh
+++ b/scripts/indi-core-deb.sh
@@ -17,7 +17,10 @@ INDI_SRCS=$(dirname $(realpath $0))/..
 rm -rf build/deb_indi-core
 mkdir -p build/deb_indi-core
 pushd build/deb_indi-core
-cp -r ${INDI_SRCS}/* ./
+for x in "${INDI_SRCS}"/*; do
+    [ "$(basename "$x")" = "build" ] && continue
+    cp -r "$x" ./
+done
 fakeroot debian/rules -j$(($(nproc)+1)) binary
 pwd
 popd


### PR DESCRIPTION
if running from the indi directory itself, this line is problematic as it tries to copy over build ... 

Attempt to avoid this. 

Another working solution with rsync would be 

if [ -d "$INDI_SRCS" ]; then 
  rsync -a --exclude 'build' "$INDI_SRCS"/ ./ 
fi