### PR TITLE
Gemini dust-cap Pro variant suport

### DIFF
--- a/drivers/auxiliary/gemini_flatpanel.cpp
+++ b/drivers/auxiliary/gemini_flatpanel.cpp
@@ -48,6 +48,7 @@ bool GeminiFlatpanel::initProperties()
     DeviceTypeSP[DEVICE_REV1].fill("REV1", "Revision 1", ISS_OFF);
     DeviceTypeSP[DEVICE_REV2].fill("REV2", "Revision 2", ISS_OFF);
     DeviceTypeSP[DEVICE_LITE].fill("LITE", "Lite", ISS_OFF);
+    DeviceTypeSP[DEVICE_PRO].fill("PRO", "Pro", ISS_OFF);
     DeviceTypeSP.load();
 
     addAuxControls();
@@ -74,6 +75,7 @@ bool GeminiFlatpanel::updateProperties()
 
         defineProperty(StatusTP);
         defineProperty(ConfigurationTP);
+        updateConfigStatus();
 
         // Only register advanced features if supported by the current adapter
         if (adapter && adapter->supportsBeep())
@@ -399,6 +401,11 @@ void GeminiFlatpanel::TimerHit()
 
     if (error)
     {
+        // Keep polling active after transient communication errors.
+        if (configStatus == GEMINI_CONFIG_READY)
+        {
+            SetTimer(getCurrentPollingPeriod());
+        }
         return;
     }
 
@@ -416,8 +423,9 @@ void GeminiFlatpanel::TimerHit()
         StatusTP.apply();
     }
 
+    const bool isPro = (adapter && adapter->getRevision() == GEMINI_REVISION_PRO);
     if (motorStatus == GEMINI_MOTOR_STATUS_RUNNING && (coverStatus == GEMINI_COVER_STATUS_TIMED_OUT
-            || coverStatus == GEMINI_COVER_STATUS_MOVING))
+            || (!isPro && coverStatus == GEMINI_COVER_STATUS_MOVING)))
     {
         LOG_WARN("Motor running with unknown cover status.");
         configStatus = GEMINI_CONFIG_NOTREADY;
@@ -460,7 +468,7 @@ IPState GeminiFlatpanel::ParkCap()
     ParkCapSP.apply();
     if (closeCover())
     {
-        return IPS_OK;
+        return (adapter && adapter->getRevision() == GEMINI_REVISION_PRO) ? IPS_BUSY : IPS_OK;
     }
     return IPS_ALERT;
 }
@@ -475,13 +483,18 @@ IPState GeminiFlatpanel::UnParkCap()
     ParkCapSP.apply();
     if (openCover())
     {
-        return IPS_OK;
+        return (adapter && adapter->getRevision() == GEMINI_REVISION_PRO) ? IPS_BUSY : IPS_OK;
     }
     return IPS_ALERT;
 }
 
 IPState GeminiFlatpanel::AbortCap()
 {
+    if (adapter && adapter->getRevision() == GEMINI_REVISION_PRO)
+    {
+        return IPS_OK;
+    }
+
     return IPS_ALERT;
 }
 
@@ -536,7 +549,8 @@ bool GeminiFlatpanel::Handshake()
         {
             {[]() { return std::make_unique<GeminiFlatpanelRev1Adapter>(); }, "Rev1", DEVICE_REV1},
             {[]() { return std::make_unique<GeminiFlatpanelRev2Adapter>(); }, "Rev2", DEVICE_REV2},
-            {[]() { return std::make_unique<GeminiFlatpanelLiteAdapter>(); }, "Lite", DEVICE_LITE}
+            {[]() { return std::make_unique<GeminiFlatpanelLiteAdapter>(); }, "Lite", DEVICE_LITE},
+            {[]() { return std::make_unique<GeminiFlatpanelProAdapter>(); }, "Pro", DEVICE_PRO}
         };
     }
     else
@@ -552,6 +566,9 @@ bool GeminiFlatpanel::Handshake()
                 break;
             case DEVICE_LITE:
                 adapterTypes = {{[]() { return std::make_unique<GeminiFlatpanelLiteAdapter>(); }, "Lite", DEVICE_LITE}};
+                break;
+            case DEVICE_PRO:
+                adapterTypes = {{[]() { return std::make_unique<GeminiFlatpanelProAdapter>(); }, "Pro", DEVICE_PRO}};
                 break;
         }
     }
@@ -605,7 +622,6 @@ bool GeminiFlatpanel::Handshake()
     if (adapter->getConfigStatus(&adapterConfigStatus))
     {
         configStatus = adapterConfigStatus;
-        updateConfigStatus();
         return true;
     }
 
@@ -689,9 +705,12 @@ bool GeminiFlatpanel::updateCoverStatus(char coverStatus)
         {
             case GEMINI_COVER_STATUS_MOVING:
                 StatusTP[STATUS_COVER].setText("Moving");
-                ParkCapSP.reset();
-                ParkCapSP.setState(IPS_BUSY);
-                ParkCapSP.apply();
+                if (ParkCapSP.getState() == IPS_BUSY || ParkCapSP.getState() == IPS_IDLE)
+                {
+                    ParkCapSP.reset();
+                    ParkCapSP.setState(IPS_BUSY);
+                    ParkCapSP.apply();
+                }
                 break;
             case GEMINI_COVER_STATUS_CLOSED:
                 StatusTP[STATUS_COVER].setText("Closed");
@@ -717,10 +736,13 @@ bool GeminiFlatpanel::updateCoverStatus(char coverStatus)
                 break;
             case GEMINI_COVER_STATUS_TIMED_OUT:
                 StatusTP[STATUS_COVER].setText("Timed Out");
-                ParkCapSP.reset();
-                ParkCapSP.setState(IPS_ALERT);
-                LOG_ERROR("Cover operation timed out.");
-                ParkCapSP.apply();
+                if (ParkCapSP.getState() == IPS_BUSY)
+                {
+                    ParkCapSP.reset();
+                    ParkCapSP.setState(IPS_ALERT);
+                    LOG_ERROR("Cover operation timed out.");
+                    ParkCapSP.apply();
+                }
                 break;
         }
     }

--- a/drivers/auxiliary/gemini_flatpanel.cpp
+++ b/drivers/auxiliary/gemini_flatpanel.cpp
@@ -75,7 +75,6 @@ bool GeminiFlatpanel::updateProperties()
 
         defineProperty(StatusTP);
         defineProperty(ConfigurationTP);
-        updateConfigStatus();
 
         // Only register advanced features if supported by the current adapter
         if (adapter && adapter->supportsBeep())
@@ -401,11 +400,6 @@ void GeminiFlatpanel::TimerHit()
 
     if (error)
     {
-        // Keep polling active after transient communication errors.
-        if (configStatus == GEMINI_CONFIG_READY)
-        {
-            SetTimer(getCurrentPollingPeriod());
-        }
         return;
     }
 
@@ -622,6 +616,7 @@ bool GeminiFlatpanel::Handshake()
     if (adapter->getConfigStatus(&adapterConfigStatus))
     {
         configStatus = adapterConfigStatus;
+        updateConfigStatus();
         return true;
     }
 
@@ -705,12 +700,9 @@ bool GeminiFlatpanel::updateCoverStatus(char coverStatus)
         {
             case GEMINI_COVER_STATUS_MOVING:
                 StatusTP[STATUS_COVER].setText("Moving");
-                if (ParkCapSP.getState() == IPS_BUSY || ParkCapSP.getState() == IPS_IDLE)
-                {
                     ParkCapSP.reset();
                     ParkCapSP.setState(IPS_BUSY);
                     ParkCapSP.apply();
-                }
                 break;
             case GEMINI_COVER_STATUS_CLOSED:
                 StatusTP[STATUS_COVER].setText("Closed");
@@ -736,13 +728,10 @@ bool GeminiFlatpanel::updateCoverStatus(char coverStatus)
                 break;
             case GEMINI_COVER_STATUS_TIMED_OUT:
                 StatusTP[STATUS_COVER].setText("Timed Out");
-                if (ParkCapSP.getState() == IPS_BUSY)
-                {
                     ParkCapSP.reset();
                     ParkCapSP.setState(IPS_ALERT);
                     LOG_ERROR("Cover operation timed out.");
                     ParkCapSP.apply();
-                }
                 break;
         }
     }

--- a/drivers/auxiliary/gemini_flatpanel.h
+++ b/drivers/auxiliary/gemini_flatpanel.h
@@ -146,6 +146,7 @@ class GeminiFlatpanel : public INDI::DefaultDevice, public INDI::LightBoxInterfa
             DEVICE_REV1,
             DEVICE_REV2,
             DEVICE_LITE,
+            DEVICE_PRO,
             DEVICE_N
         };
         INDI::PropertySwitch DeviceTypeSP{DEVICE_N};

--- a/drivers/auxiliary/gemini_flatpanel_adapters.cpp
+++ b/drivers/auxiliary/gemini_flatpanel_adapters.cpp
@@ -1204,6 +1204,418 @@ bool GeminiFlatpanelLiteAdapter::sendCommand(const char *command, char *response
 }
 
 //////////////////////////////////////////////////////////////////////////////
+// GeminiFlatpanelProAdapter Implementation
+//////////////////////////////////////////////////////////////////////////////
+
+// Device detection and identification
+bool GeminiFlatpanelProAdapter::ping()
+{
+    // This command is only supported by Pro devices
+    // It is used to check if the device is a Pro device
+    char response[MAXRBUF] = {0};
+
+    if (!sendCommand(">H#", response, SERIAL_TIMEOUT_SEC, false))
+    {
+        return false;
+    }
+
+    if (strcmp(response, "*HGeminiFlatPanelPro#") != 0)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelProAdapter::getFirmwareVersion(int *version)
+{
+    // This command is supported by Pro devices
+    // It is used to get the firmware version
+    char response[MAXRBUF] = {0};
+
+    // Initialize version to 0 in case of errors
+    *version = 0;
+
+    if (!sendCommand(">V#", response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'V')
+    {
+        return false;
+    }
+
+    int firmwareVersion;
+    if (!extractIntValue(response, 2, &firmwareVersion))
+    {
+        return false;
+    }
+
+    *version = firmwareVersion;
+    return true;
+}
+
+bool GeminiFlatpanelProAdapter::getConfigStatus(int *status)
+{
+    // Pro devices don't have a separate config status command
+    *status = GEMINI_CONFIG_READY;
+    return true;
+}
+
+bool GeminiFlatpanelProAdapter::getBrightness(int *brightness)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('J', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 4)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'J')
+    {
+        return false;
+    }
+
+    // Lite brightness response index is at position 2
+    return extractIntValue(response, 2, brightness);
+}
+
+bool GeminiFlatpanelProAdapter::setBrightness(int value)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (value > GEMINI_MAX_BRIGHTNESS)
+    {
+        value = GEMINI_MAX_BRIGHTNESS;
+    }
+
+    if (value < GEMINI_MIN_BRIGHTNESS)
+    {
+        value = GEMINI_MIN_BRIGHTNESS;
+    }
+
+    if (!formatCommand('B', command, value))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (strlen(response) < 3)
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'B')
+    {
+        return false;
+    }
+
+    int response_value;
+    if (!extractIntValue(response, 2, &response_value))
+    {
+        return false;
+    }
+
+    return (response_value == value);
+}
+
+bool GeminiFlatpanelProAdapter::lightOn()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('L', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'L');
+}
+
+bool GeminiFlatpanelProAdapter::lightOff()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('D', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    return (strlen(response) >= 3 && response[0] == '*' && response[1] == 'D');
+}
+
+bool GeminiFlatpanelProAdapter::openCover()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('O', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
+    {
+        return false;
+    }
+
+    // Pro firmware can acknowledge with variants like *O, *O#, or *OOpened#
+    return (response[0] == '*' && response[1] == 'O');
+}
+
+bool GeminiFlatpanelProAdapter::closeCover()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('C', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response, SERIAL_TIMEOUT_SEC_LONG))
+    {
+        return false;
+    }
+
+    // Pro firmware can acknowledge with variants like *C, *C#, or *CClosed#
+    return (response[0] == '*' && response[1] == 'C');
+}
+
+bool GeminiFlatpanelProAdapter::getStatus(int *coverStatus, int *lightStatus, int *motorStatus)
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('S', command))
+    {
+        return false;
+    }
+
+    if (!sendCommand(command, response))
+    {
+        return false;
+    }
+
+    if (response[0] != '*' || response[1] != 'S')
+    {
+        return false;
+    }
+
+    if (strlen(response) < 7)
+    {
+        return false;
+    }
+
+    *motorStatus = response[2] - '0';
+    *lightStatus = response[4] - '0';
+    *coverStatus = response[6] - '0';
+
+    if (*motorStatus < GEMINI_MOTOR_STATUS_STOPPED || *motorStatus > GEMINI_MOTOR_STATUS_RUNNING)
+    {
+        return false;
+    }
+    if (*lightStatus < GEMINI_LIGHT_STATUS_OFF || *lightStatus > GEMINI_LIGHT_STATUS_ON)
+    {
+        return false;
+    }
+    if (*coverStatus < GEMINI_COVER_STATUS_MOVING || *coverStatus > GEMINI_COVER_STATUS_TIMED_OUT)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+// Motion/calibration commands
+bool GeminiFlatpanelProAdapter::move(uint16_t value, int direction)
+{
+    char command[MAXRBUF] = {0};
+
+    if (direction == -1)
+    {
+        snprintf(command, sizeof(command), ">M-%02d#", value);
+    }
+    else
+    {
+        snprintf(command, sizeof(command), ">M%03d#", value);
+    }
+
+    char response[MAXRBUF] = {0};
+
+    return sendCommand(command, response, 30);
+}
+
+bool GeminiFlatpanelProAdapter::setClosePosition()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('F', command))
+    {
+        return false;
+    }
+
+    return sendCommand(command, response);
+}
+
+bool GeminiFlatpanelProAdapter::setOpenPosition()
+{
+    char command[MAXRBUF] = {0};
+    char response[MAXRBUF] = {0};
+
+    if (!formatCommand('E', command))
+    {
+        return false;
+    }
+
+    return sendCommand(command, response);
+}
+
+bool GeminiFlatpanelProAdapter::setBeep(bool enable)
+{
+    (void) enable;
+    return false;
+}
+
+bool GeminiFlatpanelProAdapter::setBrightnessMode(int mode)
+{
+    (void) mode;
+    return false;
+}
+
+// Helper methods for Pro
+bool GeminiFlatpanelProAdapter::formatCommand(char commandLetter, char *commandString, int value)
+{
+    if (commandString == nullptr)
+    {
+        return false;
+    }
+
+    // Pro format: >X# (no value) or >Xnnn# (with value) where X is command letter and nnn is value
+    if (value == NO_VALUE)
+    {
+        // No value provided
+        snprintf(commandString, MAXRBUF, ">%c#", commandLetter);
+    }
+    else
+    {
+        // Value provided
+        snprintf(commandString, MAXRBUF, ">%c%d#", commandLetter, value);
+    }
+
+    return true;
+}
+
+bool GeminiFlatpanelProAdapter::extractIntValue(const char *response, int startPos, int *value)
+{
+    if (response == nullptr || value == nullptr)
+    {
+        return false;
+    }
+
+    const char *terminator = strchr(response, '#');
+    if (terminator == nullptr)
+    {
+        return false;
+    }
+
+    // Calculate the length of the numeric part
+    int length = terminator - (response + startPos);
+
+    if (length <= 0)
+    {
+        return false;
+    }
+
+    // Extract the numeric part
+    char value_str[MAXRBUF] = {0};
+    strncpy(value_str, response + startPos, length);
+    *value = atoi(value_str);
+
+    return true;
+}
+
+bool GeminiFlatpanelProAdapter::sendCommand(const char *command, char *response, int timeout, bool log)
+{
+    int nbytes_written = 0, nbytes_read = 0, rc = -1;
+
+    tcflush(portFD, TCIOFLUSH);
+    if ((rc = tty_write_string(portFD, command, &nbytes_written)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+            // The main driver should handle logging of errors
+        }
+        return false;
+    }
+
+    if (response == nullptr)
+        return true;
+
+    if ((rc = tty_nread_section(portFD, response, MAXRBUF, getCommandTerminator(), timeout, &nbytes_read)) != TTY_OK)
+    {
+        if (log)
+        {
+            char errstr[MAXRBUF] = {0};
+            tty_error_msg(rc, errstr, MAXRBUF);
+            // Note: Cannot use LOGF_ERROR here as we don't have access to logging
+        }
+        return false;
+    }
+
+    // Remove trailing newline character if present
+    if (nbytes_read > 0 && response[nbytes_read - 1] == '\n')
+    {
+        response[nbytes_read - 1] = '\0';
+    }
+    tcflush(portFD, TCIOFLUSH);
+
+    if (response[0] != '*' || response[1] != command[1])
+    {
+        return false;
+    }
+
+    return true;
+}
+
+//////////////////////////////////////////////////////////////////////////////
 // GeminiFlatpanelSimulationAdapter Implementation
 //////////////////////////////////////////////////////////////////////////////
 

--- a/drivers/auxiliary/gemini_flatpanel_adapters.h
+++ b/drivers/auxiliary/gemini_flatpanel_adapters.h
@@ -19,7 +19,8 @@ enum GeminiRevision
     GEMINI_REVISION_UNKNOWN = 0,
     GEMINI_REVISION_1 = 1,
     GEMINI_REVISION_2 = 2,
-    GEMINI_REVISION_LITE = 3
+    GEMINI_REVISION_LITE = 3,
+    GEMINI_REVISION_PRO = 4
 };
 
 enum GeminiConfigStatus
@@ -549,6 +550,106 @@ class GeminiFlatpanelLiteAdapter : public GeminiFlatpanelAdapter
 };
 
 /**
+ * @brief Concrete adapter implementation for Gemini Pro firmware
+ *
+ * This adapter handles the specific protocol and commands for Pro devices:
+ * - Command format: >X# (no value) or >Xnnn# (with value)
+ * - Command terminator: '#'
+ * - Response format: *X<variable_length_number># or *X<text>#
+ * - Features: light control, beep control, brightness mode selection
+ * - No dust cap/motor support (lite version is not motorized)
+ */
+class GeminiFlatpanelProAdapter : public GeminiFlatpanelAdapter
+{
+    private:
+        int portFD;
+
+        // Internal helper methods for Pro protocol
+
+        /**
+         * @brief Format a command according to Pro protocol
+         * @param commandLetter the command character (B, L, D, etc.)
+         * @param commandString buffer to store the formatted command
+         * @param value optional value to include (NO_VALUE if not needed)
+         * @return true if successful, false otherwise
+         */
+        bool formatCommand(char commandLetter, char *commandString, int value = NO_VALUE);
+
+        /**
+         * @brief Send a command to the device and receive response
+         * @param command command string to send
+         * @param response buffer to store response (can be nullptr if no response expected)
+         * @param timeout timeout in seconds
+         * @param log whether to log errors
+         * @return true if successful, false otherwise
+         */
+        bool sendCommand(const char *command, char *response, int timeout = SERIAL_TIMEOUT_SEC, bool log = true);
+
+        /**
+         * @brief Extract integer value from Lite response format
+         * @param response response string from device
+         * @param startPos position to start extracting from
+         * @param value pointer to store extracted value
+         * @return true if successful, false otherwise
+         */
+        bool extractIntValue(const char *response, int startPos, int *value);
+
+    public:
+        GeminiFlatpanelProAdapter() : portFD(-1) {}
+
+        // Device detection and identification
+        bool ping() override;
+        int getRevision() const override
+        {
+            return GEMINI_REVISION_PRO;
+        }
+        bool getFirmwareVersion(int *version) override;
+
+        // Capability checks
+        bool supportsBeep() const override
+        {
+            return false;
+        }
+        bool supportsDustCap() const override
+        {
+            return true; 
+        }
+        bool supportsBrightnessMode() const override
+        {
+            return false;
+        }
+
+        // Basic device commands
+        bool getConfigStatus(int *status) override;
+        bool getBrightness(int *brightness) override;
+        bool setBrightness(int value) override;
+        bool lightOn() override;
+        bool lightOff() override;
+        bool openCover() override;   // Not supported, always returns false
+        bool closeCover() override;  // Not supported, always returns false
+        bool getStatus(int *coverStatus, int *lightStatus, int *motorStatus) override;
+
+        // Motion/calibration commands
+        bool move(uint16_t value, int direction) override;
+        bool setClosePosition() override;
+        bool setOpenPosition() override;
+
+        // Advanced commands (fully supported by Pro)
+        bool setBeep(bool enable) override;
+        bool setBrightnessMode(int mode) override;
+
+        // Communication setup
+        char getCommandTerminator() const override
+        {
+            return '#';
+        }
+        void setupCommunication(int portFD) override
+        {
+            this->portFD = portFD;
+        }
+};
+
+/**
  * @brief Simulation adapter for testing and development
  *
  * This adapter simulates device behavior without requiring actual hardware.
@@ -611,3 +712,4 @@ class GeminiFlatpanelSimulationAdapter : public GeminiFlatpanelAdapter
         int simulatedRevision;
         int simulatedFirmwareVersion;
 };
+


### PR DESCRIPTION
Support Gemini dust-cap Pro variant. This is a fairly new release and is likely to be what you will get now from Ali-Express.                                                                                                       
                                                                                                                                                                            
- Port Gemini Pro commands
- Scope behavior to preserve existing non-Pro panel behavior while improving Pro motion flow.                                                                               
- Return IPS_OK for Pro abort handling to avoid false dust-cap error escalation in clients after successful motion.                                                         
- Verified by rebuilding indi_gemini_flatpanel and runtime tests with Kstars/Ekos: handshake is successful, park/unpark and light on/off now operate fine.  