### PR TITLE
docs: add liberfa to install prerequisites in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ sudo apt-get install -y \
   libboost-regex-dev \
   libcurl4-gnutls-dev \
   libtheora-dev \
-  libxisf-dev
+  libxisf-dev \
+  liberfa-dev
 
 ```
 
@@ -97,7 +98,8 @@ sudo pacman -S --needed \
   curl \
   libtiff \
   fftw \
-  libxisf
+  libxisf \
+  erfa
 ```
 
 ## Create Project Directory


### PR DESCRIPTION
## Summary

- Add `liberfa-dev` to the Debian/Ubuntu prerequisites block
- Add `erfa` to the Arch Linux prerequisites block

These packages are already listed in the CI Dockerfiles (`.github/docker/`) but were missing from the README install instructions, which could cause build failures for users following the guide.