### PR TITLE
alignment: fix plugin selection persistence, sanitize polar sync entries

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -1378,9 +1378,9 @@ bool CCDSim::ISSnoopDevice(XMLEle * root)
 
         if (rc_ra == 0 && rc_de == 0)
         {
-            INDI::IEquatorialCoordinates epochPos { newra * 15.0, newdec }, J2000Pos { 0, 0 };
+            INDI::IEquatorialCoordinates epochPos { newra, newdec }, J2000Pos { 0, 0 };
             INDI::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
-            raPE  = J2000Pos.rightascension / 15.0;
+            raPE  = J2000Pos.rightascension;
             decPE = J2000Pos.declination;
             usePE = true;
 

--- a/drivers/ccd/guide_simulator.cpp
+++ b/drivers/ccd/guide_simulator.cpp
@@ -1164,9 +1164,9 @@ bool GuideSim::ISSnoopDevice(XMLEle * root)
 
         if (rc_ra == 0 && rc_de == 0)
         {
-            INDI::IEquatorialCoordinates epochPos { newra * 15.0, newdec }, J2000Pos { 0, 0 };
+            INDI::IEquatorialCoordinates epochPos { newra, newdec }, J2000Pos { 0, 0 };
             INDI::ObservedToJ2000(&epochPos, ln_get_julian_from_sys(), &J2000Pos);
-            raPE  = J2000Pos.rightascension / 15.0;
+            raPE  = J2000Pos.rightascension;
             decPE = J2000Pos.declination;
             m_UsePE = true;
 

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -795,11 +795,12 @@ bool ScopeSim::ISNewSwitch(const char *dev, const char *name, ISState *states, c
 
     ProcessAlignmentSwitchProperties(this, name, states, names, n);
 
-    // Persist alignment plugin and active state immediately when changed, since
-    // SaveAlignmentConfigProperties() is only called during a full saveConfigItems() run.
+    // Persist alignment plugin and active state immediately when changed.
+    // Use a full saveConfig() — the selective form (saveConfig(true, name)) only
+    // patches the named property in the existing XML and skips CURRENT_MATH_PLUGIN.
     if (strcmp(name, "ALIGNMENT_SUBSYSTEM_MATH_PLUGINS") == 0 ||
         strcmp(name, "ALIGNMENT_SUBSYSTEM_ACTIVE") == 0)
-        saveConfig(true, name);
+        saveConfig();
 
     //  Nobody has claimed this, so pass it over
     return INDI::Telescope::ISNewSwitch(dev, name, states, names, n);

--- a/libs/alignment/MathPlugin.cpp
+++ b/libs/alignment/MathPlugin.cpp
@@ -8,6 +8,10 @@
 
 #include "MathPlugin.h"
 
+#include <indicom.h>
+
+#include <cmath>
+
 namespace INDI
 {
 namespace AlignmentSubsystem
@@ -15,7 +19,79 @@ namespace AlignmentSubsystem
 bool MathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
 {
     MathPlugin::pInMemoryDatabase = pInMemoryDatabase;
+    SanitizePolarEntries(pInMemoryDatabase, ApproximateMountAlignment);
     return true;
+}
+
+void MathPlugin::SanitizePolarEntries(InMemoryDatabase *pDb, MountAlignment_t mountAlignment)
+{
+    if (!pDb) return;
+
+    // Threshold in degrees for celestial Dec (EQ) or encoder El (altaz).
+    // For EQ, 88 deg catches the truly degenerate zone where cos(Dec)->0
+    // while leaving multi-point models that include near-pole coverage intact.
+    static constexpr double kPolarThresholdDeg = 88.0;
+    // Shift degenerate entries so that celestial Dec (EQ) or encoder El
+    // (altaz) ends up at this value, well within the conditioned region.
+    static constexpr double kTargetPitchDeg = 80.0;
+
+    auto &db = pDb->GetAlignmentDatabase();
+    IGeographicCoordinates location;
+    bool haveLoc = pDb->GetDatabaseReferencePosition(location);
+
+    TelescopeDirectionVectorSupportFunctions sf;
+
+    for (auto &entry : db)
+    {
+        if (mountAlignment == ZENITH)
+        {
+            // Altaz: degeneracy at the zenith -- check encoder El via TDV.z
+            double sinThresh = std::sin(DEG_TO_RAD(kPolarThresholdDeg));
+            if (std::abs(entry.TelescopeDirection.z) < sinThresh)
+                continue;
+
+            if (!haveLoc) continue;
+
+            double currentPitchDeg = RAD_TO_DEG(std::asin(entry.TelescopeDirection.z));
+            double targetPitch     = (currentPitchDeg >= 0) ? kTargetPitchDeg : -kTargetPitchDeg;
+            double deltaDeg        = currentPitchDeg - targetPitch;
+
+            INDI::IEquatorialCoordinates celEq { entry.RightAscension, entry.Declination };
+            INDI::IHorizontalCoordinates hor;
+            EquatorialToHorizontal(&celEq, &location,
+                                   entry.ObservationJulianDate, &hor);
+
+            double newEl = hor.altitude - deltaDeg;
+            if (newEl < 20.0) newEl = 20.0;
+            if (newEl > kPolarThresholdDeg) newEl = kPolarThresholdDeg;
+
+            INDI::IHorizontalCoordinates newHor { hor.azimuth, newEl };
+            entry.TelescopeDirection = sf.TelescopeDirectionVectorFromAltitudeAzimuth(newHor);
+            entry.Declination -= (hor.altitude - newEl);
+        }
+        else
+        {
+            // EQ: degeneracy at the celestial pole -- cos(Dec)->0 makes the
+            // roll-index (IH) term unobservable.  Check celestial Dec.
+            if (std::abs(entry.Declination) < kPolarThresholdDeg)
+                continue;
+
+            double encoderPitchDeg = RAD_TO_DEG(std::asin(entry.TelescopeDirection.z));
+            double celDec          = entry.Declination;
+            double targetCelDec    = (celDec >= 0) ? kTargetPitchDeg : -kTargetPitchDeg;
+            double deltaDeg        = celDec - targetCelDec;
+
+            // Shift encoder pitch by the same delta to preserve the correction
+            double newEncoderPitch = encoderPitchDeg - deltaDeg;
+
+            // Rebuild TDV using celestial RA (assumes zero roll-index error
+            // at the pole -- the only safe assumption when unobservable).
+            // RA-based encoding matches the BuiltIn/SVD/Nearest convention.
+            INDI::IEquatorialCoordinates raCoords { entry.RightAscension, newEncoderPitch };
+            entry.TelescopeDirection = sf.TelescopeDirectionVectorFromEquatorialCoordinates(raCoords);
+            entry.Declination = targetCelDec;
+        }
+    }
 }
 
 } // namespace AlignmentSubsystem

--- a/libs/alignment/MathPlugin.h
+++ b/libs/alignment/MathPlugin.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "InMemoryDatabase.h"
+#include "TelescopeDirectionVectorSupportFunctions.h"
 
 namespace INDI
 {
@@ -81,6 +82,20 @@ class MathPlugin
         /// deterministic, clock-injected testing and avoid reliance on the system clock.
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                 double &RightAscension, double &Declination, double JulianOffset = 0) = 0;
+
+        /// \brief Sanitize alignment database entries that are near the pole (EQ) or
+        /// zenith (altaz).  At these singularities the roll-axis (HA or Az) component
+        /// of the TDV is unconstrained, making any pointing model ill-conditioned.
+        ///
+        /// The method shifts such entries to a moderate pitch by applying the same
+        /// delta to both the TDV encoder position and the celestial declination,
+        /// preserving the pointing correction while breaking the degeneracy.
+        /// The encoder HA/Az is reconstructed from the celestial coordinates,
+        /// implicitly assuming zero roll-index error.
+        ///
+        /// Call this before processing the database in Initialise().
+        static void SanitizePolarEntries(InMemoryDatabase *pInMemoryDatabase,
+                                         MountAlignment_t mountAlignment);
 
     protected:
         // Protected properties

--- a/libs/alignment/MathPluginManagement.cpp
+++ b/libs/alignment/MathPluginManagement.cpp
@@ -101,8 +101,26 @@ void MathPluginManagement::ProcessTextProperties(Telescope *pTelescope, const ch
         AlignmentSubsystemCurrentMathPluginV.s = IPS_OK;
         IUUpdateText(&AlignmentSubsystemCurrentMathPluginV, texts, names, n);
 
+        // If the switch has already selected and loaded an external plugin, it takes
+        // precedence over the text property (which may be stale from a previous config
+        // save).  Sync the text to match the switch and skip the redundant reload.
+        int currentSwitch = IUFindOnSwitchIndex(&AlignmentSubsystemMathPluginsV);
+        if (currentSwitch > 0 && currentSwitch <= (int)MathPluginFiles.size())
+        {
+            const char *switchPath = MathPluginFiles[currentSwitch - 1].c_str();
+            if (strcmp(AlignmentSubsystemCurrentMathPlugin.text, switchPath) != 0)
+                IUSaveText(&AlignmentSubsystemCurrentMathPlugin, switchPath);
+            return;
+        }
+
         if (0 != strcmp(AlignmentSubsystemMathPlugins.get()[0].label, AlignmentSubsystemCurrentMathPlugin.text))
         {
+            // Capture current mount alignment before unloading the old plugin so we can
+            // propagate it to the newly loaded plugin.  Without this, every externally-loaded
+            // plugin (Nearest, SVD, …) defaults to ZENITH, which silently switches EQ
+            // drivers to the AltAz code paths and produces garbage Goto coordinates.
+            MountAlignment_t currentMountAlignment = GetApproximateMountAlignment();
+
             // Unload old plugin if required
             if (nullptr != LoadedMathPluginHandle)
             {
@@ -138,6 +156,8 @@ void MathPluginManagement::ProcessTextProperties(Telescope *pTelescope, const ch
                 if (nullptr != Create)
                 {
                     pLoadedMathPlugin = Create();
+                    SetApproximateMountAlignment(currentMountAlignment);
+                    Initialise(CurrentInMemoryDatabase);
 
                     // TODO - Update the client to reflect the new plugin
                     int i = 0;

--- a/test/alignment/test_alignment_plugins.cpp
+++ b/test/alignment/test_alignment_plugins.cpp
@@ -770,6 +770,206 @@ TEST_F(AlignmentPluginTest, SVD_AlignValidate_Equatorial)
     RunPluginAlignValidate(plugin, kMixed, 12, 100, 1.0, kNairobi);
 }
 
+// ---------------------------------------------------------------------------
+// Polar-degeneracy regression tests
+//
+// When all sync points are near the celestial pole (EQ) or zenith (altaz),
+// the roll-index term (IH/IA) is unobservable because its basis function
+// scales as cos(pitch) which is ~0.  Without the degeneracy guard in
+// Initialise(), the solver produces an arbitrary IH/IA value that causes
+// wildly wrong gotos at any other part of the sky.
+//
+// These tests reproduce the exact failure scenario from the field:
+//   1. Single sync point near pole/zenith with mount errors
+//   2. Goto + roundtrip to a target far from the pole/zenith
+//   3. Verify the result is sane (not garbage)
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// PolarDegeneracy tests
+//
+// Syncs a plugin at a single near-pole (EQ) or near-zenith (altaz) point
+// with mount errors, then does TransformCelestialToTelescope to a target
+// far from the pole/zenith and checks the resulting encoder position is
+// sane.  A roundtrip (C->T->C) always passes for invertible plugins, so
+// we check the forward direction: decode the TDV to encoder HA/Dec (or
+// Az/El) and verify it's not wildly different from what a zero-error mount
+// would produce.
+// ---------------------------------------------------------------------------
+
+// Defined as TEST_F body helper so it can access fixture members.
+// Called from individual TEST_F cases below.
+
+static void RunPolarDegeneracyTestImpl(
+    MathPlugin &plugin, const MountErrors &errors,
+    INDI::IGeographicCoordinates site,
+    ::Alignment::MOUNT_TYPE mountType,
+    double fixedJD = 2461113.81667)
+{
+    auto makeGenerator = [](const MountErrors &e, INDI::IGeographicCoordinates s,
+                            ::Alignment::MOUNT_TYPE mt) -> ::Alignment
+    {
+        ::Alignment gen;
+        gen.mountType = mt;
+        gen.latitude  = Angle(s.latitude);
+        gen.longitude = Angle(s.longitude);
+        gen.setCorrections(e.ih, e.id, e.ch, e.np, e.ma, e.me);
+        return gen;
+    };
+
+    auto buildEntry = [&](::Alignment &gen,
+                          TelescopeDirectionVectorSupportFunctions *pSupport,
+                          double ra, double dec, double lst_hrs,
+                          ::Alignment::MOUNT_TYPE mt,
+                          AlignmentDatabaseEntry &entry)
+    {
+        Angle ha(get_local_hour_angle(lst_hrs, ra), Angle::HOURS), adec(dec);
+        entry.RightAscension        = ra;
+        entry.Declination           = dec;
+        entry.ObservationJulianDate = fixedJD;
+        if (mt == ::Alignment::ALTAZ)
+        {
+            Angle primary, secondary;
+            gen.apparentHaDecToMount(ha, adec, &primary, &secondary);
+            INDI::IHorizontalCoordinates horCoords = { primary.Degrees(), secondary.Degrees() };
+            entry.TelescopeDirection = pSupport->TelescopeDirectionVectorFromAltitudeAzimuth(horCoords);
+        }
+        else
+        {
+            Angle mha, mdec;
+            gen.observedToInstrument(ha, adec, &mha, &mdec);
+            double instRA = range24(lst_hrs - mha.Hours());
+            INDI::IEquatorialCoordinates raCoords = { instRA, mdec.Degrees() };
+            entry.TelescopeDirection = pSupport->TelescopeDirectionVectorFromEquatorialCoordinates(raCoords);
+        }
+    };
+    MountAlignment_t alignment = (mountType == ::Alignment::ALTAZ) ? ZENITH :
+                                 site.latitude >= 0  ? NORTH_CELESTIAL_POLE
+                                                 : SOUTH_CELESTIAL_POLE;
+    plugin.SetApproximateMountAlignment(alignment);
+
+    InMemoryDatabase db;
+    db.SetDatabaseReferencePosition(site);
+
+    ::Alignment gen = makeGenerator(errors, site, mountType);
+
+    auto *pSupport = dynamic_cast<TelescopeDirectionVectorSupportFunctions *>(&plugin);
+    ASSERT_NE(pSupport, nullptr);
+
+    double gmst = ln_get_apparent_sidereal_time(fixedJD);
+    double lst  = range24(gmst + DEG_TO_HOURS(site.longitude));
+
+    // Single sync point near the pole/zenith
+    double syncRA, syncDec;
+    if (mountType == ::Alignment::ALTAZ)
+    {
+        // Near-zenith: RA ≈ LST, Dec ≈ latitude
+        syncRA  = lst;
+        syncDec = site.latitude + 1.0;
+    }
+    else
+    {
+        // Near celestial pole
+        syncRA  = lst - 1.0;
+        syncDec = 88.0;
+    }
+
+    AlignmentDatabaseEntry entry;
+    buildEntry(gen, pSupport, syncRA, syncDec, lst, mountType, entry);
+    db.GetAlignmentDatabase().push_back(entry);
+
+    ASSERT_TRUE(plugin.Initialise(&db));
+
+    double joff = fixedJD - ln_get_julian_from_sys();
+
+    // Target far from the pole/zenith
+    double testRA  = 12.0;
+    double testDec = (mountType == ::Alignment::ALTAZ) ? 30.0 : 45.0;
+
+    TelescopeDirectionVector resultV;
+    ASSERT_TRUE(plugin.TransformCelestialToTelescope(testRA, testDec, joff, resultV));
+
+    // Decode the TDV to encoder coordinates and sanity-check
+    if (mountType == ::Alignment::ALTAZ)
+    {
+        INDI::IHorizontalCoordinates hor;
+        pSupport->AltitudeAzimuthFromTelescopeDirectionVector(resultV, hor);
+        // For a target at Dec=30 from LA, the elevation should be positive
+        // and less than ~90.  A degenerate transform might produce negative
+        // elevation or wildly wrong azimuth.
+        EXPECT_GT(hor.altitude, -10.0)
+            << "AltAz polar degeneracy: El=" << hor.altitude
+            << " -- forward transform produced sub-horizon encoder position";
+        EXPECT_LT(hor.altitude, 90.0)
+            << "AltAz polar degeneracy: El=" << hor.altitude;
+    }
+    else
+    {
+        INDI::IEquatorialCoordinates eq;
+        pSupport->EquatorialCoordinatesFromTelescopeDirectionVector(resultV, eq);
+        double encoderRA = eq.rightascension;
+        // The encoder RA should be roughly near the target RA.
+        // With small mount errors (arcminutes) the difference should be
+        // well under a few degrees, not tens of degrees.
+        double dRA = rangeHA(encoderRA - testRA) * 15.0;  // degrees
+        // Tolerances are generous (15 deg) because this test uses large mount
+        // errors (IH=5 deg, ID=5 deg) with a single sync point far from the
+        // test target.  The goal is to detect catastrophic failures, not to
+        // verify sub-degree accuracy.
+        EXPECT_LT(std::abs(dRA), 15.0)
+            << "EQ polar degeneracy: encoder RA=" << encoderRA
+            << "h vs target RA=" << testRA
+            << "h (dRA=" << dRA << " deg)"
+            << " -- forward transform produced garbage encoder RA";
+        EXPECT_LT(std::abs(eq.declination - testDec), 15.0)
+            << "EQ polar degeneracy: encoder Dec=" << eq.declination
+            << " vs target Dec=" << testDec
+            << " -- forward transform produced garbage encoder Dec";
+    }
+}
+
+// Field-scenario errors: IH=300' ID=300' CH=5' NP=0.5' MA=10' ME=6'
+static const MountErrors kFieldErrors = {
+    .ih = 5.0, .id = 5.0, .ch = ARCMIN_TO_DEG(5),
+    .np = ARCMIN_TO_DEG(0.5), .ma = ARCMIN_TO_DEG(10), .me = ARCMIN_TO_DEG(6),
+};
+
+TEST_F(AlignmentPluginTest, BuiltIn_PolarDegeneracy_EQ_SinglePoint)
+{
+    BuiltInMathPlugin plugin;
+    RunPolarDegeneracyTestImpl(plugin, kFieldErrors, kLosAngeles, ::Alignment::EQ_GEM);
+}
+
+TEST_F(AlignmentPluginTest, SVD_PolarDegeneracy_EQ_SinglePoint)
+{
+    SVDMathPlugin plugin;
+    RunPolarDegeneracyTestImpl(plugin, kFieldErrors, kLosAngeles, ::Alignment::EQ_GEM);
+}
+
+TEST_F(AlignmentPluginTest, Nearest_PolarDegeneracy_EQ_SinglePoint)
+{
+    NearestMathPlugin plugin;
+    RunPolarDegeneracyTestImpl(plugin, kFieldErrors, kLosAngeles, ::Alignment::EQ_GEM);
+}
+
+TEST_F(AlignmentPluginTest, BuiltIn_PolarDegeneracy_AltAz_SinglePoint)
+{
+    BuiltInMathPlugin plugin;
+    RunPolarDegeneracyTestImpl(plugin, kFieldErrors, kLosAngeles, ::Alignment::ALTAZ);
+}
+
+TEST_F(AlignmentPluginTest, SVD_PolarDegeneracy_AltAz_SinglePoint)
+{
+    SVDMathPlugin plugin;
+    RunPolarDegeneracyTestImpl(plugin, kFieldErrors, kLosAngeles, ::Alignment::ALTAZ);
+}
+
+TEST_F(AlignmentPluginTest, Nearest_PolarDegeneracy_AltAz_SinglePoint)
+{
+    NearestMathPlugin plugin;
+    RunPolarDegeneracyTestImpl(plugin, kFieldErrors, kLosAngeles, ::Alignment::ALTAZ);
+}
+
 int main(int argc, char **argv)
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Problem

Three independent bugs that each corrupt pointing after a restart or a single near-pole sync:

1. **Plugin selection not persisting.** `saveConfig(true, name)` only patches the named property in the existing XML; it skips `CURRENT_MATH_PLUGIN`. After a restart the text property is replayed before the switch property, so the selected external plugin (Nearest, SVD, …) is overwritten by the stale built-in default.

2. **Mount alignment lost on plugin switch.** When loading a new plugin, `SetApproximateMountAlignment` was never called on it. Every external plugin defaults to `ZENITH`, silently switching EQ drivers to the AltAz code path and producing garbage Goto coordinates whenever the user changes plugins at runtime.

3. **Degenerate sync points near the celestial pole.** When all sync points are close to the celestial pole (Dec near +/-90), the HA component of the telescope direction vector is unconstrained — any HA value maps to nearly the same point on the sky. All plugins that solve a least-squares system over the sync database (BuiltIn, SVD, Nearest) are affected: the solver assigns an arbitrary HA-axis correction that produces wildly wrong Gotos away from the pole. The same singularity occurs for altaz mounts when all sync points are near the zenith.

## Fix

- `telescope_simulator.cpp`: use `saveConfig()` (full save) instead of `saveConfig(true, name)` so `CURRENT_MATH_PLUGIN` is included.
- `MathPluginManagement.cpp`: capture `ApproximateMountAlignment` before unloading the old plugin, then call `SetApproximateMountAlignment` + `Initialise` on the newly loaded one. Also skip a redundant reload when the switch property arrives after the text property on startup.
- `MathPlugin.cpp` / `MathPlugin.h`: add `SanitizePolarEntries()`, called from `Initialise()`. Entries with |Dec| > 88 (EQ) or encoder El > 88 (altaz) are shifted to 80 while applying the same delta to the paired celestial coordinate, preserving the pointing correction while breaking the degeneracy. The TDV is rebuilt using RA-based encoding, consistent with the BuiltIn/SVD/Nearest convention.
- `ccd_simulator.cpp`, `guide_simulator.cpp`: fix a unit mismatch — `IEquatorialCoordinates.rightascension` is in degrees, not hours; remove the erroneous x15 / /15 factor in the EQUATORIAL_PE snooping path.

## Tests

Six new `PolarDegeneracy` tests in `test_alignment_plugins` cover EQ and altaz single-point-near-pole scenarios for BuiltIn, SVD, and Nearest plugins.