### PR TITLE
gitignore: ignore compiled dylib files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ unitybuild_*.c*
 *.a
 *.so.*
 *.so
+*.dylib
 Makefile
 moc_*.cpp
 CMakeFiles


### PR DESCRIPTION
## Summary

- Adds `*.dylib` to `.gitignore` to prevent macOS dynamic libraries from being accidentally committed

## Test plan

- No functional changes; gitignore-only