### PR TITLE
Alignment: add TransformCelestialToTelescopeJD / TransformTelescopeToCelestialJD

### DIFF
--- a/libs/alignment/BasicMathPlugin.cpp
+++ b/libs/alignment/BasicMathPlugin.cpp
@@ -97,10 +97,8 @@ bool BasicMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
                 case NORTH_CELESTIAL_POLE:
                 {
                     INDI::IEquatorialCoordinates DummyRaDec;
-                    //INDI::IHorizontalCoordinates DummyAltAz;
                     DummyRaDec.rightascension  = 0.0;
                     DummyRaDec.declination = 90.0;
-                    //EquatorialToHorizontal(&DummyRaDec, &Position, ln_get_julian_from_sys(), &DummyAltAz);
                     DummyActualDirectionCosine2   = TelescopeDirectionVectorFromEquatorialCoordinates(DummyRaDec);
                     DummyApparentDirectionCosine2 = DummyActualDirectionCosine2;
                     break;
@@ -108,10 +106,8 @@ bool BasicMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
                 case SOUTH_CELESTIAL_POLE:
                 {
                     INDI::IEquatorialCoordinates DummyRaDec;
-                    //INDI::IHorizontalCoordinates DummyAltAz;
                     DummyRaDec.rightascension  = 0.0;
                     DummyRaDec.declination = -90.0;
-                    //EquatorialToHorizontal(&DummyRaDec, &Position, ln_get_julian_from_sys(), &DummyAltAz);
                     DummyActualDirectionCosine2   = TelescopeDirectionVectorFromEquatorialCoordinates(DummyRaDec);
                     DummyApparentDirectionCosine2 = DummyActualDirectionCosine2;
                     break;

--- a/libs/alignment/BasicMathPlugin.cpp
+++ b/libs/alignment/BasicMathPlugin.cpp
@@ -366,6 +366,15 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
         double JulianOffset,
         TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
+}
+
+bool BasicMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate,
+        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
     INDI::IEquatorialCoordinates ActualRaDec;
     ActualRaDec.rightascension  = RightAscension;
     ActualRaDec.declination = Declination;
@@ -385,7 +394,7 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
             {
                 case ZENITH:
                     INDI::IHorizontalCoordinates ActualAltAz;
-                    EquatorialToHorizontal(&ActualRaDec, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualAltAz);
+                    EquatorialToHorizontal(&ActualRaDec, &Position, JulianDate, &ActualAltAz);
                     ApparentTelescopeDirectionVector = TelescopeDirectionVectorFromAltitudeAzimuth(ActualAltAz);
                     ASSDEBUGF("Celestial to telescope - Actual Az %lf Alt %lf", ActualAltAz.azimuth, ActualAltAz.altitude);
                     break;
@@ -411,7 +420,7 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
             if (ApproximateMountAlignment == ZENITH)
             {
                 INDI::IHorizontalCoordinates ActualAltAz;
-                EquatorialToHorizontal(&ActualRaDec, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualAltAz);
+                EquatorialToHorizontal(&ActualRaDec, &Position, JulianDate, &ActualAltAz);
                 ActualVector = TelescopeDirectionVectorFromAltitudeAzimuth(ActualAltAz);
             }
             else
@@ -439,7 +448,7 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
             if (ApproximateMountAlignment == ZENITH)
             {
                 INDI::IHorizontalCoordinates ActualAltAz;
-                EquatorialToHorizontal(&ActualRaDec, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualAltAz);
+                EquatorialToHorizontal(&ActualRaDec, &Position, JulianDate, &ActualAltAz);
                 ActualVector = TelescopeDirectionVectorFromAltitudeAzimuth(ActualAltAz);
             }
             else
@@ -593,6 +602,13 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
 bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
         double &RightAscension, double &Declination, double JulianOffset)
 {
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
+}
+
+bool BasicMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double JulianDate)
+{
     IGeographicCoordinates Position;
 
     //INDI::IHorizontalCoordinates ApparentAltAz;
@@ -625,7 +641,7 @@ bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVect
                               ApparentTelescopeDirectionVector.y, ApparentTelescopeDirectionVector.z);
                     //ASSDEBUGF("ActualVector x %lf y %lf z %lf", RotatedTDV.x, RotatedTDV.y, RotatedTDV.z);
                     AltitudeAzimuthFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, ActualAltAz);
-                    HorizontalToEquatorial(&ActualAltAz, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualRaDec);
+                    HorizontalToEquatorial(&ActualAltAz, &Position, JulianDate, &ActualRaDec);
                 }
                 break;
 
@@ -663,7 +679,7 @@ bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVect
             if (ApproximateMountAlignment == ZENITH)
             {
                 AltitudeAzimuthFromTelescopeDirectionVector(ActualTelescopeDirectionVector, ActualAltAz);
-                HorizontalToEquatorial(&ActualAltAz, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualRaDec);
+                HorizontalToEquatorial(&ActualAltAz, &Position, JulianDate, &ActualRaDec);
             }
             else
             {
@@ -796,7 +812,7 @@ bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVect
             if (ApproximateMountAlignment == ZENITH)
             {
                 AltitudeAzimuthFromTelescopeDirectionVector(ActualTelescopeDirectionVector, ActualAltAz);
-                HorizontalToEquatorial(&ActualAltAz, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualRaDec);
+                HorizontalToEquatorial(&ActualAltAz, &Position, JulianDate, &ActualRaDec);
             }
             else
             {

--- a/libs/alignment/BasicMathPlugin.h
+++ b/libs/alignment/BasicMathPlugin.h
@@ -30,25 +30,25 @@ class BasicMathPlugin : public AlignmentSubsystemForMathPlugins
         virtual ~BasicMathPlugin();
 
         /// \brief Override for the base class virtual function
-        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
+        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
         /// \brief Override for the base class virtual function
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         /// \brief Override for the base class virtual function
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianDate);
+                double &RightAscension, double &Declination, double JulianDate) override;
 
-        /// \brief Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
+        /// \brief Compat shim - resolves JD and delegates to TransformCelestialToTelescopeJD
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
-        /// \brief Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
+        /// \brief Compat shim - resolves JD and delegates to TransformTelescopeToCelestialJD
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset = 0);
+                double &RightAscension, double &Declination, double JulianOffset = 0) override;
 
     protected:
         /// \brief Calculate transformation matrices from the supplied vectors

--- a/libs/alignment/BasicMathPlugin.h
+++ b/libs/alignment/BasicMathPlugin.h
@@ -33,11 +33,20 @@ class BasicMathPlugin : public AlignmentSubsystemForMathPlugins
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
 
         /// \brief Override for the base class virtual function
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        /// \brief Override for the base class virtual function
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
+        /// \brief Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);
 
-        /// \brief Override for the base class virtual function
+        /// \brief Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                 double &RightAscension, double &Declination, double JulianOffset = 0);
 

--- a/libs/alignment/DummyMathPlugin.cpp
+++ b/libs/alignment/DummyMathPlugin.cpp
@@ -44,15 +44,28 @@ bool DummyMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
     return false;
 }
 
-bool DummyMathPlugin::TransformCelestialToTelescope(const double RightAscension, const double Declination,
-        double JulianOffset,
-        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+bool DummyMathPlugin::TransformCelestialToTelescopeJD(double /*RightAscension*/, double /*Declination*/,
+        double /*JulianDate*/,
+        TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/)
 {
     return false;
 }
 
-bool DummyMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-        double &RightAscension, double &Declination, double /*JulianOffset*/)
+bool DummyMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/,
+        double &/*RightAscension*/, double &/*Declination*/, double /*JulianDate*/)
+{
+    return false;
+}
+
+bool DummyMathPlugin::TransformCelestialToTelescope(const double /*RightAscension*/, const double /*Declination*/,
+        double /*JulianOffset*/,
+        TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/)
+{
+    return false;
+}
+
+bool DummyMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/,
+        double &/*RightAscension*/, double &/*Declination*/, double /*JulianOffset*/)
 {
     return false;
 }

--- a/libs/alignment/DummyMathPlugin.h
+++ b/libs/alignment/DummyMathPlugin.h
@@ -16,6 +16,13 @@ class DummyMathPlugin : public AlignmentSubsystemForMathPlugins
 
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
 
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);

--- a/libs/alignment/DummyMathPlugin.h
+++ b/libs/alignment/DummyMathPlugin.h
@@ -14,21 +14,21 @@ class DummyMathPlugin : public AlignmentSubsystemForMathPlugins
         DummyMathPlugin();
         virtual ~DummyMathPlugin();
 
-        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
+        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianDate);
+                double &RightAscension, double &Declination, double JulianDate) override;
 
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset = 0);
+                double &RightAscension, double &Declination, double JulianOffset = 0) override;
 };
 
 } // namespace AlignmentSubsystem

--- a/libs/alignment/MathPlugin.cpp
+++ b/libs/alignment/MathPlugin.cpp
@@ -9,6 +9,7 @@
 #include "MathPlugin.h"
 
 #include <indicom.h>
+#include <libnova/julian_day.h>
 
 #include <cmath>
 
@@ -17,15 +18,17 @@ namespace INDI
 namespace AlignmentSubsystem
 {
 bool MathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
-        double /*JulianDate*/, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+        double JulianDate, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
-    return TransformCelestialToTelescope(RightAscension, Declination, 0.0, ApparentTelescopeDirectionVector);
+    return TransformCelestialToTelescope(RightAscension, Declination,
+                                         JulianDate - ln_get_julian_from_sys(), ApparentTelescopeDirectionVector);
 }
 
 bool MathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-        double &RightAscension, double &Declination, double /*JulianDate*/)
+        double &RightAscension, double &Declination, double JulianDate)
 {
-    return TransformTelescopeToCelestial(ApparentTelescopeDirectionVector, RightAscension, Declination, 0.0);
+    return TransformTelescopeToCelestial(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                         JulianDate - ln_get_julian_from_sys());
 }
 
 bool MathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)

--- a/libs/alignment/MathPlugin.cpp
+++ b/libs/alignment/MathPlugin.cpp
@@ -16,6 +16,18 @@ namespace INDI
 {
 namespace AlignmentSubsystem
 {
+bool MathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double /*JulianDate*/, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
+    return TransformCelestialToTelescope(RightAscension, Declination, 0.0, ApparentTelescopeDirectionVector);
+}
+
+bool MathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double /*JulianDate*/)
+{
+    return TransformTelescopeToCelestial(ApparentTelescopeDirectionVector, RightAscension, Declination, 0.0);
+}
+
 bool MathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
 {
     MathPlugin::pInMemoryDatabase = pInMemoryDatabase;

--- a/libs/alignment/MathPlugin.h
+++ b/libs/alignment/MathPlugin.h
@@ -19,7 +19,7 @@ namespace AlignmentSubsystem
  * \class MathPlugin
  * \brief Provides alignment subsystem functions to INDI alignment math plugins
  *
- * \note This class is intended to be implemented within a dynamic shared object. If the
+ * \note This class is intended to be implemented within an external plugin. If the
  * implementation of this class uses a standard 3 by 3 transformation matrix to convert between coordinate systems
  * then it will not normally need to know the handedness of either the celestial or telescope coordinate systems, as the
  * necessary rotations and scaling will be handled in the derivation of the matrix coefficients. This will normally
@@ -65,8 +65,9 @@ class MathPlugin
         /// \param[out] ApparentTelescopeDirectionVector Parameter to receive the corrected telescope direction
         /// \return True if successful
         /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
-        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
-        /// ignores JulianDate and delegates to TransformCelestialToTelescope with JulianOffset=0.
+        /// External plugins that have not yet adopted this interface use the default implementation, which
+        /// computes JulianOffset = JulianDate - ln_get_julian_from_sys() and delegates to
+        /// TransformCelestialToTelescope, so the plugin recovers the correct absolute JD internally.
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);
@@ -78,7 +79,7 @@ class MathPlugin
         /// \param[in] JulianDate Absolute Julian Date (days).
         /// \return True if successful
         /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
-        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
+        /// External plugins that have not yet adopted this interface use the default implementation, which
         /// ignores JulianDate and delegates to TransformTelescopeToCelestial with JulianOffset=0.
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                 double &RightAscension, double &Declination, double JulianDate);

--- a/libs/alignment/MathPlugin.h
+++ b/libs/alignment/MathPlugin.h
@@ -61,12 +61,36 @@ class MathPlugin
         /// \brief Get the alignment corrected telescope pointing direction for the supplied celestial coordinates
         /// \param[in] RightAscension Right Ascension (Decimal Hours).
         /// \param[in] Declination Declination (Decimal Degrees).
-        /// \param[in] JulianOffset to be applied to the current julian date.
+        /// \param[in] JulianDate Absolute Julian Date (days).
         /// \param[out] ApparentTelescopeDirectionVector Parameter to receive the corrected telescope direction
         /// \return True if successful
-        /// \note TODO: Currently, JulianOffset is added to the system time (ln_get_julian_from_sys()) internally.
-        /// In a future release, this should be refactored to take an absolute fixed Julian Date to support
-        /// deterministic, clock-injected testing and avoid reliance on the system clock.
+        /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
+        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
+        /// ignores JulianDate and delegates to TransformCelestialToTelescope with JulianOffset=0.
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        /// \brief Get the true celestial coordinates for the supplied telescope pointing direction
+        /// \param[in] ApparentTelescopeDirectionVector the telescope direction
+        /// \param[out] RightAscension Parameter to receive the Right Ascension (Decimal Hours).
+        /// \param[out] Declination Parameter to receive the Declination (Decimal Degrees).
+        /// \param[in] JulianDate Absolute Julian Date (days).
+        /// \return True if successful
+        /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
+        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
+        /// ignores JulianDate and delegates to TransformTelescopeToCelestial with JulianOffset=0.
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
+        /// \brief Get the alignment corrected telescope pointing direction for the supplied celestial coordinates
+        /// \param[in] RightAscension Right Ascension (Decimal Hours).
+        /// \param[in] Declination Declination (Decimal Degrees).
+        /// \param[in] JulianOffset Offset (days) added to ln_get_julian_from_sys() to form the Julian Date.
+        /// \param[out] ApparentTelescopeDirectionVector Parameter to receive the corrected telescope direction
+        /// \return True if successful
+        /// \note Built-in plugins implement this as a thin shim that resolves the absolute JD and calls
+        /// TransformCelestialToTelescopeJD. New callers should use TransformCelestialToTelescopeJD directly.
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector) = 0;
@@ -75,11 +99,10 @@ class MathPlugin
         /// \param[in] ApparentTelescopeDirectionVector the telescope direction
         /// \param[out] RightAscension Parameter to receive the Right Ascension (Decimal Hours).
         /// \param[out] Declination Parameter to receive the Declination (Decimal Degrees).
-        /// \param[in] JulianOffset to be applied to the current julian date (default 0).
+        /// \param[in] JulianOffset Offset (days) added to ln_get_julian_from_sys() to form the Julian Date (default 0).
         /// \return True if successful
-        /// \note TODO: Currently, JulianOffset is added to the system time (ln_get_julian_from_sys()) internally.
-        /// In a future release, this should be refactored to take an absolute fixed Julian Date to support
-        /// deterministic, clock-injected testing and avoid reliance on the system clock.
+        /// \note Built-in plugins implement this as a thin shim that resolves the absolute JD and calls
+        /// TransformTelescopeToCelestialJD. New callers should use TransformTelescopeToCelestialJD directly.
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                 double &RightAscension, double &Declination, double JulianOffset = 0) = 0;
 

--- a/libs/alignment/MathPluginManagement.cpp
+++ b/libs/alignment/MathPluginManagement.cpp
@@ -11,6 +11,7 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <cerrno>
+#include <libnova/julian_day.h>
 
 namespace INDI
 {
@@ -386,26 +387,43 @@ void MathPluginManagement::SetApproximateMountAlignment(MountAlignment_t Approxi
     (pLoadedMathPlugin->*pSetApproximateMountAlignment)(ApproximateAlignment);
 }
 
+bool MathPluginManagement::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate,
+        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
+    if (AlignmentSubsystemActive.s == ISS_ON)
+        return pLoadedMathPlugin->TransformCelestialToTelescopeJD(RightAscension, Declination, JulianDate,
+                ApparentTelescopeDirectionVector);
+    else
+        return false;
+}
+
+bool MathPluginManagement::TransformTelescopeToCelestialJD(
+    const TelescopeDirectionVector &ApparentTelescopeDirectionVector, double &RightAscension, double &Declination,
+    double JulianDate)
+{
+    if (AlignmentSubsystemActive.s == ISS_ON)
+        return pLoadedMathPlugin->TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension,
+                Declination, JulianDate);
+    else
+        return false;
+}
+
 bool MathPluginManagement::TransformCelestialToTelescope(const double RightAscension, const double Declination,
         double JulianOffset,
         TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
-    if (AlignmentSubsystemActive.s == ISS_ON)
-        return (pLoadedMathPlugin->*pTransformCelestialToTelescope)(RightAscension, Declination, JulianOffset,
-                ApparentTelescopeDirectionVector);
-    else
-        return false;
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
 }
 
 bool MathPluginManagement::TransformTelescopeToCelestial(
     const TelescopeDirectionVector &ApparentTelescopeDirectionVector, double &RightAscension, double &Declination,
     double JulianOffset)
 {
-    if (AlignmentSubsystemActive.s == ISS_ON)
-        return (pLoadedMathPlugin->*pTransformTelescopeToCelestial)(ApparentTelescopeDirectionVector, RightAscension,
-                Declination, JulianOffset);
-    else
-        return false;
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
 }
 
 void MathPluginManagement::EnumeratePlugins()

--- a/libs/alignment/MathPluginManagement.cpp
+++ b/libs/alignment/MathPluginManagement.cpp
@@ -21,8 +21,6 @@ MathPluginManagement::MathPluginManagement() : CurrentInMemoryDatabase(nullptr),
     pGetApproximateMountAlignment(&MathPlugin::GetApproximateMountAlignment),
     pInitialise(&MathPlugin::Initialise),
     pSetApproximateMountAlignment(&MathPlugin::SetApproximateMountAlignment),
-    pTransformCelestialToTelescope(&MathPlugin::TransformCelestialToTelescope),
-    pTransformTelescopeToCelestial(&MathPlugin::TransformTelescopeToCelestial),
     pLoadedMathPlugin(&BuiltInPlugin), LoadedMathPluginHandle(nullptr)
 {
     memset(&AlignmentSubsystemCurrentMathPlugin, 0, sizeof(IText));

--- a/libs/alignment/MathPluginManagement.h
+++ b/libs/alignment/MathPluginManagement.h
@@ -114,10 +114,32 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
         void SetApproximateMountAlignment(MountAlignment_t ApproximateAlignment);
 
         /**
-         * @brief TransformCelestialToTelescope Transforms Celestial (Sky) Coords to Mount Coordinates
+         * @brief TransformCelestialToTelescopeJD Transforms Celestial (Sky) Coords to Mount Coordinates
          * @param RightAscension Sky Right Ascension in hours.
          * @param Declination Sky Declination in degrees
-         * @param JulianOffset Julian time Offset in days
+         * @param JulianDate Absolute Julian Date (days)
+         * @param ApparentTelescopeDirectionVector Output Apparent Telescope Direction Vector
+         * @return True if transformation is successful, false otherwise.
+         */
+        bool TransformCelestialToTelescopeJD(double RightAscension, double Declination, double JulianDate,
+                                             TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        /**
+         * @brief TransformTelescopeToCelestialJD Transforms Mount Coords to Celestial (Sky) Coordinates
+         * @param ApparentTelescopeDirectionVector Input Apparent Telescope Direction Vector
+         * @param RightAscension Output Celestial Right Ascension
+         * @param Declination Output Celestial Declination
+         * @param JulianDate Absolute Julian Date (days)
+         * @return True if transformation is successful, false otherwise.
+         */
+        bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                                             double &RightAscension, double &Declination, double JulianDate);
+
+        /**
+         * @brief TransformCelestialToTelescope Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
+         * @param RightAscension Sky Right Ascension in hours.
+         * @param Declination Sky Declination in degrees
+         * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys()
          * @param ApparentTelescopeDirectionVector Output Apparent Telescope Direction Vector
          * @return True if transformation is successful, false otherwise.
          */
@@ -125,10 +147,11 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
                                            TelescopeDirectionVector &ApparentTelescopeDirectionVector);
 
         /**
-         * @brief TransformTelescopeToCelestial Transforms Mount Coords to Celestial (Sky) Coordinates
+         * @brief TransformTelescopeToCelestial Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
          * @param ApparentTelescopeDirectionVector Input Apparent Telescope Direction Vector
          * @param RightAscension Output Celestial Right Ascension
          * @param Declination Output Celestial Declination
+         * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys() (default 0)
          * @return True if transformation is successful, false otherwise.
          */
         bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,

--- a/libs/alignment/MathPluginManagement.h
+++ b/libs/alignment/MathPluginManagement.h
@@ -136,7 +136,7 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
                                              double &RightAscension, double &Declination, double JulianDate);
 
         /**
-         * @brief TransformCelestialToTelescope Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
+         * @brief TransformCelestialToTelescope Compat shim - resolves JD and delegates to TransformCelestialToTelescopeJD
          * @param RightAscension Sky Right Ascension in hours.
          * @param Declination Sky Declination in degrees
          * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys()
@@ -147,7 +147,7 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
                                            TelescopeDirectionVector &ApparentTelescopeDirectionVector);
 
         /**
-         * @brief TransformTelescopeToCelestial Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
+         * @brief TransformTelescopeToCelestial Compat shim - resolves JD and delegates to TransformTelescopeToCelestialJD
          * @param ApparentTelescopeDirectionVector Input Apparent Telescope Direction Vector
          * @param RightAscension Output Celestial Right Ascension
          * @param Declination Output Celestial Declination
@@ -181,11 +181,6 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
         MountAlignment_t (MathPlugin::*pGetApproximateMountAlignment)();
         bool (MathPlugin::*pInitialise)(InMemoryDatabase *pInMemoryDatabase);
         void (MathPlugin::*pSetApproximateMountAlignment)(MountAlignment_t ApproximateAlignment);
-        bool (MathPlugin::*pTransformCelestialToTelescope)(const double RightAscension, const double Declination,
-                double JulianOffset,
-                TelescopeDirectionVector &TelescopeDirectionVector);
-        bool (MathPlugin::*pTransformTelescopeToCelestial)(const TelescopeDirectionVector &TelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset);
         MathPlugin *pLoadedMathPlugin;
         void *LoadedMathPluginHandle;
 

--- a/libs/alignment/NearestMathPlugin.cpp
+++ b/libs/alignment/NearestMathPlugin.cpp
@@ -148,12 +148,10 @@ bool NearestMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, d
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    double JDD = JulianDate;
-
     // Compute CURRENT horizontal coords.
     INDI::IEquatorialCoordinates CelestialRADE {RightAscension, Declination};
     INDI::IHorizontalCoordinates CelestialAltAz;
-    EquatorialToHorizontal(&CelestialRADE, &Position, JDD, &CelestialAltAz);
+    EquatorialToHorizontal(&CelestialRADE, &Position, JulianDate, &CelestialAltAz);
 
     // Return Telescope Direction Vector directly from Celestial coordinates if we
     // do not have any sync points.
@@ -206,7 +204,7 @@ bool NearestMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, d
     if (ApproximateMountAlignment == ZENITH)
     {
         INDI::IHorizontalCoordinates TransformedTelescopeAltAz;
-        EquatorialToHorizontal(&TransformedTelescopeRADE, &Position, JDD, &TransformedTelescopeAltAz);
+        EquatorialToHorizontal(&TransformedTelescopeRADE, &Position, JulianDate, &TransformedTelescopeAltAz);
         ApparentTelescopeDirectionVector = TelescopeDirectionVectorFromAltitudeAzimuth(TransformedTelescopeAltAz);
     }
     // Equatorial?
@@ -235,8 +233,6 @@ bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirection
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    double JDD = JulianDate;
-
     // Telescope Equatorial Coordinates
     INDI::IEquatorialCoordinates TelescopeRADE;
 
@@ -248,7 +244,7 @@ bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirection
         {
             INDI::IHorizontalCoordinates TelescopeAltAz;
             AltitudeAzimuthFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, TelescopeAltAz);
-            HorizontalToEquatorial(&TelescopeAltAz, &Position, JDD, &TelescopeRADE);
+            HorizontalToEquatorial(&TelescopeAltAz, &Position, JulianDate, &TelescopeRADE);
         }
         // Equatorial?
         else
@@ -267,13 +263,13 @@ bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirection
     if (ApproximateMountAlignment == ZENITH)
     {
         AltitudeAzimuthFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, TelescopeAltAz);
-        HorizontalToEquatorial(&TelescopeAltAz, &Position, JDD, &TelescopeRADE);
+        HorizontalToEquatorial(&TelescopeAltAz, &Position, JulianDate, &TelescopeRADE);
     }
     // Equatorial?
     else
     {
         EquatorialCoordinatesFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, TelescopeRADE);
-        EquatorialToHorizontal(&TelescopeRADE, &Position, JDD, &TelescopeAltAz);
+        EquatorialToHorizontal(&TelescopeRADE, &Position, JulianDate, &TelescopeAltAz);
     }
 
     // Find the nearest point to our telescope now

--- a/libs/alignment/NearestMathPlugin.cpp
+++ b/libs/alignment/NearestMathPlugin.cpp
@@ -135,13 +135,20 @@ bool NearestMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
 bool NearestMathPlugin::TransformCelestialToTelescope(const double RightAscension, const double Declination,
         double JulianOffset, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
+}
+
+bool NearestMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
     // Get Position
     IGeographicCoordinates Position;
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    // Get Julian date from system and apply Julian Offset if any.
-    double JDD = ln_get_julian_from_sys() + JulianOffset;
+    double JDD = JulianDate;
 
     // Compute CURRENT horizontal coords.
     INDI::IEquatorialCoordinates CelestialRADE {RightAscension, Declination};
@@ -217,11 +224,18 @@ bool NearestMathPlugin::TransformCelestialToTelescope(const double RightAscensio
 bool NearestMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
         double &RightAscension, double &Declination, double JulianOffset)
 {
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
+}
+
+bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double JulianDate)
+{
     IGeographicCoordinates Position;
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    double JDD = ln_get_julian_from_sys() + JulianOffset;
+    double JDD = JulianDate;
 
     // Telescope Equatorial Coordinates
     INDI::IEquatorialCoordinates TelescopeRADE;

--- a/libs/alignment/NearestMathPlugin.h
+++ b/libs/alignment/NearestMathPlugin.h
@@ -100,21 +100,21 @@ class NearestMathPlugin : public AlignmentSubsystemForMathPlugins
         NearestMathPlugin();
         virtual ~NearestMathPlugin();
 
-        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
+        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianDate);
+                double &RightAscension, double &Declination, double JulianDate) override;
 
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset = 0);
+                double &RightAscension, double &Declination, double JulianOffset = 0) override;
 
     private:
 

--- a/libs/alignment/NearestMathPlugin.h
+++ b/libs/alignment/NearestMathPlugin.h
@@ -102,6 +102,13 @@ class NearestMathPlugin : public AlignmentSubsystemForMathPlugins
 
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
 
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);

--- a/libs/alignment/SPKMathPlugin.cpp
+++ b/libs/alignment/SPKMathPlugin.cpp
@@ -164,8 +164,17 @@ bool SPKMathPlugin::TransformCelestialToTelescope(const double RightAscension, c
         double JulianOffset,
         TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
+}
+
+bool SPKMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate,
+        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
     if (!UpdateObsConfig()) return false;
-    UpdateAstrometry(ln_get_julian_from_sys() + JulianOffset);
+    UpdateAstrometry(JulianDate);
 
     spkTAR tar;
     // Input RA/Dec is in INDI's "observed" (= SOFA's "apparent") form: precession,
@@ -209,8 +218,15 @@ bool SPKMathPlugin::TransformCelestialToTelescope(const double RightAscension, c
 bool SPKMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
         double &RightAscension, double &Declination, double JulianOffset)
 {
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
+}
+
+bool SPKMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double JulianDate)
+{
     if (!UpdateObsConfig()) return false;
-    UpdateAstrometry(ln_get_julian_from_sys() + JulianOffset);
+    UpdateAstrometry(JulianDate);
 
     spkAX3 ax3;
     double roll, pitch;

--- a/libs/alignment/SPKMathPlugin.h
+++ b/libs/alignment/SPKMathPlugin.h
@@ -38,6 +38,13 @@ class SPKMathPlugin : public MathPlugin, public TelescopeDirectionVectorSupportF
 
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
+
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate) override;
+
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;

--- a/test/alignment/test_alignment_plugins.cpp
+++ b/test/alignment/test_alignment_plugins.cpp
@@ -24,6 +24,7 @@
 #include <alignment/TelescopeDirectionVectorSupportFunctions.h>
 #include "../../drivers/telescope/scopesim_helper.h"
 
+#include <libnova/julian_day.h>
 #include <libnova/sidereal_time.h>
 
 using namespace INDI::AlignmentSubsystem;
@@ -442,7 +443,7 @@ protected:
             TelescopeDirectionVector noisyV;
             ASSERT_TRUE(noisyPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, noisyV));
 
-            // Reference (noiseless) plugin's predicted direction — same JD
+            // Reference (noiseless) plugin's predicted direction - same JD
             TelescopeDirectionVector refV;
             ASSERT_TRUE(refPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, refV));
 
@@ -2249,6 +2250,78 @@ TEST_F(DriverPipelineTest, AltAz_InstrumentRoundTrip_Southern)
         EXPECT_NEAR(testRA,  recoveredRA,    0.001) << "RA round-trip failed";
         EXPECT_NEAR(testDec, instDec.Degrees(), 0.001) << "Dec round-trip failed";
     }
+}
+
+// ---------------------------------------------------------------------------
+// LegacyPlugin fallback: verifies MathPlugin::TransformCelestialToTelescopeJD
+// default converts absolute JD -> correct JulianOffset for legacy external plugins.
+//
+// A legacy plugin implements only the old pure-virtual methods and does not
+// override the new *JD methods.  The base-class default must compute
+//   JulianOffset = JulianDate - ln_get_julian_from_sys()
+// so that when the legacy plugin adds ln_get_julian_from_sys() internally it
+// recovers the original absolute JD.  Passing 0.0 (the old bug) would give
+// the wrong time to any legacy plugin.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct LegacyPlugin : public MathPlugin
+{
+    double lastOffset = 999.0;  // sentinel; 0.0 would mask the old bug
+
+    bool TransformCelestialToTelescope(const double, const double,
+                                        double JulianOffset,
+                                        TelescopeDirectionVector &) override
+    {
+        lastOffset = JulianOffset;
+        return true;
+    }
+
+    bool TransformTelescopeToCelestial(const TelescopeDirectionVector &,
+                                        double &, double &, double JulianOffset) override
+    {
+        lastOffset = JulianOffset;
+        return true;
+    }
+};
+
+} // namespace
+
+TEST_F(AlignmentPluginTest, LegacyPlugin_JD_Fallback_CelestialToTelescope)
+{
+    LegacyPlugin plugin;
+    InMemoryDatabase db;
+    plugin.Initialise(&db);
+
+    TelescopeDirectionVector tdv;
+    double t1 = ln_get_julian_from_sys();
+    plugin.TransformCelestialToTelescopeJD(1.0, 45.0, fixedJD, tdv);
+    double t2 = ln_get_julian_from_sys();
+
+    // The default fallback computes offset = fixedJD - ln_get_julian_from_sys().
+    // Bracket with t1/t2 to tolerate any wall-clock delta during the call:
+    //   fixedJD - t2  <=  capturedOffset  <=  fixedJD - t1
+    // With the old 0.0 bug, capturedOffset == 0.0 which fails EXPECT_LE when
+    // fixedJD != now (i.e., always in practice).
+    EXPECT_GE(plugin.lastOffset, fixedJD - t2) << "offset too small";
+    EXPECT_LE(plugin.lastOffset, fixedJD - t1) << "offset too large (was 0.0 before fix)";
+}
+
+TEST_F(AlignmentPluginTest, LegacyPlugin_JD_Fallback_TelescopeToCelestial)
+{
+    LegacyPlugin plugin;
+    InMemoryDatabase db;
+    plugin.Initialise(&db);
+
+    TelescopeDirectionVector tdv{0.0, 0.0, 1.0};
+    double ra = 0, dec = 0;
+    double t1 = ln_get_julian_from_sys();
+    plugin.TransformTelescopeToCelestialJD(tdv, ra, dec, fixedJD);
+    double t2 = ln_get_julian_from_sys();
+
+    EXPECT_GE(plugin.lastOffset, fixedJD - t2) << "offset too small";
+    EXPECT_LE(plugin.lastOffset, fixedJD - t1) << "offset too large (was 0.0 before fix)";
 }
 
 int main(int argc, char **argv)

--- a/test/alignment/test_alignment_plugins.cpp
+++ b/test/alignment/test_alignment_plugins.cpp
@@ -25,7 +25,6 @@
 #include "../../drivers/telescope/scopesim_helper.h"
 
 #include <libnova/sidereal_time.h>
-#include <libnova/julian_day.h>
 
 using namespace INDI::AlignmentSubsystem;
 
@@ -268,13 +267,12 @@ protected:
 
         double testRA  = 12.0;
         double testDec = (mountType == ::Alignment::ALTAZ) ? 60.0 : 45.0;
-        double joff    = fixedJD - ln_get_julian_from_sys();
 
         TelescopeDirectionVector resultV;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(testRA, testDec, joff, resultV));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, resultV));
 
         double outRA, outDec;
-        plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+        plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
         ASSERT_NEAR(testRA,  outRA,  kRoundTripTolHours);
         ASSERT_NEAR(testDec, outDec, kRoundTripTolDeg);
@@ -328,8 +326,6 @@ protected:
 
         ASSERT_TRUE(plugin.Initialise(&alignDb));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Validation layer: Halton(5, 7)
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
@@ -341,10 +337,10 @@ protected:
             getSkyPoint(raw.first, raw.second, minDec, maxDec, ra, dec);
 
             TelescopeDirectionVector resultV;
-            ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+            ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, resultV));
 
             double outRA, outDec;
-            plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+            plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
             double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
             double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -433,8 +429,6 @@ protected:
         ASSERT_TRUE(refPlugin.Initialise(&cleanDb));
         ASSERT_TRUE(noisyPlugin.Initialise(&noisyDb));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
 
@@ -446,11 +440,11 @@ protected:
 
             // Noisy plugin's predicted direction
             TelescopeDirectionVector noisyV;
-            ASSERT_TRUE(noisyPlugin.TransformCelestialToTelescope(ra, dec, joff, noisyV));
+            ASSERT_TRUE(noisyPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, noisyV));
 
-            // Reference (noiseless) plugin's predicted direction — same joff
+            // Reference (noiseless) plugin's predicted direction — same JD
             TelescopeDirectionVector refV;
-            ASSERT_TRUE(refPlugin.TransformCelestialToTelescope(ra, dec, joff, refV));
+            ASSERT_TRUE(refPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, refV));
 
             // Angular separation in arcseconds
             double dot = noisyV.x * refV.x + noisyV.y * refV.y + noisyV.z * refV.z;
@@ -518,7 +512,6 @@ protected:
 
         // Validation Phase: JD = fixedJD + shiftHours/24
         double valJD = fixedJD + shiftHours / 24.0;
-        double joff = valJD - ln_get_julian_from_sys();
 
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
@@ -530,11 +523,10 @@ protected:
             getSkyPoint(raw.first, raw.second, minDec, maxDec, ra, dec);
 
             TelescopeDirectionVector resultV;
-            // The plugin must correctly interpret ra, dec relative to the new joff (time)
-            ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+            ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, valJD, resultV));
 
             double outRA, outDec;
-            plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+            plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, valJD);
 
             double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
             double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -593,8 +585,6 @@ protected:
         }
         ASSERT_TRUE(plugin.Initialise(&db));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Ground truth encoder position
         Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
         Angle adec(valDec);
@@ -603,7 +593,7 @@ protected:
 
         // Plugin C->T prediction, decoded to Az/Alt without T->C
         TelescopeDirectionVector tdv;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
         INDI::IHorizontalCoordinates hor;
         pSupport->AltitudeAzimuthFromTelescopeDirectionVector(tdv, hor);
 
@@ -651,8 +641,6 @@ protected:
         }
         ASSERT_TRUE(plugin.Initialise(&db));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Ground truth encoder position (RA/Dec) from scopesim
         Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
         Angle adec(valDec);
@@ -662,7 +650,7 @@ protected:
 
         // Plugin C->T prediction, decoded to RA/Dec without T->C
         TelescopeDirectionVector tdv;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
         INDI::IEquatorialCoordinates raCoords;
         pSupport->EquatorialCoordinatesFromTelescopeDirectionVector(tdv, raCoords);
 
@@ -714,8 +702,6 @@ protected:
         }
         ASSERT_TRUE(plugin.Initialise(&db));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Ground truth encoder position (Alt/Az) from scopesim
         Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
         Angle adec(valDec);
@@ -724,7 +710,7 @@ protected:
 
         // Plugin C->T prediction, decoded to Alt/Az without T->C
         TelescopeDirectionVector tdv;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
         INDI::IHorizontalCoordinates horCoords;
         pSupport->AltitudeAzimuthFromTelescopeDirectionVector(tdv, horCoords);
 
@@ -777,8 +763,6 @@ protected:
 
         ASSERT_TRUE(plugin.Initialise(&alignDb));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // 100-point validation set for flip tests
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
@@ -790,10 +774,10 @@ protected:
             getSkyPoint(raw.first, raw.second, kEQ_MinDec, kEQ_MaxDec, ra, dec);
 
             TelescopeDirectionVector resultV;
-            ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+            ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, resultV));
 
             double outRA, outDec;
-            plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+            plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
             double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
             double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -866,7 +850,6 @@ protected:
     void verifyHotMatchesCold(SPKMathPlugin &hotPlugin, SPKMathPlugin &coldPlugin,
                                ::Alignment::MOUNT_TYPE mountType = ::Alignment::EQ_GEM)
     {
-        double joff = fixedJD - ln_get_julian_from_sys();
         // Hot path uses pm=0 as the linearization point (Pmfit iteration-0);
         // Pmfit iterates to convergence.  With arcminute-level mount errors
         // the difference is a few arcseconds in angle space (~5e-5 in
@@ -881,8 +864,8 @@ protected:
             for (double testDec : decs)
             {
                 TelescopeDirectionVector hotV, coldV;
-                ASSERT_TRUE(hotPlugin.TransformCelestialToTelescope(testRA, testDec, joff, hotV));
-                ASSERT_TRUE(coldPlugin.TransformCelestialToTelescope(testRA, testDec, joff, coldV));
+                ASSERT_TRUE(hotPlugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, hotV));
+                ASSERT_TRUE(coldPlugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, coldV));
                 EXPECT_NEAR(hotV.x, coldV.x, tol) << "RA=" << testRA << " Dec/El=" << testDec;
                 EXPECT_NEAR(hotV.y, coldV.y, tol) << "RA=" << testRA << " Dec/El=" << testDec;
                 EXPECT_NEAR(hotV.z, coldV.z, tol) << "RA=" << testRA << " Dec/El=" << testDec;
@@ -1166,15 +1149,13 @@ TEST_F(AlignmentPluginTest, Nearest_AltAz_Goto_Convention_Regression)
     }
     ASSERT_TRUE(plugin.Initialise(&db));
 
-    double joff = fixedJD - ln_get_julian_from_sys();
-
     Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
     Angle adec(valDec);
     Angle encAz, encAlt;
     gen.apparentHaDecToMount(ha, adec, &encAz, &encAlt);
 
     TelescopeDirectionVector tdv;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
     INDI::IHorizontalCoordinates hor;
     pSupport->AltitudeAzimuthFromTelescopeDirectionVector(tdv, hor);
 
@@ -1230,8 +1211,6 @@ TEST_F(AlignmentPluginTest, SVD_AlignValidate_ConvexHullFallback)
 
     ASSERT_TRUE(plugin.Initialise(&alignDb));
 
-    double joff = fixedJD - ln_get_julian_from_sys();
-
     // Validation from western sky: RA in [6h, 18h) -- outside the convex hull
     int validateCount = 0;
     for (int i = 1; validateCount < 6; ++i)
@@ -1245,10 +1224,10 @@ TEST_F(AlignmentPluginTest, SVD_AlignValidate_ConvexHullFallback)
 
         TelescopeDirectionVector resultV;
         // Must not crash or fail; fallback should return a usable (if coarse) TDV
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, resultV));
 
         double outRA, outDec;
-        plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+        plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
         double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
         double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -1815,14 +1794,12 @@ static void RunPolarDegeneracyTestImpl(
 
     ASSERT_TRUE(plugin.Initialise(&db));
 
-    double joff = fixedJD - ln_get_julian_from_sys();
-
     // Target far from the pole/zenith
     double testRA  = 12.0;
     double testDec = (mountType == ::Alignment::ALTAZ) ? 30.0 : 45.0;
 
     TelescopeDirectionVector resultV;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(testRA, testDec, joff, resultV));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, resultV));
 
     // Decode the TDV to encoder coordinates and sanity-check
     if (mountType == ::Alignment::ALTAZ)
@@ -2001,11 +1978,10 @@ TEST_F(AlignmentPluginTest, SPK_Incremental_InvalidStateNotUsed)
         ASSERT_TRUE(plugin.Initialise(&db));
     }
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(12.0, 45.0, joff, v));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 45.0, fixedJD, v));
     double outRA, outDec;
-    plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff);
+    plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD);
     EXPECT_NEAR(12.0, outRA,  kRoundTripTolHours);
     EXPECT_NEAR(45.0, outDec, kRoundTripTolDeg);
 }
@@ -2024,11 +2000,10 @@ TEST_F(AlignmentPluginTest, SPK_Incremental_MountTypeChange)
     auto generatorAz = buildIncrementalDb(plugin, kMixed, 7, dbAz, ::Alignment::ALTAZ);
     (void)generatorAz;
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(12.0, 60.0, joff, v));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 60.0, fixedJD, v));
     double outRA, outDec;
-    plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff);
+    plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD);
     EXPECT_NEAR(12.0, outRA,  kRoundTripTolHours);
     EXPECT_NEAR(60.0, outDec, kRoundTripTolDeg);
 }
@@ -2047,14 +2022,13 @@ TEST_F(AlignmentPluginTest, SPK_Lifecycle_NoLocation_TransformsFail)
     plugin.Initialise(&db);
     plugin.SetApproximateMountAlignment(ZENITH);
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    EXPECT_FALSE(plugin.TransformCelestialToTelescope(12.0, 45.0, joff, v));
+    EXPECT_FALSE(plugin.TransformCelestialToTelescopeJD(12.0, 45.0, fixedJD, v));
 
     // Provide a dummy TDV and confirm T->C also fails without a location.
     v = TelescopeDirectionVector{0, 0, 1};
     double outRA, outDec;
-    EXPECT_FALSE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    EXPECT_FALSE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
 }
 
 // Initialise without a location must not crash and must return true
@@ -2078,11 +2052,10 @@ TEST_F(AlignmentPluginTest, SPK_Lifecycle_LateLocation_TransformsSucceed)
     // Location arrives late (e.g. from a saved config property).
     db.SetDatabaseReferencePosition(kLosAngeles);
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    EXPECT_TRUE(plugin.TransformCelestialToTelescope(12.0, 45.0, joff, v));
+    EXPECT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 45.0, fixedJD, v));
     double outRA, outDec;
-    EXPECT_TRUE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    EXPECT_TRUE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
 }
 
 // Mount type set after Initialise must be picked up on the next transform call,
@@ -2103,18 +2076,17 @@ TEST_F(AlignmentPluginTest, SPK_Lifecycle_MountTypeAfterInit_PickedUpByTransform
     plugin.SetApproximateMountAlignment(ZENITH);
 
     // Transform should use ALTAZ formulas.  Verify by round-trip: C->T->C.
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(12.0, 30.0, joff, v));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 30.0, fixedJD, v));
     double outRA, outDec;
-    ASSERT_TRUE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    ASSERT_TRUE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
     EXPECT_NEAR(12.0, outRA,  kRoundTripTolHours);
     EXPECT_NEAR(30.0, outDec, kRoundTripTolDeg);
 
     // Now switch to EQUAT without Initialise — must also be picked up.
     plugin.SetApproximateMountAlignment(NORTH_CELESTIAL_POLE);
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(6.0, 45.0, joff, v));
-    ASSERT_TRUE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(6.0, 45.0, fixedJD, v));
+    ASSERT_TRUE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
     EXPECT_NEAR(6.0,  outRA,  kRoundTripTolHours);
     EXPECT_NEAR(45.0, outDec, kRoundTripTolDeg);
 }


### PR DESCRIPTION
## Reviewer note

This PR changes a core alignment subsystem API (`MathPlugin`, `MathPluginManagement`)
that is used by multiple drivers inside this repo and by third-party drivers in
`indi-3rdparty` (notably `indi-celestronaux` and `indi-eqmod`). Would appreciate
architectural feedback before merge.

## Summary

Refactors the INDI alignment subsystem so that the core transform methods no longer read
the system clock internally. Two new methods are added to `MathPlugin` that accept an
absolute Julian Date directly:

- `TransformCelestialToTelescopeJD(RA, Dec, JulianDate, TDV)`
- `TransformTelescopeToCelestialJD(TDV, RA, Dec, JulianDate)`

All built-in plugins (`BasicMathPlugin` / `SVDMathPlugin`, `NearestMathPlugin`,
`SPKMathPlugin`, `DummyMathPlugin`) implement the new methods as their primary
implementation. The old `TransformCelestialToTelescope` / `TransformTelescopeToCelestial`
methods become thin compat shims that resolve `ln_get_julian_from_sys() + JulianOffset`
and delegate to the new JD variants. `MathPluginManagement` gains matching `*JD` dispatch
methods; its old public methods are similarly shimmed.

## Motivation

The old interface forced every plugin to call `ln_get_julian_from_sys()` internally.
This had two consequences:

1. **Tests were non-deterministic.** The test suite worked around this with a
   `joff = fixedJD - ln_get_julian_from_sys()` hack to re-anchor transforms to a fixed
   point in time. This was fragile and obscured intent.

2. **Simulated time was impossible.** Any future support for injected/simulated time
   (e.g. KStars time simulation) requires callers to supply the JD — the plugins cannot
   intercept `ln_get_julian_from_sys()` from the outside.

## Backward compatibility

External plugins that have not yet adopted the new interface are unaffected at the
source and binary level. The new `*JD` methods are non-pure virtual. The base-class
default computes `JulianOffset = JulianDate - ln_get_julian_from_sys()` and calls the
old pure-virtual, so an unmodified external plugin recovers the correct absolute JD
when it adds `ln_get_julian_from_sys()` internally.

All existing drivers that call the old `TransformCelestialToTelescope` /
`TransformTelescopeToCelestial` interface — including `skywatcherAPIMount`,
`indi-celestronaux`, `eqmod`, `telescope_simulator`, `astrotrac`, `temmadriver`, `dsc` —
continue to work unchanged through the compat shims. Non-zero `JulianOffset` calls
(e.g. bracket tracking in `skywatcherAPIMount` and `celestronaux`) are correctly
handled: the shim resolves the absolute JD before dispatching.

## Changes

### `libs/alignment/MathPlugin.h/.cpp`
- Add `TransformCelestialToTelescopeJD` and `TransformTelescopeToCelestialJD` as
  non-pure virtual methods with default fallback implementations.

### `libs/alignment/BasicMathPlugin.h/.cpp`, `NearestMathPlugin`, `SPKMathPlugin`, `DummyMathPlugin`
- Override the new `*JD` methods as the primary implementation (clock-free).
- Reduce the old `Transform*` overrides to one-liner shims.

### `libs/alignment/MathPluginManagement.h/.cpp`
- Add public `TransformCelestialToTelescopeJD` / `TransformTelescopeToCelestialJD`
  dispatch methods (direct virtual call on `pLoadedMathPlugin`).
- Convert old public `Transform*` methods to compat shims.
- Remove now-dead `pTransformCelestialToTelescope` / `pTransformTelescopeToCelestial`
  function pointer members (dispatch goes through direct virtual calls).

### `test/alignment/test_alignment_plugins.cpp`
- Remove the `joff = fixedJD - ln_get_julian_from_sys()` workaround from all test
  blocks; replace with direct `*JD` calls using `static constexpr double fixedJD`.
- Add two regression tests (`LegacyPlugin_JD_Fallback_CelestialToTelescope` and
  `LegacyPlugin_JD_Fallback_TelescopeToCelestial`) that verify the base-class fallback
  correctly converts an absolute JD to the offset expected by legacy external plugins.

## Test results

```
[==========] 110 tests from 2 test suites ran.
[  PASSED  ] 110 tests.
```

## Follow-up (not in this PR)

**Phase 2 — Deprecate:** Mark the old `Transform*` pure-virtual methods `[[deprecated]]`
to produce compiler warnings for external plugins that haven't migrated.

**Phase 3 — Driver API:** Thread a `JD` parameter (with default `= ln_get_julian_from_sys()`)
through the six public methods of `AlignmentSubsystemForDrivers`
(`SkyToTelescopeEquatorial`, `TelescopeEquatorialToSky`, etc.) and update the internal
call sites to use `*JD` directly. Migrate direct `MathPluginManagement` callers
(`skywatcherAPIMount`, `indi-celestronaux`) to use `*JD` with explicit JD values.

**Phase 4 — Remove:** Once no callers use the old interface, make `*JD` pure virtual and
remove the compat layer entirely.