### PR TITLE
TCP retry on establishing connection

### DIFF
--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -76,6 +76,28 @@ TCP::TCP(INDI::DefaultDevice *dev, IPerm permission) : Interface(dev, CONNECTION
     IUFillSwitchVector(&LANSearchSP, LANSearchS, 2, dev->getDeviceName(), INDI::SP::DEVICE_LAN_SEARCH, "LAN Search",
                        CONNECTION_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
 
+    // Retry/backoff configuration: number vector property
+    // Default values
+    IUFillNumber(&RetryN[TCP::RETRY_RETRIES], "CONNECT_RETRIES", "Connection retries", "%.0f", 0, 100, 1,
+                 static_cast<double>(m_ConnectRetries));
+    IUFillNumber(&RetryN[TCP::RETRY_BACKOFF_MS], "BACKOFF_BASE_MS", "Backoff base (ms)", "%.0f", 0, 60000, 1,
+                 static_cast<double>(m_BackoffBaseMs));
+    IUFillNumberVector(&RetryNP, RetryN, 2, getDeviceName(), "CONNECTION_RETRY", "Connection Retry",
+                       CONNECTION_TAB, IP_RW, 60, IPS_IDLE);
+
+    // Try to load persisted values from config (if any)
+    double dval = 0;
+    if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_RETRIES].name, &dval) == 0)
+    {
+        RetryN[TCP::RETRY_RETRIES].value = dval;
+        m_ConnectRetries = static_cast<int>(dval);
+    }
+    if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_BACKOFF_MS].name, &dval) == 0)
+    {
+        RetryN[TCP::RETRY_BACKOFF_MS].value = dval;
+        m_BackoffBaseMs = static_cast<int>(dval);
+    }
+
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -131,6 +153,41 @@ bool TCP::ISNewSwitch(const char *dev, const char *name, ISState *states, char *
             else if (wasEnabled && LANSearchS[1].s == ISS_ON)
                 LOG_INFO("Auto search is disabled.");
             IDSetSwitch(&LANSearchSP, nullptr);
+
+            return true;
+        }
+    }
+
+    return false;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////
+///
+//////////////////////////////////////////////////////////////////////////////////////////////////
+bool TCP::ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n)
+{
+    if (!strcmp(dev, m_Device->getDeviceName()))
+    {
+        // Connection retry/backoff configuration
+        if (!strcmp(name, RetryNP.name))
+        {
+            IUUpdateNumber(&RetryNP, values, names, n);
+            RetryNP.s = IPS_OK;
+
+            // Update runtime values
+            m_ConnectRetries = static_cast<int>(RetryN[TCP::RETRY_RETRIES].value);
+            m_BackoffBaseMs = static_cast<int>(RetryN[TCP::RETRY_BACKOFF_MS].value);
+
+            // Persist the change
+            m_Device->saveConfig(true, RetryNP.name);
+
+            // Log the new configuration for visibility
+            LOGF_INFO("Connection retry configuration updated: CONNECT_RETRIES=%d, BACKOFF_BASE_MS=%d",
+                      m_ConnectRetries, m_BackoffBaseMs);
+
+            // Notify clients of the change if initialization is complete
+            if (m_Device->isInitializationComplete())
+                IDSetNumber(&RetryNP, nullptr);
 
             return true;
         }
@@ -219,41 +276,66 @@ bool TCP::Connect()
         return false;
     }
 
-    bool handshakeResult = true;
+    bool handshakeResult = false;
     std::string hostname = AddressT[0].text;
     std::string port = AddressT[1].text;
 
-    // Should just call handshake on simulation
-    if (m_Device->isSimulation())
-        handshakeResult = Handshake();
+    // Use runtime-configurable retry/backoff parameters (can be changed via the Connection Retry property)
+    int connectRetries = m_ConnectRetries > 0 ? m_ConnectRetries : 1;
+    int backoffBaseMs = m_BackoffBaseMs > 0 ? m_BackoffBaseMs : 200;
 
+    // Simulation devices bypass connection/retry logic and simply call the handshake
+    if (m_Device->isSimulation())
+    {
+        handshakeResult = Handshake();
+    }
     else
     {
-        handshakeResult = false;
         std::regex ipv4("^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$");
         const auto isIPv4 = regex_match(hostname, ipv4);
 
-        // Establish connection to host:port
-        if (establishConnection(hostname, port))
+        // Try a small number of retries on the requested address before falling back to LAN search
+        for (int attempt = 1; attempt <= connectRetries; ++attempt)
         {
-            PortFD = m_SockFD;
-            LOGF_DEBUG("Connection to %s@%s is successful, attempting handshake...", hostname.c_str(), port.c_str());
-            handshakeResult = Handshake();
-
-            // Auto search is disabled.
-            if (handshakeResult == false && LANSearchS[INDI::DefaultDevice::INDI_ENABLED].s == ISS_OFF)
+            if (establishConnection(hostname, port))
             {
-                LOG_DEBUG("Handshake failed.");
-                return false;
+                PortFD = m_SockFD;
+                LOGF_DEBUG("Connection to %s@%s is successful, attempting handshake...", hostname.c_str(), port.c_str());
+                handshakeResult = Handshake();
+
+                if (handshakeResult)
+                    break;
+
+                // Handshake failed, close and retry according to policy (unless LAN search is disabled)
+                close(m_SockFD);
+                m_SockFD = -1;
+                PortFD = -1;
+                if (LANSearchS[INDI::DefaultDevice::INDI_ENABLED].s == ISS_OFF)
+                {
+                    LOGF_DEBUG("Handshake failed on attempt %d/%d to %s@%s, will retry.", attempt, connectRetries, hostname.c_str(), port.c_str());
+                }
+                else
+                {
+                    LOGF_DEBUG("Handshake failed on attempt %d/%d to %s@%s, will retry before attempting LAN search.", attempt, connectRetries, hostname.c_str(), port.c_str());
+                }
+            }
+            else
+            {
+                LOGF_DEBUG("Connection attempt %d/%d to %s@%s failed.", attempt, CONNECT_RETRIES, hostname.c_str(), port.c_str());
+            }
+
+            if (attempt < connectRetries)
+            {
+                // backoff before retrying
+                int backoff = backoffBaseMs * (1 << (attempt - 1));
+                LOGF_DEBUG("Waiting %d ms before next connect attempt.", backoff);
+                usleep(static_cast<useconds_t>(backoff * 1000));
             }
         }
 
-        // If connection failed; or
-        // handshake failed; then we can search LAN if the IP address is v4
-        // LAN search is enabled.
-        if (handshakeResult == false &&
-                LANSearchS[INDI::DefaultDevice::INDI_ENABLED].s == ISS_ON &&
-                isIPv4)
+        // If all direct retries failed and LAN search is enabled and the provided address looks like an IPv4,
+        // proceed with the existing LAN search fallback behavior.
+        if (!handshakeResult && LANSearchS[INDI::DefaultDevice::INDI_ENABLED].s == ISS_ON && isIPv4)
         {
             size_t found = hostname.find_last_of(".");
 
@@ -300,13 +382,16 @@ bool TCP::Connect()
                         if (establishConnection(newAddress, port, 1))
                         {
                             PortFD = m_SockFD;
-                            LOGF_DEBUG("Connection to %s@%s is successful, attempting handshake...", hostname.c_str(), port.c_str());
+                            LOGF_DEBUG("Connection to %s@%s is successful, attempting handshake...", newAddress.c_str(), port.c_str());
                             handshakeResult = Handshake();
                             if (handshakeResult)
                             {
                                 hostname = newAddress;
                                 break;
                             }
+                            close(m_SockFD);
+                            m_SockFD = -1;
+                            PortFD = -1;
                         }
                     }
 
@@ -363,6 +448,7 @@ void TCP::Activated()
     {
         m_Device->defineProperty(&TcpUdpSP);
         m_Device->defineProperty(&LANSearchSP);
+        m_Device->defineProperty(&RetryNP);
     }
 }
 
@@ -376,6 +462,7 @@ void TCP::Deactivated()
     {
         m_Device->deleteProperty(TcpUdpSP.name);
         m_Device->deleteProperty(LANSearchSP.name);
+        m_Device->deleteProperty(RetryNP.name);
     }
 }
 
@@ -389,6 +476,7 @@ bool TCP::saveConfigItems(FILE * fp)
         IUSaveConfigText(fp, &AddressTP);
         IUSaveConfigSwitch(fp, &TcpUdpSP);
         IUSaveConfigSwitch(fp, &LANSearchSP);
+        IUSaveConfigNumber(fp, &RetryNP);
     }
 
     return true;

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -445,7 +445,7 @@ bool TCP::Connect()
 //////////////////////////////////////////////////////////////////////////////////////////////////
 bool TCP::Disconnect()
 {
-    if (m_SockFD > 0)
+    if (m_SockFD != -1)
     {
         close(m_SockFD);
         m_SockFD = PortFD = -1;

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -83,7 +83,7 @@ TCP::TCP(INDI::DefaultDevice *dev, IPerm permission) : Interface(dev, CONNECTION
     // Default values
     IUFillNumber(&RetryN[TCP::RETRY_RETRIES], "CONNECT_RETRIES", "Connection retries", "%.0f", 0, TCP::MAX_CONNECT_RETRIES, 1,
                  static_cast<double>(m_ConnectRetries));
-    IUFillNumber(&RetryN[TCP::RETRY_BACKOFF_MS], "BACKOFF_BASE_MS", "Backoff base (ms)", "%.0f", 0, TCP::MAX_BACKOFF_DELAY, 1,
+    IUFillNumber(&RetryN[TCP::RETRY_BACKOFF_MS], "BACKOFF_BASE_MS", "Backoff base (ms)", "%.0f", 0, TCP::MAX_BACKOFF_BASE_DELAY, 1,
                  static_cast<double>(m_BackoffBaseMs));
     IUFillNumberVector(&RetryNP, RetryN, 2, getDeviceName(), "CONNECTION_RETRY", "Connection Retry",
                        CONNECTION_TAB, IP_RW, 60, IPS_IDLE);
@@ -100,7 +100,7 @@ TCP::TCP(INDI::DefaultDevice *dev, IPerm permission) : Interface(dev, CONNECTION
     if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_BACKOFF_MS].name, &dval) == 0)
     {
         // Clamp BACKOFF_BASE_MS to valid range [0, 60000]
-        dval = std::max(0.0, std::min(dval, static_cast<double>(TCP::MAX_BACKOFF_DELAY)));
+        dval = std::max(0.0, std::min(dval, static_cast<double>(TCP::MAX_BACKOFF_BASE_DELAY)));
         RetryN[TCP::RETRY_BACKOFF_MS].value = dval;
         m_BackoffBaseMs = static_cast<int>(dval);
     }
@@ -182,17 +182,17 @@ bool TCP::ISNewNumber(const char *dev, const char *name, double values[], char *
             RetryNP.s = IPS_OK;
 
             // Validate and clamp CONNECT_RETRIES to [0, 100]
-            RetryN[TCP::RETRY_RETRIES].value = std::max(0.0, std::min(RetryN[TCP::RETRY_RETRIES].value, 100.0));
+            RetryN[TCP::RETRY_RETRIES].value = std::max(0.0, std::min(RetryN[TCP::RETRY_RETRIES].value, TCP::MAX_CONNECT_RETRIES));
             // Validate and clamp BACKOFF_BASE_MS to [0, 60000]
             RetryN[TCP::RETRY_BACKOFF_MS].value = std::max(0.0, std::min(RetryN[TCP::RETRY_BACKOFF_MS].value,
-                                                                            static_cast<double>(TCP::MAX_BACKOFF_DELAY)));
+                                                                            static_cast<double>(TCP::MAX_BACKOFF_BASE_DELAY)));
 
             // Update runtime values
             m_ConnectRetries = static_cast<int>(RetryN[TCP::RETRY_RETRIES].value);
             m_BackoffBaseMs = static_cast<int>(RetryN[TCP::RETRY_BACKOFF_MS].value);
 
-            // Persist the change
-            m_Device->saveConfig(true, RetryNP.name);
+            // Mark config as dirty; actual save will be deferred
+            m_RetryConfigDirty = true;
 
             // Log the new configuration for visibility
             LOGF_INFO("Connection retry configuration updated: CONNECT_RETRIES=%d, BACKOFF_BASE_MS=%d",
@@ -308,7 +308,10 @@ bool TCP::Connect()
         const auto isIPv4 = regex_match(hostname, ipv4);
 
         // Try a small number of retries on the requested address before falling back to LAN search
-        for (int attempt = 1; attempt <= connectRetries; ++attempt)
+        auto start_time = std::chrono::steady_clock::now();
+        long long total_elapsed_ms = 0;
+
+        for (int attempt = 1; attempt <= connectRetries && total_elapsed_ms < MAX_TOTAL_RETRY_TIME_MS; ++attempt)
         {
             if (establishConnection(hostname, port))
             {
@@ -337,15 +340,29 @@ bool TCP::Connect()
                 LOGF_DEBUG("Connection attempt %d/%d to %s@%s failed.", attempt, connectRetries, hostname.c_str(), port.c_str());
             }
 
-            if (attempt < connectRetries)
+            if (attempt < connectRetries && total_elapsed_ms < MAX_TOTAL_RETRY_TIME_MS)
             {
-                // backoff before retrying
-                int shift = std::min(attempt - 1, 30);
+                // Calculate backoff with capped exponential growth
+                int shift = std::min(attempt - 1, MAX_CONNECT_RETRIES);
                 long long backoff_ms = static_cast<long long>(backoffBaseMs) * (1LL << shift);
-                // Clamp to maximum
+                // Cap individual backoff
                 backoff_ms = std::min(backoff_ms, MAX_BACKOFF_DELAY);
-                LOGF_DEBUG("Waiting %lld ms before next connect attempt.", backoff_ms);
-                std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+
+                // Ensure we don't exceed total retry time limit
+                long long remaining_time_ms = MAX_TOTAL_RETRY_TIME_MS - total_elapsed_ms;
+                backoff_ms = std::min(backoff_ms, remaining_time_ms);
+
+                if (backoff_ms > 0)
+                {
+                    LOGF_DEBUG("Waiting %lld ms before next connect attempt (total elapsed: %lld ms).", backoff_ms, total_elapsed_ms);
+                    std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
+                    total_elapsed_ms += backoff_ms;
+                }
+                else
+                {
+                    LOGF_DEBUG("Skipping backoff - total retry time limit reached.");
+                    break;
+                }
             }
         }
 

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -377,7 +377,7 @@ bool TCP::Connect()
                 }
                 else
                 {
-                    LOGF_DEBUG("Skipping backoff - total retry time limit reached.");
+                    LOG_DEBUG("Skipping backoff - total retry time limit reached.");
                     break;
                 }
             }

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -93,14 +93,14 @@ TCP::TCP(INDI::DefaultDevice *dev, IPerm permission) : Interface(dev, CONNECTION
     if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_RETRIES].name, &dval) == 0)
     {
         // Clamp CONNECT_RETRIES to valid range [0, 100]
-        dval = std::max(0.0, std::min(dval, static_cast<double>(TCP::MAX_CONNECT_RETRIES)));
+        dval = std::max(0.0, std::min(dval, TCP::MAX_CONNECT_RETRIES));
         RetryN[TCP::RETRY_RETRIES].value = dval;
         m_ConnectRetries = static_cast<int>(dval);
     }
     if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_BACKOFF_MS].name, &dval) == 0)
     {
         // Clamp BACKOFF_BASE_MS to valid range [0, 60000]
-        dval = std::max(0.0, std::min(dval, static_cast<double>(TCP::MAX_BACKOFF_BASE_DELAY)));
+        dval = std::max(0.0, std::min(dval, TCP::MAX_BACKOFF_BASE_DELAY));
         RetryN[TCP::RETRY_BACKOFF_MS].value = dval;
         m_BackoffBaseMs = static_cast<int>(dval);
     }

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -308,12 +308,25 @@ bool TCP::Connect()
         const auto isIPv4 = regex_match(hostname, ipv4);
 
         // Try a small number of retries on the requested address before falling back to LAN search
-        auto start_time = std::chrono::steady_clock::now();
-        long long total_elapsed_ms = 0;
+        auto retry_start_time = std::chrono::steady_clock::now();
 
-        for (int attempt = 1; attempt <= connectRetries && total_elapsed_ms < MAX_TOTAL_RETRY_TIME_MS; ++attempt)
+        for (int attempt = 1; attempt <= connectRetries; ++attempt)
         {
-            if (establishConnection(hostname, port))
+            // Check if we've exceeded total retry time before starting this attempt
+            auto attempt_start = std::chrono::steady_clock::now();
+            long long total_elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                attempt_start - retry_start_time).count();
+
+            if (total_elapsed_ms >= MAX_TOTAL_RETRY_TIME_MS)
+            {
+                LOGF_DEBUG("Total retry time limit (%lld ms) exceeded, stopping retry loop.", MAX_TOTAL_RETRY_TIME_MS);
+                break;
+            }
+
+            // Attempt connection
+            bool connection_succeeded = establishConnection(hostname, port);
+
+            if (connection_succeeded)
             {
                 PortFD = m_SockFD;
                 LOGF_DEBUG("Connection to %s@%s is successful, attempting handshake...", hostname.c_str(), port.c_str());
@@ -340,10 +353,15 @@ bool TCP::Connect()
                 LOGF_DEBUG("Connection attempt %d/%d to %s@%s failed.", attempt, connectRetries, hostname.c_str(), port.c_str());
             }
 
+            // Calculate elapsed time including connection/handshake attempt
+            auto attempt_end = std::chrono::steady_clock::now();
+            total_elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                attempt_end - retry_start_time).count();
+
             if (attempt < connectRetries && total_elapsed_ms < MAX_TOTAL_RETRY_TIME_MS)
             {
                 // Calculate backoff with capped exponential growth
-                int shift = std::min(attempt - 1, MAX_CONNECT_RETRIES);
+                int shift = std::min(attempt - 1, MAX_BACKOFF_SHIFT);
                 long long backoff_ms = static_cast<long long>(backoffBaseMs) * (1LL << shift);
                 // Cap individual backoff
                 backoff_ms = std::min(backoff_ms, MAX_BACKOFF_DELAY);
@@ -356,7 +374,6 @@ bool TCP::Connect()
                 {
                     LOGF_DEBUG("Waiting %lld ms before next connect attempt (total elapsed: %lld ms).", backoff_ms, total_elapsed_ms);
                     std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
-                    total_elapsed_ms += backoff_ms;
                 }
                 else
                 {

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -191,8 +191,8 @@ bool TCP::ISNewNumber(const char *dev, const char *name, double values[], char *
             m_ConnectRetries = static_cast<int>(RetryN[TCP::RETRY_RETRIES].value);
             m_BackoffBaseMs = static_cast<int>(RetryN[TCP::RETRY_BACKOFF_MS].value);
 
-            // Mark config as dirty; actual save will be deferred
-            m_RetryConfigDirty = true;
+            // Persist the change
+            m_Device->saveConfig(true, RetryNP.name);
 
             // Log the new configuration for visibility
             LOGF_INFO("Connection retry configuration updated: CONNECT_RETRIES=%d, BACKOFF_BASE_MS=%d",

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -321,7 +321,7 @@ bool TCP::Connect()
             }
             else
             {
-                LOGF_DEBUG("Connection attempt %d/%d to %s@%s failed.", attempt, CONNECT_RETRIES, hostname.c_str(), port.c_str());
+                LOGF_DEBUG("Connection attempt %d/%d to %s@%s failed.", attempt, connectRetries, hostname.c_str(), port.c_str());
             }
 
             if (attempt < connectRetries)

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -92,15 +92,15 @@ TCP::TCP(INDI::DefaultDevice *dev, IPerm permission) : Interface(dev, CONNECTION
     double dval = 0;
     if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_RETRIES].name, &dval) == 0)
     {
-        // Clamp CONNECT_RETRIES to valid range [0, 100]
+        // Clamp CONNECT_RETRIES to valid range
         dval = std::max(0.0, std::min(dval, TCP::MAX_CONNECT_RETRIES));
         RetryN[TCP::RETRY_RETRIES].value = dval;
         m_ConnectRetries = static_cast<int>(dval);
     }
     if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_BACKOFF_MS].name, &dval) == 0)
     {
-        // Clamp BACKOFF_BASE_MS to valid range [0, 60000]
-        dval = std::max(0.0, std::min(dval, TCP::MAX_BACKOFF_BASE_DELAY));
+        // Clamp BACKOFF_BASE_MS to valid range
+        dval = std::max(0.0, std::min(dval, static_cast<double>(TCP::MAX_BACKOFF_BASE_DELAY)));
         RetryN[TCP::RETRY_BACKOFF_MS].value = dval;
         m_BackoffBaseMs = static_cast<int>(dval);
     }
@@ -181,9 +181,9 @@ bool TCP::ISNewNumber(const char *dev, const char *name, double values[], char *
             IUUpdateNumber(&RetryNP, values, names, n);
             RetryNP.s = IPS_OK;
 
-            // Validate and clamp CONNECT_RETRIES to [0, 100]
+            // Validate and clamp CONNECT_RETRIES to valid range
             RetryN[TCP::RETRY_RETRIES].value = std::max(0.0, std::min(RetryN[TCP::RETRY_RETRIES].value, TCP::MAX_CONNECT_RETRIES));
-            // Validate and clamp BACKOFF_BASE_MS to [0, 60000]
+            // Validate and clamp BACKOFF_BASE_MS to valid range
             RetryN[TCP::RETRY_BACKOFF_MS].value = std::max(0.0, std::min(RetryN[TCP::RETRY_BACKOFF_MS].value,
                                                                             static_cast<double>(TCP::MAX_BACKOFF_BASE_DELAY)));
 
@@ -361,10 +361,10 @@ bool TCP::Connect()
             if (attempt < connectRetries && total_elapsed_ms < MAX_TOTAL_RETRY_TIME_MS)
             {
                 // Calculate backoff with capped exponential growth
-                int shift = std::min(attempt - 1, MAX_BACKOFF_SHIFT);
+                int shift = std::min(attempt - 1, static_cast<int>(MAX_BACKOFF_SHIFT));
                 long long backoff_ms = static_cast<long long>(backoffBaseMs) * (1LL << shift);
                 // Cap individual backoff
-                backoff_ms = std::min(backoff_ms, MAX_BACKOFF_DELAY);
+                backoff_ms = std::min(backoff_ms, static_cast<long long>(MAX_BACKOFF_DELAY));
 
                 // Ensure we don't exceed total retry time limit
                 long long remaining_time_ms = MAX_TOTAL_RETRY_TIME_MS - total_elapsed_ms;

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -81,9 +81,9 @@ TCP::TCP(INDI::DefaultDevice *dev, IPerm permission) : Interface(dev, CONNECTION
 
     // Retry/backoff configuration: number vector property
     // Default values
-    IUFillNumber(&RetryN[TCP::RETRY_RETRIES], "CONNECT_RETRIES", "Connection retries", "%.0f", 0, 100, 1,
+    IUFillNumber(&RetryN[TCP::RETRY_RETRIES], "CONNECT_RETRIES", "Connection retries", "%.0f", 0, TCP::MAX_CONNECT_RETRIES, 1,
                  static_cast<double>(m_ConnectRetries));
-    IUFillNumber(&RetryN[TCP::RETRY_BACKOFF_MS], "BACKOFF_BASE_MS", "Backoff base (ms)", "%.0f", 0, 60000, 1,
+    IUFillNumber(&RetryN[TCP::RETRY_BACKOFF_MS], "BACKOFF_BASE_MS", "Backoff base (ms)", "%.0f", 0, TCP::MAX_BACKOFF_DELAY, 1,
                  static_cast<double>(m_BackoffBaseMs));
     IUFillNumberVector(&RetryNP, RetryN, 2, getDeviceName(), "CONNECTION_RETRY", "Connection Retry",
                        CONNECTION_TAB, IP_RW, 60, IPS_IDLE);
@@ -92,11 +92,15 @@ TCP::TCP(INDI::DefaultDevice *dev, IPerm permission) : Interface(dev, CONNECTION
     double dval = 0;
     if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_RETRIES].name, &dval) == 0)
     {
+        // Clamp CONNECT_RETRIES to valid range [0, 100]
+        dval = std::max(0.0, std::min(dval, static_cast<double>(TCP::MAX_CONNECT_RETRIES)));
         RetryN[TCP::RETRY_RETRIES].value = dval;
         m_ConnectRetries = static_cast<int>(dval);
     }
     if (IUGetConfigNumber(dev->getDeviceName(), RetryNP.name, RetryN[TCP::RETRY_BACKOFF_MS].name, &dval) == 0)
     {
+        // Clamp BACKOFF_BASE_MS to valid range [0, 60000]
+        dval = std::max(0.0, std::min(dval, static_cast<double>(TCP::MAX_BACKOFF_DELAY)));
         RetryN[TCP::RETRY_BACKOFF_MS].value = dval;
         m_BackoffBaseMs = static_cast<int>(dval);
     }
@@ -176,6 +180,12 @@ bool TCP::ISNewNumber(const char *dev, const char *name, double values[], char *
         {
             IUUpdateNumber(&RetryNP, values, names, n);
             RetryNP.s = IPS_OK;
+
+            // Validate and clamp CONNECT_RETRIES to [0, 100]
+            RetryN[TCP::RETRY_RETRIES].value = std::max(0.0, std::min(RetryN[TCP::RETRY_RETRIES].value, 100.0));
+            // Validate and clamp BACKOFF_BASE_MS to [0, 60000]
+            RetryN[TCP::RETRY_BACKOFF_MS].value = std::max(0.0, std::min(RetryN[TCP::RETRY_BACKOFF_MS].value,
+                                                                            static_cast<double>(TCP::MAX_BACKOFF_DELAY)));
 
             // Update runtime values
             m_ConnectRetries = static_cast<int>(RetryN[TCP::RETRY_RETRIES].value);

--- a/libs/indibase/connectionplugins/connectiontcp.cpp
+++ b/libs/indibase/connectionplugins/connectiontcp.cpp
@@ -27,6 +27,9 @@
 #include <cstring>
 #include <unistd.h>
 #include <regex>
+#include <algorithm>
+#include <chrono>
+#include <thread>
 
 #if defined(__FreeBSD__) || defined(__OpenBSD__)
 #include <arpa/inet.h>
@@ -327,9 +330,12 @@ bool TCP::Connect()
             if (attempt < connectRetries)
             {
                 // backoff before retrying
-                int backoff = backoffBaseMs * (1 << (attempt - 1));
-                LOGF_DEBUG("Waiting %d ms before next connect attempt.", backoff);
-                usleep(static_cast<useconds_t>(backoff * 1000));
+                int shift = std::min(attempt - 1, 30);
+                long long backoff_ms = static_cast<long long>(backoffBaseMs) * (1LL << shift);
+                // Clamp to maximum
+                backoff_ms = std::min(backoff_ms, MAX_BACKOFF_DELAY);
+                LOGF_DEBUG("Waiting %lld ms before next connect attempt.", backoff_ms);
+                std::this_thread::sleep_for(std::chrono::milliseconds(backoff_ms));
             }
         }
 

--- a/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libs/indibase/connectionplugins/connectiontcp.h
@@ -44,7 +44,8 @@ class TCP : public Interface
         // Max retry time
         static const long long MAX_TOTAL_RETRY_TIME_MS = 300000LL; // 5 minutes
 
-        static const int MAX_CONNECT_RETRIES = 10;
+        static constexpr double MAX_CONNECT_RETRIES = 10;
+        static constexpr double MAX_BACKOFF_SHIFT = 10;
         enum ConnectionType
         {
             TYPE_TCP = 0,

--- a/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libs/indibase/connectionplugins/connectiontcp.h
@@ -47,6 +47,7 @@ class TCP : public Interface
         virtual ~TCP() = default;
 
         virtual bool Connect() override;
+        virtual bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
 
         virtual bool Disconnect() override;
 
@@ -113,14 +114,27 @@ class TCP : public Interface
         // Auto search
         ISwitch LANSearchS[2];
         ISwitchVectorProperty LANSearchSP;
+        // Retry/backoff configuration
+        enum RetryIndex
+        {
+            RETRY_RETRIES = 0,
+            RETRY_BACKOFF_MS = 1,
+        };
+        INumber RetryN[2];
+        INumberVectorProperty RetryNP;
 
         // Variables
         IPerm m_Permission = IP_RW;
         std::string m_ConfigHost;
         std::string m_ConfigPort;
         int m_ConfigConnectionType {-1};
+        int m_ConfigConnectRetries {-1};
+        int m_ConfigBackoffBaseMs {-1};
         int m_SockFD {-1};
         int PortFD = -1;
         static constexpr uint8_t SOCKET_TIMEOUT {5};
+        // Runtime-configurable connection retry parameters
+        int m_ConnectRetries {3};
+        int m_BackoffBaseMs {500}; // milliseconds
 };
 }

--- a/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libs/indibase/connectionplugins/connectiontcp.h
@@ -37,8 +37,14 @@ namespace Connection
 class TCP : public Interface
 {
     public:
-        static const long long MAX_BACKOFF_DELAY = 60000LL;
-        static const int MAX_CONNECT_RETRIES = 100;
+        // Max base delay for the exponential backoff retry
+        static const long long MAX_BACKOFF_BASE_DELAY = 10000LL;
+        // Max delay to wait for the next backoff retry
+        static const long long MAX_BACKOFF_DELAY = 30000LL;
+        // Max retry time
+        static const long long MAX_TOTAL_RETRY_TIME_MS = 300000LL; // 5 minutes
+
+        static const int MAX_CONNECT_RETRIES = 10;
         enum ConnectionType
         {
             TYPE_TCP = 0,
@@ -130,13 +136,13 @@ class TCP : public Interface
         std::string m_ConfigHost;
         std::string m_ConfigPort;
         int m_ConfigConnectionType {-1};
-        int m_ConfigConnectRetries {-1};
-        int m_ConfigBackoffBaseMs {-1};
         int m_SockFD {-1};
         int PortFD = -1;
         static constexpr uint8_t SOCKET_TIMEOUT {5};
         // Runtime-configurable connection retry parameters
         int m_ConnectRetries {3};
         int m_BackoffBaseMs {500}; // milliseconds
+        // Flag to defer config persistence (avoid frequent saveConfig calls)
+        bool m_RetryConfigDirty {false};
 };
 }

--- a/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libs/indibase/connectionplugins/connectiontcp.h
@@ -141,8 +141,6 @@ class TCP : public Interface
         static constexpr uint8_t SOCKET_TIMEOUT {5};
         // Runtime-configurable connection retry parameters
         int m_ConnectRetries {3};
-        int m_BackoffBaseMs {500}; // milliseconds
-        // Flag to defer config persistence (avoid frequent saveConfig calls)
-        bool m_RetryConfigDirty {false};
-};
+        int m_BackoffBaseMs {500}; // milliseconds};
+  };
 }

--- a/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libs/indibase/connectionplugins/connectiontcp.h
@@ -38,6 +38,7 @@ class TCP : public Interface
 {
     public:
         static const long long MAX_BACKOFF_DELAY = 60000LL;
+        static const int MAX_CONNECT_RETRIES = 100;
         enum ConnectionType
         {
             TYPE_TCP = 0,

--- a/libs/indibase/connectionplugins/connectiontcp.h
+++ b/libs/indibase/connectionplugins/connectiontcp.h
@@ -37,6 +37,7 @@ namespace Connection
 class TCP : public Interface
 {
     public:
+        static const long long MAX_BACKOFF_DELAY = 60000LL;
         enum ConnectionType
         {
             TYPE_TCP = 0,


### PR DESCRIPTION
This is a PR to refactor the Connection::TCP class to allow reconnect in case of network failures. It implements exponential backoff delay, with suitable limits to prevent blocking the driver.

It adds two config params to the Connection:

- Number of retries.
- Base backoff delay.