### PR TITLE
Fix updating of rotator backlash & reverse direction

### DIFF
--- a/libs/indibase/indirotatorinterface.cpp
+++ b/libs/indibase/indirotatorinterface.cpp
@@ -253,9 +253,9 @@ bool RotatorInterface::processSwitch(const char *dev, const char *name, ISState 
         ////////////////////////////////////////////
         else if (ReverseRotatorSP.isNameMatch(name))
         {
-            m_defaultDevice->updateProperty(ReverseRotatorSP, states, names, n, [this, states]()
+            m_defaultDevice->updateProperty(ReverseRotatorSP, states, names, n, [this, names]()
             {
-                bool enabled = states[0] == ISS_ON;
+                bool enabled = ReverseRotatorSP[0].isNameMatch(names[0]) == ISS_ON;
 
                 if (ReverseRotator(enabled))
                 {
@@ -274,9 +274,9 @@ bool RotatorInterface::processSwitch(const char *dev, const char *name, ISState 
         ////////////////////////////////////////////
         else if (RotatorBacklashSP.isNameMatch(name))
         {
-            m_defaultDevice->updateProperty(RotatorBacklashSP, states, names, n, [this, states]()
+            m_defaultDevice->updateProperty(RotatorBacklashSP, states, names, n, [this, names]()
             {
-                bool enabled = states[0] == ISS_ON;
+                bool enabled = RotatorBacklashSP[0].isNameMatch(names[0]) == ISS_ON;
 
                 if (SetRotatorBacklashEnabled(enabled))
                 {


### PR DESCRIPTION
This PR fixes two signifiicant errors introduced with https://github.com/indilib/indi/commit/b74820236c65456d32591f330c50cb1989efc828.

The switches "ReverseRotatorSP" and "RotatorBacklashSP" didn't update correctly: Both were sticky when switched on. The bug is mentioned [here](https://indilib.org/forum/astro-arch/15662-what-about-derotating-feature-for-alt-az-user.html?start=48#107479).

I couldn't test "RotatorBacklash", but it has the very same structure like "ReverseRotator". So I decided to adapt this code too.