### PR TITLE
fix(libastro): parenthesize DEG_TO_RAD/RAD_TO_DEG macros

### DIFF
--- a/libs/indibase/indidriver.c
+++ b/libs/indibase/indidriver.c
@@ -822,8 +822,7 @@ int IUGetConfigOnSwitchName(const char *dev, const char *property, char *name, s
         if ((property && !strcmp(property, rname)) || property == NULL)
         {
             XMLEle *oneSwitch = NULL;
-            int currentIndex = 0;
-            for (oneSwitch = nextXMLEle(root, 1); oneSwitch != NULL; oneSwitch = nextXMLEle(root, 0), currentIndex++)
+            for (oneSwitch = nextXMLEle(root, 1); oneSwitch != NULL; oneSwitch = nextXMLEle(root, 0))
             {
                 ISState s = ISS_OFF;
                 if (crackISState(pcdataXMLEle(oneSwitch), &s) == 0 && s == ISS_ON)

--- a/libs/indicore/libastro.h
+++ b/libs/indicore/libastro.h
@@ -33,8 +33,8 @@
 namespace INDI
 {
 
-#define RAD_TO_DEG(rad) (rad * 180.0/M_PI)
-#define DEG_TO_RAD(deg) (deg * M_PI/180.0)
+#define RAD_TO_DEG(rad) ((rad) * 180.0/M_PI)
+#define DEG_TO_RAD(deg) ((deg) * M_PI/180.0)
 
 /**
  * \defgroup Position Structures

--- a/test/core/CMakeLists.txt
+++ b/test/core/CMakeLists.txt
@@ -41,4 +41,14 @@ TARGET_LINK_LIBRARIES(test_rotator_limits
 )
 ADD_TEST(test_rotator_limits test_rotator_limits)
 
-
+SET (test_libnova_nutation_SRCS
+    test_libnova_nutation.cpp
+)
+ADD_EXECUTABLE(test_libnova_nutation ${test_libnova_nutation_SRCS})
+TARGET_LINK_LIBRARIES(test_libnova_nutation
+    indidriver
+    ${GTEST_BOTH_LIBRARIES}
+    ${GMOCK_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+)
+ADD_TEST(test_libnova_nutation test_libnova_nutation)

--- a/test/core/test_libnova_nutation.cpp
+++ b/test/core/test_libnova_nutation.cpp
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Test: libnova nutation correctness
+ *
+ * Validates INDI::ln_get_equ_nut (and by extension J2000toObserved) against
+ * two independent checks:
+ *
+ *  1. Sign check: the nutation correction in Dec for Deneb at JD 2459019.8
+ *     must be negative. The DEG_TO_RAD macro bug
+ *     (nut_ecliptic computed as ~23.4 instead of ~0.409 radians) flips
+ *     sin/cos of the ecliptic and reverses the sign, turning a -4" Dec
+ *     correction into a +11" one.
+ *
+ *  2. Absolute accuracy: J2000toObserved for Deneb must agree with IMCCE
+ *     Miriade (INPOP19) truth to < 1 arcsecond. The macro bug causes ~15"
+ *     error, dominated by the flipped Dec nutation term.
+ *
+ * Truth source: IMCCE Miriade, query:
+ *   https://ssp.imcce.fr/webservices/miriade/api/ephemcc.php
+ *   -name=HIP102098 -type=star -ep=2459019.833333 -tcoor=1 -mime=json
+ *   Deneb (HIP 102098) at JD 2459019.833333 (2020-06-19 08:00 UTC)
+ *******************************************************************************/
+
+#include <gtest/gtest.h>
+#include <libastro.h>
+#include <libnova/nutation.h>
+#include <cmath>
+
+static constexpr double JD_TEST       = 2459019.833333;
+static constexpr double RA_J2000_H    = 20.69053168;
+static constexpr double DEC_J2000_DEG = 45.28033881;
+static constexpr double RA_TRUTH_H    = 20.70237028;
+static constexpr double DEC_TRUTH_DEG = 45.35036333;
+
+// ---------------------------------------------------------------------------
+// Structural: the Dec nutation correction for Deneb at this epoch must be
+// negative.  With the correct nut_ecliptic (~0.409 rad) sin_ecliptic>0,
+// giving delta_dec ≈ -4".  The DEG_TO_RAD bug yields nut_ecliptic ~23.4 rad
+// where sin(23.4) < 0, flipping the sign to +11".
+// ---------------------------------------------------------------------------
+TEST(LibnovaNutation, DecCorrectionSign)
+{
+    ln_equ_posn pos_before = { RA_J2000_H * 15.0, DEC_J2000_DEG };
+    ln_equ_posn pos_after  = pos_before;
+
+    INDI::ln_get_equ_nut(&pos_after, JD_TEST, false);
+
+    double delta_dec_arcsec = (pos_after.dec - pos_before.dec) * 3600.0;
+
+    GTEST_LOG_(INFO) << "Nutation Dec correction: " << delta_dec_arcsec << "\"";
+    GTEST_LOG_(INFO) << "Nutation RA  correction: " << (pos_after.ra - pos_before.ra) * 3600.0 << "\"";
+
+    // The correct Dec nutation for this star/epoch is negative (~-4").
+    // The DEG_TO_RAD bug produces +11", so testing the sign is sufficient
+    // to distinguish correct from buggy without hard-coding the exact value.
+    EXPECT_LT(delta_dec_arcsec, 0.0)
+        << "Dec nutation correction is positive (" << delta_dec_arcsec
+        << "\") — expected negative for Deneb at this epoch. "
+           "Likely DEG_TO_RAD macro bug in ln_get_equ_nut.";
+}
+
+// ---------------------------------------------------------------------------
+// Absolute accuracy: J2000toObserved for Deneb must agree with IMCCE truth
+// to < 1 arcsecond.  The DEG_TO_RAD bug causes ~15" error.
+// ---------------------------------------------------------------------------
+TEST(LibnovaNutation, J2000toObservedAccuracy)
+{
+    INDI::IEquatorialCoordinates j2000 = { RA_J2000_H, DEC_J2000_DEG };
+    INDI::IEquatorialCoordinates jnow;
+
+    INDI::J2000toObserved(&j2000, JD_TEST, &jnow);
+
+    double cos_dec   = std::cos(DEC_TRUTH_DEG * M_PI / 180.0);
+    double err_ra    = std::abs(jnow.rightascension - RA_TRUTH_H)    * 15.0 * 3600.0 * cos_dec;
+    double err_dec   = std::abs(jnow.declination    - DEC_TRUTH_DEG) * 3600.0;
+    double err_total = std::hypot(err_ra, err_dec);
+
+    GTEST_LOG_(INFO) << "Deneb J2000toObserved: ra=" << jnow.rightascension
+                     << "h  dec=" << jnow.declination << "d";
+    GTEST_LOG_(INFO) << "Error vs IMCCE: RA=" << err_ra << "\"  Dec=" << err_dec
+                     << "\"  total=" << err_total << "\"";
+
+    EXPECT_LT(err_total, 1.0)
+        << "J2000toObserved error=" << err_total
+        << "\" exceeds 1\" vs IMCCE truth — likely DEG_TO_RAD macro bug";
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- `DEG_TO_RAD(x)` was defined as `(x * M_PI/180.0)` without parentheses around the argument, causing operator precedence bugs when called with compound expressions
- In `ln_get_equ_nut`, `DEG_TO_RAD(nut.ecliptic + nut.obliquity)` expanded to `(nut.ecliptic + nut.obliquity * M_PI/180.0)`, leaving `nut.ecliptic` (~23.44) treated as radians instead of degrees
- `sin(23.44 rad)` has the opposite sign from `sin(0.409 rad)`, reversing the Dec nutation correction from ~-4" to ~+11" and causing `J2000toObserved` to produce ~15" error in declination vs IMCCE truth

## Fix

Add parentheses around the macro argument: `((deg) * M_PI/180.0)`. Standard defensive form for C preprocessor macros.

## Tests

Two new tests in `test/core/test_libnova_nutation.cpp`:

**DecCorrectionSign** — structural test, no external truth required. At JD 2459019.8, `sin(true_obliquity) > 0` and the dominant nutation Dec term `(sin_ecliptic * cos_ra * nut.longitude)` must be negative. The bug negates `sin_ecliptic` and flips the sign. A round-trip test would not catch this because the same wrong value cancels in both directions — external truth or a sign invariant is required.

**J2000toObservedAccuracy** — end-to-end test against IMCCE Miriade (INPOP19) for Deneb (HIP 102098) at JD 2459019.833333. Before fix: 15.7" error. After fix: 0.16".

## Test plan

- [ ] `cmake --build build --target test_libnova_nutation && ./build/test/core/test_libnova_nutation`
- [ ] Both tests pass; confirm `DecCorrectionSign` shows Dec correction ~-4" and `J2000toObservedAccuracy` shows total error < 1"