### PR TITLE
Fix HotPlugManager destroying connected devices during transient USB resets

### DIFF
--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -4991,6 +4991,9 @@ bool LX200_OnStep::Sync(double ra, double dec)
     currentRA  = ra;
     currentDEC = dec;
 
+    EqNP.setState(IPS_OK);
+    NewRaDec(currentRA, currentDEC);
+
     LOG_INFO("OnStep: Synchronization successful.");
     return true;
 }

--- a/libs/indibase/hotplugmanager.cpp
+++ b/libs/indibase/hotplugmanager.cpp
@@ -323,12 +323,21 @@ void HotPlugManager::checkHotPlugEvents()
         {
             if (currentConnected.find(identifier) == currentConnected.end())
             {
-                // Device disconnected
-                LOGF_DEBUG("HotPlugManager: Device disconnected: %s", identifier.c_str());
                 std::shared_ptr<DefaultDevice> deviceToRemove = managedDevices.at(identifier);
+
+                // If the device is currently connected to a client, skip removal.
+                // Some devices (e.g. ZWO ASI cameras) perform USB resets after each
+                // frame readout, causing them to transiently disappear from USB
+                // enumeration. Destroying a connected device in this window breaks
+                // all INDI clients (KStars, PHD2) that hold property references.
+                if (deviceToRemove->isConnected())
+                {
+                    LOGF_DEBUG("HotPlugManager: Device %s not found on USB but is connected to a client, skipping removal.", identifier.c_str());
+                    continue;
+                }
+
+                LOGF_DEBUG("HotPlugManager: Device disconnected: %s", identifier.c_str());
                 handler->destroyDevice(deviceToRemove);
-                // Note: The handler's internal map should be updated by destroyDevice or subsequent createDevice calls
-                // For std::deque, this means removing the element.
             }
         }
 


### PR DESCRIPTION
Some USB cameras (notably ZWO ASI) perform a USB bus reset after each frame readout as part of normal operation. The kernel reports this as a device disconnect/reconnect cycle (usb X-X.X.X: reset high-speed USB device), which triggers a udev event.

When the HotPlugManager's checkHotPlugEvents() runs during this brief window, discoverConnectedDeviceIdentifiers() (which calls ASIGetNumOfConnectedCameras()) does not see the camera on the bus. The manager treats this as a genuine disconnection and calls destroyDevice(), which:

1) Calls Disconnect() on the device
2) Calls deleteProperty(nullptr), removing all INDI properties from the server
3) Removes the device from the managed list

On the next poll cycle (typically 1 second later), the camera reappears and createDevice() builds a fresh device instance with new property definitions. However, any INDI clients that were connected (KStars/Ekos, PHD2, etc.) still hold references to the old properties. Every subsequent property update from the driver hits "Could not find property" errors, effectively breaking all client communication with the camera.

This is particularly problematic when PHD2 is used as an external guider alongside Ekos, as PHD2 maintains its own INDI client connection. The property cache invalidation causes PHD2 to fail to complete exposures, leading to camera disconnection timeouts and guiding failure.

The fix adds a check in checkHotPlugEvents(): if a managed device is not found on USB but is currently connected to a client (isConnected() returns true), skip the removal. The device will be cleaned up naturally when the INDI connection fails on the next I/O operation (in the case of a true physical disconnection), or will continue operating normally (in the case of a transient USB reset).

This fix applies to all drivers using the HotPlugManager (ASI, SVBony, PlayerOne, etc.).