### PR TITLE
alignment: guard SPK test target when erfa is not found

### DIFF
--- a/test/alignment/CMakeLists.txt
+++ b/test/alignment/CMakeLists.txt
@@ -14,7 +14,9 @@ TARGET_LINK_LIBRARIES(test_alignment
 ADD_TEST(test-alignment test_alignment)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(ERFA REQUIRED IMPORTED_TARGET erfa)
+pkg_check_modules(ERFA IMPORTED_TARGET erfa)
+
+if(ERFA_FOUND)
 
 ADD_EXECUTABLE(test_alignment_plugins
     test_alignment_plugins.cpp
@@ -47,4 +49,6 @@ TARGET_LINK_LIBRARIES(test_alignment_plugins
 TARGET_COMPILE_DEFINITIONS(test_alignment_plugins PRIVATE NO_PLUGIN_HOOKS)
 
 ADD_TEST(test-alignment-plugins test_alignment_plugins)
+
+endif(ERFA_FOUND)
 


### PR DESCRIPTION
libs/alignment/CMakeLists.txt already guards indi_SPK_MathPlugin behind if(ERFA_FOUND), but test/alignment/CMakeLists.txt was missing the same guard. It used REQUIRED which caused cmake to fail on systems without erfa, and unconditionally added SPKMathPlugin sources to test_alignment_plugins. This fix applies the same optional pattern to the test target.

To verify, remove erfa and reconfigure:

    cmake -B build -U "*ERFA*" 2>&1 | grep -i erfa
    ninja -C build -t targets all | grep -i mathplugin

SPK targets should not appear in the second command's output.