### PR TITLE
add pkgconf to the control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Jasem Mutlaq <mutlaqja@ikarustech.com>
 Build-Depends: debhelper (>= 9),
                cdbs,
                cmake (>= 3.0),
+               pkgconf,
                libcfitsio-dev,
                libnova-dev,
                libusb-1.0-0-dev,


### PR DESCRIPTION
Add pkgconf to the control file, as the launchpad is no longer building libindi due to this missing package