### PR TITLE
V4L2: Apply software binning after frame stacking

### DIFF
--- a/drivers/video/v4l2driver.cpp
+++ b/drivers/video/v4l2driver.cpp
@@ -1726,6 +1726,8 @@ void V4L2_Driver::newFrame()
                         guard.unlock();
                     }
                 }
+
+                PrimaryCCD.binFrame();
             }
             PrimaryCCD.setImageExtension("fits");
         }


### PR DESCRIPTION
Fixes horizontal striping artifacts when both software binning and frame stacking (Mean/Additive/Take Dark) are enabled simultaneously in the V4L2 driver.

## Problem

The non-stacked mono capture path correctly calls `PrimaryCCD.binFrame()` after writing frame data to the CCD buffer, applying the requested software binning. However, the stacked path writes the full-resolution accumulated frame directly to the buffer without calling `binFrame()`. This causes a stride mismatch — the buffer contains full-resolution data but the frame metadata expects binned dimensions — resulting in horizontal striping artifacts.

## Fix

Add `PrimaryCCD.binFrame()` after the stacked frame is written to the output buffer, matching the behavior of the non-stacked path. This applies to all stacking modes (STACK_MEAN, STACK_ADDITIVE, STACK_TAKE_DARK).

## Reported by

User on stellarmate discord forum using IMX415 sensor (3840x2160 native, 1920x1080 with 2x2 binning) with indi_v4l2_ccd v1.2. Binning and stacking work correctly individually but produce striped images when combined.