### PR TITLE
driverio: Fix multi-device BLOB interleave crash in unix IO path

### DIFF
--- a/libs/indibase/indidriverio.c
+++ b/libs/indibase/indidriverio.c
@@ -327,10 +327,11 @@ static void driverio_init_unix(driverio * dio)
     dio->user = (void*)dio;
     dio->joins = NULL;
     dio->joinSizes = NULL;
-    dio->locked = 0;
     dio->joinCount = 0;
     dio->outBuff = NULL;
     dio->outPos = 0;
+    pthread_mutex_lock(&stdout_mutex);
+    dio->locked = 1;
 }
 
 static void driverio_finish_unix(driverio * dio)


### PR DESCRIPTION
## Problem

When multiple device threads in a HotPlug multi-device driver simultaneously write BLOB data, the INDI XML protocol stream between the driver and indiserver can get corrupted. This causes XML parse errors followed by a segfault in libindidriver.so, crashing both the driver and KStars.

## Root Cause

In the unix IO path (`driverio_init_unix()`), the `stdout_mutex` was only acquired lazily inside `driverio_flush()`, not at initialization. When the output buffer exceeds `OUTPUTBUFF_FLUSH_THRESOLD` (64KB), an intermediate flush sends a partial XML message. Between this flush and the final flush at `driverio_finish()`, another thread's message can be sent, interleaving the XML stream.

The stdout path (`driverio_init_stdout()`) already locks the mutex upfront — this fix brings the unix path in line with that behavior.

## Failing scenario

- 3 SVBONY cameras (`SV605CC` + `SV605MC` + `SV305C`) in one `indi_svbony_ccd` process (HotPlug multi-device)
- Guide camera (SV305C) in streaming mode, two imaging cameras capturing at 0.5s
- Crashes after 6–60 minutes
- Reproduced on both x86_64 (Ubuntu 25.04) and aarch64 (RPi 5 / StellarMate)
- could be not vendor /  SVBONY SDK-specific — any multi-device HotPlug driver could be affected in a similar setup

## Symptoms Before Crash

```
indi_svbony_ccd XML error: Line 2: Bogus tag char <
indi_svbony_ccd XML error: Line 2: Bogus tag char /
indi_svbony_ccd dispatch error: oneNumber requires 'device' attribute (×11)
```

Followed by segfault in `libindidriver.so` (thread 79, the streaming worker).

## Fix

Acquire `stdout_mutex` at `driverio_init_unix()` (2-line change), ensuring the entire XML generation + flush + sendmsg sequence is atomic per message. The existing `driverio_flush()` already checks `dio->locked` before attempting to lock, so there's no double-lock risk.

## Testing

pending feedback from Discord channel user