### PR TITLE
Prevending Redefinition of Header Files

### DIFF
--- a/libs/indicore/indiapi.h
+++ b/libs/indicore/indiapi.h
@@ -1,3 +1,6 @@
+#ifndef _INDIAPI_H
+#define _INDIAPI_H
+
 #if 0
 INDI
 Copyright (C) 2003 Elwood C. Downey
@@ -510,4 +513,6 @@ extern "C" {
 // FIXME: duplicated from indidevapi.h. Can we share ?
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/libs/indicore/indidevapi.h
+++ b/libs/indicore/indidevapi.h
@@ -1,3 +1,6 @@
+#ifndef _INDIDEVAPI_H
+#define _INDIDEVAPI_H
+
 /** INDI
  *  Copyright (C) 2003 - 2006 Elwood C. Downey
  *
@@ -831,4 +834,6 @@ extern void xmlv1();
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif


### PR DESCRIPTION
I found some cases the other day where building software based on libindi caused redefinition issues with the INDIAPI and INDIDEVAPI header files.  "#Pragma Once" should usually take care of this issue, but since these header files include defined structs, it seems it is not always enough.  This change seemed to fix the error.