### PR TITLE
telescope simulator: add INDI alignment integration, and robust Alt-Az support 

### DIFF
--- a/drivers/ccd/CMakeLists.txt
+++ b/drivers/ccd/CMakeLists.txt
@@ -3,6 +3,7 @@ SET(ccdsimulator_SRC
     ccd_simulator.cpp)
 
 add_executable(indi_simulator_ccd ${ccdsimulator_SRC})
+target_compile_definitions(indi_simulator_ccd PRIVATE USE_EQUATORIAL_PE)
 target_link_libraries(indi_simulator_ccd indidriver)
 install(TARGETS indi_simulator_ccd RUNTIME DESTINATION bin)
 

--- a/drivers/ccd/CMakeLists.txt
+++ b/drivers/ccd/CMakeLists.txt
@@ -12,6 +12,7 @@ SET(guidesimulator_SRC
     guide_simulator.cpp)
 
 add_executable(indi_simulator_guide ${guidesimulator_SRC})
+target_compile_definitions(indi_simulator_guide PRIVATE USE_EQUATORIAL_PE)
 target_link_libraries(indi_simulator_guide indidriver)
 install(TARGETS indi_simulator_guide RUNTIME DESTINATION bin)
 

--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -649,7 +649,14 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
         ImageScaley = Scaley;
 
 #ifdef USE_EQUATORIAL_PE
-        if (!usePE)
+        if (usePE)
+        {
+            // Use the true pointing position (Wallace errors applied) published as
+            // EQUATORIAL_PE by the telescope simulator.  raPE/decPE are J2000.
+            currentRA = raPE + guideWEOffset;
+            currentDE = decPE + guideNSOffset;
+        }
+        else
         {
 #endif
             currentRA  = RA;
@@ -673,11 +680,6 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
 
             currentRA  = J2000Pos.rightascension;
             currentDE = J2000Pos.declination;
-
-            //LOGF_DEBUG("DrawCcdFrame JNow %f, %f J2000 %f, %f", epochPos.ra, epochPos.dec, J2000Pos.ra, J2000Pos.dec);
-            //INDI::IEquatorialCoordinates jnpos;
-            //INDI::J2000toObserved(&J2000Pos, jd, &jnpos);
-            //LOGF_DEBUG("J2000toObserved JNow %f, %f J2000 %f, %f", jnpos.ra, jnpos.dec, J2000Pos.ra, J2000Pos.dec);
 
             currentDE += guideNSOffset;
             currentRA += guideWEOffset;
@@ -803,7 +805,7 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
 #ifdef __DEV__
                         if (rc == 1)
                         {
-                            LOGF_DEBUG("star %s scope %6.4f %6.4f star %6.4f %6.4f ccd %6.2f %6.2f", id, rad, decPE, ra, dec, ccdx, ccdy);
+                            LOGF_DEBUG("star %s scope %6.4f %6.4f star %6.4f %6.4f ccd %6.2f %6.2f", id, rad, currentDE, ra, dec, ccdx, ccdy);
                             LOGF_DEBUG("star %s ccd %6.2f %6.2f", id, ccdx, ccdy);
                         }
 #endif
@@ -1299,10 +1301,9 @@ bool CCDSim::watchDirectory()
 void CCDSim::activeDevicesUpdated()
 {
 #ifdef USE_EQUATORIAL_PE
-    IDSnoopDevice(ActiveDeviceT[0].text, "EQUATORIAL_PE");
-#else
-    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_PE");
 #endif
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
     IDSnoopDevice(ActiveDeviceTP[ACTIVE_FOCUSER].getText(), "FWHM");
 
     strncpy(FWHMNP.device, ActiveDeviceTP[ACTIVE_FOCUSER].getText(), MAXINDIDEVICE);
@@ -1357,12 +1358,11 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
             }
         }
     }
-    // We try to snoop EQPEC first, if not found, we snoop regular EQNP
+    // We try to snoop EQUATORIAL_PE first (true pointing with mount errors injected);
+    // if not found we fall through to the regular EQUATORIAL_EOD_COORD snoop below.
 #ifdef USE_EQUATORIAL_PE
-    const char * propName = findXMLAttValu(root, "name");
-    if (!strcmp(propName, EqPENP.name))
+    if (!strcmp(propName, "EQUATORIAL_PE"))
     {
-        XMLEle * ep = nullptr;
         int rc_ra = -1, rc_de = -1;
         double newra = 0, newdec = 0;
 
@@ -1376,22 +1376,19 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
                 rc_de = f_scansexa(pcdataXMLEle(ep), &newdec);
         }
 
-        if (rc_ra == 0 && rc_de == 0 && ((newra != raPE) || (newdec != decPE)))
+        if (rc_ra == 0 && rc_de == 0)
         {
-            INDI::IEquatorialCoordinates epochPos { 0, 0 }, J2000Pos { 0, 0 };
-            epochPos.ra  = newra * 15.0;
-            epochPos.dec = newdec;
-            ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
-            raPE  = J2000Pos.ra / 15.0;
-            decPE = J2000Pos.dec;
+            INDI::IEquatorialCoordinates epochPos { newra * 15.0, newdec }, J2000Pos { 0, 0 };
+            INDI::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
+            raPE  = J2000Pos.rightascension / 15.0;
+            decPE = J2000Pos.declination;
             usePE = true;
 
-            EqPEN[AXIS_RA].value = newra;
-            EqPEN[AXIS_DE].value = newdec;
-            IDSetNumber(&EqPENP, nullptr);
+            EqPENP[AXIS_RA].setValue(newra);
+            EqPENP[AXIS_DE].setValue(newdec);
+            EqPENP.apply();
 
-            LOGF_DEBUG("raPE %g  decPE %g Snooped raPE %g  decPE %g", raPE, decPE, newra, newdec);
-
+            LOGF_DEBUG("Snooped EQUATORIAL_PE JNow RA %g Dec %g -> J2000 RA %g Dec %g", newra, newdec, raPE, decPE);
             return true;
         }
     }

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -190,6 +190,8 @@ protected:
     double currentRA { 0 };
     double currentDE { 0 };
     bool usePE { false };
+    double raPE  { 0 };   // J2000 RA  from snooped EQUATORIAL_PE (hours)
+    double decPE { 0 };   // J2000 Dec from snooped EQUATORIAL_PE (degrees)
     time_t RunStart;
 
     float guideNSOffset {0};

--- a/drivers/ccd/guide_simulator.cpp
+++ b/drivers/ccd/guide_simulator.cpp
@@ -510,7 +510,14 @@ int GuideSim::DrawCcdFrame(INDI::CCDChip * targetChip)
         m_ImageScaleY = Scaley;
 
 #ifdef USE_EQUATORIAL_PE
-        if (!m_UsePE)
+        if (m_UsePE)
+        {
+            // Use the true pointing position (Wallace errors applied) published as
+            // EQUATORIAL_PE by the telescope simulator.  raPE/decPE are J2000.
+            m_CurrentRA  = raPE + m_GuideWEOffset;
+            m_CurrentDEC = decPE + m_GuideNSOffset;
+        }
+        else
         {
 #endif
             m_CurrentRA  = RA;
@@ -619,7 +626,7 @@ int GuideSim::DrawCcdFrame(INDI::CCDChip * targetChip)
             // tra, tdec are at the center of the projection center for the simulated
             // images
             //double J2ra = J2000Pos.ra;  // J2000Pos: 0,360, RA: 0,24
-            double J2dec = J2000Pos.declination;
+            double J2dec = m_CurrentDEC;
 
             //double J2rar = J2ra * DEGREES_TO_RADIANS;
             double J2decr = J2dec * DEGREES_TO_RADIANS;
@@ -1128,18 +1135,18 @@ bool GuideSim::ISNewSwitch(const char * dev, const char * name, ISState * states
 void GuideSim::activeDevicesUpdated()
 {
 #ifdef USE_EQUATORIAL_PE
-    IDSnoopDevice(ActiveDeviceTP[0].getText(), "EQUATORIAL_PE");
-#else
-    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_PE");
 #endif
+    IDSnoopDevice(ActiveDeviceTP[ACTIVE_TELESCOPE].getText(), "EQUATORIAL_EOD_COORD");
 }
 
 bool GuideSim::ISSnoopDevice(XMLEle * root)
 {
-    // We try to snoop EQPEC first, if not found, we snoop regular EQNP
+    // We try to snoop EQUATORIAL_PE first (true pointing with mount errors injected);
+    // if not found we fall through to the regular EQUATORIAL_EOD_COORD snoop below.
 #ifdef USE_EQUATORIAL_PE
     const char * propName = findXMLAttValu(root, "name");
-    if (!strcmp(propName, EqPENP.name))
+    if (!strcmp(propName, "EQUATORIAL_PE"))
     {
         XMLEle * ep = nullptr;
         int rc_ra = -1, rc_de = -1;
@@ -1155,21 +1162,19 @@ bool GuideSim::ISSnoopDevice(XMLEle * root)
                 rc_de = f_scansexa(pcdataXMLEle(ep), &newdec);
         }
 
-        if (rc_ra == 0 && rc_de == 0 && ((newra != raPE) || (newdec != decPE)))
+        if (rc_ra == 0 && rc_de == 0)
         {
-            INDI::IEquatorialCoordinates epochPos { 0, 0 }, J2000Pos { 0, 0 };
-            epochPos.ra  = newra * 15.0;
-            epochPos.dec = newdec;
-            ln_get_equ_prec2(&epochPos, ln_get_julian_from_sys(), JD2000, &J2000Pos);
-            raPE  = J2000Pos.ra / 15.0;
-            decPE = J2000Pos.dec;
+            INDI::IEquatorialCoordinates epochPos { newra * 15.0, newdec }, J2000Pos { 0, 0 };
+            INDI::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
+            raPE  = J2000Pos.rightascension / 15.0;
+            decPE = J2000Pos.declination;
             m_UsePE = true;
 
-            EqPEN[AXIS_RA].value = newra;
-            EqPEN[AXIS_DE].value = newdec;
-            IDSetNumber(&EqPENP, nullptr);
+            EqPENP[AXIS_RA].setValue(newra);
+            EqPENP[AXIS_DE].setValue(newdec);
+            EqPENP.apply();
 
-            LOGF_DEBUG("raPE %g  decPE %g Snooped raPE %g  decPE %g", raPE, decPE, newra, newdec);
+            LOGF_DEBUG("Snooped EQUATORIAL_PE JNow RA %g Dec %g -> J2000 RA %g Dec %g", newra, newdec, raPE, decPE);
 
             return true;
         }

--- a/drivers/ccd/guide_simulator.h
+++ b/drivers/ccd/guide_simulator.h
@@ -151,6 +151,8 @@ class GuideSim : public INDI::CCD
         double m_CurrentRA { 0 };
         double m_CurrentDEC { 0 };
         bool m_UsePE { false };
+        double raPE  { 0 };
+        double decPE { 0 };
         time_t m_RunStart;
         time_t m_LastSim;
         bool m_RunStartInitialized { false };

--- a/drivers/telescope/CMakeLists.txt
+++ b/drivers/telescope/CMakeLists.txt
@@ -241,7 +241,7 @@ add_executable(indi_simulator_telescope
     telescope_simulator.cpp
     scopesim_helper.cpp)
 
-target_link_libraries(indi_simulator_telescope indidriver)
+target_link_libraries(indi_simulator_telescope AlignmentDriver indidriver)
 
 install(TARGETS indi_simulator_telescope RUNTIME DESTINATION bin)
 

--- a/drivers/telescope/scopesim_helper.cpp
+++ b/drivers/telescope/scopesim_helper.cpp
@@ -25,6 +25,8 @@
 
 #include "indilogger.h"
 
+char device_str[64] = "Telescope Simulator";
+
 /////////////////////////////////////////////////////////////////////
 
 // Angle implementation
@@ -294,13 +296,22 @@ void Alignment::mountToApparentRaDec(Angle primary, Angle secondary, Angle * app
 
 void Alignment::mountToInstrumentHaDec(Angle primary, Angle secondary, Angle *instrumentHa, Angle *instrumentDec)
 {
-    // Replicate the axis-to-prio/seco step from mountToApparentHaDec, but stop before
-    // applying instrumentToObserved.  The result is the raw encoder HA/Dec — what the
-    // mount axis angles represent in the telescope coordinate system, without any
-    // Wallace pointing-model correction.
+    // Convert axis positions to equatorial HA/Dec without any Wallace pointing-model correction.
+    // For EQ mounts the axes are already in HA/Dec space; for ALTAZ we must apply the inverse
+    // spherical rotation (Az/Alt → HA/Dec) to match what apparentHaDecToMount does, but skip
+    // the instrumentToObserved step (which applies IH/ID/CH/NP).
     switch (mountType)
     {
         case MOUNT_TYPE::ALTAZ:
+        {
+            // primary = Az in scopesim convention (0=South), secondary = Alt.
+            // Undo the +180° offset, then rotate back from horizontal to equatorial.
+            Angle rot = latitude - Angle(90);  // inverse of rotateY(90 - lat)
+            Vector haDec = Vector(primary - Angle(180.0), secondary).rotateY(rot);
+            *instrumentHa  = haDec.primary();
+            *instrumentDec = haDec.secondary();
+            break;
+        }
         case MOUNT_TYPE::EQ_FORK:
             *instrumentDec = (latitude >= 0) ? secondary : -secondary;
             *instrumentHa  = primary;
@@ -320,6 +331,40 @@ void Alignment::mountToInstrumentHaDec(Angle primary, Angle secondary, Angle *in
             }
             break;
         }
+    }
+}
+
+void Alignment::instrumentHaDecToMount(Angle instrumentHa, Angle instrumentDec, Angle *primary, Angle *secondary)
+{
+    switch (mountType)
+    {
+        case MOUNT_TYPE::ALTAZ:
+        {
+            // Convert equatorial HA/Dec to Az/Alt via spherical rotation (no Wallace errors),
+            // mirroring apparentHaDecToMount but skipping the observedToInstrument step.
+            Vector altAzm = Vector(instrumentHa, instrumentDec).rotateY(Angle(90) - latitude);
+            *primary   = altAzm.primary() + Angle(180.0);  // scopesim Az: 0=South
+            *secondary = altAzm.secondary();
+            break;
+        }
+        case MOUNT_TYPE::EQ_FORK:
+            *primary   = instrumentHa;
+            *secondary = (latitude >= 0) ? instrumentDec : -instrumentDec;
+            break;
+        case MOUNT_TYPE::EQ_GEM:
+            if (instrumentHa < flipHourAngle)  // west side — same condition as apparentHaDecToMount
+            {
+                *primary   = instrumentHa + Angle(180);
+                *secondary = Angle(180) - instrumentDec;
+            }
+            else
+            {
+                *primary   = instrumentHa;
+                *secondary = instrumentDec;
+            }
+            if (latitude < 0)
+                *secondary = -*secondary;
+            break;
     }
 }
 

--- a/drivers/telescope/scopesim_helper.cpp
+++ b/drivers/telescope/scopesim_helper.cpp
@@ -269,8 +269,8 @@ void Alignment::mountToApparentHaDec(Angle primary, Angle secondary, Angle * app
     if (mountType == MOUNT_TYPE::ALTAZ)
     {
         Angle rot = latitude - Angle(90);
-        // apparentHa and apparentDec hold corrected Azimuth and Altitude.
-        // Convert Azimuth (0=North) back to scopesim convention (0=South) before forming Vector
+        // apparentHa and apparentDec hold corrected INDI Az and Altitude.
+        // Vector uses scopesim Az (0=South); subtract 180 deg to convert from INDI Az.
         Vector trueAzAlt(*apparentHa - Angle(180.0), *apparentDec);
         Vector haDec = trueAzAlt.rotateY(rot);
         // Primary instrument axis: Negative PA-system looking down from Zenith:Nadir, origin "HA-like" ...
@@ -304,8 +304,8 @@ void Alignment::mountToInstrumentHaDec(Angle primary, Angle secondary, Angle *in
     {
         case MOUNT_TYPE::ALTAZ:
         {
-            // primary = Az in scopesim convention (0=South), secondary = Alt.
-            // Undo the +180° offset, then rotate back from horizontal to equatorial.
+            // primary = INDI Az (0=North), secondary = Alt.
+            // Vector uses scopesim Az (0=South); subtract 180 deg before rotating to HA/Dec.
             Angle rot = latitude - Angle(90);  // inverse of rotateY(90 - lat)
             Vector haDec = Vector(primary - Angle(180.0), secondary).rotateY(rot);
             *instrumentHa  = haDec.primary();
@@ -342,8 +342,9 @@ void Alignment::instrumentHaDecToMount(Angle instrumentHa, Angle instrumentDec, 
         {
             // Convert equatorial HA/Dec to Az/Alt via spherical rotation (no Wallace errors),
             // mirroring apparentHaDecToMount but skipping the observedToInstrument step.
+            // Vector.primary() returns scopesim Az (0=South); add 180 deg to yield INDI Az (0=North).
             Vector altAzm = Vector(instrumentHa, instrumentDec).rotateY(Angle(90) - latitude);
-            *primary   = altAzm.primary() + Angle(180.0);  // scopesim Az: 0=South
+            *primary   = altAzm.primary() + Angle(180.0);  // INDI Az (0=North)
             *secondary = altAzm.secondary();
             break;
         }
@@ -376,8 +377,8 @@ void Alignment::apparentHaDecToMount(Angle apparentHa, Angle apparentDec, Angle*
         // rotate the apparent HaDec vector to the vertical
         // TODO sort out Southern Hemisphere
         Vector altAzm = Vector(apparentHa, apparentDec).rotateY(Angle(90) - latitude);
-        // azimuth in scopesim convention is 0° = South, increasing clockwise West→North→East
-        // INDI's IHorizontalCoordinates uses 0° = North.
+        // azimuth in scopesim convention is 0 deg = South, increasing clockwise West->North->East
+        // INDI's IHorizontalCoordinates uses 0 deg = North.
         Angle apparentAz = altAzm.primary() + Angle(180.0);
         Angle apparentAlt = altAzm.secondary();
 

--- a/drivers/telescope/scopesim_helper.cpp
+++ b/drivers/telescope/scopesim_helper.cpp
@@ -349,21 +349,25 @@ void Alignment::instrumentHaDecToMount(Angle instrumentHa, Angle instrumentDec, 
             break;
         }
         case MOUNT_TYPE::EQ_FORK:
+            // Primary instrument axis: HA (negative PA-system looking down to NCP:SCP)
+            // Secondary instrument axis: Dec (positive PA-system looking E)
             *primary   = instrumentHa;
             *secondary = (latitude >= 0) ? instrumentDec : -instrumentDec;
             break;
         case MOUNT_TYPE::EQ_GEM:
-            if (instrumentHa < flipHourAngle)  // west side — same condition as apparentHaDecToMount
+            if (instrumentHa < flipHourAngle)  // pierside west (looking east)
             {
-                *primary   = instrumentHa + Angle(180);
-                *secondary = Angle(180) - instrumentDec;
+                // Ha axis: Negative PA-system looking down from NCP:SCP, origin HA-like
+                // Dec axis: Positive PA-system looking at E, origin DEC-like
+                *primary   = instrumentHa + Angle(180);    // Ha to Primary: negative PA-system with origin opposite HA-like
+                *secondary = Angle(180) - instrumentDec;   // Dec to Secondary: positive PA-system with origin DEC-like
             }
             else
             {
-                *primary   = instrumentHa;
-                *secondary = instrumentDec;
+                *primary   = instrumentHa;    // Ha already rotated by 180
+                *secondary = instrumentDec;   // Dec already rotated by 180
             }
-            if (latitude < 0)
+            if (latitude < 0)  // southern hemisphere
                 *secondary = -*secondary;
             break;
     }
@@ -391,45 +395,13 @@ void Alignment::apparentHaDecToMount(Angle apparentHa, Angle apparentDec, Angle*
                     secondary->Degrees() );
         return; // Prevent fallthrough to equatorial override
     }
-    // Ha is negative PA-system looking down to NCP:SCP
-    // Dec is positive PA-system looking E
+    // EQ: apply Wallace pointing-model correction in HA/Dec space, then delegate axis mapping.
+    // (For ALTAZ the correction is applied in Az/Alt space above, before the early return.)
     Angle instrumentHa, instrumentDec;
-    // ignore diurnal aberrations and refractions to get observed ha, dec
-    // apply telescope pointing to get instrument
     observedToInstrument(apparentHa, apparentDec, &instrumentHa, &instrumentDec);
-
-    switch (mountType)
-    {
-        case MOUNT_TYPE::ALTAZ:
-            // Ha axis: Negative PA-system looking down to Zenith:Nadir pole, origin "HA-like"
-            // Dec axis: Positive PA-system looking at east, origin "DEC-like"
-            break;
-        case MOUNT_TYPE::EQ_FORK:
-            // Primary instrument axis: ??
-            // Secondary instrument axis: ??
-            *primary = instrumentHa;
-            *secondary = (latitude >= 0) ? instrumentDec : -instrumentDec;  // northern : southern hemisphere
-            break;
-        case MOUNT_TYPE::EQ_GEM:
-            if (instrumentHa < flipHourAngle)  // pierside west (looking east)
-            {
-                // Ha axis: Negative PA-system looking down from NCP:SCP, origin HA-like
-                // Dec axis: Positive PA-system looking at E, origin DEC-like
-                *primary = instrumentHa + Angle(180);    // Ha to Primary to get negative PA-system with origin opposite HA-like
-                *secondary = Angle(180) - instrumentDec; // Dec to Secondary to get positive PA-system with origin DEC-like
-            }
-            else
-            {
-                *primary = instrumentHa;    // Ha already rotated by 180, so no transformation to get origin opposite HA-like
-                *secondary = instrumentDec; // Dec already rotated by 180, so no transformation to get origin opposite DEC-like
-            }
-            if (latitude < 0)  // southern hemisphere
-                *secondary = -*secondary;
-            break;
-    }
-    if (mountType != MOUNT_TYPE::ALTAZ)
-        LOGF_EXTRA1("apparent HaDec to EQ: ha %f, dec %f to pri %f, sec %f", apparentHa.Degrees(), apparentDec.Degrees(), primary->Degrees(),
-                    secondary->Degrees() );
+    instrumentHaDecToMount(instrumentHa, instrumentDec, primary, secondary);
+    LOGF_EXTRA1("apparent HaDec to EQ: ha %f, dec %f to pri %f, sec %f", apparentHa.Degrees(), apparentDec.Degrees(), primary->Degrees(),
+                secondary->Degrees() );
 }
 
 void Alignment::apparentRaDecToMount(Angle apparentRa, Angle apparentDec, Angle* primary, Angle* secondary)

--- a/drivers/telescope/scopesim_helper.cpp
+++ b/drivers/telescope/scopesim_helper.cpp
@@ -292,6 +292,37 @@ void Alignment::mountToApparentRaDec(Angle primary, Angle secondary, Angle * app
                 apparentRa->Degrees(), apparentDec->Degrees());
 }
 
+void Alignment::mountToInstrumentHaDec(Angle primary, Angle secondary, Angle *instrumentHa, Angle *instrumentDec)
+{
+    // Replicate the axis-to-prio/seco step from mountToApparentHaDec, but stop before
+    // applying instrumentToObserved.  The result is the raw encoder HA/Dec — what the
+    // mount axis angles represent in the telescope coordinate system, without any
+    // Wallace pointing-model correction.
+    switch (mountType)
+    {
+        case MOUNT_TYPE::ALTAZ:
+        case MOUNT_TYPE::EQ_FORK:
+            *instrumentDec = (latitude >= 0) ? secondary : -secondary;
+            *instrumentHa  = primary;
+            break;
+        case MOUNT_TYPE::EQ_GEM:
+        {
+            Angle seco = (latitude >= 0) ? secondary : -secondary;
+            if (seco.Degrees() > 90 || seco.Degrees() < -90)
+            {
+                *instrumentHa  = primary + Angle(180.0);
+                *instrumentDec = Angle(180.0) - seco;
+            }
+            else
+            {
+                *instrumentHa  = primary;
+                *instrumentDec = seco;
+            }
+            break;
+        }
+    }
+}
+
 void Alignment::apparentHaDecToMount(Angle apparentHa, Angle apparentDec, Angle* primary, Angle* secondary)
 {
     // convert to Alt Azm first

--- a/drivers/telescope/scopesim_helper.h
+++ b/drivers/telescope/scopesim_helper.h
@@ -41,7 +41,7 @@
 
 #include <indicom.h>
 
-static char device_str[64] = "Telescope Simulator";
+extern char device_str[64];
 
 ///
 /// \brief The Angle class
@@ -501,6 +501,11 @@ class Alignment
         /// without applying the Wallace pointing-model corrections.
         ///
         void mountToInstrumentHaDec(Angle primary, Angle secondary, Angle *instrumentHa, Angle *instrumentDec);
+
+        // Inverse of mountToInstrumentHaDec: converts raw instrument HA/Dec (no Wallace) to
+        // axis positions.  Uses the same flipHourAngle condition as apparentHaDecToMount so
+        // it selects the correct pier side for a Goto without applying pointing corrections.
+        void instrumentHaDecToMount(Angle instrumentHa, Angle instrumentDec, Angle *primary, Angle *secondary);
 
         ///
         /// \brief apparentHaDecToMount

--- a/drivers/telescope/scopesim_helper.h
+++ b/drivers/telescope/scopesim_helper.h
@@ -441,6 +441,10 @@ class Alignment
         /// \param me
         ///
         void setCorrections(double ih, double id, double ch, double np, double ma, double me);
+        void setCorrections(double *coeffs)
+        {
+            setCorrections(coeffs[0], coeffs[1], coeffs[2], coeffs[3], coeffs[4], coeffs[5]);
+        }
 
         void setFlipHourAngle(double deg)
         {
@@ -491,6 +495,12 @@ class Alignment
         /// \param apparentDec
         ///
         void mountToApparentHaDec(Angle primary, Angle secondary, Angle *apparentHa, Angle *apparentDec);
+
+        ///
+        /// \brief mountToInstrumentHaDec: convert mount axis positions to instrument (encoder) HA/Dec
+        /// without applying the Wallace pointing-model corrections.
+        ///
+        void mountToInstrumentHaDec(Angle primary, Angle secondary, Angle *instrumentHa, Angle *instrumentDec);
 
         ///
         /// \brief apparentHaDecToMount

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -353,9 +353,21 @@ bool ScopeSim::ReadScopeStatus()
         double JDnow   = ln_get_julian_from_sys();
         double JDoffset = dt / 86400.0;
 
+        // RA drift rate relative to sidereal for the selected track mode, in hours/sec.
+        // Nudging RA at each parabola sample by the non-sidereal offset makes the
+        // derived Az/Alt rates correct for the track mode without changing the meaning
+        // of m_targetRA/Dec.  Mirrors EQ behaviour: RA is corrected, Dec is not.
+        int trackMode = TrackModeSP.findOnSwitchIndex();
+        double raDriftHrsPerSec = 0;
+        if (trackMode == TRACK_SOLAR)
+            raDriftHrsPerSec = (TRACKRATE_SIDEREAL - TRACKRATE_SOLAR) / 3600.0 / 15.0;
+        else if (trackMode == TRACK_LUNAR)
+            raDriftHrsPerSec = (TRACKRATE_SIDEREAL - TRACKRATE_LUNAR) / 3600.0 / 15.0;
+
         auto getAltAz = [&](double JD, INDI::IHorizontalCoordinates &coords)
         {
-            INDI::IEquatorialCoordinates eq { m_targetRA, m_targetDEC };
+            double dtFromNow = (JD - JDnow) * 86400.0;
+            INDI::IEquatorialCoordinates eq { m_targetRA + raDriftHrsPerSec * dtFromNow, m_targetDEC };
             INDI::EquatorialToHorizontal(&eq, &m_Location, JD, &coords);
         };
 

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -82,23 +82,14 @@ bool ScopeSim::initProperties()
     simPierSideSP.fill(getDeviceName(), "SIM_PIER_SIDE", "Sim Pier Side",
                        "Simulation", IP_WO, ISR_1OFMANY, 60, IPS_IDLE);
 
-    mountModelArcminNP[MM_IH].fill("MM_IH", "Ha Zero (IH) '", "%.1f", -10800, 10800, 0.1, 0);
-    mountModelArcminNP[MM_ID].fill("MM_ID", "Dec Zero (ID) '", "%.1f", -10800, 10800, 0.1, 0);
-    mountModelArcminNP[MM_CH].fill("MM_CH", "Cone (CH) '", "%.1f", -300, 300, 0.1, 0);
-    mountModelArcminNP[MM_NP].fill("MM_NP", "Ha/Dec (NP) '", "%.1f", -300, 300, 0.1, 0);
-    mountModelArcminNP[MM_MA].fill("MM_MA", "Pole Azm (MA) '", "%.1f", -300, 300, 0.1, 0);
-    mountModelArcminNP[MM_ME].fill("MM_ME", "Pole elev (ME) '", "%.1f", -300, 300, 0.1, 0);
-    mountModelArcminNP.fill(getDeviceName(), "MOUNT_MODEL_ARCMIN", "Mount Model",
-                            "Simulation", IP_RW, 0, IPS_IDLE);
-
-    mountModelNP[MM_IH].fill("MM_IH", "Ha Zero (IH) deg", "%g", -180, 180, 0.01, 0);
-    mountModelNP[MM_ID].fill("MM_ID", "Dec Zero (ID) deg", "%g", -180, 180, 0.01, 0);
-    mountModelNP[MM_CH].fill("MM_CH", "Cone (CH) deg", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_NP].fill("MM_NP", "Ha/Dec (NP) deg", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_MA].fill("MM_MA", "Pole Azm (MA) deg", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_ME].fill("MM_ME", "Pole elev (ME) deg", "%g", -5, 5, 0.01, 0);
-    mountModelNP.fill(getDeviceName(), "MOUNT_MODEL", "Mount Model (deg)",
-                      "Simulation", IP_RO, 0, IPS_IDLE);
+    mountModelNP[MM_IH].fill("MM_IH", "Ha Zero (IH) '", "%.1f", -10800, 10800, 0.1, 0);
+    mountModelNP[MM_ID].fill("MM_ID", "Dec Zero (ID) '", "%.1f", -10800, 10800, 0.1, 0);
+    mountModelNP[MM_CH].fill("MM_CH", "Cone (CH) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelNP[MM_NP].fill("MM_NP", "Ha/Dec (NP) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelNP[MM_MA].fill("MM_MA", "Pole Azm (MA) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelNP[MM_ME].fill("MM_ME", "Pole elev (ME) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelNP.fill(getDeviceName(), "MOUNT_MODEL", "Mount Model",
+                      "Simulation", IP_RW, 0, IPS_IDLE);
 
     flipHourAngleNP[0].fill("FLIP_HA", "Hour Angle (deg)", "%g", -20, 20, 0.1, 0);
     flipHourAngleNP.fill(getDeviceName(), "FLIP_HA", "Flip Posn.",
@@ -175,15 +166,11 @@ void ScopeSim::ISGetProperties(const char *dev)
     defineProperty(simPierSideSP);
     simPierSideSP.load();
     updateMountAndPierSide();
-    defineProperty(mountModelArcminNP);
-    mountModelArcminNP.load();
-    // Apply loaded arcmin values to the degrees mirror and alignment
-    for (int i = 0; i < 6; i++)
-        mountModelNP[i].setValue(mountModelArcminNP[i].getValue() / 60.0);
-    alignment.setCorrections(mountModelNP[MM_IH].getValue(), mountModelNP[MM_ID].getValue(),
-                             mountModelNP[MM_CH].getValue(), mountModelNP[MM_NP].getValue(),
-                             mountModelNP[MM_MA].getValue(), mountModelNP[MM_ME].getValue());
     defineProperty(mountModelNP);
+    mountModelNP.load();
+    alignment.setCorrections(mountModelNP[MM_IH].getValue() / 60.0, mountModelNP[MM_ID].getValue() / 60.0,
+                             mountModelNP[MM_CH].getValue() / 60.0, mountModelNP[MM_NP].getValue() / 60.0,
+                             mountModelNP[MM_MA].getValue() / 60.0, mountModelNP[MM_ME].getValue() / 60.0);
     defineProperty(mountAxisNP);
     defineProperty(flipHourAngleNP);
     flipHourAngleNP.load();
@@ -726,22 +713,18 @@ bool ScopeSim::ISNewNumber(const char *dev, const char *name, double values[], c
         }
 
 #ifdef USE_SIM_TAB
-        if (mountModelArcminNP.isNameMatch(name))
+        if (mountModelNP.isNameMatch(name))
         {
-            if (mountModelArcminNP.isUpdated(values, names, n))
+            if (mountModelNP.isUpdated(values, names, n))
             {
-                mountModelArcminNP.update(values, names, n);
-                for (int i = 0; i < 6; i++)
-                    mountModelNP[i].setValue(mountModelArcminNP[i].getValue() / 60.0);
-                alignment.setCorrections(mountModelNP[MM_IH].getValue(), mountModelNP[MM_ID].getValue(),
-                                         mountModelNP[MM_CH].getValue(), mountModelNP[MM_NP].getValue(),
-                                         mountModelNP[MM_MA].getValue(), mountModelNP[MM_ME].getValue());
-                mountModelNP.setState(IPS_OK);
-                mountModelNP.apply();
-                saveConfig(mountModelArcminNP);
+                mountModelNP.update(values, names, n);
+                alignment.setCorrections(mountModelNP[MM_IH].getValue() / 60.0, mountModelNP[MM_ID].getValue() / 60.0,
+                                         mountModelNP[MM_CH].getValue() / 60.0, mountModelNP[MM_NP].getValue() / 60.0,
+                                         mountModelNP[MM_MA].getValue() / 60.0, mountModelNP[MM_ME].getValue() / 60.0);
+                saveConfig(mountModelNP);
             }
-            mountModelArcminNP.setState(IPS_OK);
-            mountModelArcminNP.apply();
+            mountModelNP.setState(IPS_OK);
+            mountModelNP.apply();
             return true;
         }
 
@@ -880,23 +863,19 @@ bool ScopeSim::ISSnoopDevice(XMLEle *root)
                 // the physical delta correction applied to the mount.
                 double oldMA = mountModelNP[MM_MA].getValue();
                 double oldME = mountModelNP[MM_ME].getValue();
-                double newMA = oldMA + m_snoopedAzError;
-                double newME = oldME + m_snoopedAltError;
+                double newMA = oldMA + m_snoopedAzError * 60.0;
+                double newME = oldME + m_snoopedAltError * 60.0;
 
                 mountModelNP[MM_MA].setValue(newMA);
                 mountModelNP[MM_ME].setValue(newME);
-                mountModelArcminNP[MM_MA].setValue(newMA * 60.0);
-                mountModelArcminNP[MM_ME].setValue(newME * 60.0);
-                alignment.setCorrections(mountModelNP[MM_IH].getValue(), mountModelNP[MM_ID].getValue(),
-                                         mountModelNP[MM_CH].getValue(), mountModelNP[MM_NP].getValue(),
-                                         mountModelNP[MM_MA].getValue(), mountModelNP[MM_ME].getValue());
+                alignment.setCorrections(mountModelNP[MM_IH].getValue() / 60.0, mountModelNP[MM_ID].getValue() / 60.0,
+                                         mountModelNP[MM_CH].getValue() / 60.0, mountModelNP[MM_NP].getValue() / 60.0,
+                                         mountModelNP[MM_MA].getValue() / 60.0, mountModelNP[MM_ME].getValue() / 60.0);
 
                 mountModelNP.setState(IPS_OK);
                 mountModelNP.apply();
-                mountModelArcminNP.setState(IPS_OK);
-                mountModelArcminNP.apply();
 
-                LOGF_INFO("Applied PAC correction: MA %.4f -> %.4f, ME %.4f -> %.4f",
+                LOGF_INFO("Applied PAC correction: MA %.4f -> %.4f, ME %.4f -> %.4f (arcmin)",
                           oldMA, newMA, oldME, newME);
 
                 // Force an immediate coordinate update so that the next CCD capture
@@ -1177,7 +1156,7 @@ bool ScopeSim::saveConfigItems(FILE *fp)
     GuideRateNP.save(fp);
     MountTypeSP.save(fp);
     simPierSideSP.save(fp);
-    mountModelArcminNP.save(fp);
+    mountModelNP.save(fp);
     flipHourAngleNP.save(fp);
     decBacklashNP.save(fp);
     PACDeviceTP.save(fp);

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -192,7 +192,7 @@ void ScopeSim::ISGetProperties(const char *dev)
     defineProperty(PACDeviceTP);
     PACDeviceTP.load();
 #endif
-    m_currentAz  = 180 + axisPrimary.position.Degrees();
+    m_currentAz  = axisPrimary.position.Degrees();
     m_currentAlt = axisSecondary.position.Degrees();
 }
 
@@ -223,7 +223,7 @@ bool ScopeSim::updateProperties()
                     // Convert stored INDI Az/Alt park position to instrument RA/Dec.
                     Angle instHA, instDec;
                     alignment.mountToInstrumentHaDec(
-                        Angle(ParkPositionNP[AXIS_RA].getValue() - 180.0),  // INDI Az -> scopesim Az
+                        Angle(ParkPositionNP[AXIS_RA].getValue()),
                         Angle(ParkPositionNP[AXIS_DE].getValue()),
                         &instHA, &instDec);
                     m_currentRA  = (alignment.lst() - instHA).Hours();
@@ -259,7 +259,7 @@ bool ScopeSim::updateProperties()
             alignment.instrumentHaDecToMount(ha, Angle(m_currentDEC), &primary, &secondary);
             axisPrimary.position   = primary;
             axisSecondary.position = secondary;
-            m_currentAz  = 180 + axisPrimary.position.Degrees();
+            m_currentAz  = axisPrimary.position.Degrees();
             m_currentAlt = axisSecondary.position.Degrees();
             m_targetRA   = m_currentRA;
             m_targetDEC  = m_currentDEC;
@@ -347,7 +347,7 @@ bool ScopeSim::ReadScopeStatus()
         if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
         {
             // ALTAZ: alignment math plugin uses Az/Alt encoding.
-            double indi_az  = axisPrimary.position.Degrees() + 180.0;
+            double indi_az  = axisPrimary.position.Degrees();
             double indi_alt = axisSecondary.position.Degrees();
             corrected = TelescopeAltAzToSky(indi_alt, indi_az, corrRA, corrDec);
         }
@@ -369,8 +369,8 @@ bool ScopeSim::ReadScopeStatus()
     // axis motors; it must compare axis-space positions against axis-space targets.  Using
     // Wallace-corrected (true) Az/Alt here would inject the Wallace error as a permanent
     // position offset, causing the servo to oscillate every tick.  Use raw axis positions.
-    // axisPrimary is in scopesim Az convention (0=South); +180° converts to INDI (0=North).
-    m_currentAz  = 180 + axisPrimary.position.Degrees();
+    // axisPrimary stores INDI Az (0=North through East), same convention as m_currentAz.
+    m_currentAz  = axisPrimary.position.Degrees();
     m_currentAlt = axisSecondary.position.Degrees();
 
     // update properties from the axis
@@ -419,6 +419,7 @@ bool ScopeSim::ReadScopeStatus()
                     double dSec = (axisSecondary.position - tSecondary).Degrees();
                     LOGF_DEBUG("slew accuracy pri %f arcsec, sec %f arcsec", dPri * 3600, dSec * 3600);
                 }
+
             }
             break;
         case SCOPE_PARKED:
@@ -486,15 +487,13 @@ bool ScopeSim::Goto(double r, double d)
         double instrumentAlt, instrumentAz_INDI;
         if (SkyToTelescopeAltAz(r, d, instrumentAlt, instrumentAz_INDI))
         {
-            // Convert INDI Az (0=North) to scopesim Az (0=South) for axis positions.
-            Angle scopesim_az = Angle(instrumentAz_INDI - 180.0);
-            axisPrimary.StartSlew(scopesim_az);
+            axisPrimary.StartSlew(Angle(instrumentAz_INDI));
             axisSecondary.StartSlew(Angle(instrumentAlt));
 
             // m_targetRA/Dec must be the instrument position (not celestial) so the ALTAZ
             // tracking servo's getAltAz() computes instrument Az/Alt rates, not celestial.
             Angle instHA, instDec;
-            alignment.mountToInstrumentHaDec(scopesim_az, Angle(instrumentAlt), &instHA, &instDec);
+            alignment.mountToInstrumentHaDec(Angle(instrumentAz_INDI), Angle(instrumentAlt), &instHA, &instDec);
             m_targetRA  = (alignment.lst() - instHA).Hours();
             m_targetDEC = instDec.Degrees();
 
@@ -531,8 +530,7 @@ bool ScopeSim::Sync(double ra, double dec)
 
     if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
     {
-        // Axis positions are scopesim Az (0=South) and Alt; convert to INDI Az (0=North).
-        double indi_az  = axisPrimary.position.Degrees() + 180.0;  // → (0, 360]
+        double indi_az  = axisPrimary.position.Degrees();
         double indi_alt = axisSecondary.position.Degrees();
         AddAlignmentEntryAltAz(ra, dec, indi_alt, indi_az);  // handles DB + Initialise
     }
@@ -587,12 +585,12 @@ bool ScopeSim::Park()
         // For ALTAZ, park position is stored as INDI Az (degrees) / Alt (degrees).
         // Convert directly to axis positions and slew; do not go through StartSlew's
         // HA/Dec path which treats Axis1 as hours.
-        Angle scopesim_az = Angle(GetAxis1Park() - 180.0);  // INDI Az -> scopesim Az
-        Angle alt         = Angle(GetAxis2Park());
-        axisPrimary.StartSlew(scopesim_az);
+        Angle indi_az = Angle(GetAxis1Park());
+        Angle alt     = Angle(GetAxis2Park());
+        axisPrimary.StartSlew(indi_az);
         axisSecondary.StartSlew(alt);
         Angle instHA, instDec;
-        alignment.mountToInstrumentHaDec(scopesim_az, alt, &instHA, &instDec);
+        alignment.mountToInstrumentHaDec(indi_az, alt, &instHA, &instDec);
         m_targetRA  = (alignment.lst() - instHA).Hours();
         m_targetDEC = instDec.Degrees();
         TrackState  = SCOPE_PARKING;
@@ -851,7 +849,7 @@ bool ScopeSim::ISSnoopDevice(XMLEle *root)
                     bool corrected = false;
                     if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
                     {
-                        double indi_az  = axisPrimary.position.Degrees() + 180.0;
+                        double indi_az  = axisPrimary.position.Degrees();
                         double indi_alt = axisSecondary.position.Degrees();
                         corrected = TelescopeAltAzToSky(indi_alt, indi_az, corrRA, corrDec);
                     }
@@ -1186,6 +1184,13 @@ bool ScopeSim::updateMountAndPierSide()
     }
 
     alignment.mountType = static_cast<Alignment::MOUNT_TYPE>(mountType);
+
+    // Tell the INDI alignment subsystem (SPK et al.) whether this is an equatorial or ALTAZ mount.
+    // Without this, the math plugin always fits an ALTAZ model regardless of mount type.
+    SetApproximateMountAlignmentFromMountType(
+        alignment.mountType == Alignment::MOUNT_TYPE::ALTAZ
+            ? INDI::AlignmentSubsystem::MathPluginManagement::ALTAZ
+            : INDI::AlignmentSubsystem::MathPluginManagement::EQUATORIAL);
 
     // Set the park data type appropriate for the mount geometry.
     if (mountType == static_cast<int>(Alignment::MOUNT_TYPE::ALTAZ))

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -346,7 +346,8 @@ void ScopeSim::setTargetFromAxisPosition(Angle primary, Angle secondary)
 
 bool ScopeSim::ReadScopeStatus()
 {
-    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ && TrackState == SCOPE_TRACKING)
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ && TrackState == SCOPE_TRACKING &&
+        TrackModeSP.findOnSwitchIndex() != TRACK_CUSTOM)
     {
         double dt      = getCurrentPollingPeriod() / 1000.0;
         double JDnow   = ln_get_julian_from_sys();

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -53,28 +53,12 @@ ScopeSim::ScopeSim(): GI(this)
     /* initialize random seed: */
     srand(static_cast<uint32_t>(time(nullptr)));
 
-    // initialise axis positions
-    // Note: Primary and secondary axes are always perpendicular
-    switch (m_MountType)
-    {
-        // ALTAZ pointing at northern zenith
-        case Alignment::MOUNT_TYPE::ALTAZ:
-            // Primary instrument axis: looking at zenith, angle form negative PA-system, *origin HA-like*!
-            axisPrimary.setDegrees(0.0);
-            axisPrimary.TrackRate(Axis::SIDEREAL);
-            // Secondary instrument axis: looking at east, angle form negative PA-system, origin opposite DEC-like!
-            axisSecondary.setDegrees(90.0);
-            axisSecondary.TrackRate(Axis::SIDEREAL);
-            break;
-        //EQ_XXX pointing at NCP (counterweight down)
-        default:
-            // Primary instrument axis: looking at SCP, angle form negative PA-system, origin opposite HA!
-            axisPrimary.setDegrees(0.0);
-            axisPrimary.TrackRate(Axis::SIDEREAL);
-            // Secondary instrument axis: looling at east, angle form negative PA-system, origin opposite DEC!
-            axisSecondary.setDegrees(90.0);
-            axisSecondary.TrackRate(Axis::OFF);
-    }
+    // Initialize axes to a safe default (EQ pointing at NCP, counterweight down).
+    // updateMountAndPierSide() sets mount-type-dependent rates when config is loaded.
+    axisPrimary.setDegrees(0.0);
+    axisPrimary.TrackRate(Axis::SIDEREAL);
+    axisSecondary.setDegrees(90.0);
+    axisSecondary.TrackRate(Axis::OFF);
 }
 
 const char *ScopeSim::getDefaultName()
@@ -158,8 +142,7 @@ bool ScopeSim::initProperties()
     AddTrackMode("TRACK_LUNAR", "Lunar");
     AddTrackMode("TRACK_CUSTOM", "Custom");
 
-    // RA is a rotating frame, while HA or Alt/Az is not
-    SetParkDataType(PARK_HA_DEC);
+    // Park data type is set in updateMountAndPierSide() based on the mount type.
 
     GI::initProperties(MOTION_TAB);
 
@@ -171,6 +154,10 @@ bool ScopeSim::initProperties()
     setDefaultPollingPeriod(250);
 
     InitAlignmentProperties(this);
+
+    EqPENP[PE_RA].fill("RA_PE",  "RA (hh:mm:ss)",  "%010.6m", 0,   24, 0, 0);
+    EqPENP[PE_DEC].fill("DEC_PE", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
+    EqPENP.fill(getDeviceName(), "EQUATORIAL_PE", "True Pointing", MAIN_CONTROL_TAB, IP_RO, 0, IPS_IDLE);
 
     return true;
 }
@@ -205,9 +192,6 @@ void ScopeSim::ISGetProperties(const char *dev)
     defineProperty(PACDeviceTP);
     PACDeviceTP.load();
 #endif
-    double Latitude = LocationNP[LOCATION_LATITUDE].getValue();
-    m_sinLat = std::sin(Latitude * 0.0174533);
-    m_cosLat = std::cos(Latitude * 0.0174533);
     m_currentAz  = 180 + axisPrimary.position.Degrees();
     m_currentAlt = axisSecondary.position.Degrees();
 }
@@ -222,20 +206,34 @@ bool ScopeSim::updateProperties()
     {
         defineProperty(GuideRateNP);
         GuideRateNP.load();
+        // Always set lat/lon before axis init so instrumentHaDecToMount uses the right location.
+        // updateLocation() is called later by the framework; this ensures it's set now from config.
+        alignment.latitude  = Angle(LocationNP[LOCATION_LATITUDE].getValue());
+        alignment.longitude = Angle(LocationNP[LOCATION_LONGITUDE].getValue());
+
         if (InitPark())
         {
-
             if (isParked())
             {
-                // at this point there is a valid ParkData.xml available
-                alignment.latitude = Angle(LocationNP[LOCATION_LATITUDE].getValue());
-                alignment.longitude = Angle(LocationNP[LOCATION_LONGITUDE].getValue());
-                // RA-parkposition in Ha full circle!!
-                m_currentRA = (alignment.lst() - Angle(ParkPositionNP[AXIS_RA].getValue(), Angle::ANGLE_UNITS::HOURS)).Hours();
-                m_currentDEC = ParkPositionNP[AXIS_DE].getValue();
-                Sync(m_currentRA, m_currentDEC);
-                m_currentAz = 180 + axisPrimary.position.Degrees(); // ALTAZ-Primary to Azm
-                m_currentAlt = axisSecondary.position.Degrees();
+                // at this point there is a valid ParkData.xml available.
+                // For ALTAZ, Axis1=Az (degrees), Axis2=Alt (degrees).
+                // For EQ, Axis1=HA (hours), Axis2=Dec (degrees).
+                if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+                {
+                    // Convert stored INDI Az/Alt park position to instrument RA/Dec.
+                    Angle instHA, instDec;
+                    alignment.mountToInstrumentHaDec(
+                        Angle(ParkPositionNP[AXIS_RA].getValue() - 180.0),  // INDI Az -> scopesim Az
+                        Angle(ParkPositionNP[AXIS_DE].getValue()),
+                        &instHA, &instDec);
+                    m_currentRA  = (alignment.lst() - instHA).Hours();
+                    m_currentDEC = instDec.Degrees();
+                }
+                else
+                {
+                    m_currentRA  = (alignment.lst() - Angle(ParkPositionNP[AXIS_RA].getValue(), Angle::ANGLE_UNITS::HOURS)).Hours();
+                    m_currentDEC = ParkPositionNP[AXIS_DE].getValue();
+                }
             }
             // If loading parking data is successful, we just set the default parking values.
             SetAxis1ParkDefault(-6.);
@@ -250,6 +248,23 @@ bool ScopeSim::updateProperties()
             SetAxis2ParkDefault(0.);
         }
 
+        // Initialize axis positions from the current RA/Dec (park position if parked,
+        // last known position otherwise) using naive (no Wallace) conversion.
+        // Do NOT call Sync() here — it would add a spurious identity entry to the INDI
+        // alignment database that conflicts with real sync points.
+        // Also seed m_targetRA/Dec so the ALTAZ tracking servo has a valid target from the start.
+        {
+            Angle ha = alignment.lst() - Angle(m_currentRA * 15.0);
+            Angle primary, secondary;
+            alignment.instrumentHaDecToMount(ha, Angle(m_currentDEC), &primary, &secondary);
+            axisPrimary.position   = primary;
+            axisSecondary.position = secondary;
+            m_currentAz  = 180 + axisPrimary.position.Degrees();
+            m_currentAlt = axisSecondary.position.Degrees();
+            m_targetRA   = m_currentRA;
+            m_targetDEC  = m_currentDEC;
+        }
+
         sendTimeFromSystem();
 
 #ifdef USE_SIM_TAB
@@ -258,10 +273,12 @@ bool ScopeSim::updateProperties()
             IDSnoopDevice(pacDevice, "PAC_MANUAL_ADJUSTMENT");
 #endif
 
+        defineProperty(EqPENP);
         SetAlignmentSubsystemActive(true);
     }
     else
     {
+        deleteProperty(EqPENP);
         deleteProperty(GuideRateNP);
         //deleteProperty(HomeSP);
     }
@@ -306,46 +323,55 @@ bool ScopeSim::ReadScopeStatus()
     axisPrimary.update();
     axisSecondary.update();
 
-    // transform to new RA & DEC
-    Angle ra, dec;
-    alignment.mountToApparentRaDec(axisPrimary.position, axisSecondary.position, &ra, &dec);
-    m_currentRA = ra.Hours();
-    m_currentDEC = dec.Degrees();
+    // True pointing: apply Wallace error injection to get where the scope physically points.
+    // Published as EQUATORIAL_PE so the CCD simulator generates star fields at this position.
+    Angle trueRa, trueDec;
+    alignment.mountToApparentRaDec(axisPrimary.position, axisSecondary.position, &trueRa, &trueDec);
+    EqPENP[PE_RA].setValue(trueRa.Hours());
+    EqPENP[PE_DEC].setValue(trueDec.Degrees());
+    EqPENP.setState(IPS_OK);
+    EqPENP.apply();
 
-    // If the INDI alignment subsystem has 2+ sync points, apply its correction on top
-    // of the raw mount position.
-    if (GetAlignmentDatabase().size() > 1)
+    // Raw encoder position: what the mount "reports" without knowing its own errors.
+    // This is what EQUATORIAL_EOD_COORD carries and what the INDI alignment module uses.
+    Angle instHA, instDec;
+    alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position, &instHA, &instDec);
+    m_currentRA  = (alignment.lst() - instHA).Hours();
+    m_currentDEC = instDec.Degrees();
+
+    // Apply INDI alignment correction when sync points exist.
+    if (GetAlignmentDatabase().size() >= 1)
     {
-        Angle instHA, instDec;
-        alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
-                                         &instHA, &instDec);
-        INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
-        TelescopeDirectionVector tdv =
-            TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
-
         double corrRA, corrDec;
-        if (TransformTelescopeToCelestial(tdv, corrRA, corrDec))
+        bool corrected = false;
+        if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+        {
+            // ALTAZ: alignment math plugin uses Az/Alt encoding.
+            double indi_az  = axisPrimary.position.Degrees() + 180.0;
+            double indi_alt = axisSecondary.position.Degrees();
+            corrected = TelescopeAltAzToSky(indi_alt, indi_az, corrRA, corrDec);
+        }
+        else
+        {
+            INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
+            TelescopeDirectionVector tdv =
+                TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
+            corrected = TransformTelescopeToCelestial(tdv, corrRA, corrDec);
+        }
+        if (corrected)
         {
             m_currentRA  = corrRA;
             m_currentDEC = corrDec;
         }
     }
 
-    // Derive Az/Alt from the finalised RA/Dec so the AltAz tracking rate calculation
-    // uses the same convention as EquatorialToHorizontal used for the target position.
-    if (alignment.mountType == Alignment::MOUNT_TYPE::ALTAZ)
-    {
-        INDI::IEquatorialCoordinates eq { m_currentRA, m_currentDEC };
-        INDI::IHorizontalCoordinates hz;
-        INDI::EquatorialToHorizontal(&eq, &m_Location, ln_get_julian_from_sys(), &hz);
-        m_currentAz  = hz.azimuth;
-        m_currentAlt = hz.altitude;
-    }
-    else
-    {
-        m_currentAz  = 180 + axisPrimary.position.Degrees();
-        m_currentAlt = axisSecondary.position.Degrees();
-    }
+    // Az/Alt for the ALTAZ tracking servo.  The servo (top of ReadScopeStatus) drives the
+    // axis motors; it must compare axis-space positions against axis-space targets.  Using
+    // Wallace-corrected (true) Az/Alt here would inject the Wallace error as a permanent
+    // position offset, causing the servo to oscillate every tick.  Use raw axis positions.
+    // axisPrimary is in scopesim Az convention (0=South); +180° converts to INDI (0=North).
+    m_currentAz  = 180 + axisPrimary.position.Degrees();
+    m_currentAlt = axisSecondary.position.Degrees();
 
     // update properties from the axis
     if (alignment.mountType == Alignment::MOUNT_TYPE::EQ_GEM)
@@ -383,10 +409,16 @@ bool ScopeSim::ReadScopeStatus()
                 else
                     LOG_INFO("Telescope slew is complete. Tracking...");
 
-                // check the slew accuracy
-                auto dRa = m_targetRA - m_currentRA;
-                auto dDec = m_targetDEC - m_currentDEC;
-                LOGF_DEBUG("slew accuracy %f, %f", dRa * 15 * 3600, dDec * 3600);
+                // Check slew accuracy in axis space so the result is frame-independent:
+                // m_targetRA/Dec are instrument-frame; m_currentRA/Dec may be alignment-corrected.
+                {
+                    Angle targetHa = alignment.lst() - Angle(m_targetRA * 15.0);
+                    Angle tPrimary, tSecondary;
+                    alignment.instrumentHaDecToMount(targetHa, Angle(m_targetDEC), &tPrimary, &tSecondary);
+                    double dPri = (axisPrimary.position   - tPrimary).Degrees();
+                    double dSec = (axisSecondary.position - tSecondary).Degrees();
+                    LOGF_DEBUG("slew accuracy pri %f arcsec, sec %f arcsec", dPri * 3600, dSec * 3600);
+                }
             }
             break;
         case SCOPE_PARKED:
@@ -421,8 +453,8 @@ bool ScopeSim::ReadScopeStatus()
         mountAxisNP[PRIMARY].setValue(PrimaryAngle);
         mountAxisNP[SECONDARY].setValue(SecondaryAngle);
 
-        LOGF_EXTRA1("new %s: %f, ra %f", axisPrimary.axisName, PrimaryAngle, ra.Hours());
-        LOGF_EXTRA1("new %s: %f, dec %f", axisSecondary.axisName, SecondaryAngle, dec.Degrees());
+        LOGF_EXTRA1("new %s: %f, ra %f", axisPrimary.axisName, PrimaryAngle, trueRa.Hours());
+        LOGF_EXTRA1("new %s: %f, dec %f", axisSecondary.axisName, SecondaryAngle, trueDec.Degrees());
 
         mountAxisNP.apply();
     }
@@ -440,35 +472,102 @@ bool ScopeSim::ReadScopeStatus()
 
 bool ScopeSim::Goto(double r, double d)
 {
-    StartSlew(r, d, SCOPE_SLEWING);
+    // When the INDI alignment subsystem has learned sync points, transform the celestial
+    // target through the alignment database so the mount ends up at the right sky position
+    // despite the injected mount errors.
+    //
+    // ALTAZ mounts: the math plugin uses Az/Alt encoding.  Decode via SkyToTelescopeAltAz
+    // and set axis slew targets directly in Az/Alt space.
+    //
+    // EQ mounts: the math plugin uses HA/Dec encoding.  Decode via LocalHourAngle... and
+    // convert back through instrumentHaDecToMount inside StartSlew.
+    if (GetAlignmentDatabase().size() >= 1 && m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+    {
+        double instrumentAlt, instrumentAz_INDI;
+        if (SkyToTelescopeAltAz(r, d, instrumentAlt, instrumentAz_INDI))
+        {
+            // Convert INDI Az (0=North) to scopesim Az (0=South) for axis positions.
+            Angle scopesim_az = Angle(instrumentAz_INDI - 180.0);
+            axisPrimary.StartSlew(scopesim_az);
+            axisSecondary.StartSlew(Angle(instrumentAlt));
+
+            // m_targetRA/Dec must be the instrument position (not celestial) so the ALTAZ
+            // tracking servo's getAltAz() computes instrument Az/Alt rates, not celestial.
+            Angle instHA, instDec;
+            alignment.mountToInstrumentHaDec(scopesim_az, Angle(instrumentAlt), &instHA, &instDec);
+            m_targetRA  = (alignment.lst() - instHA).Hours();
+            m_targetDEC = instDec.Degrees();
+
+            TrackState = SCOPE_SLEWING;
+            EqNP.setState(IPS_BUSY);
+            return true;
+        }
+    }
+
+    double targetRA = r, targetDec = d;
+    if (GetAlignmentDatabase().size() >= 1)
+    {
+        TelescopeDirectionVector tdv;
+        if (TransformCelestialToTelescope(r, d, 0.0, tdv))
+        {
+            INDI::IEquatorialCoordinates haCoords;
+            LocalHourAngleDeclinationFromTelescopeDirectionVector(tdv, haCoords);
+            targetRA  = (alignment.lst() - Angle(haCoords.rightascension, Angle::HOURS)).Hours();
+            targetDec = haCoords.declination;
+        }
+    }
+
+    StartSlew(targetRA, targetDec, SCOPE_SLEWING);
     return true;
 }
 
 bool ScopeSim::Sync(double ra, double dec)
 {
-    // Build a telescope direction vector from the current instrument (encoder) HA/Dec,
-    // without Wallace pointing-model corrections applied.
+    // The INDI alignment math plugins encode telescope directions as:
+    //   - ALTAZ (ZENITH) mounts: Az/Alt via TelescopeDirectionVectorFromAltitudeAzimuth
+    //   - EQ mounts: HA/Dec via TelescopeDirectionVectorFromLocalHourAngleDeclination
+    // Using the wrong encoding causes the correction to be applied in the wrong coordinate
+    // system, which after Goto's instrumentHaDecToMount re-rotation produces garbage altitudes.
+
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+    {
+        // Axis positions are scopesim Az (0=South) and Alt; convert to INDI Az (0=North).
+        double indi_az  = axisPrimary.position.Degrees() + 180.0;  // → (0, 360]
+        double indi_alt = axisSecondary.position.Degrees();
+        AddAlignmentEntryAltAz(ra, dec, indi_alt, indi_az);  // handles DB + Initialise
+    }
+    else
+    {
+        // EQ mounts: encode the raw encoder HA/Dec as the telescope direction.
+        Angle instHA, instDec;
+        alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
+                                         &instHA, &instDec);
+
+        INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
+        TelescopeDirectionVector tdv =
+            TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
+
+        AlignmentDatabaseEntry entry;
+        entry.ObservationJulianDate = ln_get_julian_from_sys();
+        entry.RightAscension        = ra;
+        entry.Declination           = dec;
+        entry.TelescopeDirection    = tdv;
+        entry.PrivateDataSize       = 0;
+
+        if (!CheckForDuplicateSyncPoint(entry))
+        {
+            GetAlignmentDatabase().push_back(entry);
+            UpdateSize();
+            Initialise(this);
+        }
+    }
+
+    // Keep the ALTAZ tracking servo on the current instrument position after sync.
     Angle instHA, instDec;
     alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
                                      &instHA, &instDec);
-
-    INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
-    TelescopeDirectionVector tdv =
-        TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
-
-    AlignmentDatabaseEntry entry;
-    entry.ObservationJulianDate = ln_get_julian_from_sys();
-    entry.RightAscension        = ra;
-    entry.Declination           = dec;
-    entry.TelescopeDirection    = tdv;
-    entry.PrivateDataSize       = 0;
-
-    if (!CheckForDuplicateSyncPoint(entry))
-    {
-        GetAlignmentDatabase().push_back(entry);
-        UpdateSize();
-        Initialise(this);
-    }
+    m_targetRA  = (alignment.lst() - instHA).Hours();
+    m_targetDEC = instDec.Degrees();
 
     LOGF_DEBUG("Sync at RA %f Dec %f  instHA %f instDec %f",
                ra, dec, instHA.Degrees(), instDec.Degrees());
@@ -483,22 +582,49 @@ bool ScopeSim::Sync(double ra, double dec)
 
 bool ScopeSim::Park()
 {
-    double ra = (alignment.lst() - Angle(GetAxis1Park() * 15.)).Degrees() / 15.;
-    StartSlew(ra, GetAxis2Park(), SCOPE_PARKING);
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+    {
+        // For ALTAZ, park position is stored as INDI Az (degrees) / Alt (degrees).
+        // Convert directly to axis positions and slew; do not go through StartSlew's
+        // HA/Dec path which treats Axis1 as hours.
+        Angle scopesim_az = Angle(GetAxis1Park() - 180.0);  // INDI Az -> scopesim Az
+        Angle alt         = Angle(GetAxis2Park());
+        axisPrimary.StartSlew(scopesim_az);
+        axisSecondary.StartSlew(alt);
+        Angle instHA, instDec;
+        alignment.mountToInstrumentHaDec(scopesim_az, alt, &instHA, &instDec);
+        m_targetRA  = (alignment.lst() - instHA).Hours();
+        m_targetDEC = instDec.Degrees();
+        TrackState  = SCOPE_PARKING;
+        EqNP.setState(IPS_BUSY);
+        LOG_INFO("Parking...");
+    }
+    else
+    {
+        double ra = (alignment.lst() - Angle(GetAxis1Park() * 15.)).Degrees() / 15.;
+        StartSlew(ra, GetAxis2Park(), SCOPE_PARKING);
+    }
     return true;
 }
 
 // common code for GoTo and park
 void ScopeSim::StartSlew(double ra, double dec, TelescopeStatus status)
 {
+    // Naive axis conversion: no Wallace corrections.  The mount slews to where its
+    // encoders say, unaware of its own IH/ID/etc. errors — just like a real mount.
+    Angle ha = alignment.lst() - Angle(ra * 15.0);
     Angle primary, secondary;
-    alignment.apparentRaDecToMount(Angle(ra * 15.0), Angle(dec), &primary, &secondary);
+    alignment.instrumentHaDecToMount(ha, Angle(dec), &primary, &secondary);
 
     axisPrimary.StartSlew(primary);
     axisSecondary.StartSlew(secondary);
 
-    m_targetRA  = ra;
-    m_targetDEC = dec;
+    // Store instrument-frame RA/Dec so the ALTAZ tracking servo always works
+    // in a consistent coordinate frame, regardless of how StartSlew was called.
+    Angle instHA, instDec;
+    alignment.mountToInstrumentHaDec(primary, secondary, &instHA, &instDec);
+    m_targetRA  = (alignment.lst() - instHA).Hours();
+    m_targetDEC = instDec.Degrees();
     char RAStr[64], DecStr[64];
 
     fs_sexa(RAStr, m_targetRA, 2, 3600);
@@ -712,11 +838,36 @@ bool ScopeSim::ISSnoopDevice(XMLEle *root)
                 // Force an immediate coordinate update so that the next CCD capture
                 // uses the corrected pointing rather than waiting up to one full
                 // polling cycle (default 500 ms) for ReadScopeStatus to run.
-                Angle immediateRa, immediateDec;
-                alignment.mountToApparentRaDec(axisPrimary.position, axisSecondary.position,
-                                               &immediateRa, &immediateDec);
-                m_currentRA  = immediateRa.Hours();
-                m_currentDEC = immediateDec.Degrees();
+                // Mirror the ReadScopeStatus coordinate path: instrument position,
+                // then INDI alignment correction if sync points exist.
+                Angle instHA, instDec;
+                alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
+                                                 &instHA, &instDec);
+                m_currentRA  = (alignment.lst() - instHA).Hours();
+                m_currentDEC = instDec.Degrees();
+                if (GetAlignmentDatabase().size() >= 1)
+                {
+                    double corrRA, corrDec;
+                    bool corrected = false;
+                    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+                    {
+                        double indi_az  = axisPrimary.position.Degrees() + 180.0;
+                        double indi_alt = axisSecondary.position.Degrees();
+                        corrected = TelescopeAltAzToSky(indi_alt, indi_az, corrRA, corrDec);
+                    }
+                    else
+                    {
+                        INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
+                        TelescopeDirectionVector tdv =
+                            TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
+                        corrected = TransformTelescopeToCelestial(tdv, corrRA, corrDec);
+                    }
+                    if (corrected)
+                    {
+                        m_currentRA  = corrRA;
+                        m_currentDEC = corrDec;
+                    }
+                }
                 NewRaDec(m_currentRA, m_currentDEC);
             }
             return true;
@@ -730,6 +881,8 @@ bool ScopeSim::Abort()
 {
     axisPrimary.Abort();
     axisSecondary.Abort();
+    if (TrackState == SCOPE_PARKING || TrackState == SCOPE_SLEWING)
+        TrackState = SCOPE_IDLE;
     return true;
 }
 
@@ -744,7 +897,7 @@ bool ScopeSim::MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command)
     mcRate = std::max(1, std::min(4, mcRate));
 
     int rate = (dir == INDI_DIR_NS::DIRECTION_NORTH) ? mcRate : -mcRate;
-    if (HasPierSide() & (currentPierSide == PIER_WEST)) // see scopesim_helper.cpp: alignment
+    if (HasPierSide() && (currentPierSide == PIER_WEST)) // see scopesim_helper.cpp: alignment
         rate = -rate;
     LOGF_DEBUG("MoveNS dir %s, motion %s, rate %d", dir == DIRECTION_NORTH ? "N" : "S", command == 0 ? "start" : "stop", rate);
 
@@ -815,51 +968,114 @@ uint32_t ScopeSim::applyDecBacklash(double rate, uint32_t ms)
     }
 }
 
+void ScopeSim::guideAltAzDecomposed(double dNS, double dEW, uint32_t ms)
+{
+    // Decompose a celestial N/S/E/W guide pulse into Az/Alt axis components using
+    // the parallactic angle q.  Both sinQ and cosQ include the 1/cos(alt) factor
+    // from the standard parallactic angle formula, so the azimuth decomposition
+    // requires a second 1/cos(alt) division.
+    //
+    // Celestial North in Az/Alt:  dAlt = cos(q),   dAz = -sin(q)/cos(alt)
+    // Celestial East  in Az/Alt:  dAlt = sin(q),   dAz =  cos(q)/cos(alt)
+
+    double H      = (alignment.lst() - Angle(m_currentRA * 15.0)).radians();
+    double dec    = Angle(m_currentDEC).radians();
+    double lat    = alignment.latitude.radians();
+    double alt    = m_currentAlt * M_PI / 180.0;
+    double cosAlt = std::cos(alt);
+
+    if (std::abs(cosAlt) > 1e-4)
+    {
+        double sinQ = std::sin(H) * std::cos(lat) / cosAlt;
+        double cosQ = (std::sin(lat) - std::sin(dec) * std::sin(alt))
+                      / (std::cos(dec) * cosAlt);
+
+        double dAlt_N =  cosQ;
+        double dAz_N  = -sinQ / cosAlt;
+        double dAlt_E =  sinQ;
+        double dAz_E  =  cosQ / cosAlt;
+
+        axisPrimary.StartGuide(dNS * dAz_N + dEW * dAz_E, ms);
+        axisSecondary.StartGuide(dNS * dAlt_N + dEW * dAlt_E, ms);
+    }
+    else
+    {
+        // Near zenith: Az is degenerate; fall back to direct axis motion.
+        axisPrimary.StartGuide(dEW, ms);
+        axisSecondary.StartGuide(dNS, ms);
+    }
+}
+
 IPState ScopeSim::GuideNorth(uint32_t ms)
 {
-    double rate = GuideRateNP[DEC_AXIS].getValue();
-    if (HasPierSide() & (currentPierSide == PIER_WEST)) // see scopsim_helper.cpp: alignment
-        rate = -rate;
-    ms = applyDecBacklash(rate, ms);
-    axisSecondary.StartGuide(rate, ms);
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+    {
+        guideAltAzDecomposed(GuideRateNP[DEC_AXIS].getValue(), 0.0, ms);
+    }
+    else
+    {
+        double rate = GuideRateNP[DEC_AXIS].getValue();
+        if (HasPierSide() && (currentPierSide == PIER_WEST)) // see scopsim_helper.cpp: alignment
+            rate = -rate;
+        ms = applyDecBacklash(rate, ms);
+        axisSecondary.StartGuide(rate, ms);
+    }
     guidingNS = true;
     return IPS_BUSY;
 }
 
 IPState ScopeSim::GuideSouth(uint32_t ms)
 {
-    double rate = GuideRateNP[DEC_AXIS].getValue();
-    if (HasPierSide() & (currentPierSide == PIER_WEST)) // see scopsim_helper.cpp: alignment
-        rate = -rate;
-    ms = applyDecBacklash(-rate, ms);
-    axisSecondary.StartGuide(-rate, ms);
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+    {
+        guideAltAzDecomposed(-GuideRateNP[DEC_AXIS].getValue(), 0.0, ms);
+    }
+    else
+    {
+        double rate = GuideRateNP[DEC_AXIS].getValue();
+        if (HasPierSide() && (currentPierSide == PIER_WEST)) // see scopsim_helper.cpp: alignment
+            rate = -rate;
+        ms = applyDecBacklash(-rate, ms);
+        axisSecondary.StartGuide(-rate, ms);
+    }
     guidingNS = true;
     return IPS_BUSY;
 }
 
 IPState ScopeSim::GuideEast(uint32_t ms)
 {
-    double rate = GuideRateNP[RA_AXIS].getValue();
-    axisPrimary.StartGuide(-rate, ms);
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+        guideAltAzDecomposed(0.0, -GuideRateNP[RA_AXIS].getValue(), ms);
+    else
+        axisPrimary.StartGuide(-GuideRateNP[RA_AXIS].getValue(), ms);
     guidingEW = true;
     return IPS_BUSY;
 }
 
 IPState ScopeSim::GuideWest(uint32_t ms)
 {
-    double rate = GuideRateNP[RA_AXIS].getValue();
-    axisPrimary.StartGuide(rate, ms);
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+        guideAltAzDecomposed(0.0, GuideRateNP[RA_AXIS].getValue(), ms);
+    else
+        axisPrimary.StartGuide(GuideRateNP[RA_AXIS].getValue(), ms);
     guidingEW = true;
     return IPS_BUSY;
 }
 
 bool ScopeSim::SetCurrentPark()
 {
-
-    double ha  = (alignment.lst() - Angle(m_currentRA, Angle::ANGLE_UNITS::HOURS)).Hours();
-    SetAxis1Park(ha);
-    SetAxis2Park(m_currentDEC);
-
+    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+    {
+        // Store INDI Az (0=North) and Alt in degrees.
+        SetAxis1Park(m_currentAz);
+        SetAxis2Park(m_currentAlt);
+    }
+    else
+    {
+        double ha  = (alignment.lst() - Angle(m_currentRA, Angle::ANGLE_UNITS::HOURS)).Hours();
+        SetAxis1Park(ha);
+        SetAxis2Park(m_currentDEC);
+    }
     return true;
 }
 
@@ -879,15 +1095,18 @@ bool ScopeSim::SetTrackMode(uint8_t mode)
     {
         case TRACK_SIDEREAL:
             axisPrimary.TrackRate(Axis::SIDEREAL);
-            axisSecondary.TrackRate(Axis::OFF);
+            if (m_MountType != Alignment::MOUNT_TYPE::ALTAZ)
+                axisSecondary.TrackRate(Axis::OFF);
             return true;
         case TRACK_SOLAR:
             axisPrimary.TrackRate(Axis::SOLAR);
-            axisSecondary.TrackRate(Axis::OFF);
+            if (m_MountType != Alignment::MOUNT_TYPE::ALTAZ)
+                axisSecondary.TrackRate(Axis::OFF);
             return true;
         case TRACK_LUNAR:
             axisPrimary.TrackRate(Axis::LUNAR);
-            axisSecondary.TrackRate(Axis::OFF);
+            if (m_MountType != Alignment::MOUNT_TYPE::ALTAZ)
+                axisSecondary.TrackRate(Axis::OFF);
             return true;
         case TRACK_CUSTOM:
             SetTrackRate(TrackRateNP[AXIS_RA].getValue(), TrackRateNP[AXIS_DE].getValue());
@@ -914,6 +1133,8 @@ bool ScopeSim::saveConfigItems(FILE *fp)
 {
     INDI::Telescope::saveConfigItems(fp);
 
+    SaveAlignmentConfigProperties(fp);
+
 #ifdef USE_SIM_TAB
     GuideRateNP.save(fp);
     MountTypeSP.save(fp);
@@ -935,8 +1156,6 @@ bool ScopeSim::updateLocation(double latitude, double longitude, double elevatio
     alignment.longitude = Angle(longitude);
 
     UpdateLocation(latitude, longitude, elevation);
-
-    INDI_UNUSED(elevation);
     return true;
 }
 
@@ -957,8 +1176,8 @@ bool ScopeSim::updateMountAndPierSide()
 
     LOGF_INFO("update mount and pier side: Pier Side %s, mount type %d", pierSide == 0 ? "Off" : "On", mountType);
 #else
-    int mountType = 2;
-    int pierSide = 1;
+    int mountType = static_cast<int>(Alignment::MOUNT_TYPE::EQ_GEM);
+    int pierSide  = PS_ON;
 #endif
     if ( mountType == Alignment::MOUNT_TYPE::ALTAZ)
     {
@@ -967,6 +1186,12 @@ bool ScopeSim::updateMountAndPierSide()
     }
 
     alignment.mountType = static_cast<Alignment::MOUNT_TYPE>(mountType);
+
+    // Set the park data type appropriate for the mount geometry.
+    if (mountType == static_cast<int>(Alignment::MOUNT_TYPE::ALTAZ))
+        SetParkDataType(PARK_AZ_ALT);
+    else
+        SetParkDataType(PARK_HA_DEC);
 
     // Reinitialize the secondary axis track rate for the selected mount type.
     // ALTAZ: both axes need sidereal rate (overridden each tick by parabolic tracking).
@@ -978,7 +1203,7 @@ bool ScopeSim::updateMountAndPierSide()
 
     // update the pier side capability depending on the mount type
     uint32_t cap = GetTelescopeCapability();
-    if (pierSide == 1 && mountType == 2)
+    if (pierSide == PS_ON && mountType == static_cast<int>(Alignment::MOUNT_TYPE::EQ_GEM))
     {
         cap |= TELESCOPE_HAS_PIER_SIDE;
     }

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -344,18 +344,64 @@ void ScopeSim::setTargetFromAxisPosition(Angle primary, Angle secondary)
     m_targetDEC = instDec.Degrees();
 }
 
-/// ALTAZ: The tracking rates of the mechanical axes vary with the angle positions.
-/// (See "Deriving Field Rotation Rate for an Alt-Az Mounted Telescope" by Russell P. Patera1)
 bool ScopeSim::ReadScopeStatus()
 {
     if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ && TrackState == SCOPE_TRACKING)
     {
-        double sinAz = std::sin(DEG_TO_RAD(m_currentAz));
-        double cosAz = std::cos(DEG_TO_RAD(m_currentAz));
-        double sinAlt = std::sin(DEG_TO_RAD(m_currentAlt));
-        double cosAlt = std::cos(DEG_TO_RAD(m_currentAlt));
-        SetTrackRate((m_sinLat - ((cosAz * sinAlt * m_cosLat) / cosAlt)) * TRACKRATE_SIDEREAL,
-                     m_cosLat * sinAz * TRACKRATE_SIDEREAL);
+        double dt      = getCurrentPollingPeriod() / 1000.0;
+        double JDnow   = ln_get_julian_from_sys();
+        double JDoffset = dt / 86400.0;
+
+        auto getAltAz = [&](double JD, INDI::IHorizontalCoordinates &coords)
+        {
+            INDI::IEquatorialCoordinates eq { m_targetRA, m_targetDEC };
+            INDI::EquatorialToHorizontal(&eq, &m_Location, JD, &coords);
+        };
+
+        bool targetChanged = std::abs(m_LastTrackingRA  - m_targetRA)  > 1e-6 ||
+                             std::abs(m_LastTrackingDec - m_targetDEC) > 1e-6;
+
+        if (!m_IsPipelinePrimed || targetChanged)
+        {
+            getAltAz(JDnow - JDoffset, m_TrackingWindowCoords[0]);
+            getAltAz(JDnow,            m_TrackingWindowCoords[1]);
+            getAltAz(JDnow + JDoffset, m_TrackingWindowCoords[2]);
+            m_IsPipelinePrimed = true;
+            m_LastTrackingRA   = m_targetRA;
+            m_LastTrackingDec  = m_targetDEC;
+        }
+        else
+        {
+            m_TrackingWindowCoords[0] = m_TrackingWindowCoords[1];
+            m_TrackingWindowCoords[1] = m_TrackingWindowCoords[2];
+            getAltAz(JDnow + JDoffset, m_TrackingWindowCoords[2]);
+        }
+
+        // Unwrap azimuth around the center point to avoid 360/0 discontinuity
+        // Angle(x).Degrees() normalizes x to (-180, +180], same as the private Angle::range()
+        auto range180 = [](double x) { return Angle(x).Degrees(); };
+        double pAz[3] = { m_TrackingWindowCoords[0].azimuth,
+                          m_TrackingWindowCoords[1].azimuth,
+                          m_TrackingWindowCoords[2].azimuth };
+        pAz[0] = pAz[1] + range180(pAz[0] - pAz[1]);
+        pAz[2] = pAz[1] + range180(pAz[2] - pAz[1]);
+
+        // Parabolic coefficients (t in normalized units; points at t = -1, 0, +1)
+        double az_a  = (pAz[2] + pAz[0] - 2.0 * pAz[1]) / 2.0;
+        double az_b  = (pAz[2] - pAz[0]) / 2.0;
+        double alt_a = (m_TrackingWindowCoords[2].altitude + m_TrackingWindowCoords[0].altitude
+                        - 2.0 * m_TrackingWindowCoords[1].altitude) / 2.0;
+        double alt_b = (m_TrackingWindowCoords[2].altitude - m_TrackingWindowCoords[0].altitude) / 2.0;
+
+        // Predicted position at next tick (t = +1 normalized = +dt seconds from now)
+        double targetAzNext  = az_a  + az_b  + pAz[1];
+        double targetAltNext = alt_a + alt_b + m_TrackingWindowCoords[1].altitude;
+
+        // Rate to close the gap in exactly dt seconds, converted to arcsec/s for SetTrackRate
+        double azRate  = range180(targetAzNext - m_currentAz)  / dt * 3600.0;
+        double altRate = (targetAltNext - m_currentAlt) / dt * 3600.0;
+
+        SetTrackRate(azRate, altRate);
     }
 
     // new mechanical angle calculation
@@ -667,18 +713,22 @@ bool ScopeSim::ISNewNumber(const char *dev, const char *name, double values[], c
         }
 
 #ifdef USE_SIM_TAB
-        if (mountModelNP.isNameMatch(name))
+        if (mountModelArcminNP.isNameMatch(name))
         {
-            if (mountModelNP.isUpdated(values, names, n))
+            if (mountModelArcminNP.isUpdated(values, names, n))
             {
-                mountModelNP.update(values, names, n);
+                mountModelArcminNP.update(values, names, n);
+                for (int i = 0; i < 6; i++)
+                    mountModelNP[i].setValue(mountModelArcminNP[i].getValue() / 60.0);
                 alignment.setCorrections(mountModelNP[MM_IH].getValue(), mountModelNP[MM_ID].getValue(),
                                          mountModelNP[MM_CH].getValue(), mountModelNP[MM_NP].getValue(),
                                          mountModelNP[MM_MA].getValue(), mountModelNP[MM_ME].getValue());
-                saveConfig(mountModelNP);
+                mountModelNP.setState(IPS_OK);
+                mountModelNP.apply();
+                saveConfig(mountModelArcminNP);
             }
-            mountModelNP.setState(IPS_OK);
-            mountModelNP.apply();
+            mountModelArcminNP.setState(IPS_OK);
+            mountModelArcminNP.apply();
             return true;
         }
 
@@ -822,12 +872,16 @@ bool ScopeSim::ISSnoopDevice(XMLEle *root)
 
                 mountModelNP[MM_MA].setValue(newMA);
                 mountModelNP[MM_ME].setValue(newME);
+                mountModelArcminNP[MM_MA].setValue(newMA * 60.0);
+                mountModelArcminNP[MM_ME].setValue(newME * 60.0);
                 alignment.setCorrections(mountModelNP[MM_IH].getValue(), mountModelNP[MM_ID].getValue(),
                                          mountModelNP[MM_CH].getValue(), mountModelNP[MM_NP].getValue(),
                                          mountModelNP[MM_MA].getValue(), mountModelNP[MM_ME].getValue());
 
                 mountModelNP.setState(IPS_OK);
                 mountModelNP.apply();
+                mountModelArcminNP.setState(IPS_OK);
+                mountModelArcminNP.apply();
 
                 LOGF_INFO("Applied PAC correction: MA %.4f -> %.4f, ME %.4f -> %.4f",
                           oldMA, newMA, oldME, newME);
@@ -1086,6 +1140,8 @@ bool ScopeSim::SetTrackMode(uint8_t mode)
 
 bool ScopeSim::SetTrackEnabled(bool enabled)
 {
+    if (enabled)
+        m_IsPipelinePrimed = false;
     axisPrimary.Tracking(enabled);
     axisSecondary.Tracking(enabled);
     return true;
@@ -1108,7 +1164,7 @@ bool ScopeSim::saveConfigItems(FILE *fp)
     GuideRateNP.save(fp);
     MountTypeSP.save(fp);
     simPierSideSP.save(fp);
-    mountModelNP.save(fp);
+    mountModelArcminNP.save(fp);
     flipHourAngleNP.save(fp);
     decBacklashNP.save(fp);
     PACDeviceTP.save(fp);

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -236,15 +236,18 @@ bool ScopeSim::updateProperties()
                 }
             }
             // If loading parking data is successful, we just set the default parking values.
-            SetAxis1ParkDefault(-6.);
+            // ALTAZ: Az=0 (North horizon), Alt=0.  EQ: HA=-6h (counterweight down), Dec=0.
+            double defaultAxis1 = (m_MountType == Alignment::MOUNT_TYPE::ALTAZ) ? 0. : -6.;
+            SetAxis1ParkDefault(defaultAxis1);
             SetAxis2ParkDefault(0.);
         }
         else
         {
             // Otherwise, we set all parking data to default in case no parking data is found.
-            SetAxis1Park(-6.);
+            double defaultAxis1 = (m_MountType == Alignment::MOUNT_TYPE::ALTAZ) ? 0. : -6.;
+            SetAxis1Park(defaultAxis1);
             SetAxis2Park(0.);
-            SetAxis1ParkDefault(-6.);
+            SetAxis1ParkDefault(defaultAxis1);
             SetAxis2ParkDefault(0.);
         }
 
@@ -280,7 +283,6 @@ bool ScopeSim::updateProperties()
     {
         deleteProperty(EqPENP);
         deleteProperty(GuideRateNP);
-        //deleteProperty(HomeSP);
     }
 
     GI::updateProperties();
@@ -303,6 +305,45 @@ bool ScopeSim::Disconnect()
 }
 
 
+void ScopeSim::updateCurrentCoordsFromAxes()
+{
+    Angle instHA, instDec;
+    alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position, &instHA, &instDec);
+    m_currentRA  = (alignment.lst() - instHA).Hours();
+    m_currentDEC = instDec.Degrees();
+
+    if (GetAlignmentDatabase().size() >= 1)
+    {
+        double corrRA, corrDec;
+        bool corrected = false;
+        if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
+        {
+            corrected = TelescopeAltAzToSky(axisSecondary.position.Degrees(),
+                                            axisPrimary.position.Degrees(), corrRA, corrDec);
+        }
+        else
+        {
+            INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
+            TelescopeDirectionVector tdv =
+                TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
+            corrected = TransformTelescopeToCelestial(tdv, corrRA, corrDec);
+        }
+        if (corrected)
+        {
+            m_currentRA  = corrRA;
+            m_currentDEC = corrDec;
+        }
+    }
+}
+
+void ScopeSim::setTargetFromAxisPosition(Angle primary, Angle secondary)
+{
+    Angle instHA, instDec;
+    alignment.mountToInstrumentHaDec(primary, secondary, &instHA, &instDec);
+    m_targetRA  = (alignment.lst() - instHA).Hours();
+    m_targetDEC = instDec.Degrees();
+}
+
 /// ALTAZ: The tracking rates of the mechanical axes vary with the angle positions.
 /// (See "Deriving Field Rotation Rate for an Alt-Az Mounted Telescope" by Russell P. Patera1)
 bool ScopeSim::ReadScopeStatus()
@@ -316,8 +357,6 @@ bool ScopeSim::ReadScopeStatus()
         SetTrackRate((m_sinLat - ((cosAz * sinAlt * m_cosLat) / cosAlt)) * TRACKRATE_SIDEREAL,
                      m_cosLat * sinAz * TRACKRATE_SIDEREAL);
     }
-
-    // SetTrackRate(TrackRateNP[AXIS_RA].getValue(), TrackRateNP[AXIS_DE].getValue());
 
     // new mechanical angle calculation
     axisPrimary.update();
@@ -334,36 +373,8 @@ bool ScopeSim::ReadScopeStatus()
 
     // Raw encoder position: what the mount "reports" without knowing its own errors.
     // This is what EQUATORIAL_EOD_COORD carries and what the INDI alignment module uses.
-    Angle instHA, instDec;
-    alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position, &instHA, &instDec);
-    m_currentRA  = (alignment.lst() - instHA).Hours();
-    m_currentDEC = instDec.Degrees();
-
-    // Apply INDI alignment correction when sync points exist.
-    if (GetAlignmentDatabase().size() >= 1)
-    {
-        double corrRA, corrDec;
-        bool corrected = false;
-        if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
-        {
-            // ALTAZ: alignment math plugin uses Az/Alt encoding.
-            double indi_az  = axisPrimary.position.Degrees();
-            double indi_alt = axisSecondary.position.Degrees();
-            corrected = TelescopeAltAzToSky(indi_alt, indi_az, corrRA, corrDec);
-        }
-        else
-        {
-            INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
-            TelescopeDirectionVector tdv =
-                TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
-            corrected = TransformTelescopeToCelestial(tdv, corrRA, corrDec);
-        }
-        if (corrected)
-        {
-            m_currentRA  = corrRA;
-            m_currentDEC = corrDec;
-        }
-    }
+    // Apply INDI alignment correction if sync points exist.
+    updateCurrentCoordsFromAxes();
 
     // Az/Alt for the ALTAZ tracking servo.  The servo (top of ReadScopeStatus) drives the
     // axis motors; it must compare axis-space positions against axis-space targets.  Using
@@ -492,13 +503,11 @@ bool ScopeSim::Goto(double r, double d)
 
             // m_targetRA/Dec must be the instrument position (not celestial) so the ALTAZ
             // tracking servo's getAltAz() computes instrument Az/Alt rates, not celestial.
-            Angle instHA, instDec;
-            alignment.mountToInstrumentHaDec(Angle(instrumentAz_INDI), Angle(instrumentAlt), &instHA, &instDec);
-            m_targetRA  = (alignment.lst() - instHA).Hours();
-            m_targetDEC = instDec.Degrees();
+            setTargetFromAxisPosition(Angle(instrumentAz_INDI), Angle(instrumentAlt));
 
             TrackState = SCOPE_SLEWING;
             EqNP.setState(IPS_BUSY);
+            LOGF_INFO("Slewing to RA: %.4f Dec: %.4f", m_targetRA, m_targetDEC);
             return true;
         }
     }
@@ -561,14 +570,10 @@ bool ScopeSim::Sync(double ra, double dec)
     }
 
     // Keep the ALTAZ tracking servo on the current instrument position after sync.
-    Angle instHA, instDec;
-    alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
-                                     &instHA, &instDec);
-    m_targetRA  = (alignment.lst() - instHA).Hours();
-    m_targetDEC = instDec.Degrees();
+    setTargetFromAxisPosition(axisPrimary.position, axisSecondary.position);
 
-    LOGF_DEBUG("Sync at RA %f Dec %f  instHA %f instDec %f",
-               ra, dec, instHA.Degrees(), instDec.Degrees());
+    LOGF_DEBUG("Sync at RA %f Dec %f  m_targetRA %f m_targetDEC %f",
+               ra, dec, m_targetRA, m_targetDEC);
 
     LOG_INFO("Sync is successful.");
 
@@ -589,10 +594,7 @@ bool ScopeSim::Park()
         Angle alt     = Angle(GetAxis2Park());
         axisPrimary.StartSlew(indi_az);
         axisSecondary.StartSlew(alt);
-        Angle instHA, instDec;
-        alignment.mountToInstrumentHaDec(indi_az, alt, &instHA, &instDec);
-        m_targetRA  = (alignment.lst() - instHA).Hours();
-        m_targetDEC = instDec.Degrees();
+        setTargetFromAxisPosition(indi_az, alt);
         TrackState  = SCOPE_PARKING;
         EqNP.setState(IPS_BUSY);
         LOG_INFO("Parking...");
@@ -619,10 +621,7 @@ void ScopeSim::StartSlew(double ra, double dec, TelescopeStatus status)
 
     // Store instrument-frame RA/Dec so the ALTAZ tracking servo always works
     // in a consistent coordinate frame, regardless of how StartSlew was called.
-    Angle instHA, instDec;
-    alignment.mountToInstrumentHaDec(primary, secondary, &instHA, &instDec);
-    m_targetRA  = (alignment.lst() - instHA).Hours();
-    m_targetDEC = instDec.Degrees();
+    setTargetFromAxisPosition(primary, secondary);
     char RAStr[64], DecStr[64];
 
     fs_sexa(RAStr, m_targetRA, 2, 3600);
@@ -836,36 +835,7 @@ bool ScopeSim::ISSnoopDevice(XMLEle *root)
                 // Force an immediate coordinate update so that the next CCD capture
                 // uses the corrected pointing rather than waiting up to one full
                 // polling cycle (default 500 ms) for ReadScopeStatus to run.
-                // Mirror the ReadScopeStatus coordinate path: instrument position,
-                // then INDI alignment correction if sync points exist.
-                Angle instHA, instDec;
-                alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
-                                                 &instHA, &instDec);
-                m_currentRA  = (alignment.lst() - instHA).Hours();
-                m_currentDEC = instDec.Degrees();
-                if (GetAlignmentDatabase().size() >= 1)
-                {
-                    double corrRA, corrDec;
-                    bool corrected = false;
-                    if (m_MountType == Alignment::MOUNT_TYPE::ALTAZ)
-                    {
-                        double indi_az  = axisPrimary.position.Degrees();
-                        double indi_alt = axisSecondary.position.Degrees();
-                        corrected = TelescopeAltAzToSky(indi_alt, indi_az, corrRA, corrDec);
-                    }
-                    else
-                    {
-                        INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
-                        TelescopeDirectionVector tdv =
-                            TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
-                        corrected = TransformTelescopeToCelestial(tdv, corrRA, corrDec);
-                    }
-                    if (corrected)
-                    {
-                        m_currentRA  = corrRA;
-                        m_currentDEC = corrDec;
-                    }
-                }
+                updateCurrentCoordsFromAxes();
                 NewRaDec(m_currentRA, m_currentDEC);
             }
             return true;
@@ -969,9 +939,10 @@ uint32_t ScopeSim::applyDecBacklash(double rate, uint32_t ms)
 void ScopeSim::guideAltAzDecomposed(double dNS, double dEW, uint32_t ms)
 {
     // Decompose a celestial N/S/E/W guide pulse into Az/Alt axis components using
-    // the parallactic angle q.  Both sinQ and cosQ include the 1/cos(alt) factor
-    // from the standard parallactic angle formula, so the azimuth decomposition
-    // requires a second 1/cos(alt) division.
+    // the parallactic angle q.  sinQ = sin(q)/cos(alt), cosQ = cos(q)/cos(alt).
+    // The azimuth rate for celestial North is -sin(q)/cos(alt); since sinQ already
+    // carries one 1/cos(alt), dAz_N = -sinQ/cosAlt gives -sin(q)/cos^2(alt), which
+    // is the correct field rotation formula.
     //
     // Celestial North in Az/Alt:  dAlt = cos(q),   dAz = -sin(q)/cos(alt)
     // Celestial East  in Az/Alt:  dAlt = sin(q),   dAz =  cos(q)/cos(alt)
@@ -1185,7 +1156,7 @@ bool ScopeSim::updateMountAndPierSide()
 
     alignment.mountType = static_cast<Alignment::MOUNT_TYPE>(mountType);
 
-    // Tell the INDI alignment subsystem (SPK et al.) whether this is an equatorial or ALTAZ mount.
+    // Tell the INDI alignment subsystem whether this is an equatorial or ALTAZ mount.
     // Without this, the math plugin always fits an ALTAZ model regardless of mount type.
     SetApproximateMountAlignmentFromMountType(
         alignment.mountType == Alignment::MOUNT_TYPE::ALTAZ

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -94,14 +94,23 @@ bool ScopeSim::initProperties()
     simPierSideSP.fill(getDeviceName(), "SIM_PIER_SIDE", "Sim Pier Side",
                        "Simulation", IP_WO, ISR_1OFMANY, 60, IPS_IDLE);
 
-    mountModelNP[MM_IH].fill("MM_IH", "Ha Zero (IH)", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_ID].fill("MM_ID", "Dec Zero (ID)", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_CH].fill("MM_CH", "Cone (CH)", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_NP].fill("MM_NP", "Ha/Dec (NP)", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_MA].fill("MM_MA", "Pole Azm (MA)", "%g", -5, 5, 0.01, 0);
-    mountModelNP[MM_ME].fill("MM_ME", "Pole elev (ME)", "%g", -5, 5, 0.01, 0);
-    mountModelNP.fill(getDeviceName(), "MOUNT_MODEL", "Mount Model",
-                      "Simulation", IP_WO, 0, IPS_IDLE);
+    mountModelArcminNP[MM_IH].fill("MM_IH", "Ha Zero (IH) '", "%.1f", -10800, 10800, 0.1, 0);
+    mountModelArcminNP[MM_ID].fill("MM_ID", "Dec Zero (ID) '", "%.1f", -10800, 10800, 0.1, 0);
+    mountModelArcminNP[MM_CH].fill("MM_CH", "Cone (CH) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelArcminNP[MM_NP].fill("MM_NP", "Ha/Dec (NP) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelArcminNP[MM_MA].fill("MM_MA", "Pole Azm (MA) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelArcminNP[MM_ME].fill("MM_ME", "Pole elev (ME) '", "%.1f", -300, 300, 0.1, 0);
+    mountModelArcminNP.fill(getDeviceName(), "MOUNT_MODEL_ARCMIN", "Mount Model",
+                            "Simulation", IP_RW, 0, IPS_IDLE);
+
+    mountModelNP[MM_IH].fill("MM_IH", "Ha Zero (IH) deg", "%g", -180, 180, 0.01, 0);
+    mountModelNP[MM_ID].fill("MM_ID", "Dec Zero (ID) deg", "%g", -180, 180, 0.01, 0);
+    mountModelNP[MM_CH].fill("MM_CH", "Cone (CH) deg", "%g", -5, 5, 0.01, 0);
+    mountModelNP[MM_NP].fill("MM_NP", "Ha/Dec (NP) deg", "%g", -5, 5, 0.01, 0);
+    mountModelNP[MM_MA].fill("MM_MA", "Pole Azm (MA) deg", "%g", -5, 5, 0.01, 0);
+    mountModelNP[MM_ME].fill("MM_ME", "Pole elev (ME) deg", "%g", -5, 5, 0.01, 0);
+    mountModelNP.fill(getDeviceName(), "MOUNT_MODEL", "Mount Model (deg)",
+                      "Simulation", IP_RO, 0, IPS_IDLE);
 
     flipHourAngleNP[0].fill("FLIP_HA", "Hour Angle (deg)", "%g", -20, 20, 0.1, 0);
     flipHourAngleNP.fill(getDeviceName(), "FLIP_HA", "Flip Posn.",
@@ -170,8 +179,15 @@ void ScopeSim::ISGetProperties(const char *dev)
     MountTypeSP.load();
     defineProperty(simPierSideSP);
     simPierSideSP.load();
+    defineProperty(mountModelArcminNP);
+    mountModelArcminNP.load();
+    // Apply loaded arcmin values to the degrees mirror and alignment
+    for (int i = 0; i < 6; i++)
+        mountModelNP[i].setValue(mountModelArcminNP[i].getValue() / 60.0);
+    alignment.setCorrections(mountModelNP[MM_IH].getValue(), mountModelNP[MM_ID].getValue(),
+                             mountModelNP[MM_CH].getValue(), mountModelNP[MM_NP].getValue(),
+                             mountModelNP[MM_MA].getValue(), mountModelNP[MM_ME].getValue());
     defineProperty(mountModelNP);
-    mountModelNP.load();
     defineProperty(mountAxisNP);
     defineProperty(flipHourAngleNP);
     flipHourAngleNP.load();

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -22,6 +22,10 @@
 #include "indicom.h"
 #include "lilxml.h"
 
+#include <libnova/julian_day.h>
+
+using namespace INDI::AlignmentSubsystem;
+
 #include <cmath>
 #include <cstring>
 #include <memory>
@@ -166,6 +170,8 @@ bool ScopeSim::initProperties()
 
     setDefaultPollingPeriod(250);
 
+    InitAlignmentProperties(this);
+
     return true;
 }
 
@@ -175,10 +181,13 @@ void ScopeSim::ISGetProperties(const char *dev)
     INDI::Telescope::ISGetProperties(dev);
 
 #ifdef USE_SIM_TAB
-    // Load mount type settings
+    // Load mount type settings and apply immediately so axis track rates and
+    // alignment.mountType are correct before the first ReadScopeStatus tick.
     MountTypeSP.load();
+    MountTypeSP.apply();
     defineProperty(simPierSideSP);
     simPierSideSP.load();
+    updateMountAndPierSide();
     defineProperty(mountModelArcminNP);
     mountModelArcminNP.load();
     // Apply loaded arcmin values to the degrees mirror and alignment
@@ -199,7 +208,7 @@ void ScopeSim::ISGetProperties(const char *dev)
     double Latitude = LocationNP[LOCATION_LATITUDE].getValue();
     m_sinLat = std::sin(Latitude * 0.0174533);
     m_cosLat = std::cos(Latitude * 0.0174533);
-    m_currentAz = 180 + axisPrimary.position.Degrees(); // Primary to Azm
+    m_currentAz  = 180 + axisPrimary.position.Degrees();
     m_currentAlt = axisSecondary.position.Degrees();
 }
 
@@ -248,6 +257,8 @@ bool ScopeSim::updateProperties()
         if (pacDevice && strlen(pacDevice) > 0)
             IDSnoopDevice(pacDevice, "PAC_MANUAL_ADJUSTMENT");
 #endif
+
+        SetAlignmentSubsystemActive(true);
     }
     else
     {
@@ -300,8 +311,41 @@ bool ScopeSim::ReadScopeStatus()
     alignment.mountToApparentRaDec(axisPrimary.position, axisSecondary.position, &ra, &dec);
     m_currentRA = ra.Hours();
     m_currentDEC = dec.Degrees();
-    m_currentAz = 180 + axisPrimary.position.Degrees(); // ALTAZ-Primary to Azm
-    m_currentAlt = axisSecondary.position.Degrees();
+
+    // If the INDI alignment subsystem has 2+ sync points, apply its correction on top
+    // of the raw mount position.
+    if (GetAlignmentDatabase().size() > 1)
+    {
+        Angle instHA, instDec;
+        alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
+                                         &instHA, &instDec);
+        INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
+        TelescopeDirectionVector tdv =
+            TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
+
+        double corrRA, corrDec;
+        if (TransformTelescopeToCelestial(tdv, corrRA, corrDec))
+        {
+            m_currentRA  = corrRA;
+            m_currentDEC = corrDec;
+        }
+    }
+
+    // Derive Az/Alt from the finalised RA/Dec so the AltAz tracking rate calculation
+    // uses the same convention as EquatorialToHorizontal used for the target position.
+    if (alignment.mountType == Alignment::MOUNT_TYPE::ALTAZ)
+    {
+        INDI::IEquatorialCoordinates eq { m_currentRA, m_currentDEC };
+        INDI::IHorizontalCoordinates hz;
+        INDI::EquatorialToHorizontal(&eq, &m_Location, ln_get_julian_from_sys(), &hz);
+        m_currentAz  = hz.azimuth;
+        m_currentAlt = hz.altitude;
+    }
+    else
+    {
+        m_currentAz  = 180 + axisPrimary.position.Degrees();
+        m_currentAlt = axisSecondary.position.Degrees();
+    }
 
     // update properties from the axis
     if (alignment.mountType == Alignment::MOUNT_TYPE::EQ_GEM)
@@ -402,22 +446,36 @@ bool ScopeSim::Goto(double r, double d)
 
 bool ScopeSim::Sync(double ra, double dec)
 {
-    Angle a1, a2;
-    // set the mount axes to the position that will cause it to report the sync position
-    alignment.apparentRaDecToMount(Angle(ra * 15.0), Angle(dec), &a1, &a2);
-    axisPrimary.setDegrees(a1.Degrees());
-    axisSecondary.setDegrees(a2.Degrees());
+    // Build a telescope direction vector from the current instrument (encoder) HA/Dec,
+    // without Wallace pointing-model corrections applied.
+    Angle instHA, instDec;
+    alignment.mountToInstrumentHaDec(axisPrimary.position, axisSecondary.position,
+                                     &instHA, &instDec);
 
-    Angle r, d;
-    alignment.mountToApparentRaDec(a1, a2, &r, &d);
-    LOGF_DEBUG("sync to %f, %f, reached %f, %f", ra, dec, r.Hours(), d.Degrees());
-    m_currentRA = r.Hours();
-    m_currentDEC = d.Degrees();
+    INDI::IEquatorialCoordinates haCoords{ instHA.Hours(), instDec.Degrees() };
+    TelescopeDirectionVector tdv =
+        TelescopeDirectionVectorFromLocalHourAngleDeclination(haCoords);
+
+    AlignmentDatabaseEntry entry;
+    entry.ObservationJulianDate = ln_get_julian_from_sys();
+    entry.RightAscension        = ra;
+    entry.Declination           = dec;
+    entry.TelescopeDirection    = tdv;
+    entry.PrivateDataSize       = 0;
+
+    if (!CheckForDuplicateSyncPoint(entry))
+    {
+        GetAlignmentDatabase().push_back(entry);
+        UpdateSize();
+        Initialise(this);
+    }
+
+    LOGF_DEBUG("Sync at RA %f Dec %f  instHA %f instDec %f",
+               ra, dec, instHA.Degrees(), instDec.Degrees());
 
     LOG_INFO("Sync is successful.");
 
     EqNP.setState(IPS_OK);
-
     NewRaDec(m_currentRA, m_currentDEC);
 
     return true;
@@ -520,6 +578,8 @@ bool ScopeSim::ISNewNumber(const char *dev, const char *name, double values[], c
 #endif
     }
 
+    ProcessAlignmentNumberProperties(this, name, values, names, n);
+
     //  if we didn't process it, continue up the chain, let somebody else
     //  give it a shot
     return INDI::Telescope::ISNewNumber(dev, name, values, names, n);
@@ -538,6 +598,7 @@ bool ScopeSim::ISNewSwitch(const char *dev, const char *name, ISState *states, c
             MountTypeSP.setState(IPS_OK);
             MountTypeSP.apply();
             updateMountAndPierSide();
+            saveConfig(MountTypeSP);
             return true;
         }
         if (simPierSideSP.isNameMatch(name))
@@ -563,6 +624,14 @@ bool ScopeSim::ISNewSwitch(const char *dev, const char *name, ISState *states, c
         }
     }
 
+    ProcessAlignmentSwitchProperties(this, name, states, names, n);
+
+    // Persist alignment plugin and active state immediately when changed, since
+    // SaveAlignmentConfigProperties() is only called during a full saveConfigItems() run.
+    if (strcmp(name, "ALIGNMENT_SUBSYSTEM_MATH_PLUGINS") == 0 ||
+        strcmp(name, "ALIGNMENT_SUBSYSTEM_ACTIVE") == 0)
+        saveConfig(true, name);
+
     //  Nobody has claimed this, so pass it over
     return INDI::Telescope::ISNewSwitch(dev, name, states, names, n);
 }
@@ -587,6 +656,7 @@ bool ScopeSim::ISNewText(const char *dev, const char *name, char *texts[], char 
         }
     }
 #endif
+    ProcessAlignmentTextProperties(this, name, texts, names, n);
     return INDI::Telescope::ISNewText(dev, name, texts, names, n);
 }
 
@@ -864,6 +934,8 @@ bool ScopeSim::updateLocation(double latitude, double longitude, double elevatio
     alignment.latitude = Angle(latitude);
     alignment.longitude = Angle(longitude);
 
+    UpdateLocation(latitude, longitude, elevation);
+
     INDI_UNUSED(elevation);
     return true;
 }
@@ -895,6 +967,15 @@ bool ScopeSim::updateMountAndPierSide()
     }
 
     alignment.mountType = static_cast<Alignment::MOUNT_TYPE>(mountType);
+
+    // Reinitialize the secondary axis track rate for the selected mount type.
+    // ALTAZ: both axes need sidereal rate (overridden each tick by parabolic tracking).
+    // EQ: primary tracks sidereal, secondary (Dec) is driven only when slewing.
+    if (mountType == Alignment::MOUNT_TYPE::ALTAZ)
+        axisSecondary.TrackRate(Axis::SIDEREAL);
+    else
+        axisSecondary.TrackRate(Axis::OFF);
+
     // update the pier side capability depending on the mount type
     uint32_t cap = GetTelescopeCapability();
     if (pierSide == 1 && mountType == 2)

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -149,6 +149,14 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface,
         int m_MountType {-1};
 
         Alignment alignment;
+
+        // Parabolic Alt-Az tracking window: three sky positions bracketing the current time,
+        // used to fit a 2nd-order polynomial for axis rate prediction.
+        INDI::IHorizontalCoordinates m_TrackingWindowCoords[3] {};
+        bool   m_IsPipelinePrimed { false };
+        double m_LastTrackingRA  { 0 };
+        double m_LastTrackingDec { 0 };
+
         bool updateMountAndPierSide();
 
 #ifdef USE_SIM_TAB

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -21,6 +21,7 @@
 #include "indiguiderinterface.h"
 #include "inditelescope.h"
 #include "scopesim_helper.h"
+#include "alignment/AlignmentSubsystemForDrivers.h"
 
 #define USE_SIM_TAB
 
@@ -39,7 +40,8 @@
  *
  * @author Jasem Mutlaq
  */
-class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface
+class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface,
+                 public INDI::AlignmentSubsystem::AlignmentSubsystemForDrivers
 {
     public:
         ScopeSim();

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -160,7 +160,8 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface
             PS_ON
         };
 
-        INDI::PropertyNumber mountModelNP {6};
+        INDI::PropertyNumber mountModelArcminNP {6}; // R/W input in arcminutes
+        INDI::PropertyNumber mountModelNP {6};        // R/O mirror in degrees (for snooping)
         enum
         {
             MM_IH,

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -177,8 +177,7 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface,
             PS_ON
         };
 
-        INDI::PropertyNumber mountModelArcminNP {6}; // R/W input in arcminutes
-        INDI::PropertyNumber mountModelNP {6};        // R/O mirror in degrees (for snooping)
+        INDI::PropertyNumber mountModelNP {6};
         enum
         {
             MM_IH,

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -93,7 +93,7 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface,
     private:
         double m_currentRA { 0 };
         double m_currentDEC { 90 };
-        double m_currentAz { 180 };
+        double m_currentAz { 180 };  // INDI Az convention: 0=North, increasing eastward
         double m_currentAlt { 0 };
         double m_targetRA { 0 };
         double m_targetDEC { 0 };
@@ -104,7 +104,12 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface,
         /// via the parallactic angle, for ALTAZ mount guiding.
         void guideAltAzDecomposed(double dNS, double dEW, uint32_t ms);
 
-        // bool forceMeridianFlip { false }; // #PS: unused
+        /// Compute m_currentRA/DEC from axis positions, then apply any INDI alignment correction.
+        void updateCurrentCoordsFromAxes();
+
+        /// Set m_targetRA/DEC from raw axis positions (for ALTAZ tracking servo consistency).
+        void setTargetFromAxisPosition(Angle primary, Angle secondary);
+
         unsigned int DBG_SCOPE { 0 };
 
         int mcRate = 0;

--- a/drivers/telescope/telescope_simulator.h
+++ b/drivers/telescope/telescope_simulator.h
@@ -97,10 +97,12 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface,
         double m_currentAlt { 0 };
         double m_targetRA { 0 };
         double m_targetDEC { 0 };
-        double m_sinLat, m_cosLat;
-
         /// used by GoTo and Park
         void StartSlew(double ra, double dec, TelescopeStatus status);
+
+        /// Decompose a celestial N/S/E/W guide pulse into Az/Alt axis motion
+        /// via the parallactic angle, for ALTAZ mount guiding.
+        void guideAltAzDecomposed(double dNS, double dEW, uint32_t ms);
 
         // bool forceMeridianFlip { false }; // #PS: unused
         unsigned int DBG_SCOPE { 0 };
@@ -189,6 +191,12 @@ class ScopeSim : public INDI::Telescope, public INDI::GuiderInterface,
         double m_snoopedAltError { 0 };
 
 #endif
+
+        // True pointing position (Wallace errors applied) published as EQUATORIAL_PE so the
+        // CCD simulator can generate star fields at the physically-correct sky position while
+        // EQUATORIAL_EOD_COORD carries the raw encoder position for the INDI alignment module.
+        INDI::PropertyNumber EqPENP {2};
+        enum { PE_RA = 0, PE_DEC = 1 };
 
 };
 

--- a/libs/alignment/AlignmentSubsystemForDrivers.cpp
+++ b/libs/alignment/AlignmentSubsystemForDrivers.cpp
@@ -113,7 +113,7 @@ bool AlignmentSubsystemForDrivers::SkyToTelescopeEquatorial(double actualRA, dou
         return false;
     }
 
-    if (GetAlignmentDatabase().size() > 1)
+    if (GetAlignmentDatabase().size() >= 1)
     {
         if (TransformCelestialToTelescope(actualRA, actualDec, 0.0, TDV))
         {
@@ -143,7 +143,7 @@ bool AlignmentSubsystemForDrivers::TelescopeEquatorialToSky(double mountRA, doub
         return false;
     }
 
-    if (GetAlignmentDatabase().size() > 1)
+    if (GetAlignmentDatabase().size() >= 1)
     {
         TelescopeDirectionVector TDV;
         eq.rightascension = mountRA;
@@ -200,7 +200,7 @@ bool AlignmentSubsystemForDrivers::SkyToTelescopeAltAz(double actualRA, double a
         return false;
     }
 
-    if (GetAlignmentDatabase().size() > 1)
+    if (GetAlignmentDatabase().size() >= 1)
     {
         if (TransformCelestialToTelescope(actualRA, actualDec, 0.0, TDV))
         {
@@ -224,7 +224,7 @@ bool AlignmentSubsystemForDrivers::TelescopeAltAzToSky(double mountAlt, double m
         return false;
     }
 
-    if (GetAlignmentDatabase().size() > 1)
+    if (GetAlignmentDatabase().size() >= 1)
     {
         TelescopeDirectionVector TDV;
         altaz.azimuth  = range360(mountAz);

--- a/libs/alignment/MathPluginManagement.cpp
+++ b/libs/alignment/MathPluginManagement.cpp
@@ -46,7 +46,7 @@ void MathPluginManagement::InitProperties(Telescope *ChildTelescope)
 
     int configPlugin = -1;
     IUGetConfigOnSwitchIndex(ChildTelescope->getDeviceName(),  "ALIGNMENT_SUBSYSTEM_MATH_PLUGINS", &configPlugin);
-    if (configPlugin > 0 && configPlugin < AlignmentSubsystemMathPluginsV.nsp)
+    if (configPlugin >= 0 && configPlugin < AlignmentSubsystemMathPluginsV.nsp)
     {
         IUResetSwitch(&AlignmentSubsystemMathPluginsV);
         AlignmentSubsystemMathPluginsV.sp[configPlugin].s = ISS_ON;

--- a/test/alignment/test_alignment_plugins.cpp
+++ b/test/alignment/test_alignment_plugins.cpp
@@ -442,6 +442,41 @@ TEST_F(AlignmentPluginTest, Test_SVD_AltAz)
 }
 
 // ---------------------------------------------------------------------------
+// Single sync point -- all plugins
+//
+// Verifies that each plugin initialises, transforms, and round-trips correctly
+// with exactly one sync point.  This exercises the size() >= 1 gate in
+// AlignmentSubsystemForDrivers: corrections must apply from the first sync.
+//
+// Index errors on both axes (IH = 5 arcmin, ID = 3 arcmin) are used so the
+// correction has both an RA and a Dec component.  With a single sync point
+// every plugin's minimal model recovers only index errors, not polar errors,
+// so pure index errors are the appropriate choice here.
+//
+// NearestMathPlugin applies the single point's offset uniformly across the
+// sky — for pure index errors the offset is position-independent, so the
+// round-trip is exact at any validation point.
+// ---------------------------------------------------------------------------
+
+TEST_F(AlignmentPluginTest, SinglePoint_BuiltIn)
+{
+    BuiltInMathPlugin plugin;
+    RunPluginAllInAlignment(plugin, {.ih = ARCMIN_TO_DEG(5), .id = ARCMIN_TO_DEG(3)}, 1);
+}
+
+TEST_F(AlignmentPluginTest, SinglePoint_SVD)
+{
+    SVDMathPlugin plugin;
+    RunPluginAllInAlignment(plugin, {.ih = ARCMIN_TO_DEG(5), .id = ARCMIN_TO_DEG(3)}, 1);
+}
+
+TEST_F(AlignmentPluginTest, SinglePoint_Nearest)
+{
+    NearestMathPlugin plugin;
+    RunPluginAllInAlignment(plugin, {.ih = ARCMIN_TO_DEG(5), .id = ARCMIN_TO_DEG(3)}, 1);
+}
+
+// ---------------------------------------------------------------------------
 // AlignValidate -- equatorial mounts
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This turned out to be a lot more involved than I had anticipated, but it helped me uncover a couple of bugs in the new math plugin I am working on. I tried to break it up into individual commits to make it easier to review, but let me know if you want me to break it into multiple PRs

## Summary

This PR extends the telescope simulator to serve as a testbed for evaluating INDI alignment math plugins against physically realistic mount errors. I can now run a complete model building for an Alt-Az telescope after injecting errors.

The simulator already injects configurable pointing errors based on Patrick Wallace's classical 6-term mount model. This PR integrates the INDI alignment subsystem and brings Alt-Az support to feature parity with equatorial modes, so the full goto/track/sync loop can be exercised end-to-end.

### INDI alignment integration

The INDI alignment subsystem is now integrated for both equatorial and Alt-Az mount types. Syncing on stars feeds the math plugin with the instrument-to-sky discrepancies produced by the injected Wallace errors. A correct alignment model should converge goto and tracking accuracy back toward the noise floor, making it possible to evaluate plugin quality quantitatively using the CCD simulator's star fields.

### Arcminute input fields

The existing degree-valued mount model properties are hard to use for realistic error magnitudes (typical mount errors are a few arcminutes, not degrees). This PR adds companion arcminute-valued input fields for all 6 Wallace terms, with tightened limits: index errors (IH/ID) allow up to +/-180 deg to accommodate a misaligned Az zero point; all other terms continue to be limited to +/-5 deg.

### Robust Alt-Az support

Prior to this PR the Alt-Az mount type was only partially implemented. This PR brings it to feature parity with the equatorial modes:

- **Coordinate system correctness**: axisPrimary now consistently uses the INDI Az convention (North=0, East=90) throughout goto, sync, tracking, guiding, and park. The previous mixed convention caused systematic pointing errors in Az.
- **Goto and sync**: Alt-Az goto correctly converts the celestial target through `EquatorialToHorizontal`, routes through the alignment subsystem when sync points exist, and sets axis slew targets directly in Az/Alt space.
- **Tracking servo**: a parabolic 3-point window replaces the previous Patera formula for axis rate prediction. The tracking target is the alignment-corrected instrument position, so the servo tracks the sky position the alignment model has learned rather than the raw encoder position. Solar and lunar modes apply the correct RA drift rate at each sample point, consistent with EQ behaviour.
- **Guiding**: N/S/E/W guide pulses are decomposed into Az/Alt axis motion via the parallactic angle.
- **Park defaults**: Alt-Az park defaults to Az=0/Alt=0 (horizon north) instead of the equatorial default.
- **Mount type notification**: the alignment subsystem is informed of the mount type at connect time so math plugins use the correct coordinate encoding.

## Changes

- **Arcminute input fields** for all 6 Wallace model terms, with tightened limits; mirrored as degrees to `MOUNT_MODEL` for snooping by external tools
- **INDI alignment subsystem** integrated: sync points are recorded, goto corrects for learned errors, and the mount type (EQ/Alt-Az) is communicated so plugins use the right coordinate model
- **Alt-Az tracking servo**: uses alignment-corrected RA/Dec as the tracking target and a parabolic 2nd-order polynomial fit to predict axis rates; solar/lunar modes apply RA drift offset
- **Coordinate and pier-side fixes**: axisPrimary Az convention unified to INDI North=0/East=90, meridian flip detection corrected, ALTAZ park defaults corrected
- **CCD and guide simulator PE snoop fixes**: both simulators had a logic inversion (`if (!usePE)`) that meant the EQUATORIAL_PE branch was never taken — star fields were always generated from the raw encoder position rather than the true (error-injected) position. Fixed in both. The guide simulator had additional issues: `raPE`/`decPE` were missing from the header entirely (making the PE blocks permanently dead code), `USE_EQUATORIAL_PE` was not set in CMakeLists, and the snoop handler used the old `INumberVectorProperty` API. All three are corrected; both simulators now use `INDI::ObservedToJ2000` and the `PropertyNumber` API for the PE snoop path.
