### PR TITLE
Improves support for the Pegasus PowerBox Micro (PPBM) when used with the `indi_pegasus_ppba` driver.

### DIFF
--- a/drivers/power/pegasus_ppba.h
+++ b/drivers/power/pegasus_ppba.h
@@ -30,6 +30,7 @@
 #include "indipowerinterface.h"
 
 #include <vector>
+#include <string>
 #include <stdint.h>
 
 namespace Connection
@@ -239,12 +240,23 @@ class PegasusPPBA : public INDI::DefaultDevice, public INDI::FocuserInterface, p
         /// Firmware
         ////////////////////////////////////////////////////////////////////////////////////
 
-        INDI::PropertyText FirmwareTP {2};
+        INDI::PropertyText FirmwareTP {3};
         enum
         {
             FIRMWARE_VERSION,
             FIRMWARE_UPTIME,
+            FIRMWARE_DEVICE_TYPE,
         };
+
+        // Quad Output On/Off buttons (shown in Power tab — replaces PI's single checkbox)
+        INDI::PropertySwitch QuadOutputSP {2};
+        // Quad Output On/Off buttons duplicated in Main Control tab
+        INDI::PropertySwitch QuadOutputMainSP {2};
+        // Power sensors (Voltage / Current / Power) mirrored in Main Control tab
+        INDI::PropertyNumber MainSensorsNP {3};
+
+        // Device type string extracted from handshake response (e.g. "PPBA", "PPBM")
+        std::string m_DeviceType {"PPBA"};
 
         std::vector<std::string> lastSensorData;
         std::vector<std::string> lastConsumptionData;


### PR DESCRIPTION
__Changes__

- `Handshake()` now extracts the device model from the handshake response (`PPBA_OK` → `PPBA`, `PPBM_OK` → `PPBM`). The detected type is shown in a new "Device Type" row in the Firmware tab, and in the connection log message.
- The `POWER_CHANNELS` single-toggle checkbox from `PI::PowerInterface` is replaced by a two-button __On / Off__ `ISR_1OFMANY` switch (`QUAD_OUTPUT`) in the Power tab — consistent with the LED control style and clearer to use.
- An identical __Quad Output On/Off__ control and a live __Power (Voltage / Current / Power)__ readout are added to the __Main Control__ tab, so the most-used controls are immediately visible without tab-switching.
- Both On/Off controls stay in sync with each other and with the internal `PI::PowerChannelsSP` state.

__Tested__ against PPBM firmware 2.7 connected via USB serial.
