### PR TITLE
Myfocuserpro2 - Support for devices without Temperature Probes

### DIFF
--- a/drivers/focuser/myfocuserpro2.cpp
+++ b/drivers/focuser/myfocuserpro2.cpp
@@ -502,6 +502,30 @@ bool MyFocuserPro2::readPosition()
     return true;
 }
 
+bool MyFocuserPro2::readTempProbeAvailability()
+{
+    char res[ML_RES] = {0};
+
+    if (sendCommand(":83#", res) == false)
+    {
+        return false;
+    }
+
+    int32_t val;
+    int rc = sscanf(res, "c%d#", &val);
+
+    if (rc > 0)
+    {
+        return val==0 ? false : true;
+    }
+    else
+    {
+        LOGF_ERROR("Unknown error: Temp Probe Availability value (%s). We assume available.", res);
+    }
+
+    return true;
+}
+
 bool MyFocuserPro2::readTemperatureCoefficient()
 {
     char res[ML_RES] = {0};

--- a/drivers/focuser/myfocuserpro2.cpp
+++ b/drivers/focuser/myfocuserpro2.cpp
@@ -423,6 +423,9 @@ bool MyFocuserPro2::readTemperature()
 {
     char res[ML_RES] = {0};
 
+    if(!readTempProbeAvailability())
+        return false;
+
     if (sendCommand(":06#", res) == false)
         return false;
 

--- a/drivers/focuser/myfocuserpro2.h
+++ b/drivers/focuser/myfocuserpro2.h
@@ -132,6 +132,9 @@ class MyFocuserPro2 : public INDI::Focuser
         // Read and update Step Mode
         bool readStepMode();
 
+        // Read Temperature Probe availability
+        bool readTempProbeAvailability();
+
         // Read and update Temperature
         bool readTemperature();
 


### PR DESCRIPTION
The current MyFocuserPro2:readTemperature() function expects a response otherwise it waits for a timeout, which is not necessary.

The MyFocuserPro2 Devices expose their temperature support through :83# -> 1: temp support 0: no temp support.

The driver should only query for a temp, if :83# returns 1. 

Without this modification the driver waits until it reaches a timeout, which is unnecessary.


