### PR TITLE
wake_on_lan, lx200_10micron: replace raw socket WoL with wakeonlan

### DIFF
--- a/drivers/auxiliary/wake_on_lan.cpp
+++ b/drivers/auxiliary/wake_on_lan.cpp
@@ -24,12 +24,8 @@
 
 #include "wake_on_lan.h"
 
-#include <arpa/inet.h>
 #include <cstring>
-#include <netinet/in.h>
 #include <string>
-#include <sys/socket.h>
-#include <unistd.h>
 
 // We declare an auto pointer to WakeOnLAN.
 std::unique_ptr<WakeOnLAN> wakeonlan(new WakeOnLAN());
@@ -308,146 +304,35 @@ bool WakeOnLAN::ISNewSwitch(const char *dev, const char *name, ISState *states, 
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        if (Send1SP.isNameMatch(name))
+        auto handleSend = [&](INDI::PropertyText &devTP, INDI::PropertySwitch &sendSP, int num) -> bool
         {
-            if (Device1TP[0].getText() == nullptr || strlen(Device1TP[0].getText()) == 0)
+            if (!sendSP.isNameMatch(name))
+                return false;
+            if (devTP[0].getText() == nullptr || strlen(devTP[0].getText()) == 0)
             {
-                LOG_ERROR("MAC address 1 not configured.");
-                Send1SP.setState(IPS_ALERT);
-                Send1SP.apply();
-                return true;
+                LOGF_ERROR("MAC address %d not configured.", num);
+                sendSP.setState(IPS_ALERT);
             }
-
-            if (sendWakeOnLan(Device1TP[0].getText()))
+            else if (sendWakeOnLan(devTP[0].getText()))
             {
-                LOGF_INFO("Wake On Lan packet sent to %s (%s)", Device1TP[1].getText(), Device1TP[0].getText());
-                // Start pinging if an IP is configured; button turns green when device responds
-                const char *ip1 = Device1TP[2].getText();
-                if (ip1 && strlen(ip1) > 0)
-                {
-                    Send1SP.setState(IPS_BUSY);
-                    Send1SP.apply();
-                }
-                else
-                {
-                    Send1SP.setState(IPS_OK);
-                    Send1SP.apply();
-                }
+                LOGF_INFO("Wake On Lan packet sent to %s (%s)", devTP[1].getText(), devTP[0].getText());
+                const char *ip = devTP[2].getText();
+                sendSP.setState((ip && strlen(ip) > 0) ? IPS_BUSY : IPS_OK);
             }
             else
             {
-                LOGF_ERROR("Failed to send Wake On Lan packet for %s (%s)", Device1TP[1].getText(), Device1TP[0].getText());
-                Send1SP.setState(IPS_ALERT);
-                Send1SP.apply();
+                LOGF_ERROR("Failed to send Wake On Lan packet for %s (%s)", devTP[1].getText(), devTP[0].getText());
+                sendSP.setState(IPS_ALERT);
             }
-            Send1SP.reset();
+            sendSP.reset();
+            sendSP.apply();
             return true;
-        }
+        };
 
-        if (Send2SP.isNameMatch(name))
-        {
-            if (Device2TP[0].getText() == nullptr || strlen(Device2TP[0].getText()) == 0)
-            {
-                LOG_ERROR("MAC address 2 not configured.");
-                Send2SP.setState(IPS_ALERT);
-                Send2SP.apply();
-                return true;
-            }
-
-            if (sendWakeOnLan(Device2TP[0].getText()))
-            {
-                LOGF_INFO("Wake On Lan packet sent to %s (%s)", Device2TP[1].getText(), Device2TP[0].getText());
-                const char *ip2 = Device2TP[2].getText();
-                if (ip2 && strlen(ip2) > 0)
-                {
-                    Send2SP.setState(IPS_BUSY);
-                    Send2SP.apply();
-                }
-                else
-                {
-                    Send2SP.setState(IPS_OK);
-                    Send2SP.apply();
-                }
-            }
-            else
-            {
-                LOGF_ERROR("Failed to send Wake On Lan packet for %s (%s)", Device2TP[1].getText(), Device2TP[0].getText());
-                Send2SP.setState(IPS_ALERT);
-                Send2SP.apply();
-            }
-            Send2SP.reset();
-            return true;
-        }
-
-        if (Send3SP.isNameMatch(name))
-        {
-            if (Device3TP[0].getText() == nullptr || strlen(Device3TP[0].getText()) == 0)
-            {
-                LOG_ERROR("MAC address 3 not configured.");
-                Send3SP.setState(IPS_ALERT);
-                Send3SP.apply();
-                return true;
-            }
-
-            if (sendWakeOnLan(Device3TP[0].getText()))
-            {
-                LOGF_INFO("Wake On Lan packet sent to %s (%s)", Device3TP[1].getText(), Device3TP[0].getText());
-                const char *ip3 = Device3TP[2].getText();
-                if (ip3 && strlen(ip3) > 0)
-                {
-                    Send3SP.setState(IPS_BUSY);
-                    Send3SP.apply();
-                }
-                else
-                {
-                    Send3SP.setState(IPS_OK);
-                    Send3SP.apply();
-                }
-            }
-            else
-            {
-                LOGF_ERROR("Failed to send Wake On Lan packet for %s (%s)", Device3TP[1].getText(), Device3TP[0].getText());
-                Send3SP.setState(IPS_ALERT);
-                Send3SP.apply();
-            }
-            Send3SP.reset();
-            return true;
-        }
-
-        if (Send4SP.isNameMatch(name))
-        {
-            if (Device4TP[0].getText() == nullptr || strlen(Device4TP[0].getText()) == 0)
-            {
-                LOG_ERROR("MAC address 4 not configured.");
-                Send4SP.setState(IPS_ALERT);
-                Send4SP.apply();
-                return true;
-            }
-
-            if (sendWakeOnLan(Device4TP[0].getText()))
-            {
-                LOGF_INFO("Wake On Lan packet sent to %s (%s)", Device4TP[1].getText(), Device4TP[0].getText());
-                const char *ip4 = Device4TP[2].getText();
-                if (ip4 && strlen(ip4) > 0)
-                {
-                    Send4SP.setState(IPS_BUSY);
-                    Send4SP.apply();
-                }
-                else
-                {
-                    Send4SP.setState(IPS_OK);
-                    Send4SP.apply();
-                }
-            }
-            else
-            {
-                LOGF_ERROR("Failed to send Wake On Lan packet for %s (%s)", Device4TP[1].getText(), Device4TP[0].getText());
-                Send4SP.setState(IPS_ALERT);
-                Send4SP.apply();
-            }
-            Send4SP.reset();
-            return true;
-        }
+        if (handleSend(Device1TP, Send1SP, 1)) return true;
+        if (handleSend(Device2TP, Send2SP, 2)) return true;
+        if (handleSend(Device3TP, Send3SP, 3)) return true;
+        if (handleSend(Device4TP, Send4SP, 4)) return true;
     }
 
     return INDI::DefaultDevice::ISNewSwitch(dev, name, states, names, n);
@@ -474,70 +359,18 @@ bool WakeOnLAN::sendWakeOnLan(const char *macAddress)
         return false;
     }
 
-    // Parse MAC address: "AA:BB:CC:DD:EE:FF" or "AABBCCDDEEFF"
-    unsigned char mac[6];
-    int macElements = sscanf(macAddress, "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
-                             &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
-
-    // Try without colons if first attempt failed
-    if (macElements != 6)
+    std::string cmd = "wakeonlan " + std::string(macAddress);
+    int ret = system(cmd.c_str());
+    if (ret == 0)
     {
-        macElements = sscanf(macAddress, "%2hhx%2hhx%2hhx%2hhx%2hhx%2hhx",
-                             &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]);
+        LOGF_INFO("Wake on LAN packet sent to %s", macAddress);
+        return true;
     }
-
-    if (macElements != 6)
+    if (ret == 127)
     {
-        LOGF_ERROR("Invalid MAC address format: %s (use AA:BB:CC:DD:EE:FF or AABBCCDDEEFF)", macAddress);
+        LOG_ERROR("WoL: wakeonlan tool not found. Please install it on your system.");
         return false;
     }
-
-    // Create magic packet: 6 bytes of 0xFF + 16 repetitions of the MAC address
-    unsigned char packet[102];
-
-    // Fill with 0xFF
-    for (int i = 0; i < 6; i++)
-        packet[i] = 0xFF;
-
-    // Fill with MAC address repeated 16 times
-    for (int i = 0; i < 16; i++)
-        for (int j = 0; j < 6; j++)
-            packet[6 + i * 6 + j] = mac[j];
-
-    // Create UDP socket for broadcast
-    int sock = socket(AF_INET, SOCK_DGRAM, 0);
-    if (sock < 0)
-    {
-        LOGF_ERROR("Failed to create socket: %s", strerror(errno));
-        return false;
-    }
-
-    // Enable broadcast option
-    int broadcast = 1;
-    if (setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast)) < 0)
-    {
-        LOGF_ERROR("Failed to set broadcast option: %s", strerror(errno));
-        close(sock);
-        return false;
-    }
-
-    // Set destination address to broadcast
-    struct sockaddr_in addr;
-    memset(&addr, 0, sizeof(addr));
-    addr.sin_family = AF_INET;
-    addr.sin_addr.s_addr = inet_addr("255.255.255.255");
-    addr.sin_port = htons(9);  // WoL standard port
-
-    // Send magic packet
-    ssize_t sent = sendto(sock, packet, sizeof(packet), 0, (struct sockaddr *)&addr, sizeof(addr));
-    close(sock);
-
-    if (sent != sizeof(packet))
-    {
-        LOGF_ERROR("Failed to send WoL packet: %s", strerror(errno));
-        return false;
-    }
-
-    LOGF_INFO("Wake on LAN packet sent to %s", macAddress);
-    return true;
+    LOG_ERROR("WoL: wakeonlan failed to send the packet.");
+    return false;
 }

--- a/drivers/telescope/lx200_10micron.cpp
+++ b/drivers/telescope/lx200_10micron.cpp
@@ -31,13 +31,10 @@
 #include "indicom.h"
 #include "lx200driver.h"
 
-#include <cerrno>
 #include <cstring>
-#include <netinet/in.h>
+#include <string>
 #include <strings.h>
-#include <sys/socket.h>
 #include <termios.h>
-#include <unistd.h>
 #include <math.h>
 #include <libnova/libnova.h>
 
@@ -1512,56 +1509,18 @@ bool LX200_10MICRON::sendWakeOnLanPacket()
         return false;
     }
 
-    // Parse MAC — supports both XX:XX:XX:XX:XX:XX and XX-XX-XX-XX-XX-XX
-    unsigned char mac[6];
-    if (sscanf(macStr, "%hhx%*c%hhx%*c%hhx%*c%hhx%*c%hhx%*c%hhx",
-               &mac[0], &mac[1], &mac[2], &mac[3], &mac[4], &mac[5]) != 6)
+    std::string cmd = "wakeonlan " + std::string(macStr);
+    int ret = system(cmd.c_str());
+    if (ret == 0)
     {
-        LOGF_ERROR("WoL: Invalid MAC address '%s'. Expected XX:XX:XX:XX:XX:XX.", macStr);
+        LOGF_INFO("WoL: magic packet sent to %s", macStr);
+        return true;
+    }
+    if (ret == 127)
+    {
+        LOG_ERROR("WoL: wakeonlan tool not found. Please install it on your system.");
         return false;
     }
-
-    // Build 102-byte magic packet: 6×0xFF followed by 16 repetitions of the MAC
-    unsigned char packet[102];
-    memset(packet, 0xFF, 6);
-    for (int i = 0; i < 16; i++)
-        memcpy(packet + 6 + i * 6, mac, 6);
-
-    int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (sock < 0)
-    {
-        LOGF_ERROR("WoL: socket() failed: %s", strerror(errno));
-        return false;
-    }
-
-    int bcast = 1;
-    if (setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &bcast, sizeof(bcast)) < 0)
-    {
-        LOGF_ERROR("WoL: setsockopt SO_BROADCAST failed: %s", strerror(errno));
-        close(sock);
-        return false;
-    }
-
-    bool success = false;
-
-    // 1. Global broadcast 255.255.255.255:9
-    {
-        struct sockaddr_in addr {};
-        addr.sin_family      = AF_INET;
-        addr.sin_port        = htons(9);
-        addr.sin_addr.s_addr = INADDR_BROADCAST;
-        if (sendto(sock, packet, sizeof(packet), 0,
-                   reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) >= 0)
-        {
-            LOGF_INFO("WoL: magic packet sent to 255.255.255.255:9 (MAC: %s)", WoLMacT[0].text);
-            success = true;
-        }
-        else
-        {
-            LOGF_WARN("WoL: global broadcast failed: %s", strerror(errno));
-        }
-    }
-
-    close(sock);
-    return success;
+    LOG_ERROR("WoL: wakeonlan failed to send the packet.");
+    return false;
 }


### PR DESCRIPTION
The raw UDP broadcast implementation (port 9, 255.255.255.255) did not reliably wake target hosts. Replace with system("wakeonlan <mac>") which delegates to the wakeonlan tool and works correctly.

If wakeonlan is not installed (exit code 127), a clear error is logged asking the user to install it. The tool is available on Linux distributions and macOS (via Homebrew).

wake_on_lan: also refactors ISNewSwitch() with a handleSend lambda to eliminate code duplication across the 4 device slots, and removes the now-unused socket headers.

lx200_10micron: removes now-unused socket headers (<sys/socket.h>, <netinet/in.h>, <cerrno>, <unistd.h>) which were introduced solely for the socket-based WoL implementation.