### PR TITLE
Add Wave 100i to SkyWatcher Alt-Az driver

### DIFF
--- a/drivers/telescope/skywatcherAPI.cpp
+++ b/drivers/telescope/skywatcherAPI.cpp
@@ -94,6 +94,8 @@ const char *SkywatcherAPI::mountTypeToString(uint8_t type)
             return "EQ5 Pro";
         case WAVE_150I:
             return "Wave 150i";
+        case WAVE_100I:
+            return "Wave 100i";
         case GT:
             return "GT";
         case MF:
@@ -508,7 +510,7 @@ bool SkywatcherAPI::InitMount()
 
     // Disable EQ mounts
     // 0x22 is code for AZEQ6 which is added as an exception as proposed by Dirk Tetzlaff
-    if (MountCode < 0x80 && MountCode != AZEQ6 && MountCode != AZEQ5 && MountCode != AZEQ6_PRO && MountCode != WAVE_150I)
+    if (MountCode < 0x80 && MountCode != AZEQ6 && MountCode != AZEQ5 && MountCode != AZEQ6_PRO && MountCode != WAVE_150I && MountCode != WAVE_100I)
     {
         MYDEBUGF(DBG_SCOPE, "Mount type not supported. %d", MountCode);
         return false;

--- a/drivers/telescope/skywatcherAPI.h
+++ b/drivers/telescope/skywatcherAPI.h
@@ -350,6 +350,7 @@ class SkywatcherAPI
             EQ6_PRO          = 0x23,
             EQ5_PRO          = 0x31,
             WAVE_150I        = 0x45,
+            WAVE_100I        = 0x44,
             GT               = 0x80,
             MF               = 0x81,
             _114GT           = 0x82,


### PR DESCRIPTION
## Summary
Adds Sky-Watcher Wave 100i support to indi_skywatcherAltAzMount. The Wave
100i reports mount code 0x44 (68), which is in the sub-0x80 "EQ" range that
InitMount() rejects unless whitelisted, so the Alt-Az driver currently fails
with "Mount type not supported" while EQMod (no whitelist) connects.

Mirrors the Wave 150i fix in 625f5fa (#2243); the 100i just reports a
different code (0x44 vs the 150i's 0x45).

## Changes
- skywatcherAPI.h: add WAVE_100I = 0x44 to the MountType enum
- skywatcherAPI.cpp: add WAVE_100I to the InitMount() whitelist
- skywatcherAPI.cpp: add WAVE_100I case to mountTypeToString()

## Testing
Confirmed on my Wave 100i hardware. Motor board version query (:e1)
returns =033A44 -> mount code 0x44. With the patch the driver logs
"Mount Code: 68 (Wave 100i)" and connects and tracks in Alt-Az.
