### PR TITLE
Redefine rotation angles of guide simulator and correct label for camera rotation offset

### DIFF
--- a/drivers/ccd/guide_simulator.h
+++ b/drivers/ccd/guide_simulator.h
@@ -125,6 +125,7 @@ class GuideSim : public INDI::CCD
         float m_OAGoffset { 0 };
         double m_RotationCW { 0 };
         float m_TimeFactor { 1 };
+        double m_RotationOffset { 0 };
 
         bool m_SimulateRGB { false };
 


### PR DESCRIPTION
Small refactor of  rotation angles of the guide simulator, so as to make the guide simulator work with  MR "calibration reuse" in KStars.