### PR TITLE
Alignment: deprecate old Transform* shims, migrate all in-tree callers to *JD

### DIFF
--- a/drivers/telescope/astrotrac.cpp
+++ b/drivers/telescope/astrotrac.cpp
@@ -682,7 +682,7 @@ bool AstroTrac::ReadScopeStatus()
     m_MountInternalCoordinates.declination = de;
     TDV = TelescopeDirectionVectorFromEquatorialCoordinates(m_MountInternalCoordinates);
 
-    if (TransformTelescopeToCelestial(TDV, skyRA, skyDE))
+    if (TransformTelescopeToCelestialJD(TDV, skyRA, skyDE, ln_get_julian_from_sys()))
     {
         // double lst = get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].getValue());
         // double dHA = rangeHA(lst - skyRA);
@@ -710,7 +710,7 @@ bool AstroTrac::ReadScopeStatus()
 bool AstroTrac::getTelescopeFromSkyCoordinates(double ra, double de, INDI::IEquatorialCoordinates &telescopeCoordinates)
 {
     TelescopeDirectionVector TDV;
-    if (TransformCelestialToTelescope(ra, de, 0.0, TDV))
+    if (TransformCelestialToTelescopeJD(ra, de, ln_get_julian_from_sys(), TDV))
     {
         EquatorialCoordinatesFromTelescopeDirectionVector(TDV, telescopeCoordinates);
         LOGF_DEBUG("TransformCelestialToTelescope: RA=%lf DE=%lf, TDV (x :%lf, y: %lf, z: %lf), local hour RA %lf DEC %lf",

--- a/drivers/telescope/dsc.cpp
+++ b/drivers/telescope/dsc.cpp
@@ -468,7 +468,7 @@ INDI::IEquatorialCoordinates DSC::TelescopeEquatorialToSky()
         eq.declination = encoderEquatorialCoordinates.declination;
         TDV    = TelescopeDirectionVectorFromLocalHourAngleDeclination(eq);
 
-        if (!TransformTelescopeToCelestial(TDV, RightAscension, Declination))
+        if (!TransformTelescopeToCelestialJD(TDV, RightAscension, Declination, ln_get_julian_from_sys()))
         {
             RightAscension = encoderEquatorialCoordinates.rightascension;
             Declination    = encoderEquatorialCoordinates.declination;
@@ -493,7 +493,7 @@ INDI::IEquatorialCoordinates DSC::TelescopeHorizontalToSky()
     TelescopeDirectionVector TDV = TelescopeDirectionVectorFromAltitudeAzimuth(encoderHorizontalCoordinates);
     double RightAscension, Declination;
 
-    if (!TransformTelescopeToCelestial(TDV, RightAscension, Declination))
+    if (!TransformTelescopeToCelestialJD(TDV, RightAscension, Declination, ln_get_julian_from_sys()))
     {
         INDI::IEquatorialCoordinates EquatorialCoordinates {0, 0};
         TelescopeDirectionVector RotatedTDV(TDV);

--- a/drivers/telescope/skywatcherAPIMount.cpp
+++ b/drivers/telescope/skywatcherAPIMount.cpp
@@ -537,7 +537,7 @@ bool SkywatcherAPIMount::Goto(double ra, double dec)
     // Transform Celestial to Telescope coordinates.
     // We have no good way to estimate how long will the mount takes to reach target (with deceleration,
     // and not just speed). So we will use iterative GOTO once the first GOTO is complete.
-    if (TransformCelestialToTelescope(ra, dec, 0.0, TDV))
+    if (TransformCelestialToTelescopeJD(ra, dec, ln_get_julian_from_sys(), TDV))
     {
         INDI::IEquatorialCoordinates EquatorialCoordinates { 0, 0 };
         AltitudeAzimuthFromTelescopeDirectionVector(TDV, AltAz);
@@ -909,7 +909,7 @@ bool SkywatcherAPIMount::getCurrentRADE(INDI::IHorizontalCoordinates altaz, INDI
     DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "TDV x %lf y %lf z %lf", TDV.x, TDV.y, TDV.z);
 
     double RightAscension, Declination;
-    if (!TransformTelescopeToCelestial(TDV, RightAscension, Declination))
+    if (!TransformTelescopeToCelestialJD(TDV, RightAscension, Declination, ln_get_julian_from_sys()))
     {
         TelescopeDirectionVector RotatedTDV(TDV);
         switch (GetApproximateMountAlignment())
@@ -981,7 +981,7 @@ bool SkywatcherAPIMount::Sync(double ra, double dec)
         INDI::IHorizontalCoordinates AltAz { 0, 0 };
         TelescopeDirectionVector TDV;
 
-        if (TransformCelestialToTelescope(ra, dec, 0.0, TDV))
+        if (TransformCelestialToTelescopeJD(ra, dec, ln_get_julian_from_sys(), TDV))
         {
             AltitudeAzimuthFromTelescopeDirectionVector(TDV, AltAz);
             double OrigAlt = AltAz.altitude;
@@ -1345,10 +1345,11 @@ void SkywatcherAPIMount::ConvertGuideCorrection(double delta_ra, double delta_de
     TelescopeDirectionVector OldTDV;
     TelescopeDirectionVector NewTDV;
 
-    TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination, 0.0, OldTDV);
+    TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                    ln_get_julian_from_sys(), OldTDV);
     AltitudeAzimuthFromTelescopeDirectionVector(OldTDV, OldAltAz);
-    TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension + delta_ra,
-                                  m_SkyTrackingTarget.declination + delta_dec, 0.0, NewTDV);
+    TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension + delta_ra,
+                                    m_SkyTrackingTarget.declination + delta_dec, ln_get_julian_from_sys(), NewTDV);
     AltitudeAzimuthFromTelescopeDirectionVector(NewTDV, NewAltAz);
     delta_alt = NewAltAz.altitude - OldAltAz.altitude;
     delta_az = NewAltAz.azimuth - OldAltAz.azimuth;
@@ -1674,7 +1675,7 @@ bool SkywatcherAPIMount::trackUsingPID()
     auto de = m_SkyTrackingTarget.declination + AxisOffsetNP[DEOffset].getValue();
     auto JDOffset = AxisOffsetNP[JulianOffset].getValue() / 86400.0;
 
-    if (TransformCelestialToTelescope(ra, de, JDOffset, TDV))
+    if (TransformCelestialToTelescopeJD(ra, de, ln_get_julian_from_sys() + JDOffset, TDV))
     {
         DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT, "TDV x %lf y %lf z %lf", TDV.x, TDV.y, TDV.z);
         AltitudeAzimuthFromTelescopeDirectionVector(TDV, AltAz);
@@ -1871,23 +1872,23 @@ bool SkywatcherAPIMount::trackUsingPredictiveRates()
     }
 
     // Start by transforming tracking target celestial coordinates to telescope coordinates.
-    if (TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
-                                      0, TDV))
+    double JDnow {ln_get_julian_from_sys()};
+    if (TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                        JDnow, TDV))
     {
         // If mount is Alt-Az then that's all we need to do
         AltitudeAzimuthFromTelescopeDirectionVector(TDV, targetMountAxisCoordinates);
-        TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
-                                      JDoffset, futureTDV);
+        TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                        JDnow + JDoffset, futureTDV);
         AltitudeAzimuthFromTelescopeDirectionVector(futureTDV, futureMountAxisCoordinates);
-        TransformCelestialToTelescope(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
-                                      -JDoffset, pastTDV);
+        TransformCelestialToTelescopeJD(m_SkyTrackingTarget.rightascension, m_SkyTrackingTarget.declination,
+                                        JDnow - JDoffset, pastTDV);
         AltitudeAzimuthFromTelescopeDirectionVector(pastTDV, pastMountAxisCoordinates);
 
     }
     // If transformation failed.
     else
     {
-        double JDnow {ln_get_julian_from_sys()};
         INDI::IEquatorialCoordinates EquatorialCoordinates { 0, 0 };
         EquatorialCoordinates.rightascension  = m_SkyTrackingTarget.rightascension;
         EquatorialCoordinates.declination = m_SkyTrackingTarget.declination;

--- a/drivers/telescope/telescope_simulator.cpp
+++ b/drivers/telescope/telescope_simulator.cpp
@@ -317,7 +317,7 @@ void ScopeSim::updateCurrentCoordsFromAxes()
             INDI::IEquatorialCoordinates raCoords{ encoderRA, instDec.Degrees() };
             TelescopeDirectionVector tdv =
                 TelescopeDirectionVectorFromEquatorialCoordinates(raCoords);
-            corrected = TransformTelescopeToCelestial(tdv, corrRA, corrDec);
+            corrected = TransformTelescopeToCelestialJD(tdv, corrRA, corrDec, ln_get_julian_from_sys());
         }
         if (corrected)
         {
@@ -571,7 +571,7 @@ bool ScopeSim::Goto(double r, double d)
     if (GetAlignmentDatabase().size() >= 1)
     {
         TelescopeDirectionVector tdv;
-        if (TransformCelestialToTelescope(r, d, 0.0, tdv))
+        if (TransformCelestialToTelescopeJD(r, d, ln_get_julian_from_sys(), tdv))
         {
             // The TDV now encodes encoder RA (time-stable), so decode with
             // EquatorialCoordinatesFromTelescopeDirectionVector — no LST conversion needed.

--- a/drivers/telescope/temmadriver.cpp
+++ b/drivers/telescope/temmadriver.cpp
@@ -419,7 +419,7 @@ bool TemmaMount::ReadScopeStatus()
 
         aligned = true;
 
-        if (!TransformTelescopeToCelestial(TDV, alignedRA, alignedDEC))
+        if (!TransformTelescopeToCelestialJD(TDV, alignedRA, alignedDEC, ln_get_julian_from_sys()))
         {
             aligned = false;
             DEBUGF(INDI::AlignmentSubsystem::DBG_ALIGNMENT,
@@ -938,7 +938,7 @@ INDI::IEquatorialCoordinates TemmaMount::TelescopeToSky(double ra, double dec)
         eq.dec = dec;
         TDV    = TelescopeDirectionVectorFromLocalHourAngleDeclination(eq);
 
-        if (TransformTelescopeToCelestial(TDV, RightAscension, Declination))
+        if (TransformTelescopeToCelestialJD(TDV, RightAscension, Declination, ln_get_julian_from_sys()))
         {
             //  if we get here, the conversion was successful
             //LOG_DEBUG"new values %6.4f %6.4f %6.4f  %6.4f Deltas %3.0lf %3.0lf\n",ra,dec,RightAscension,Declination,(ra-RightAscension)*60,(dec-Declination)*60);
@@ -977,7 +977,7 @@ INDI::IEquatorialCoordinates TemmaMount::SkyToTelescope(double ra, double dec)
         //  if the alignment system has been turned off
         //  this transformation will fail, and we fall thru
         //  to using raw co-ordinates from the mount
-        if (TransformCelestialToTelescope(ra, dec, 0.0, TDV))
+        if (TransformCelestialToTelescopeJD(ra, dec, ln_get_julian_from_sys(), TDV))
         {
             /*  Initial attempt, using RA/DEC co-ordinates talking to alignment system
             EquatorialCoordinatesFromTelescopeDirectionVector(TDV,eq);

--- a/examples/tutorial_seven/simple_telescope_simulator.cpp
+++ b/examples/tutorial_seven/simple_telescope_simulator.cpp
@@ -102,7 +102,7 @@ bool ScopeSim::Goto(double ra, double dec)
     TelescopeDirectionVector TDV;
     INDI::IHorizontalCoordinates AltAz { 0, 0 };
 
-    if (TransformCelestialToTelescope(ra, dec, 0.0, TDV))
+    if (TransformCelestialToTelescopeJD(ra, dec, ln_get_julian_from_sys(), TDV))
     {
         // The alignment subsystem has successfully transformed my coordinate
         AltitudeAzimuthFromTelescopeDirectionVector(TDV, AltAz);
@@ -287,7 +287,7 @@ bool ScopeSim::ReadScopeStatus()
     INDI::IHorizontalCoordinates AltAz { CurrentEncoderMicrostepsRA / MICROSTEPS_PER_DEGREE, CurrentEncoderMicrostepsDEC / MICROSTEPS_PER_DEGREE };
     TelescopeDirectionVector TDV = TelescopeDirectionVectorFromAltitudeAzimuth(AltAz);
     double RightAscension, Declination;
-    if (!TransformTelescopeToCelestial(TDV, RightAscension, Declination))
+    if (!TransformTelescopeToCelestialJD(TDV, RightAscension, Declination, ln_get_julian_from_sys()))
     {
         if (TraceThisTick)
             DEBUG(DBG_SIMULATOR, "ReadScopeStatus - TransformTelescopeToCelestial failed");
@@ -613,8 +613,9 @@ void ScopeSim::TimerHit()
             TelescopeDirectionVector TDV;
             INDI::IHorizontalCoordinates AltAz { 0, 0 };
 
-            if (TransformCelestialToTelescope(CurrentTrackingTarget.rightascension, CurrentTrackingTarget.declination, JulianOffset,
-                                              TDV))
+            if (TransformCelestialToTelescopeJD(CurrentTrackingTarget.rightascension,
+                                                CurrentTrackingTarget.declination,
+                                                ln_get_julian_from_sys() + JulianOffset, TDV))
                 AltitudeAzimuthFromTelescopeDirectionVector(TDV, AltAz);
             else
             {

--- a/libs/alignment/AlignmentSubsystemForDrivers.cpp
+++ b/libs/alignment/AlignmentSubsystemForDrivers.cpp
@@ -65,7 +65,7 @@ void AlignmentSubsystemForDrivers::SaveAlignmentConfigProperties(FILE *fp)
 // Helper methods
 
 bool AlignmentSubsystemForDrivers::AddAlignmentEntryEquatorial(double actualRA, double actualDec, double mountRA,
-        double mountDec)
+        double mountDec, double JD)
 {
     IGeographicCoordinates location;
     if (!GetDatabaseReferencePosition(location))
@@ -77,7 +77,7 @@ bool AlignmentSubsystemForDrivers::AddAlignmentEntryEquatorial(double actualRA, 
     AlignmentDatabaseEntry NewEntry;
     TelescopeDirectionVector TDV = TelescopeDirectionVectorFromEquatorialCoordinates(RaDec);
 
-    NewEntry.ObservationJulianDate = ln_get_julian_from_sys();
+    NewEntry.ObservationJulianDate = JD;
     NewEntry.RightAscension = actualRA;
     NewEntry.Declination = actualDec;
     NewEntry.TelescopeDirection = TDV;
@@ -98,7 +98,7 @@ bool AlignmentSubsystemForDrivers::AddAlignmentEntryEquatorial(double actualRA, 
 }
 
 bool AlignmentSubsystemForDrivers::SkyToTelescopeEquatorial(double actualRA, double actualDec, double &mountRA,
-        double &mountDec)
+        double &mountDec, double JD)
 {
     INDI::IEquatorialCoordinates eq{0, 0};
     TelescopeDirectionVector TDV;
@@ -115,7 +115,7 @@ bool AlignmentSubsystemForDrivers::SkyToTelescopeEquatorial(double actualRA, dou
 
     if (GetAlignmentDatabase().size() >= 1)
     {
-        if (TransformCelestialToTelescope(actualRA, actualDec, 0.0, TDV))
+        if (TransformCelestialToTelescopeJD(actualRA, actualDec, JD, TDV))
         {
             EquatorialCoordinatesFromTelescopeDirectionVector(TDV, eq);
             //  and now we have to convert from lha back to RA
@@ -129,7 +129,7 @@ bool AlignmentSubsystemForDrivers::SkyToTelescopeEquatorial(double actualRA, dou
 }
 
 bool AlignmentSubsystemForDrivers::TelescopeEquatorialToSky(double mountRA, double mountDec, double &actualRA,
-        double &actualDec)
+        double &actualDec, double JD)
 {
     INDI::IEquatorialCoordinates eq{0, 0};
     IGeographicCoordinates location;
@@ -150,14 +150,14 @@ bool AlignmentSubsystemForDrivers::TelescopeEquatorialToSky(double mountRA, doub
         eq.declination = mountDec;
 
         TDV = TelescopeDirectionVectorFromEquatorialCoordinates(eq);
-        return TransformTelescopeToCelestial(TDV, actualRA, actualDec);
+        return TransformTelescopeToCelestialJD(TDV, actualRA, actualDec, JD);
     }
 
     return false;
 }
 
 bool AlignmentSubsystemForDrivers::AddAlignmentEntryAltAz(double actualRA, double actualDec, double mountAlt,
-        double mountAz)
+        double mountAz, double JD)
 {
     IGeographicCoordinates location;
     if (!GetDatabaseReferencePosition(location))
@@ -169,7 +169,7 @@ bool AlignmentSubsystemForDrivers::AddAlignmentEntryAltAz(double actualRA, doubl
     AlignmentDatabaseEntry NewEntry;
     TelescopeDirectionVector TDV = TelescopeDirectionVectorFromAltitudeAzimuth(AltAz);
 
-    NewEntry.ObservationJulianDate = ln_get_julian_from_sys();
+    NewEntry.ObservationJulianDate = JD;
     NewEntry.RightAscension = actualRA;
     NewEntry.Declination = actualDec;
     NewEntry.TelescopeDirection = TDV;
@@ -189,7 +189,8 @@ bool AlignmentSubsystemForDrivers::AddAlignmentEntryAltAz(double actualRA, doubl
     return false;
 }
 
-bool AlignmentSubsystemForDrivers::SkyToTelescopeAltAz(double actualRA, double actualDec, double &mountAlt, double &mountAz)
+bool AlignmentSubsystemForDrivers::SkyToTelescopeAltAz(double actualRA, double actualDec, double &mountAlt,
+        double &mountAz, double JD)
 {
     INDI::IHorizontalCoordinates altAz{0, 0};
     TelescopeDirectionVector TDV;
@@ -202,7 +203,7 @@ bool AlignmentSubsystemForDrivers::SkyToTelescopeAltAz(double actualRA, double a
 
     if (GetAlignmentDatabase().size() >= 1)
     {
-        if (TransformCelestialToTelescope(actualRA, actualDec, 0.0, TDV))
+        if (TransformCelestialToTelescopeJD(actualRA, actualDec, JD, TDV))
         {
             AltitudeAzimuthFromTelescopeDirectionVector(TDV, altAz);
             mountAz = range360(altAz.azimuth);
@@ -214,7 +215,8 @@ bool AlignmentSubsystemForDrivers::SkyToTelescopeAltAz(double actualRA, double a
     return false;
 }
 
-bool AlignmentSubsystemForDrivers::TelescopeAltAzToSky(double mountAlt, double mountAz, double &actualRa, double &actualDec)
+bool AlignmentSubsystemForDrivers::TelescopeAltAzToSky(double mountAlt, double mountAz, double &actualRa,
+        double &actualDec, double JD)
 {
     INDI::IHorizontalCoordinates altaz{0, 0};
     IGeographicCoordinates location;
@@ -230,7 +232,7 @@ bool AlignmentSubsystemForDrivers::TelescopeAltAzToSky(double mountAlt, double m
         altaz.azimuth  = range360(mountAz);
         altaz.altitude = range360(mountAlt);
         TDV = TelescopeDirectionVectorFromAltitudeAzimuth(altaz);
-        return TransformTelescopeToCelestial(TDV, actualRa, actualDec);
+        return TransformTelescopeToCelestialJD(TDV, actualRa, actualDec, JD);
     }
 
     return false;

--- a/libs/alignment/AlignmentSubsystemForDrivers.h
+++ b/libs/alignment/AlignmentSubsystemForDrivers.h
@@ -104,7 +104,8 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
          * This will return false if either the alignment point was already added, or if the location
          * is not set. Call UpdateLocation to set the current location.
          */
-        bool AddAlignmentEntryEquatorial(double actualRA, double actualDec, double mountRA, double mountDec);
+        bool AddAlignmentEntryEquatorial(double actualRA, double actualDec, double mountRA, double mountDec,
+                                         double JD = ln_get_julian_from_sys());
 
         /** \brief Converts an actual sky location to coordinates to send to the mount, usually called
          * in Goto.
@@ -117,7 +118,8 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
          * This will return false if we have fewer than 2 alignment points added, or if the location
          * is not set. Call UpdateLocation to set the current location.
          */
-        bool SkyToTelescopeEquatorial(double actualRA, double actualDec, double &mountRA, double &mountDec);
+        bool SkyToTelescopeEquatorial(double actualRA, double actualDec, double &mountRA, double &mountDec,
+                                      double JD = ln_get_julian_from_sys());
 
         /** \brief Converts a mount location to actual sky coordinates, usually called in ReadScopeStatus.
          * \param[in] mountRA Right Ascension where the mount thinks it is in decimal hours
@@ -129,7 +131,8 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
          * This will return false if we have fewer than 2 alignment points added, or if the location
          * is not set. Call UpdateLocation to set the current location.
          */
-        bool TelescopeEquatorialToSky(double mountRA, double mountDec, double &actualRA, double &actualDec);
+        bool TelescopeEquatorialToSky(double mountRA, double mountDec, double &actualRA, double &actualDec,
+                                      double JD = ln_get_julian_from_sys());
 
         /** \brief Adds an alignment point to the model database, usually called from Sync.
          * \param[in] actualRA actual Right Ascension in decimal hours
@@ -141,7 +144,8 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
          * This will return false if either the alignment point was already added, or if the location
          * is not set. Call UpdateLocation to set the current location.
          */
-        bool AddAlignmentEntryAltAz(double actualRA, double actualDec, double mountAlt, double mountAz);
+        bool AddAlignmentEntryAltAz(double actualRA, double actualDec, double mountAlt, double mountAz,
+                                    double JD = ln_get_julian_from_sys());
 
         /** \brief Converts an actual sky location to coordinates to send to the mount, usually called
          * in Goto.
@@ -154,7 +158,8 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
          * This will return false if we have fewer than 2 alignment points added, or if the location
          * is not set. Call UpdateLocation to set the current location.
          */
-        bool SkyToTelescopeAltAz(double actualRA, double actualDec, double &mountAlt, double &mountAz);
+        bool SkyToTelescopeAltAz(double actualRA, double actualDec, double &mountAlt, double &mountAz,
+                                  double JD = ln_get_julian_from_sys());
 
         /** \brief Converts a mount location to actual sky coordinates, usually called in ReadScopeStatus.
          * \param[in] mountAlt Altitude where the mount thinks it is in decimal degrees
@@ -166,7 +171,8 @@ class AlignmentSubsystemForDrivers : public MapPropertiesToInMemoryDatabase,
          * This will return false if we have fewer than 2 alignment points added, or if the location
          * is not set. Call UpdateLocation to set the current location.
          */
-        bool TelescopeAltAzToSky(double mountAlt, double mountAz, double &actualRA, double &actualDec);
+        bool TelescopeAltAzToSky(double mountAlt, double mountAz, double &actualRA, double &actualDec,
+                                  double JD = ln_get_julian_from_sys());
 
     private:
         /** \brief This static function is registered as a load database callback with

--- a/libs/alignment/BasicMathPlugin.cpp
+++ b/libs/alignment/BasicMathPlugin.cpp
@@ -97,10 +97,8 @@ bool BasicMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
                 case NORTH_CELESTIAL_POLE:
                 {
                     INDI::IEquatorialCoordinates DummyRaDec;
-                    //INDI::IHorizontalCoordinates DummyAltAz;
                     DummyRaDec.rightascension  = 0.0;
                     DummyRaDec.declination = 90.0;
-                    //EquatorialToHorizontal(&DummyRaDec, &Position, ln_get_julian_from_sys(), &DummyAltAz);
                     DummyActualDirectionCosine2   = TelescopeDirectionVectorFromEquatorialCoordinates(DummyRaDec);
                     DummyApparentDirectionCosine2 = DummyActualDirectionCosine2;
                     break;
@@ -108,10 +106,8 @@ bool BasicMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
                 case SOUTH_CELESTIAL_POLE:
                 {
                     INDI::IEquatorialCoordinates DummyRaDec;
-                    //INDI::IHorizontalCoordinates DummyAltAz;
                     DummyRaDec.rightascension  = 0.0;
                     DummyRaDec.declination = -90.0;
-                    //EquatorialToHorizontal(&DummyRaDec, &Position, ln_get_julian_from_sys(), &DummyAltAz);
                     DummyActualDirectionCosine2   = TelescopeDirectionVectorFromEquatorialCoordinates(DummyRaDec);
                     DummyApparentDirectionCosine2 = DummyActualDirectionCosine2;
                     break;

--- a/libs/alignment/BasicMathPlugin.cpp
+++ b/libs/alignment/BasicMathPlugin.cpp
@@ -366,6 +366,15 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
         double JulianOffset,
         TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
+}
+
+bool BasicMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate,
+        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
     INDI::IEquatorialCoordinates ActualRaDec;
     ActualRaDec.rightascension  = RightAscension;
     ActualRaDec.declination = Declination;
@@ -385,7 +394,7 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
             {
                 case ZENITH:
                     INDI::IHorizontalCoordinates ActualAltAz;
-                    EquatorialToHorizontal(&ActualRaDec, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualAltAz);
+                    EquatorialToHorizontal(&ActualRaDec, &Position, JulianDate, &ActualAltAz);
                     ApparentTelescopeDirectionVector = TelescopeDirectionVectorFromAltitudeAzimuth(ActualAltAz);
                     ASSDEBUGF("Celestial to telescope - Actual Az %lf Alt %lf", ActualAltAz.azimuth, ActualAltAz.altitude);
                     break;
@@ -411,7 +420,7 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
             if (ApproximateMountAlignment == ZENITH)
             {
                 INDI::IHorizontalCoordinates ActualAltAz;
-                EquatorialToHorizontal(&ActualRaDec, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualAltAz);
+                EquatorialToHorizontal(&ActualRaDec, &Position, JulianDate, &ActualAltAz);
                 ActualVector = TelescopeDirectionVectorFromAltitudeAzimuth(ActualAltAz);
             }
             else
@@ -439,7 +448,7 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
             if (ApproximateMountAlignment == ZENITH)
             {
                 INDI::IHorizontalCoordinates ActualAltAz;
-                EquatorialToHorizontal(&ActualRaDec, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualAltAz);
+                EquatorialToHorizontal(&ActualRaDec, &Position, JulianDate, &ActualAltAz);
                 ActualVector = TelescopeDirectionVectorFromAltitudeAzimuth(ActualAltAz);
             }
             else
@@ -593,6 +602,13 @@ bool BasicMathPlugin::TransformCelestialToTelescope(const double RightAscension,
 bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
         double &RightAscension, double &Declination, double JulianOffset)
 {
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
+}
+
+bool BasicMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double JulianDate)
+{
     IGeographicCoordinates Position;
 
     //INDI::IHorizontalCoordinates ApparentAltAz;
@@ -625,7 +641,7 @@ bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVect
                               ApparentTelescopeDirectionVector.y, ApparentTelescopeDirectionVector.z);
                     //ASSDEBUGF("ActualVector x %lf y %lf z %lf", RotatedTDV.x, RotatedTDV.y, RotatedTDV.z);
                     AltitudeAzimuthFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, ActualAltAz);
-                    HorizontalToEquatorial(&ActualAltAz, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualRaDec);
+                    HorizontalToEquatorial(&ActualAltAz, &Position, JulianDate, &ActualRaDec);
                 }
                 break;
 
@@ -663,7 +679,7 @@ bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVect
             if (ApproximateMountAlignment == ZENITH)
             {
                 AltitudeAzimuthFromTelescopeDirectionVector(ActualTelescopeDirectionVector, ActualAltAz);
-                HorizontalToEquatorial(&ActualAltAz, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualRaDec);
+                HorizontalToEquatorial(&ActualAltAz, &Position, JulianDate, &ActualRaDec);
             }
             else
             {
@@ -796,7 +812,7 @@ bool BasicMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVect
             if (ApproximateMountAlignment == ZENITH)
             {
                 AltitudeAzimuthFromTelescopeDirectionVector(ActualTelescopeDirectionVector, ActualAltAz);
-                HorizontalToEquatorial(&ActualAltAz, &Position, ln_get_julian_from_sys() + JulianOffset, &ActualRaDec);
+                HorizontalToEquatorial(&ActualAltAz, &Position, JulianDate, &ActualRaDec);
             }
             else
             {

--- a/libs/alignment/BasicMathPlugin.h
+++ b/libs/alignment/BasicMathPlugin.h
@@ -30,25 +30,25 @@ class BasicMathPlugin : public AlignmentSubsystemForMathPlugins
         virtual ~BasicMathPlugin();
 
         /// \brief Override for the base class virtual function
-        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
+        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
         /// \brief Override for the base class virtual function
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         /// \brief Override for the base class virtual function
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianDate);
+                double &RightAscension, double &Declination, double JulianDate) override;
 
-        /// \brief Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
+        /// \brief Compat shim - resolves JD and delegates to TransformCelestialToTelescopeJD
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
-        /// \brief Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
+        /// \brief Compat shim - resolves JD and delegates to TransformTelescopeToCelestialJD
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset = 0);
+                double &RightAscension, double &Declination, double JulianOffset = 0) override;
 
     protected:
         /// \brief Calculate transformation matrices from the supplied vectors

--- a/libs/alignment/BasicMathPlugin.h
+++ b/libs/alignment/BasicMathPlugin.h
@@ -33,11 +33,20 @@ class BasicMathPlugin : public AlignmentSubsystemForMathPlugins
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
 
         /// \brief Override for the base class virtual function
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        /// \brief Override for the base class virtual function
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
+        /// \brief Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);
 
-        /// \brief Override for the base class virtual function
+        /// \brief Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                 double &RightAscension, double &Declination, double JulianOffset = 0);
 

--- a/libs/alignment/DummyMathPlugin.cpp
+++ b/libs/alignment/DummyMathPlugin.cpp
@@ -44,15 +44,28 @@ bool DummyMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
     return false;
 }
 
-bool DummyMathPlugin::TransformCelestialToTelescope(const double RightAscension, const double Declination,
-        double JulianOffset,
-        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+bool DummyMathPlugin::TransformCelestialToTelescopeJD(double /*RightAscension*/, double /*Declination*/,
+        double /*JulianDate*/,
+        TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/)
 {
     return false;
 }
 
-bool DummyMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-        double &RightAscension, double &Declination, double /*JulianOffset*/)
+bool DummyMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/,
+        double &/*RightAscension*/, double &/*Declination*/, double /*JulianDate*/)
+{
+    return false;
+}
+
+bool DummyMathPlugin::TransformCelestialToTelescope(const double /*RightAscension*/, const double /*Declination*/,
+        double /*JulianOffset*/,
+        TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/)
+{
+    return false;
+}
+
+bool DummyMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &/*ApparentTelescopeDirectionVector*/,
+        double &/*RightAscension*/, double &/*Declination*/, double /*JulianOffset*/)
 {
     return false;
 }

--- a/libs/alignment/DummyMathPlugin.h
+++ b/libs/alignment/DummyMathPlugin.h
@@ -16,6 +16,13 @@ class DummyMathPlugin : public AlignmentSubsystemForMathPlugins
 
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
 
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);

--- a/libs/alignment/DummyMathPlugin.h
+++ b/libs/alignment/DummyMathPlugin.h
@@ -14,21 +14,21 @@ class DummyMathPlugin : public AlignmentSubsystemForMathPlugins
         DummyMathPlugin();
         virtual ~DummyMathPlugin();
 
-        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
+        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianDate);
+                double &RightAscension, double &Declination, double JulianDate) override;
 
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset = 0);
+                double &RightAscension, double &Declination, double JulianOffset = 0) override;
 };
 
 } // namespace AlignmentSubsystem

--- a/libs/alignment/MathPlugin.cpp
+++ b/libs/alignment/MathPlugin.cpp
@@ -9,6 +9,7 @@
 #include "MathPlugin.h"
 
 #include <indicom.h>
+#include <libnova/julian_day.h>
 
 #include <cmath>
 
@@ -17,15 +18,17 @@ namespace INDI
 namespace AlignmentSubsystem
 {
 bool MathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
-        double /*JulianDate*/, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+        double JulianDate, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
-    return TransformCelestialToTelescope(RightAscension, Declination, 0.0, ApparentTelescopeDirectionVector);
+    return TransformCelestialToTelescope(RightAscension, Declination,
+                                         JulianDate - ln_get_julian_from_sys(), ApparentTelescopeDirectionVector);
 }
 
 bool MathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-        double &RightAscension, double &Declination, double /*JulianDate*/)
+        double &RightAscension, double &Declination, double JulianDate)
 {
-    return TransformTelescopeToCelestial(ApparentTelescopeDirectionVector, RightAscension, Declination, 0.0);
+    return TransformTelescopeToCelestial(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                         JulianDate - ln_get_julian_from_sys());
 }
 
 bool MathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)

--- a/libs/alignment/MathPlugin.cpp
+++ b/libs/alignment/MathPlugin.cpp
@@ -16,6 +16,18 @@ namespace INDI
 {
 namespace AlignmentSubsystem
 {
+bool MathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double /*JulianDate*/, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
+    return TransformCelestialToTelescope(RightAscension, Declination, 0.0, ApparentTelescopeDirectionVector);
+}
+
+bool MathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double /*JulianDate*/)
+{
+    return TransformTelescopeToCelestial(ApparentTelescopeDirectionVector, RightAscension, Declination, 0.0);
+}
+
 bool MathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
 {
     MathPlugin::pInMemoryDatabase = pInMemoryDatabase;

--- a/libs/alignment/MathPlugin.h
+++ b/libs/alignment/MathPlugin.h
@@ -19,7 +19,7 @@ namespace AlignmentSubsystem
  * \class MathPlugin
  * \brief Provides alignment subsystem functions to INDI alignment math plugins
  *
- * \note This class is intended to be implemented within a dynamic shared object. If the
+ * \note This class is intended to be implemented within an external plugin. If the
  * implementation of this class uses a standard 3 by 3 transformation matrix to convert between coordinate systems
  * then it will not normally need to know the handedness of either the celestial or telescope coordinate systems, as the
  * necessary rotations and scaling will be handled in the derivation of the matrix coefficients. This will normally
@@ -65,8 +65,9 @@ class MathPlugin
         /// \param[out] ApparentTelescopeDirectionVector Parameter to receive the corrected telescope direction
         /// \return True if successful
         /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
-        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
-        /// ignores JulianDate and delegates to TransformCelestialToTelescope with JulianOffset=0.
+        /// External plugins that have not yet adopted this interface use the default implementation, which
+        /// computes JulianOffset = JulianDate - ln_get_julian_from_sys() and delegates to
+        /// TransformCelestialToTelescope, so the plugin recovers the correct absolute JD internally.
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);
@@ -78,7 +79,7 @@ class MathPlugin
         /// \param[in] JulianDate Absolute Julian Date (days).
         /// \return True if successful
         /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
-        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
+        /// External plugins that have not yet adopted this interface use the default implementation, which
         /// ignores JulianDate and delegates to TransformTelescopeToCelestial with JulianOffset=0.
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                 double &RightAscension, double &Declination, double JulianDate);

--- a/libs/alignment/MathPlugin.h
+++ b/libs/alignment/MathPlugin.h
@@ -61,12 +61,36 @@ class MathPlugin
         /// \brief Get the alignment corrected telescope pointing direction for the supplied celestial coordinates
         /// \param[in] RightAscension Right Ascension (Decimal Hours).
         /// \param[in] Declination Declination (Decimal Degrees).
-        /// \param[in] JulianOffset to be applied to the current julian date.
+        /// \param[in] JulianDate Absolute Julian Date (days).
         /// \param[out] ApparentTelescopeDirectionVector Parameter to receive the corrected telescope direction
         /// \return True if successful
-        /// \note TODO: Currently, JulianOffset is added to the system time (ln_get_julian_from_sys()) internally.
-        /// In a future release, this should be refactored to take an absolute fixed Julian Date to support
-        /// deterministic, clock-injected testing and avoid reliance on the system clock.
+        /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
+        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
+        /// ignores JulianDate and delegates to TransformCelestialToTelescope with JulianOffset=0.
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        /// \brief Get the true celestial coordinates for the supplied telescope pointing direction
+        /// \param[in] ApparentTelescopeDirectionVector the telescope direction
+        /// \param[out] RightAscension Parameter to receive the Right Ascension (Decimal Hours).
+        /// \param[out] Declination Parameter to receive the Declination (Decimal Degrees).
+        /// \param[in] JulianDate Absolute Julian Date (days).
+        /// \return True if successful
+        /// \note Built-in plugins override this method and use JulianDate directly without reading the system clock.
+        /// External DSO plugins that have not yet adopted this interface use the default implementation, which
+        /// ignores JulianDate and delegates to TransformTelescopeToCelestial with JulianOffset=0.
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
+        /// \brief Get the alignment corrected telescope pointing direction for the supplied celestial coordinates
+        /// \param[in] RightAscension Right Ascension (Decimal Hours).
+        /// \param[in] Declination Declination (Decimal Degrees).
+        /// \param[in] JulianOffset Offset (days) added to ln_get_julian_from_sys() to form the Julian Date.
+        /// \param[out] ApparentTelescopeDirectionVector Parameter to receive the corrected telescope direction
+        /// \return True if successful
+        /// \note Built-in plugins implement this as a thin shim that resolves the absolute JD and calls
+        /// TransformCelestialToTelescopeJD. New callers should use TransformCelestialToTelescopeJD directly.
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector) = 0;
@@ -75,11 +99,10 @@ class MathPlugin
         /// \param[in] ApparentTelescopeDirectionVector the telescope direction
         /// \param[out] RightAscension Parameter to receive the Right Ascension (Decimal Hours).
         /// \param[out] Declination Parameter to receive the Declination (Decimal Degrees).
-        /// \param[in] JulianOffset to be applied to the current julian date (default 0).
+        /// \param[in] JulianOffset Offset (days) added to ln_get_julian_from_sys() to form the Julian Date (default 0).
         /// \return True if successful
-        /// \note TODO: Currently, JulianOffset is added to the system time (ln_get_julian_from_sys()) internally.
-        /// In a future release, this should be refactored to take an absolute fixed Julian Date to support
-        /// deterministic, clock-injected testing and avoid reliance on the system clock.
+        /// \note Built-in plugins implement this as a thin shim that resolves the absolute JD and calls
+        /// TransformTelescopeToCelestialJD. New callers should use TransformTelescopeToCelestialJD directly.
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                 double &RightAscension, double &Declination, double JulianOffset = 0) = 0;
 

--- a/libs/alignment/MathPluginManagement.cpp
+++ b/libs/alignment/MathPluginManagement.cpp
@@ -11,6 +11,7 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <cerrno>
+#include <libnova/julian_day.h>
 
 namespace INDI
 {
@@ -386,26 +387,43 @@ void MathPluginManagement::SetApproximateMountAlignment(MountAlignment_t Approxi
     (pLoadedMathPlugin->*pSetApproximateMountAlignment)(ApproximateAlignment);
 }
 
+bool MathPluginManagement::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate,
+        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
+    if (AlignmentSubsystemActive.s == ISS_ON)
+        return pLoadedMathPlugin->TransformCelestialToTelescopeJD(RightAscension, Declination, JulianDate,
+                ApparentTelescopeDirectionVector);
+    else
+        return false;
+}
+
+bool MathPluginManagement::TransformTelescopeToCelestialJD(
+    const TelescopeDirectionVector &ApparentTelescopeDirectionVector, double &RightAscension, double &Declination,
+    double JulianDate)
+{
+    if (AlignmentSubsystemActive.s == ISS_ON)
+        return pLoadedMathPlugin->TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension,
+                Declination, JulianDate);
+    else
+        return false;
+}
+
 bool MathPluginManagement::TransformCelestialToTelescope(const double RightAscension, const double Declination,
         double JulianOffset,
         TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
-    if (AlignmentSubsystemActive.s == ISS_ON)
-        return (pLoadedMathPlugin->*pTransformCelestialToTelescope)(RightAscension, Declination, JulianOffset,
-                ApparentTelescopeDirectionVector);
-    else
-        return false;
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
 }
 
 bool MathPluginManagement::TransformTelescopeToCelestial(
     const TelescopeDirectionVector &ApparentTelescopeDirectionVector, double &RightAscension, double &Declination,
     double JulianOffset)
 {
-    if (AlignmentSubsystemActive.s == ISS_ON)
-        return (pLoadedMathPlugin->*pTransformTelescopeToCelestial)(ApparentTelescopeDirectionVector, RightAscension,
-                Declination, JulianOffset);
-    else
-        return false;
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
 }
 
 void MathPluginManagement::EnumeratePlugins()

--- a/libs/alignment/MathPluginManagement.cpp
+++ b/libs/alignment/MathPluginManagement.cpp
@@ -21,8 +21,6 @@ MathPluginManagement::MathPluginManagement() : CurrentInMemoryDatabase(nullptr),
     pGetApproximateMountAlignment(&MathPlugin::GetApproximateMountAlignment),
     pInitialise(&MathPlugin::Initialise),
     pSetApproximateMountAlignment(&MathPlugin::SetApproximateMountAlignment),
-    pTransformCelestialToTelescope(&MathPlugin::TransformCelestialToTelescope),
-    pTransformTelescopeToCelestial(&MathPlugin::TransformTelescopeToCelestial),
     pLoadedMathPlugin(&BuiltInPlugin), LoadedMathPluginHandle(nullptr)
 {
     memset(&AlignmentSubsystemCurrentMathPlugin, 0, sizeof(IText));

--- a/libs/alignment/MathPluginManagement.h
+++ b/libs/alignment/MathPluginManagement.h
@@ -114,10 +114,32 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
         void SetApproximateMountAlignment(MountAlignment_t ApproximateAlignment);
 
         /**
-         * @brief TransformCelestialToTelescope Transforms Celestial (Sky) Coords to Mount Coordinates
+         * @brief TransformCelestialToTelescopeJD Transforms Celestial (Sky) Coords to Mount Coordinates
          * @param RightAscension Sky Right Ascension in hours.
          * @param Declination Sky Declination in degrees
-         * @param JulianOffset Julian time Offset in days
+         * @param JulianDate Absolute Julian Date (days)
+         * @param ApparentTelescopeDirectionVector Output Apparent Telescope Direction Vector
+         * @return True if transformation is successful, false otherwise.
+         */
+        bool TransformCelestialToTelescopeJD(double RightAscension, double Declination, double JulianDate,
+                                             TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        /**
+         * @brief TransformTelescopeToCelestialJD Transforms Mount Coords to Celestial (Sky) Coordinates
+         * @param ApparentTelescopeDirectionVector Input Apparent Telescope Direction Vector
+         * @param RightAscension Output Celestial Right Ascension
+         * @param Declination Output Celestial Declination
+         * @param JulianDate Absolute Julian Date (days)
+         * @return True if transformation is successful, false otherwise.
+         */
+        bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                                             double &RightAscension, double &Declination, double JulianDate);
+
+        /**
+         * @brief TransformCelestialToTelescope Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
+         * @param RightAscension Sky Right Ascension in hours.
+         * @param Declination Sky Declination in degrees
+         * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys()
          * @param ApparentTelescopeDirectionVector Output Apparent Telescope Direction Vector
          * @return True if transformation is successful, false otherwise.
          */
@@ -125,10 +147,11 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
                                            TelescopeDirectionVector &ApparentTelescopeDirectionVector);
 
         /**
-         * @brief TransformTelescopeToCelestial Transforms Mount Coords to Celestial (Sky) Coordinates
+         * @brief TransformTelescopeToCelestial Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
          * @param ApparentTelescopeDirectionVector Input Apparent Telescope Direction Vector
          * @param RightAscension Output Celestial Right Ascension
          * @param Declination Output Celestial Declination
+         * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys() (default 0)
          * @return True if transformation is successful, false otherwise.
          */
         bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,

--- a/libs/alignment/MathPluginManagement.h
+++ b/libs/alignment/MathPluginManagement.h
@@ -142,7 +142,9 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
          * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys()
          * @param ApparentTelescopeDirectionVector Output Apparent Telescope Direction Vector
          * @return True if transformation is successful, false otherwise.
+         * @deprecated Use TransformCelestialToTelescopeJD with an explicit Julian Date
          */
+        [[deprecated("Use TransformCelestialToTelescopeJD with an explicit Julian Date")]]
         bool TransformCelestialToTelescope(const double RightAscension, const double Declination, double JulianOffset,
                                            TelescopeDirectionVector &ApparentTelescopeDirectionVector);
 
@@ -153,7 +155,9 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
          * @param Declination Output Celestial Declination
          * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys() (default 0)
          * @return True if transformation is successful, false otherwise.
+         * @deprecated Use TransformTelescopeToCelestialJD with an explicit Julian Date
          */
+        [[deprecated("Use TransformTelescopeToCelestialJD with an explicit Julian Date")]]
         bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
                                            double &RightAscension, double &Declination, double JulianOffset = 0);
 

--- a/libs/alignment/MathPluginManagement.h
+++ b/libs/alignment/MathPluginManagement.h
@@ -136,7 +136,7 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
                                              double &RightAscension, double &Declination, double JulianDate);
 
         /**
-         * @brief TransformCelestialToTelescope Compat shim — resolves JD and delegates to TransformCelestialToTelescopeJD
+         * @brief TransformCelestialToTelescope Compat shim - resolves JD and delegates to TransformCelestialToTelescopeJD
          * @param RightAscension Sky Right Ascension in hours.
          * @param Declination Sky Declination in degrees
          * @param JulianOffset Julian time Offset in days added to ln_get_julian_from_sys()
@@ -147,7 +147,7 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
                                            TelescopeDirectionVector &ApparentTelescopeDirectionVector);
 
         /**
-         * @brief TransformTelescopeToCelestial Compat shim — resolves JD and delegates to TransformTelescopeToCelestialJD
+         * @brief TransformTelescopeToCelestial Compat shim - resolves JD and delegates to TransformTelescopeToCelestialJD
          * @param ApparentTelescopeDirectionVector Input Apparent Telescope Direction Vector
          * @param RightAscension Output Celestial Right Ascension
          * @param Declination Output Celestial Declination
@@ -181,11 +181,6 @@ class MathPluginManagement : private MathPlugin // Derive from MathPluign to for
         MountAlignment_t (MathPlugin::*pGetApproximateMountAlignment)();
         bool (MathPlugin::*pInitialise)(InMemoryDatabase *pInMemoryDatabase);
         void (MathPlugin::*pSetApproximateMountAlignment)(MountAlignment_t ApproximateAlignment);
-        bool (MathPlugin::*pTransformCelestialToTelescope)(const double RightAscension, const double Declination,
-                double JulianOffset,
-                TelescopeDirectionVector &TelescopeDirectionVector);
-        bool (MathPlugin::*pTransformTelescopeToCelestial)(const TelescopeDirectionVector &TelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset);
         MathPlugin *pLoadedMathPlugin;
         void *LoadedMathPluginHandle;
 

--- a/libs/alignment/NearestMathPlugin.cpp
+++ b/libs/alignment/NearestMathPlugin.cpp
@@ -148,12 +148,10 @@ bool NearestMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, d
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    double JDD = JulianDate;
-
     // Compute CURRENT horizontal coords.
     INDI::IEquatorialCoordinates CelestialRADE {RightAscension, Declination};
     INDI::IHorizontalCoordinates CelestialAltAz;
-    EquatorialToHorizontal(&CelestialRADE, &Position, JDD, &CelestialAltAz);
+    EquatorialToHorizontal(&CelestialRADE, &Position, JulianDate, &CelestialAltAz);
 
     // Return Telescope Direction Vector directly from Celestial coordinates if we
     // do not have any sync points.
@@ -206,7 +204,7 @@ bool NearestMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, d
     if (ApproximateMountAlignment == ZENITH)
     {
         INDI::IHorizontalCoordinates TransformedTelescopeAltAz;
-        EquatorialToHorizontal(&TransformedTelescopeRADE, &Position, JDD, &TransformedTelescopeAltAz);
+        EquatorialToHorizontal(&TransformedTelescopeRADE, &Position, JulianDate, &TransformedTelescopeAltAz);
         ApparentTelescopeDirectionVector = TelescopeDirectionVectorFromAltitudeAzimuth(TransformedTelescopeAltAz);
     }
     // Equatorial?
@@ -235,8 +233,6 @@ bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirection
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    double JDD = JulianDate;
-
     // Telescope Equatorial Coordinates
     INDI::IEquatorialCoordinates TelescopeRADE;
 
@@ -248,7 +244,7 @@ bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirection
         {
             INDI::IHorizontalCoordinates TelescopeAltAz;
             AltitudeAzimuthFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, TelescopeAltAz);
-            HorizontalToEquatorial(&TelescopeAltAz, &Position, JDD, &TelescopeRADE);
+            HorizontalToEquatorial(&TelescopeAltAz, &Position, JulianDate, &TelescopeRADE);
         }
         // Equatorial?
         else
@@ -267,13 +263,13 @@ bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirection
     if (ApproximateMountAlignment == ZENITH)
     {
         AltitudeAzimuthFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, TelescopeAltAz);
-        HorizontalToEquatorial(&TelescopeAltAz, &Position, JDD, &TelescopeRADE);
+        HorizontalToEquatorial(&TelescopeAltAz, &Position, JulianDate, &TelescopeRADE);
     }
     // Equatorial?
     else
     {
         EquatorialCoordinatesFromTelescopeDirectionVector(ApparentTelescopeDirectionVector, TelescopeRADE);
-        EquatorialToHorizontal(&TelescopeRADE, &Position, JDD, &TelescopeAltAz);
+        EquatorialToHorizontal(&TelescopeRADE, &Position, JulianDate, &TelescopeAltAz);
     }
 
     // Find the nearest point to our telescope now

--- a/libs/alignment/NearestMathPlugin.cpp
+++ b/libs/alignment/NearestMathPlugin.cpp
@@ -135,13 +135,20 @@ bool NearestMathPlugin::Initialise(InMemoryDatabase *pInMemoryDatabase)
 bool NearestMathPlugin::TransformCelestialToTelescope(const double RightAscension, const double Declination,
         double JulianOffset, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
+}
+
+bool NearestMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate, TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
     // Get Position
     IGeographicCoordinates Position;
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    // Get Julian date from system and apply Julian Offset if any.
-    double JDD = ln_get_julian_from_sys() + JulianOffset;
+    double JDD = JulianDate;
 
     // Compute CURRENT horizontal coords.
     INDI::IEquatorialCoordinates CelestialRADE {RightAscension, Declination};
@@ -217,11 +224,18 @@ bool NearestMathPlugin::TransformCelestialToTelescope(const double RightAscensio
 bool NearestMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
         double &RightAscension, double &Declination, double JulianOffset)
 {
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
+}
+
+bool NearestMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double JulianDate)
+{
     IGeographicCoordinates Position;
     if (!pInMemoryDatabase || !pInMemoryDatabase->GetDatabaseReferencePosition(Position))
         return false;
 
-    double JDD = ln_get_julian_from_sys() + JulianOffset;
+    double JDD = JulianDate;
 
     // Telescope Equatorial Coordinates
     INDI::IEquatorialCoordinates TelescopeRADE;

--- a/libs/alignment/NearestMathPlugin.h
+++ b/libs/alignment/NearestMathPlugin.h
@@ -100,21 +100,21 @@ class NearestMathPlugin : public AlignmentSubsystemForMathPlugins
         NearestMathPlugin();
         virtual ~NearestMathPlugin();
 
-        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
+        virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
         virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
                 double JulianDate,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianDate);
+                double &RightAscension, double &Declination, double JulianDate) override;
 
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
-                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
 
         virtual bool TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
-                double &RightAscension, double &Declination, double JulianOffset = 0);
+                double &RightAscension, double &Declination, double JulianOffset = 0) override;
 
     private:
 

--- a/libs/alignment/NearestMathPlugin.h
+++ b/libs/alignment/NearestMathPlugin.h
@@ -102,6 +102,13 @@ class NearestMathPlugin : public AlignmentSubsystemForMathPlugins
 
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase);
 
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector);
+
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate);
+
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector);

--- a/libs/alignment/SPKMathPlugin.cpp
+++ b/libs/alignment/SPKMathPlugin.cpp
@@ -164,8 +164,17 @@ bool SPKMathPlugin::TransformCelestialToTelescope(const double RightAscension, c
         double JulianOffset,
         TelescopeDirectionVector &ApparentTelescopeDirectionVector)
 {
+    return TransformCelestialToTelescopeJD(RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset,
+                                           ApparentTelescopeDirectionVector);
+}
+
+bool SPKMathPlugin::TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+        double JulianDate,
+        TelescopeDirectionVector &ApparentTelescopeDirectionVector)
+{
     if (!UpdateObsConfig()) return false;
-    UpdateAstrometry(ln_get_julian_from_sys() + JulianOffset);
+    UpdateAstrometry(JulianDate);
 
     spkTAR tar;
     // Input RA/Dec is in INDI's "observed" (= SOFA's "apparent") form: precession,
@@ -209,8 +218,15 @@ bool SPKMathPlugin::TransformCelestialToTelescope(const double RightAscension, c
 bool SPKMathPlugin::TransformTelescopeToCelestial(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
         double &RightAscension, double &Declination, double JulianOffset)
 {
+    return TransformTelescopeToCelestialJD(ApparentTelescopeDirectionVector, RightAscension, Declination,
+                                           ln_get_julian_from_sys() + JulianOffset);
+}
+
+bool SPKMathPlugin::TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+        double &RightAscension, double &Declination, double JulianDate)
+{
     if (!UpdateObsConfig()) return false;
-    UpdateAstrometry(ln_get_julian_from_sys() + JulianOffset);
+    UpdateAstrometry(JulianDate);
 
     spkAX3 ax3;
     double roll, pitch;

--- a/libs/alignment/SPKMathPlugin.h
+++ b/libs/alignment/SPKMathPlugin.h
@@ -38,6 +38,13 @@ class SPKMathPlugin : public MathPlugin, public TelescopeDirectionVectorSupportF
 
         virtual bool Initialise(InMemoryDatabase *pInMemoryDatabase) override;
 
+        virtual bool TransformCelestialToTelescopeJD(double RightAscension, double Declination,
+                double JulianDate,
+                TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;
+
+        virtual bool TransformTelescopeToCelestialJD(const TelescopeDirectionVector &ApparentTelescopeDirectionVector,
+                double &RightAscension, double &Declination, double JulianDate) override;
+
         virtual bool TransformCelestialToTelescope(const double RightAscension, const double Declination,
                 double JulianOffset,
                 TelescopeDirectionVector &ApparentTelescopeDirectionVector) override;

--- a/test/alignment/test_alignment_plugins.cpp
+++ b/test/alignment/test_alignment_plugins.cpp
@@ -24,6 +24,7 @@
 #include <alignment/TelescopeDirectionVectorSupportFunctions.h>
 #include "../../drivers/telescope/scopesim_helper.h"
 
+#include <libnova/julian_day.h>
 #include <libnova/sidereal_time.h>
 
 using namespace INDI::AlignmentSubsystem;
@@ -442,7 +443,7 @@ protected:
             TelescopeDirectionVector noisyV;
             ASSERT_TRUE(noisyPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, noisyV));
 
-            // Reference (noiseless) plugin's predicted direction — same JD
+            // Reference (noiseless) plugin's predicted direction - same JD
             TelescopeDirectionVector refV;
             ASSERT_TRUE(refPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, refV));
 
@@ -2249,6 +2250,78 @@ TEST_F(DriverPipelineTest, AltAz_InstrumentRoundTrip_Southern)
         EXPECT_NEAR(testRA,  recoveredRA,    0.001) << "RA round-trip failed";
         EXPECT_NEAR(testDec, instDec.Degrees(), 0.001) << "Dec round-trip failed";
     }
+}
+
+// ---------------------------------------------------------------------------
+// LegacyPlugin fallback: verifies MathPlugin::TransformCelestialToTelescopeJD
+// default converts absolute JD -> correct JulianOffset for legacy external plugins.
+//
+// A legacy plugin implements only the old pure-virtual methods and does not
+// override the new *JD methods.  The base-class default must compute
+//   JulianOffset = JulianDate - ln_get_julian_from_sys()
+// so that when the legacy plugin adds ln_get_julian_from_sys() internally it
+// recovers the original absolute JD.  Passing 0.0 (the old bug) would give
+// the wrong time to any legacy plugin.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct LegacyPlugin : public MathPlugin
+{
+    double lastOffset = 999.0;  // sentinel; 0.0 would mask the old bug
+
+    bool TransformCelestialToTelescope(const double, const double,
+                                        double JulianOffset,
+                                        TelescopeDirectionVector &) override
+    {
+        lastOffset = JulianOffset;
+        return true;
+    }
+
+    bool TransformTelescopeToCelestial(const TelescopeDirectionVector &,
+                                        double &, double &, double JulianOffset) override
+    {
+        lastOffset = JulianOffset;
+        return true;
+    }
+};
+
+} // namespace
+
+TEST_F(AlignmentPluginTest, LegacyPlugin_JD_Fallback_CelestialToTelescope)
+{
+    LegacyPlugin plugin;
+    InMemoryDatabase db;
+    plugin.Initialise(&db);
+
+    TelescopeDirectionVector tdv;
+    double t1 = ln_get_julian_from_sys();
+    plugin.TransformCelestialToTelescopeJD(1.0, 45.0, fixedJD, tdv);
+    double t2 = ln_get_julian_from_sys();
+
+    // The default fallback computes offset = fixedJD - ln_get_julian_from_sys().
+    // Bracket with t1/t2 to tolerate any wall-clock delta during the call:
+    //   fixedJD - t2  <=  capturedOffset  <=  fixedJD - t1
+    // With the old 0.0 bug, capturedOffset == 0.0 which fails EXPECT_LE when
+    // fixedJD != now (i.e., always in practice).
+    EXPECT_GE(plugin.lastOffset, fixedJD - t2) << "offset too small";
+    EXPECT_LE(plugin.lastOffset, fixedJD - t1) << "offset too large (was 0.0 before fix)";
+}
+
+TEST_F(AlignmentPluginTest, LegacyPlugin_JD_Fallback_TelescopeToCelestial)
+{
+    LegacyPlugin plugin;
+    InMemoryDatabase db;
+    plugin.Initialise(&db);
+
+    TelescopeDirectionVector tdv{0.0, 0.0, 1.0};
+    double ra = 0, dec = 0;
+    double t1 = ln_get_julian_from_sys();
+    plugin.TransformTelescopeToCelestialJD(tdv, ra, dec, fixedJD);
+    double t2 = ln_get_julian_from_sys();
+
+    EXPECT_GE(plugin.lastOffset, fixedJD - t2) << "offset too small";
+    EXPECT_LE(plugin.lastOffset, fixedJD - t1) << "offset too large (was 0.0 before fix)";
 }
 
 int main(int argc, char **argv)

--- a/test/alignment/test_alignment_plugins.cpp
+++ b/test/alignment/test_alignment_plugins.cpp
@@ -25,7 +25,6 @@
 #include "../../drivers/telescope/scopesim_helper.h"
 
 #include <libnova/sidereal_time.h>
-#include <libnova/julian_day.h>
 
 using namespace INDI::AlignmentSubsystem;
 
@@ -268,13 +267,12 @@ protected:
 
         double testRA  = 12.0;
         double testDec = (mountType == ::Alignment::ALTAZ) ? 60.0 : 45.0;
-        double joff    = fixedJD - ln_get_julian_from_sys();
 
         TelescopeDirectionVector resultV;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(testRA, testDec, joff, resultV));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, resultV));
 
         double outRA, outDec;
-        plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+        plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
         ASSERT_NEAR(testRA,  outRA,  kRoundTripTolHours);
         ASSERT_NEAR(testDec, outDec, kRoundTripTolDeg);
@@ -328,8 +326,6 @@ protected:
 
         ASSERT_TRUE(plugin.Initialise(&alignDb));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Validation layer: Halton(5, 7)
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
@@ -341,10 +337,10 @@ protected:
             getSkyPoint(raw.first, raw.second, minDec, maxDec, ra, dec);
 
             TelescopeDirectionVector resultV;
-            ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+            ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, resultV));
 
             double outRA, outDec;
-            plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+            plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
             double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
             double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -433,8 +429,6 @@ protected:
         ASSERT_TRUE(refPlugin.Initialise(&cleanDb));
         ASSERT_TRUE(noisyPlugin.Initialise(&noisyDb));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
 
@@ -446,11 +440,11 @@ protected:
 
             // Noisy plugin's predicted direction
             TelescopeDirectionVector noisyV;
-            ASSERT_TRUE(noisyPlugin.TransformCelestialToTelescope(ra, dec, joff, noisyV));
+            ASSERT_TRUE(noisyPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, noisyV));
 
-            // Reference (noiseless) plugin's predicted direction — same joff
+            // Reference (noiseless) plugin's predicted direction — same JD
             TelescopeDirectionVector refV;
-            ASSERT_TRUE(refPlugin.TransformCelestialToTelescope(ra, dec, joff, refV));
+            ASSERT_TRUE(refPlugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, refV));
 
             // Angular separation in arcseconds
             double dot = noisyV.x * refV.x + noisyV.y * refV.y + noisyV.z * refV.z;
@@ -518,7 +512,6 @@ protected:
 
         // Validation Phase: JD = fixedJD + shiftHours/24
         double valJD = fixedJD + shiftHours / 24.0;
-        double joff = valJD - ln_get_julian_from_sys();
 
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
@@ -530,11 +523,10 @@ protected:
             getSkyPoint(raw.first, raw.second, minDec, maxDec, ra, dec);
 
             TelescopeDirectionVector resultV;
-            // The plugin must correctly interpret ra, dec relative to the new joff (time)
-            ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+            ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, valJD, resultV));
 
             double outRA, outDec;
-            plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+            plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, valJD);
 
             double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
             double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -593,8 +585,6 @@ protected:
         }
         ASSERT_TRUE(plugin.Initialise(&db));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Ground truth encoder position
         Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
         Angle adec(valDec);
@@ -603,7 +593,7 @@ protected:
 
         // Plugin C->T prediction, decoded to Az/Alt without T->C
         TelescopeDirectionVector tdv;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
         INDI::IHorizontalCoordinates hor;
         pSupport->AltitudeAzimuthFromTelescopeDirectionVector(tdv, hor);
 
@@ -651,8 +641,6 @@ protected:
         }
         ASSERT_TRUE(plugin.Initialise(&db));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Ground truth encoder position (RA/Dec) from scopesim
         Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
         Angle adec(valDec);
@@ -662,7 +650,7 @@ protected:
 
         // Plugin C->T prediction, decoded to RA/Dec without T->C
         TelescopeDirectionVector tdv;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
         INDI::IEquatorialCoordinates raCoords;
         pSupport->EquatorialCoordinatesFromTelescopeDirectionVector(tdv, raCoords);
 
@@ -714,8 +702,6 @@ protected:
         }
         ASSERT_TRUE(plugin.Initialise(&db));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // Ground truth encoder position (Alt/Az) from scopesim
         Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
         Angle adec(valDec);
@@ -724,7 +710,7 @@ protected:
 
         // Plugin C->T prediction, decoded to Alt/Az without T->C
         TelescopeDirectionVector tdv;
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
         INDI::IHorizontalCoordinates horCoords;
         pSupport->AltitudeAzimuthFromTelescopeDirectionVector(tdv, horCoords);
 
@@ -777,8 +763,6 @@ protected:
 
         ASSERT_TRUE(plugin.Initialise(&alignDb));
 
-        double joff = fixedJD - ln_get_julian_from_sys();
-
         // 100-point validation set for flip tests
         HaltonSequence validateSeq(5, 7);
         std::vector<double> residuals;
@@ -790,10 +774,10 @@ protected:
             getSkyPoint(raw.first, raw.second, kEQ_MinDec, kEQ_MaxDec, ra, dec);
 
             TelescopeDirectionVector resultV;
-            ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+            ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, resultV));
 
             double outRA, outDec;
-            plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+            plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
             double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
             double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -866,7 +850,6 @@ protected:
     void verifyHotMatchesCold(SPKMathPlugin &hotPlugin, SPKMathPlugin &coldPlugin,
                                ::Alignment::MOUNT_TYPE mountType = ::Alignment::EQ_GEM)
     {
-        double joff = fixedJD - ln_get_julian_from_sys();
         // Hot path uses pm=0 as the linearization point (Pmfit iteration-0);
         // Pmfit iterates to convergence.  With arcminute-level mount errors
         // the difference is a few arcseconds in angle space (~5e-5 in
@@ -881,8 +864,8 @@ protected:
             for (double testDec : decs)
             {
                 TelescopeDirectionVector hotV, coldV;
-                ASSERT_TRUE(hotPlugin.TransformCelestialToTelescope(testRA, testDec, joff, hotV));
-                ASSERT_TRUE(coldPlugin.TransformCelestialToTelescope(testRA, testDec, joff, coldV));
+                ASSERT_TRUE(hotPlugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, hotV));
+                ASSERT_TRUE(coldPlugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, coldV));
                 EXPECT_NEAR(hotV.x, coldV.x, tol) << "RA=" << testRA << " Dec/El=" << testDec;
                 EXPECT_NEAR(hotV.y, coldV.y, tol) << "RA=" << testRA << " Dec/El=" << testDec;
                 EXPECT_NEAR(hotV.z, coldV.z, tol) << "RA=" << testRA << " Dec/El=" << testDec;
@@ -1166,15 +1149,13 @@ TEST_F(AlignmentPluginTest, Nearest_AltAz_Goto_Convention_Regression)
     }
     ASSERT_TRUE(plugin.Initialise(&db));
 
-    double joff = fixedJD - ln_get_julian_from_sys();
-
     Angle ha(get_local_hour_angle(lst, valRA), Angle::HOURS);
     Angle adec(valDec);
     Angle encAz, encAlt;
     gen.apparentHaDecToMount(ha, adec, &encAz, &encAlt);
 
     TelescopeDirectionVector tdv;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(valRA, valDec, joff, tdv));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(valRA, valDec, fixedJD, tdv));
     INDI::IHorizontalCoordinates hor;
     pSupport->AltitudeAzimuthFromTelescopeDirectionVector(tdv, hor);
 
@@ -1230,8 +1211,6 @@ TEST_F(AlignmentPluginTest, SVD_AlignValidate_ConvexHullFallback)
 
     ASSERT_TRUE(plugin.Initialise(&alignDb));
 
-    double joff = fixedJD - ln_get_julian_from_sys();
-
     // Validation from western sky: RA in [6h, 18h) -- outside the convex hull
     int validateCount = 0;
     for (int i = 1; validateCount < 6; ++i)
@@ -1245,10 +1224,10 @@ TEST_F(AlignmentPluginTest, SVD_AlignValidate_ConvexHullFallback)
 
         TelescopeDirectionVector resultV;
         // Must not crash or fail; fallback should return a usable (if coarse) TDV
-        ASSERT_TRUE(plugin.TransformCelestialToTelescope(ra, dec, joff, resultV));
+        ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(ra, dec, fixedJD, resultV));
 
         double outRA, outDec;
-        plugin.TransformTelescopeToCelestial(resultV, outRA, outDec, joff);
+        plugin.TransformTelescopeToCelestialJD(resultV, outRA, outDec, fixedJD);
 
         double dRA  = DEG_TO_ARCSEC(rangeHA(outRA - ra) * 15.0) * std::cos(DEG_TO_RAD(dec));
         double dDec = DEG_TO_ARCSEC(outDec - dec);
@@ -1815,14 +1794,12 @@ static void RunPolarDegeneracyTestImpl(
 
     ASSERT_TRUE(plugin.Initialise(&db));
 
-    double joff = fixedJD - ln_get_julian_from_sys();
-
     // Target far from the pole/zenith
     double testRA  = 12.0;
     double testDec = (mountType == ::Alignment::ALTAZ) ? 30.0 : 45.0;
 
     TelescopeDirectionVector resultV;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(testRA, testDec, joff, resultV));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(testRA, testDec, fixedJD, resultV));
 
     // Decode the TDV to encoder coordinates and sanity-check
     if (mountType == ::Alignment::ALTAZ)
@@ -2001,11 +1978,10 @@ TEST_F(AlignmentPluginTest, SPK_Incremental_InvalidStateNotUsed)
         ASSERT_TRUE(plugin.Initialise(&db));
     }
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(12.0, 45.0, joff, v));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 45.0, fixedJD, v));
     double outRA, outDec;
-    plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff);
+    plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD);
     EXPECT_NEAR(12.0, outRA,  kRoundTripTolHours);
     EXPECT_NEAR(45.0, outDec, kRoundTripTolDeg);
 }
@@ -2024,11 +2000,10 @@ TEST_F(AlignmentPluginTest, SPK_Incremental_MountTypeChange)
     auto generatorAz = buildIncrementalDb(plugin, kMixed, 7, dbAz, ::Alignment::ALTAZ);
     (void)generatorAz;
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(12.0, 60.0, joff, v));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 60.0, fixedJD, v));
     double outRA, outDec;
-    plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff);
+    plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD);
     EXPECT_NEAR(12.0, outRA,  kRoundTripTolHours);
     EXPECT_NEAR(60.0, outDec, kRoundTripTolDeg);
 }
@@ -2047,14 +2022,13 @@ TEST_F(AlignmentPluginTest, SPK_Lifecycle_NoLocation_TransformsFail)
     plugin.Initialise(&db);
     plugin.SetApproximateMountAlignment(ZENITH);
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    EXPECT_FALSE(plugin.TransformCelestialToTelescope(12.0, 45.0, joff, v));
+    EXPECT_FALSE(plugin.TransformCelestialToTelescopeJD(12.0, 45.0, fixedJD, v));
 
     // Provide a dummy TDV and confirm T->C also fails without a location.
     v = TelescopeDirectionVector{0, 0, 1};
     double outRA, outDec;
-    EXPECT_FALSE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    EXPECT_FALSE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
 }
 
 // Initialise without a location must not crash and must return true
@@ -2078,11 +2052,10 @@ TEST_F(AlignmentPluginTest, SPK_Lifecycle_LateLocation_TransformsSucceed)
     // Location arrives late (e.g. from a saved config property).
     db.SetDatabaseReferencePosition(kLosAngeles);
 
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    EXPECT_TRUE(plugin.TransformCelestialToTelescope(12.0, 45.0, joff, v));
+    EXPECT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 45.0, fixedJD, v));
     double outRA, outDec;
-    EXPECT_TRUE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    EXPECT_TRUE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
 }
 
 // Mount type set after Initialise must be picked up on the next transform call,
@@ -2103,18 +2076,17 @@ TEST_F(AlignmentPluginTest, SPK_Lifecycle_MountTypeAfterInit_PickedUpByTransform
     plugin.SetApproximateMountAlignment(ZENITH);
 
     // Transform should use ALTAZ formulas.  Verify by round-trip: C->T->C.
-    double joff = fixedJD - ln_get_julian_from_sys();
     TelescopeDirectionVector v;
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(12.0, 30.0, joff, v));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(12.0, 30.0, fixedJD, v));
     double outRA, outDec;
-    ASSERT_TRUE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    ASSERT_TRUE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
     EXPECT_NEAR(12.0, outRA,  kRoundTripTolHours);
     EXPECT_NEAR(30.0, outDec, kRoundTripTolDeg);
 
     // Now switch to EQUAT without Initialise — must also be picked up.
     plugin.SetApproximateMountAlignment(NORTH_CELESTIAL_POLE);
-    ASSERT_TRUE(plugin.TransformCelestialToTelescope(6.0, 45.0, joff, v));
-    ASSERT_TRUE(plugin.TransformTelescopeToCelestial(v, outRA, outDec, joff));
+    ASSERT_TRUE(plugin.TransformCelestialToTelescopeJD(6.0, 45.0, fixedJD, v));
+    ASSERT_TRUE(plugin.TransformTelescopeToCelestialJD(v, outRA, outDec, fixedJD));
     EXPECT_NEAR(6.0,  outRA,  kRoundTripTolHours);
     EXPECT_NEAR(45.0, outDec, kRoundTripTolDeg);
 }


### PR DESCRIPTION

## Reviewer note

This PR is stacked on #2387 and targets that branch as its base. After #2387 merges to master, this branch will be rebased onto master and the
PR base retargeted accordingly.

## Summary

Follow-up to #2387. That PR added `TransformCelestialToTelescopeJD` /
`TransformTelescopeToCelestialJD` to the math plugin stack and converted the old
`TransformCelestialToTelescope` / `TransformTelescopeToCelestial` methods in
`MathPluginManagement` into compat shims. This PR completes Phase 2 and Phase 3 of
the migration plan described in that PR's follow-up section:

- **Phase 2** -- Mark the old shim methods `[[deprecated]]` in `MathPluginManagement.h`
  so any caller that has not yet migrated gets a compiler warning.
- **Phase 3** -- Thread an explicit `JD` parameter through
  `AlignmentSubsystemForDrivers` and update every in-tree driver and example call
  site to use the `*JD` variants directly.

## Changes

### `libs/alignment/MathPluginManagement.h`

Added `[[deprecated("Use TransformCelestialToTelescopeJD with an explicit Julian Date")]]`
to both old public shim methods. Their implementations are unchanged.

Note: the old pure-virtual methods in `MathPlugin.h` are intentionally left
un-deprecated. External math plugins must still implement them; their deprecation is
Phase 4 work after the broader ecosystem migrates.

### `libs/alignment/AlignmentSubsystemForDrivers.h/.cpp`

Added `double JD = ln_get_julian_from_sys()` as a trailing default parameter to all
six public helper methods:

- `AddAlignmentEntryEquatorial` / `AddAlignmentEntryAltAz` -- use `JD` for
  `ObservationJulianDate` (previously always captured `ln_get_julian_from_sys()`)
- `SkyToTelescopeEquatorial` / `SkyToTelescopeAltAz` -- call
  `TransformCelestialToTelescopeJD(ra, dec, JD, TDV)` instead of the old shim
- `TelescopeEquatorialToSky` / `TelescopeAltAzToSky` -- call
  `TransformTelescopeToCelestialJD(TDV, ra, dec, JD)` instead of the old shim

Existing callers that omit the `JD` argument see no source change and identical
behavior (the default evaluates `ln_get_julian_from_sys()` at the call site).
Callers that want simulated time support can now pass an explicit JD.

### Driver and example call sites

All remaining in-tree uses of the old `MathPluginManagement` shims are updated to
call `*JD` directly with `ln_get_julian_from_sys()`:

| File | Sites |
|------|-------|
| `drivers/telescope/skywatcherAPIMount.cpp` | 9 |
| `drivers/telescope/astrotrac.cpp` | 2 |
| `drivers/telescope/telescope_simulator.cpp` | 2 |
| `drivers/telescope/temmadriver.cpp` | 3 |
| `drivers/telescope/dsc.cpp` | 2 |
| `examples/tutorial_seven/simple_telescope_simulator.cpp` | 3 |

`skywatcherAPIMount` non-zero offset sites (`JulianOffset` axis property and bracket
tracking) now compute the absolute JD explicitly
(`ln_get_julian_from_sys() + JDOffset`) instead of passing a relative offset through
the shim. The `JDnow` variable used by the bracket tracking else-branch is hoisted
before the if/else so both branches sample the clock at the same instant.

## Backward compatibility

No behavior change for any existing caller. All drivers that go through
`AlignmentSubsystemForDrivers` pick up the default `JD` argument and continue to
call the system clock as before. Third-party drivers (`indi-celestronaux`, `indi-eqmod`,
etc.) that call `MathPluginManagement` directly will see deprecation warnings on
their next rebuild but continue to function correctly through the shim.

## Test results

```
1/2 Test  #9: test-alignment ...................   Passed    0.50 sec
2/2 Test #10: test-alignment-plugins ...........   Passed    0.36 sec

100% tests passed, 0 tests failed out of 2
```

## Follow-up (not in this PR)

**indi-3rdparty driver migration:** Third-party drivers that call
`TransformCelestialToTelescope` / `TransformTelescopeToCelestial` directly
(notably `indi-celestronaux` and `indi-eqmod`) will see deprecation warnings on
their next rebuild. A follow-up PR to `indi-3rdparty` should update those call
sites to use `*JD` with explicit `ln_get_julian_from_sys()`, mirroring the
pattern applied here.

**Phase 4 -- Remove:** Once external plugins have migrated, the compat layer can be
fully removed: make `*JD` pure virtual in `MathPlugin.h`, remove the old pure
virtuals and their shim overrides in built-in plugins, remove the deprecated
`MathPluginManagement` shim methods. The full sequence is described in the
follow-up section of #2387.