### PR TITLE
Fixing return to idle after RA move in arduino_st4.cpp

### DIFF
--- a/drivers/auxiliary/arduino_st4.cpp
+++ b/drivers/auxiliary/arduino_st4.cpp
@@ -225,13 +225,13 @@ void ArduinoST4::guideTimeout(ARDUINO_DIRECTION direction)
     {
         if (sendCommand("RA0#"))
         {
-            GuideNSNP.setState(IPS_IDLE);
+            GuideWENP.setState(IPS_IDLE);
             LOG_DEBUG("Guiding: RA axis stopped.");
         }
         else
         {
             LOG_ERROR("Failed to stop RA axis.");
-            GuideNSNP.setState(IPS_ALERT);
+            GuideWENP.setState(IPS_ALERT);
         }
 
         GuideWENP[0].setValue(0);


### PR DESCRIPTION
Fix return to IDLE after stopping RA move. 
There was a mistake of name: GuideNSNP instead of GuideWENP
So the client (PHD2 in my case) never get a state=idle and freeze forever waiting it.
I compiled the driver with this changes and indiserver 2.1.7, it works fine this way.