### PR TITLE
weatherflow: fix observations endpoint and HTTP port

### DIFF
--- a/drivers/weather/weatherflow.cpp
+++ b/drivers/weather/weatherflow.cpp
@@ -293,16 +293,9 @@ bool WeatherFlow::fetchCurrentObservations()
     std::string response;
     std::string endpoint;
 
-    if (!m_deviceID.empty())
-    {
-        // Use device-specific observations if device ID is available
-        endpoint = DEVICE_OBSERVATIONS_ENDPOINT + "?device_id=" + m_deviceID + "&token=" + wfAPIKeyTP[0].getText();
-    }
-    else
-    {
-        // Use station observations
-        endpoint = OBSERVATIONS_ENDPOINT + m_stationID + "?token=" + wfAPIKeyTP[0].getText();
-    }
+    // Always use station observations: the device endpoint returns arrays, not
+    // key-value objects, so named fields like barometric_pressure are not parseable.
+    endpoint = OBSERVATIONS_ENDPOINT + m_stationID + "?token=" + wfAPIKeyTP[0].getText();
 
     if (!makeAPIRequest(endpoint, response))
     {
@@ -415,7 +408,7 @@ bool WeatherFlow::makeAPIRequest(const std::string &endpoint, std::string &respo
     {
         try
         {
-            httplib::Client cli("swd.weatherflow.com", 443);
+            httplib::Client cli(API_HOST, 80);
             cli.set_connection_timeout(static_cast<int>(wfSettingsNP[WF_CONNECTION_TIMEOUT].getValue()));
             cli.set_read_timeout(static_cast<int>(wfSettingsNP[WF_CONNECTION_TIMEOUT].getValue()));
 

--- a/drivers/weather/weatherflow.h
+++ b/drivers/weather/weatherflow.h
@@ -107,10 +107,11 @@ class WeatherFlow : public INDI::Weather
         bool m_isConnected = false;
 
         // API configuration
-        const std::string API_BASE_URL = "https://swd.weatherflow.com/swd/rest/";
-        const std::string STATIONS_ENDPOINT = "stations";
-        const std::string OBSERVATIONS_ENDPOINT = "observations/station/";
-        const std::string DEVICE_OBSERVATIONS_ENDPOINT = "observations/";
+        // httplib::Client takes host and port separately from the request path.
+        const std::string API_HOST = "swd.weatherflow.com";
+        const std::string STATIONS_ENDPOINT = "/swd/rest/stations";
+        const std::string OBSERVATIONS_ENDPOINT = "/swd/rest/observations/station/";
+        const std::string DEVICE_OBSERVATIONS_ENDPOINT = "/swd/rest/observations/";
 
         // Rate limiting
         const int RATE_LIMIT_REQUESTS = 1000;


### PR DESCRIPTION
## Summary

- Fix 400 errors caused by connecting on port 443 with plain HTTP (httplib in this build has no SSL support); switch to port 80
- Always use the station observations endpoint instead of the device endpoint — the device endpoint returns `obs` as arrays of values, but the parser expects key-value objects with named fields, causing all weather values to read zero
- Replace `API_BASE_URL` with `API_HOST` for use in the `httplib::Client` constructor, and embed the `/swd/rest/` path prefix directly in the endpoint constants, consistent with how other INDI drivers construct httplib request paths

## Test plan

- [ ] Driver connects successfully and all weather values (temperature, humidity, pressure, wind, UV, etc.) read correctly
- [ ] No regression on station info fetch (`fetchStationInfo`)