### PR TITLE
Fix OnStep Sync() to notify clients immediately via EqNP/NewRaDec, matching base class LX200Telescope::Sync() behavior — prevents ~50s ALIGN_SYNCING stall in KStars/Ekos

### DIFF
--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -4991,6 +4991,9 @@ bool LX200_OnStep::Sync(double ra, double dec)
     currentRA  = ra;
     currentDEC = dec;
 
+    EqNP.setState(IPS_OK);
+    NewRaDec(currentRA, currentDEC);
+
     LOG_INFO("OnStep: Synchronization successful.");
     return true;
 }


### PR DESCRIPTION
Fix: Notify clients immediately after successful sync in OnStep driver

The OnStep Sync() override updated currentRA/currentDEC but never called
EqNP.setState(IPS_OK) or NewRaDec(), unlike the base class LX200Telescope::Sync().

This caused INDI clients (e.g. KStars/Ekos) to stall in ALIGN_SYNCING state
waiting for an EQUATORIAL_EOD_COORD property update that only arrived on the
next ReadScopeStatus() poll cycle, introducing delays of up to ~50 seconds.
