### PR TITLE
lx200_10micron: add shutdown command, guard behind parked state

### DIFF
--- a/drivers/telescope/lx200_10micron.cpp
+++ b/drivers/telescope/lx200_10micron.cpp
@@ -61,6 +61,7 @@
 #define UNATTENDED_FLIP "UNATTENDED_FLIP"
 #define WAKE_ON_LAN_MAC  "WAKE_ON_LAN_MAC"
 #define WAKE_ON_LAN_SEND "WAKE_ON_LAN_SEND"
+#define MOUNT_SHUTDOWN "MOUNT_SHUTDOWN"
 
 LX200_10MICRON::LX200_10MICRON() : LX200Generic()
 {
@@ -197,6 +198,9 @@ bool LX200_10MICRON::initProperties()
 
         IUFillSwitch(&WoLSendS[0], "SEND", "Wake Mount", ISS_OFF);
         IUFillSwitchVector(&WoLSendSP, WoLSendS, 1, getDeviceName(), WAKE_ON_LAN_SEND, "Wake on LAN", CONNECTION_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
+
+        MountShutdownSP[0].fill("SHUTDOWN", "Shutdown Mount", ISS_OFF);
+        MountShutdownSP.fill(getDeviceName(), MOUNT_SHUTDOWN, "Shutdown", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
     }
     return result;
 }
@@ -220,6 +224,11 @@ bool LX200_10MICRON::saveConfigItems(FILE *fp)
 // Called by INDI::Telescope when connected state changes to add/remove properties
 bool LX200_10MICRON::updateProperties()
 {
+    // Define MountShutdownSP before the parent call so it appears immediately on connect,
+    // not after the slow getBasicData() mount queries inside LX200Generic::updateProperties().
+    if (isConnected())
+        defineProperty(MountShutdownSP);
+
     bool result = LX200Generic::updateProperties();
 
     if (isConnected())
@@ -266,6 +275,7 @@ bool LX200_10MICRON::updateProperties()
     }
     else
     {
+        deleteProperty(MountShutdownSP);
         deleteProperty(UnattendedFlipSP.name);
         deleteProperty(ProductTP.name);
         deleteProperty(RefractionModelTemperatureNP.name);
@@ -1335,6 +1345,32 @@ bool LX200_10MICRON::ISNewSwitch(const char *dev, const char *name, ISState *sta
             IDSetSwitch(&WoLSendSP, nullptr);
             return true;
         }
+        if (MountShutdownSP.isNameMatch(name))
+        {
+            MountShutdownSP.reset();
+            if (!isParked())
+            {
+                MountShutdownSP.setState(IPS_ALERT);
+                LOG_WARN("Mount must be parked before shutdown.");
+                MountShutdownSP.apply();
+                return false;
+            }
+            // :shutdown# — returns '1' on success, '0' on failure; ~20 s until power-off
+            if (0 != setStandardProcedureAndExpectChar(fd, ":shutdown#", "1"))
+            {
+                MountShutdownSP.setState(IPS_ALERT);
+                LOG_ERROR("Mount shutdown command failed.");
+                MountShutdownSP.apply();
+                return false;
+            }
+            MountShutdownSP.setState(IPS_OK);
+            LOG_INFO("Mount shutdown initiated. Disconnecting before mount powers off.");
+            MountShutdownSP.apply();
+            // Defer disconnect so ISNewSwitch returns cleanly before we tear down the property list
+            m_ShutdownPending = true;
+            SetTimer(100);
+            return true;
+        }
     }
 
     return LX200Generic::ISNewSwitch(dev, name, states, names, n);
@@ -1498,6 +1534,20 @@ int LX200_10MICRON::setStandardProcedureAndReturnResponse(int fd, const char *da
     }
 
     return 0;
+}
+
+void LX200_10MICRON::TimerHit()
+{
+    if (m_ShutdownPending)
+    {
+        m_ShutdownPending = false;
+        // Standard INDI disconnect sequence — same as clicking Disconnect in the UI
+        Disconnect();
+        setConnected(false, IPS_IDLE);
+        updateProperties();
+        return; // do not reschedule polling
+    }
+    LX200Generic::TimerHit();
 }
 
 bool LX200_10MICRON::sendWakeOnLanPacket()

--- a/drivers/telescope/lx200_10micron.h
+++ b/drivers/telescope/lx200_10micron.h
@@ -183,11 +183,16 @@ class LX200_10MICRON : public LX200Generic
         ISwitch WoLSendS[1];
         ISwitchVectorProperty WoLSendSP;
 
+        // Shutdown
+        INDI::PropertySwitch MountShutdownSP {1};
+
     private:
         int fd = -1; // short notation for PortFD/sockfd
         bool getMountInfo();
         bool flip();
         bool sendWakeOnLanPacket();
+        bool m_ShutdownPending { false };
+        void TimerHit() override;
 
         int OldGstat = GSTAT_UNSET;
         struct _Ginfo


### PR DESCRIPTION
Adds a Shutdown button to the Main Control tab that allows the user to power off the mount from the INDI client. 
Needed for remote controlled mounts.
  
**Park safety check**
  
The shutdown action is gated on the mount being fully parked: If the button is pressed while the mount is not parked, the property state is set to IPS_ALERT and a warning is logged . no command is sent to the hardware.
This prevents accidental power-off during active tracking, slewing, or guiding.
  
**Command**
  
 The implementation uses the standard LX200 :shutdown# command (returns 1 on success, 0 on failure) via the existing setStandardProcedureAndExpectChar helper, with no mount-specific protocol extensions.
  
**Disconnect on shutdown**
  
 After a successful :shutdown#, the driver initiates a clean INDI disconnect sequence rather than leaving the connection open.  The disconnect is deferred to TimerHit() 
Alternatively, the user should manually disconnect after mount triggering errors. 
I preferred the automatic disconnect option.

**Shutdown task**

 indi_setprop "10micron Mount.MOUNT_SHUTDOWN.SHUTDOWN=On"
can be call by Scheduler shutdown scripts