### PR TITLE
Fix hotplug usb reset with external guiders

### DIFF
--- a/drivers/telescope/lx200_OnStep.cpp
+++ b/drivers/telescope/lx200_OnStep.cpp
@@ -4991,6 +4991,9 @@ bool LX200_OnStep::Sync(double ra, double dec)
     currentRA  = ra;
     currentDEC = dec;
 
+    EqNP.setState(IPS_OK);
+    NewRaDec(currentRA, currentDEC);
+
     LOG_INFO("OnStep: Synchronization successful.");
     return true;
 }

--- a/libs/indibase/hotplugmanager.cpp
+++ b/libs/indibase/hotplugmanager.cpp
@@ -323,12 +323,21 @@ void HotPlugManager::checkHotPlugEvents()
         {
             if (currentConnected.find(identifier) == currentConnected.end())
             {
-                // Device disconnected
-                LOGF_DEBUG("HotPlugManager: Device disconnected: %s", identifier.c_str());
                 std::shared_ptr<DefaultDevice> deviceToRemove = managedDevices.at(identifier);
+
+                // If the device is currently connected to a client, skip removal.
+                // Some devices (e.g. ZWO ASI cameras) perform USB resets after each
+                // frame readout, causing them to transiently disappear from USB
+                // enumeration. Destroying a connected device in this window breaks
+                // all INDI clients (KStars, PHD2) that hold property references.
+                if (deviceToRemove->isConnected())
+                {
+                    LOGF_DEBUG("HotPlugManager: Device %s not found on USB but is connected to a client, skipping removal.", identifier.c_str());
+                    continue;
+                }
+
+                LOGF_DEBUG("HotPlugManager: Device disconnected: %s", identifier.c_str());
                 handler->destroyDevice(deviceToRemove);
-                // Note: The handler's internal map should be updated by destroyDevice or subsequent createDevice calls
-                // For std::deque, this means removing the element.
             }
         }
 


### PR DESCRIPTION
Some INDI camera drivers  perform a USB reset after each frame
readout. During this brief reset window the device transiently disappears from
USB enumeration. The HotPlug manager sees the disappearance and calls
destroyDevice(), which invalidates every property pointer held by connected
clients (KStars, PHD2, etc.). When the device reappears milliseconds later it is
re-created from scratch, but the clients are left with dangling references.

This patch adds an isConnected() check before removal. If the device is actively
connected to a client the removal is skipped and a debug message is logged. The
device will still be cleaned up normally if it genuinely disconnects.

Tested with ZWO ASI220MM Mini on StellarMate (aarch64) during extended
single-exposure and streaming guide sessions.
