### PR TITLE
indidrivermain: Fix concurrent stdin read crash in multi-device BLOB ping wait

### DIFF
--- a/libs/indibase/indidrivermain.c
+++ b/libs/indibase/indidrivermain.c
@@ -254,29 +254,35 @@ static void waitPingReplyFromEventLoopThread(const char * uid) {
 }
 
 static void waitPingReplyFromOtherThread(const char * uid) {
-    int fd = 0;
-    fd_set rfd;
+    struct timespec startTime, currentTime;
+    const int maxWaitSeconds = 5;
+
+    clock_gettime(CLOCK_MONOTONIC, &startTime);
 
     messageHandling = PROCEED_DEFERRED;
     pthread_mutex_lock(&pingReplyMutex);
     while(!consumePingReply(uid))
     {
-
-        pthread_mutex_unlock(&pingReplyMutex);
-
-        FD_ZERO(&rfd);
-        FD_SET(fd, &rfd);
-
-        int ns = select(fd + 1, &rfd, NULL, NULL, NULL);
-        if (ns < 0)
+        // Check total elapsed time — break if we've been waiting too long.
+        // Do NOT call clientMsgCB here — reading from fd 0 in a worker thread
+        // races with the event loop thread also reading from the same fd,
+        // causing split reads and XML parse corruption.
+        clock_gettime(CLOCK_MONOTONIC, &currentTime);
+        double elapsed = (currentTime.tv_sec - startTime.tv_sec)
+                         + (currentTime.tv_nsec - startTime.tv_nsec) / 1e9;
+        if (elapsed >= maxWaitSeconds)
         {
-            perror("select");
-            exit(1);
+            fprintf(stderr, "waitPingReply: timeout (%.1fs) waiting for ack of %s, proceeding\n", elapsed, uid);
+            pthread_mutex_unlock(&pingReplyMutex);
+            messageHandling = PROCEED_IMMEDIATE;
+            return;
         }
 
-        clientMsgCB(0, NULL);
-
-        pthread_mutex_lock(&pingReplyMutex);
+        // Wait on condvar with timeout instead of reading from fd
+        struct timespec absTimeout;
+        clock_gettime(CLOCK_REALTIME, &absTimeout);
+        absTimeout.tv_sec += 1;
+        pthread_cond_timedwait(&pingReplyCond, &pingReplyMutex, &absTimeout);
     }
     pthread_mutex_unlock(&pingReplyMutex);
     messageHandling = PROCEED_IMMEDIATE;


### PR DESCRIPTION
## Problem

When multiple devices in a HotPlug driver process (e.g., 3 SVBONY cameras) send BLOBs concurrently from worker threads, `waitPingReplyFromOtherThread()` calls `clientMsgCB(0, NULL)` which does `read(fd=0)` from stdin. The event loop thread also reads from the same fd via its normal callback. Two threads doing `read()` on the same fd simultaneously splits incoming XML messages mid-byte between readers, corrupting the parse state and causing a segfault.

**Reproducer:** 3 SVBONY cameras (SV605CC + SV605MC + SV305C) in one `indi_svbony_ccd` process, guide camera streaming at 10 FPS, two imaging cameras capturing 0.5s frames. Crashes after 30-50 minutes with:
```
indi_svbony_ccd XML error: Line 12: No value for attribute newNumberVector
indi_svbony_ccd XML error: Line 2: Bogus tag char /
process killed with signal 11 - Segmentation fault
```

## Root Cause

`waitPingReplyFromOtherThread()` (called from detached `ExposureComplete` worker threads) reads from fd 0 to process incoming messages while waiting for a ping ACK. This races with the event loop thread which also reads from fd 0 — splitting incoming bytes between two readers and corrupting the XML input stream.

The bug was latent since the BLOB ping flow-control was introduced, but only triggerable when:
1. Multiple devices share one process (HotPlug)
2. BLOBs are sent from worker threads (`ExposureComplete` uses `std::thread().detach()`)
3. High enough throughput that `lastBlobPingUid > 0` when a second device enters `IDSetBLOBVA`

## Fix

Replace the `select()` + `clientMsgCB()` loop with `pthread_cond_timedwait()` on `pingReplyCond` — the same condvar that `handlePingReply()` already broadcasts when the event loop thread receives a ping ACK. Worker threads now passively wait for the signal instead of reading from stdin themselves.

A 5-second overall timeout prevents indefinite starvation when a streaming device monopolizes the ping counter (the streaming camera sends BLOBs at high frequency, incrementing the global counter faster than ACKs arrive).

## Impact

- **Single-camera users**: No change — they use `waitPingReplyFromEventLoopThread()` (the condvar path), not this function.
- **Multi-camera users**: Crash eliminated. Worst case on timeout: one BLOB sent slightly out of flow-control order (marginally more server buffer pressure, not corruption).

## Testing

Tested by user jctk with 3 SVBONY cameras (SV605CC + SV605MC + SV305C) in one HotPlug process:
- Before fix: crash after 30-50 minutes
- After fix: stable continuous operation confirmed