### PR TITLE
Support for Sesto Senso 3

### DIFF
--- a/drivers/focuser/primalucacommandset.cpp
+++ b/drivers/focuser/primalucacommandset.cpp
@@ -310,7 +310,7 @@ bool Focuser::isHallSensorDetected(bool &isDetected)
 *******************************************************************************************************/
 bool Focuser::getAbsolutePosition(uint32_t &position)
 {
-    return m_Communication->get(MOT_1, "ABS_POS_STEPS", position);
+    return m_Communication->get(MOT_1, "ABS_POS_STEP", position);
 }
 
 /******************************************************************************************************

--- a/drivers/focuser/primalucacommandset.cpp
+++ b/drivers/focuser/primalucacommandset.cpp
@@ -256,7 +256,7 @@ Focuser::Focuser(const std::string &name, int port)
 *******************************************************************************************************/
 bool Focuser::goAbsolutePosition(uint32_t position)
 {
-    return m_Communication->command(MOT_1, {{"MOVE_ABS", {{"STEP", position}}}});
+    return m_Communication->command(MOT_1, {{"GOTO", position}});
 }
 
 /******************************************************************************************************
@@ -310,7 +310,7 @@ bool Focuser::isHallSensorDetected(bool &isDetected)
 *******************************************************************************************************/
 bool Focuser::getAbsolutePosition(uint32_t &position)
 {
-    return m_Communication->get(MOT_1, "ABS_POS", position);
+    return m_Communication->get(MOT_1, "ABS_POS_STEPS", position);
 }
 
 /******************************************************************************************************
@@ -337,7 +337,15 @@ bool Focuser::isBusy()
     json status;
     if (m_Communication->get(MOT_1, "STATUS", status))
     {
-        return status["BUSY"] == 1;
+        bool busy = (status["BUSY"] == 1);
+        std::string mst;
+        if (status.contains("MST"))
+            status["MST"].get_to(mst);
+        // Motor is still moving if BUSY=1, or if MST is not yet "stop".
+        // The SS3 can transiently assert BUSY=0 while MST is still
+        // "CstSpeed" or "dec" during encoder-feedback transitions.
+        bool motorStopped = mst.empty() || (mst == "stop");
+        return busy || !motorStopped;
     }
     return false;
 }


### PR DESCRIPTION
This makes the Sesto Senso 3 work properly on my test system.

Currently, these change would break other Primaluca devices (the isBusy() change should be compatible with Sesto Senso 2, however the other changes are probably not).

 @knro could you check how this could be implemented to be only applied for the Sesto Senso 3? I am no cpp dev and this is my first time going through the libindi code :)