### PR TITLE
Enhance Alpaca support, fix connection in Filterwheel and CCD image issues

### DIFF
--- a/drivers.xml
+++ b/drivers.xml
@@ -748,7 +748,7 @@
     <devGroup group="Filter Wheels">
         <device label="Alpaca FilterWheel" manufacturer="Alpaca">
             <driver name="Alpaca FilterWheel">indi_alpaca_filterwheel</driver>
-            <version>1.0</version>
+            <version>1.1</version>
         </device>
         <device label="XAGYL Wheel" manufacturer="XAGYL">
             <driver name="XAGYL Wheel">indi_xagyl_wheel</driver>

--- a/drivers/ccd/indi_alpaca_ccd.cpp
+++ b/drivers/ccd/indi_alpaca_ccd.cpp
@@ -45,6 +45,9 @@ std::unique_ptr<AlpacaCCD> alpaca_ccd(new AlpacaCCD());
 AlpacaCCD::AlpacaCCD()
 {
     // Set initial CCD capabilities based on ASCOM Alpaca Camera API
+    // CCD_CAN_ABORT, CCD_HAS_COOLER and CCD_HAS_SHUTTER are refined in Connect()
+    // once the device's CanAbortExposure/CanStopExposure/CanSetCCDTemperature/
+    // HasShutter properties are known.
     SetCCDCapability(INDI::CCD::CCD_CAN_ABORT | INDI::CCD::CCD_CAN_BIN | INDI::CCD::CCD_CAN_SUBFRAME |
                      INDI::CCD::CCD_HAS_COOLER | INDI::CCD::CCD_HAS_SHUTTER);
 }
@@ -117,6 +120,12 @@ bool AlpacaCCD::initProperties()
     CoolerPowerNP[0].fill("CCD_COOLER_VALUE", "Power (%)", "%.0f", 0, 100, 1, 0);
     CoolerPowerNP.fill(getDeviceName(), "CCD_COOLER_POWER", "Cooler Power", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
+    // Fast readout mode (only defined if the device reports CanFastReadout=true)
+    FastReadoutSP[FAST_READOUT_ENABLE].fill("FAST_READOUT_ENABLE", "Enable", ISS_OFF);
+    FastReadoutSP[FAST_READOUT_DISABLE].fill("FAST_READOUT_DISABLE", "Disable", ISS_ON);
+    FastReadoutSP.fill(getDeviceName(), "CCD_FAST_READOUT", "Fast Readout", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60,
+                        IPS_IDLE);
+
     // Device Info property
     DeviceInfoTP[0].fill("DESCRIPTION", "Description", "");
     DeviceInfoTP[1].fill("DRIVER_INFO", "Driver Info", "");
@@ -129,6 +138,9 @@ bool AlpacaCCD::initProperties()
     CameraStateTP.fill(getDeviceName(), "CCD_CAMERA_STATE", "Camera State", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
     addAuxControls();
+
+    // Default server address (subclasses may override via setDefaultServerAddress()).
+    setDefaultServerAddress("alpaca.local", "32323");
 
     return true;
 }
@@ -145,7 +157,7 @@ void AlpacaCCD::ISGetProperties(const char *dev)
 
 bool AlpacaCCD::Connect()
 {
-    if (ServerAddressTP[0].getText() == nullptr || ServerAddressTP[1].getText() == nullptr)
+    if (ServerAddressTP[0].isEmpty() || ServerAddressTP[1].isEmpty())
     {
         LOG_ERROR("Server address or port is not set.");
         return false;
@@ -241,7 +253,10 @@ bool AlpacaCCD::Connect()
         m_CanPulseGuide = false;
     }
 
-    // Check can stop exposure capability
+    // Check abort/stop exposure capability
+    success = sendAlpacaGET("/canabortexposure", response);
+    m_CanAbortExposure = success && response["Value"].get<bool>();
+
     success = sendAlpacaGET("/canstopexposure", response);
     if (success)
     {
@@ -260,6 +275,45 @@ bool AlpacaCCD::Connect()
         LOG_WARN("Failed to query CanStopExposure, assuming no stop exposure support.");
         m_CanStopExposure = false;
     }
+
+    if (m_CanAbortExposure || m_CanStopExposure)
+    {
+        cap |= INDI::CCD::CCD_CAN_ABORT;
+        LOG_INFO("Camera supports aborting exposure.");
+    }
+    else
+    {
+        cap &= ~INDI::CCD::CCD_CAN_ABORT;
+        LOG_INFO("Camera does not support aborting exposure.");
+    }
+
+    // Check if camera has a mechanical shutter
+    success = sendAlpacaGET("/hasshutter", response);
+    if (success && response["Value"].get<bool>())
+    {
+        cap |= INDI::CCD::CCD_HAS_SHUTTER;
+        LOG_INFO("Camera has a mechanical shutter.");
+    }
+    else
+    {
+        cap &= ~INDI::CCD::CCD_HAS_SHUTTER;
+        LOG_INFO("Camera does not have a mechanical shutter.");
+    }
+
+    // Check if camera can report cooler power
+    success = sendAlpacaGET("/cangetcoolerpower", response);
+    m_HasCoolerPower = success && response["Value"].get<bool>();
+    LOGF_INFO("Camera supports reading cooler power: %s", m_HasCoolerPower ? "Yes" : "No");
+
+    // Check if camera supports asymmetric binning
+    success = sendAlpacaGET("/canasymmetricbin", response);
+    m_CanAsymmetricBin = success && response["Value"].get<bool>();
+    LOGF_INFO("Camera supports asymmetric binning: %s", m_CanAsymmetricBin ? "Yes" : "No");
+
+    // Check if camera supports a fast readout mode
+    success = sendAlpacaGET("/canfastreadout", response);
+    m_HasFastReadout = success && response["Value"].get<bool>();
+    LOGF_INFO("Camera supports fast readout mode: %s", m_HasFastReadout ? "Yes" : "No");
 
     // Check camera sensor type for Bayer pattern support
     success = sendAlpacaGET("/sensortype", response);
@@ -365,6 +419,30 @@ void AlpacaCCD::updateCameraCapabilities()
     // Update CCDParams
     SetCCDParams(m_CameraXSize, m_CameraYSize, PrimaryCCD.getBPP(), m_PixelSizeX, m_PixelSizeY);
 
+    // Update binning limits (HOR_BIN/VER_BIN default to a max of 4)
+    double maxBinX = 1, maxBinY = 1;
+    success = sendAlpacaGET("/maxbinx", response);
+    if (success) maxBinX = response["Value"].get<double>();
+
+    success = sendAlpacaGET("/maxbiny", response);
+    if (success) maxBinY = response["Value"].get<double>();
+
+    PrimaryCCD.setMinMaxStep("CCD_BINNING", "HOR_BIN", 1, maxBinX, 1, false);
+    PrimaryCCD.setMinMaxStep("CCD_BINNING", "VER_BIN", 1, maxBinY, 1, false);
+
+    // Update exposure limits from the device (defaults are 0.01-3600s, step 1.0)
+    double expMin = 0.01, expMax = 3600, expStep = 1.0;
+    success = sendAlpacaGET("/exposuremin", response);
+    if (success) expMin = response["Value"].get<double>();
+
+    success = sendAlpacaGET("/exposuremax", response);
+    if (success) expMax = response["Value"].get<double>();
+
+    success = sendAlpacaGET("/exposureresolution", response);
+    if (success) expStep = response["Value"].get<double>();
+
+    PrimaryCCD.setMinMaxStep("CCD_EXPOSURE", "CCD_EXPOSURE_VALUE", expMin, expMax, expStep, false);
+
     success = sendAlpacaGET("/description", response);
     if (success) m_Description = response["Value"].get<std::string>();
 
@@ -379,15 +457,67 @@ void AlpacaCCD::updateCameraCapabilities()
 
     if (m_HasGain)
     {
-        success = sendAlpacaGET("/gainmin", response);
-        if (success) m_GainMin = response["Value"].get<double>();
+        // Some cameras expose Gain as a numeric range (GainMin/GainMax), others as a list of
+        // named presets (Gains). Per the Alpaca spec, only one of the two is implemented.
+        success = sendAlpacaGET("/gains", response);
+        if (success && response.contains("Value") && response["Value"].is_array() && !response["Value"].empty())
+        {
+            m_GainIsList = true;
+            auto gains = response["Value"];
+            GainSP.resize(gains.size());
+            for (size_t i = 0; i < gains.size(); ++i)
+            {
+                std::string gainName = gains[i].get<std::string>();
+                char nameBuf[MAXINDINAME];
+                snprintf(nameBuf, sizeof(nameBuf), "GAIN_%zu", i);
+                GainSP[i].fill(nameBuf, gainName.c_str(), ISS_OFF);
+            }
+            GainSP.fill(getDeviceName(), "CCD_GAIN_PRESET", "Gain", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+        }
+        else
+        {
+            m_GainIsList = false;
 
-        success = sendAlpacaGET("/gainmax", response);
-        if (success) m_GainMax = response["Value"].get<double>();
+            success = sendAlpacaGET("/gainmin", response);
+            if (success) m_GainMin = response["Value"].get<double>();
+
+            success = sendAlpacaGET("/gainmax", response);
+            if (success) m_GainMax = response["Value"].get<double>();
+        }
+    }
+
+    if (m_HasOffset)
+    {
+        // As with Gain, Offset is either a numeric range or a list of named presets, never both.
+        success = sendAlpacaGET("/offsets", response);
+        if (success && response.contains("Value") && response["Value"].is_array() && !response["Value"].empty())
+        {
+            m_OffsetIsList = true;
+            auto offsets = response["Value"];
+            OffsetSP.resize(offsets.size());
+            for (size_t i = 0; i < offsets.size(); ++i)
+            {
+                std::string offsetName = offsets[i].get<std::string>();
+                char nameBuf[MAXINDINAME];
+                snprintf(nameBuf, sizeof(nameBuf), "OFFSET_%zu", i);
+                OffsetSP[i].fill(nameBuf, offsetName.c_str(), ISS_OFF);
+            }
+            OffsetSP.fill(getDeviceName(), "CCD_OFFSET_PRESET", "Offset", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+        }
+        else
+        {
+            m_OffsetIsList = false;
+        }
     }
 
     success = sendAlpacaGET("/maxadu", response);
     if (success) m_MaxADU = response["Value"].get<uint32_t>();
+
+    success = sendAlpacaGET("/electronsperadu", response);
+    if (success) m_ElectronsPerADU = response["Value"].get<double>();
+
+    success = sendAlpacaGET("/fullwellcapacity", response);
+    if (success) m_FullWellCapacity = response["Value"].get<double>();
 
     if (m_SensorType >= 2)
     {
@@ -478,7 +608,7 @@ bool AlpacaCCD::ISNewNumber(const char *dev, const char *name, double values[], 
             updateProperty(GainNP, values, names, n, [this, values]()
             {
                 nlohmann::json response;
-                nlohmann::json body = {{"Gain", values[0]}};
+                nlohmann::json body = {{"Gain", static_cast<int>(values[0])}};
                 return sendAlpacaPUT("/gain", body, response);
             }, true);
             return true;
@@ -488,7 +618,7 @@ bool AlpacaCCD::ISNewNumber(const char *dev, const char *name, double values[], 
             updateProperty(OffsetNP, values, names, n, [this, values]()
             {
                 nlohmann::json response;
-                nlohmann::json body = {{"Offset", values[0]}};
+                nlohmann::json body = {{"Offset", static_cast<int>(values[0])}};
                 return sendAlpacaPUT("/offset", body, response);
             }, true);
             return true;
@@ -550,6 +680,67 @@ bool AlpacaCCD::ISNewSwitch(const char *dev, const char *name, ISState *states, 
             ReadoutModeSP.apply();
             return true;
         }
+        else if (m_GainIsList && GainSP.isNameMatch(name))
+        {
+            if (GainSP.update(states, names, n) == false)
+            {
+                GainSP.setState(IPS_ALERT);
+                GainSP.apply();
+                return true;
+            }
+
+            int index = GainSP.findOnSwitchIndex();
+            nlohmann::json response;
+            nlohmann::json body = {{"Gain", index}};
+            if (index != -1 && sendAlpacaPUT("/gain", body, response))
+            {
+                GainSP.setState(IPS_OK);
+                LOGF_INFO("Gain set to %s", GainSP[index].getLabel());
+            }
+            else
+            {
+                LOG_ERROR("Failed to set gain.");
+                GainSP.setState(IPS_ALERT);
+            }
+            GainSP.apply();
+            return true;
+        }
+        else if (m_OffsetIsList && OffsetSP.isNameMatch(name))
+        {
+            if (OffsetSP.update(states, names, n) == false)
+            {
+                OffsetSP.setState(IPS_ALERT);
+                OffsetSP.apply();
+                return true;
+            }
+
+            int index = OffsetSP.findOnSwitchIndex();
+            nlohmann::json response;
+            nlohmann::json body = {{"Offset", index}};
+            if (index != -1 && sendAlpacaPUT("/offset", body, response))
+            {
+                OffsetSP.setState(IPS_OK);
+                LOGF_INFO("Offset set to %s", OffsetSP[index].getLabel());
+            }
+            else
+            {
+                LOG_ERROR("Failed to set offset.");
+                OffsetSP.setState(IPS_ALERT);
+            }
+            OffsetSP.apply();
+            return true;
+        }
+        else if (FastReadoutSP.isNameMatch(name))
+        {
+            updateProperty(FastReadoutSP, states, names, n, [this, states]()
+            {
+                bool enable = states[0] == ISS_ON;
+                nlohmann::json response;
+                nlohmann::json body = {{"FastReadout", enable}};
+                return sendAlpacaPUT("/fastreadout", body, response);
+            });
+            return true;
+        }
     }
     return INDI::CCD::ISNewSwitch(dev, name, states, names, n);
 }
@@ -579,46 +770,97 @@ bool AlpacaCCD::updateProperties()
 
         if (m_HasGain)
         {
-            // Get current gain
+            // Get current gain (a preset index if m_GainIsList, otherwise a raw value)
             success = sendAlpacaGET("/gain", response);
-            if (success)
+            if (m_GainIsList)
             {
-                defineProperty(GainNP);
-                GainNP[0].setValue(response["Value"].get<double>());
-                GainNP.setState(IPS_OK);
-                GainNP.apply();
+                defineProperty(GainSP);
+                if (success)
+                {
+                    int index = response["Value"].get<int>();
+                    if (index >= 0 && static_cast<size_t>(index) < GainSP.count())
+                    {
+                        GainSP.reset();
+                        GainSP[index].setState(ISS_ON);
+                    }
+                }
+                GainSP.setState(IPS_OK);
+                GainSP.apply();
             }
             else
             {
-                LOG_WARN("Failed to get gain.");
-            }
+                if (success)
+                {
+                    defineProperty(GainNP);
+                    GainNP[0].setValue(response["Value"].get<double>());
+                    GainNP.setState(IPS_OK);
+                    GainNP.apply();
+                }
+                else
+                {
+                    LOG_WARN("Failed to get gain.");
+                }
 
-            // Set gain min/max from cached values
-            GainNP[0].setMin(m_GainMin);
-            GainNP[0].setMax(m_GainMax);
+                // Set gain min/max from cached values
+                GainNP[0].setMin(m_GainMin);
+                GainNP[0].setMax(m_GainMax);
+            }
         }
 
         if (m_HasOffset)
         {
-            // Get current offset
+            // Get current offset (a preset index if m_OffsetIsList, otherwise a raw value)
             success = sendAlpacaGET("/offset", response);
-            if (success)
+            if (m_OffsetIsList)
             {
-                defineProperty(OffsetNP);
-                OffsetNP[0].setValue(response["Value"].get<double>());
-                OffsetNP.setState(IPS_OK);
-                OffsetNP.apply();
+                defineProperty(OffsetSP);
+                if (success)
+                {
+                    int index = response["Value"].get<int>();
+                    if (index >= 0 && static_cast<size_t>(index) < OffsetSP.count())
+                    {
+                        OffsetSP.reset();
+                        OffsetSP[index].setState(ISS_ON);
+                    }
+                }
+                OffsetSP.setState(IPS_OK);
+                OffsetSP.apply();
             }
             else
             {
-                LOG_WARN("Failed to get offset.");
+                if (success)
+                {
+                    defineProperty(OffsetNP);
+                    OffsetNP[0].setValue(response["Value"].get<double>());
+                    OffsetNP.setState(IPS_OK);
+                    OffsetNP.apply();
+                }
+                else
+                {
+                    LOG_WARN("Failed to get offset.");
+                }
             }
         }
 
         // Cooler properties
         defineProperty(CoolerSP);
         defineProperty(TemperatureNP);
-        defineProperty(CoolerPowerNP);
+        if (m_HasCoolerPower)
+            defineProperty(CoolerPowerNP);
+
+        // Fast readout mode
+        if (m_HasFastReadout)
+        {
+            success = sendAlpacaGET("/fastreadout", response);
+            if (success)
+            {
+                bool fastReadout = response["Value"].get<bool>();
+                FastReadoutSP.reset();
+                FastReadoutSP[fastReadout ? FAST_READOUT_ENABLE : FAST_READOUT_DISABLE].setState(ISS_ON);
+                FastReadoutSP.setState(IPS_OK);
+            }
+            defineProperty(FastReadoutSP);
+        }
 
         defineProperty(ReadoutModeSP);
         updateReadoutModes();
@@ -640,8 +882,11 @@ bool AlpacaCCD::updateProperties()
         deleteProperty(CoolerSP);
         deleteProperty(TemperatureNP);
         deleteProperty(GainNP);
+        deleteProperty(GainSP);
         deleteProperty(OffsetNP);
+        deleteProperty(OffsetSP);
         deleteProperty(CoolerPowerNP);
+        deleteProperty(FastReadoutSP);
         deleteProperty(DeviceInfoTP);
         deleteProperty(ReadoutModeSP);
         deleteProperty(CameraStateTP);
@@ -667,11 +912,11 @@ bool AlpacaCCD::saveConfigItems(FILE *fp)
     ServerAddressTP.save(fp);
     DeviceNumberNP.save(fp);
     ConnectionSettingsNP.save(fp);
-    if (m_HasGain)
+    if (m_HasGain && !m_GainIsList)
     {
         GainNP.save(fp);
     }
-    if (m_HasOffset)
+    if (m_HasOffset && !m_OffsetIsList)
     {
         OffsetNP.save(fp);
     }
@@ -699,17 +944,25 @@ bool AlpacaCCD::AbortExposure()
     // Stop the worker thread
     mWorker.quit();
 
-    // Send abort command to Alpaca camera
+    // Prefer AbortExposure (discards the image); fall back to StopExposure
+    // (reads out the image normally) if that's all the device supports.
     nlohmann::json response;
-    bool success = sendAlpacaPUT("/abortexposure", {}, response);
+    bool success = false;
+
+    if (m_CanAbortExposure)
+        success = sendAlpacaPUT("/abortexposure", {}, response);
+    else if (m_CanStopExposure)
+        success = sendAlpacaPUT("/stopexposure", {}, response);
+    else
+        LOG_WARN("Camera does not support aborting or stopping exposures.");
 
     if (success)
     {
         LOG_INFO("Exposure aborted.");
     }
-    else
+    else if (m_CanAbortExposure || m_CanStopExposure)
     {
-        LOG_ERROR("Failed to send abort command to Alpaca camera.");
+        LOG_ERROR("Failed to send abort/stop command to Alpaca camera.");
     }
 
     return true;
@@ -796,6 +1049,12 @@ bool AlpacaCCD::UpdateCCDBin(int hor, int ver)
     {
         LOG_ERROR("Not connected to Alpaca camera.");
         return false;
+    }
+
+    if (!m_CanAsymmetricBin && hor != ver)
+    {
+        LOG_WARN("Camera does not support asymmetric binning, using the horizontal value for both axes.");
+        ver = hor;
     }
 
     nlohmann::json response;
@@ -891,9 +1150,12 @@ bool AlpacaCCD::sendPulseGuide(ALPACA_GUIDE_DIRECTION direction, long duration)
 ////////////////////////////////////////////////////////////////////////////////////////////
 IPState AlpacaCCD::GuideNorth(uint32_t ms)
 {
-    if (sendPulseGuide(ALPACA_GUIDE_NORTH, ms))
-        return IPS_OK;
-    return IPS_ALERT;
+    if (!sendPulseGuide(ALPACA_GUIDE_NORTH, ms))
+        return IPS_ALERT;
+
+    m_PulseGuideAxis = AXIS_DE;
+    m_PulseGuiding = true;
+    return IPS_BUSY;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -901,9 +1163,12 @@ IPState AlpacaCCD::GuideNorth(uint32_t ms)
 ////////////////////////////////////////////////////////////////////////////////////////////
 IPState AlpacaCCD::GuideSouth(uint32_t ms)
 {
-    if (sendPulseGuide(ALPACA_GUIDE_SOUTH, ms))
-        return IPS_OK;
-    return IPS_ALERT;
+    if (!sendPulseGuide(ALPACA_GUIDE_SOUTH, ms))
+        return IPS_ALERT;
+
+    m_PulseGuideAxis = AXIS_DE;
+    m_PulseGuiding = true;
+    return IPS_BUSY;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -911,9 +1176,12 @@ IPState AlpacaCCD::GuideSouth(uint32_t ms)
 ////////////////////////////////////////////////////////////////////////////////////////////
 IPState AlpacaCCD::GuideEast(uint32_t ms)
 {
-    if (sendPulseGuide(ALPACA_GUIDE_EAST, ms))
-        return IPS_OK;
-    return IPS_ALERT;
+    if (!sendPulseGuide(ALPACA_GUIDE_EAST, ms))
+        return IPS_ALERT;
+
+    m_PulseGuideAxis = AXIS_RA;
+    m_PulseGuiding = true;
+    return IPS_BUSY;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -921,9 +1189,12 @@ IPState AlpacaCCD::GuideEast(uint32_t ms)
 ////////////////////////////////////////////////////////////////////////////////////////////
 IPState AlpacaCCD::GuideWest(uint32_t ms)
 {
-    if (sendPulseGuide(ALPACA_GUIDE_WEST, ms))
-        return IPS_OK;
-    return IPS_ALERT;
+    if (!sendPulseGuide(ALPACA_GUIDE_WEST, ms))
+        return IPS_ALERT;
+
+    m_PulseGuideAxis = AXIS_RA;
+    m_PulseGuiding = true;
+    return IPS_BUSY;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -1065,7 +1336,7 @@ bool AlpacaCCD::sendAlpacaPUT(const std::string& endpoint, const nlohmann::json&
     }
     catch (const nlohmann::json::exception& e)
     {
-        LOGF_ERROR("JSON parse error for %s: %s", e.what());
+        LOGF_ERROR("JSON parse error for %s: %s", endpoint.c_str(), e.what());
         return false;
     }
 }
@@ -1573,6 +1844,17 @@ void AlpacaCCD::updateStatus()
     // Update camera state
     if (PrimaryCCD.isExposing())
         updateCameraState();
+
+    // Poll for completion of an in-progress pulse guide command
+    if (m_PulseGuiding)
+    {
+        nlohmann::json response;
+        if (!sendAlpacaGET("/ispulseguiding", response) || !response["Value"].get<bool>())
+        {
+            m_PulseGuiding = false;
+            GuideComplete(m_PulseGuideAxis);
+        }
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -1635,6 +1917,17 @@ void AlpacaCCD::workerExposure(const std::atomic_bool &isAboutToQuit, float dura
     PrimaryCCD.setExposureLeft(0);
     LOG_INFO("Exposure time complete, waiting for image...");
 
+    if (m_HasLastExposureDuration)
+    {
+        if (sendAlpacaGET("/lastexposureduration", response))
+        {
+            double actualDuration = response["Value"].get<double>();
+            LOGF_DEBUG("Last exposure duration: %.3fs (requested %.3fs)", actualDuration, duration);
+        }
+        else
+            m_HasLastExposureDuration = false;
+    }
+
     // Poll for image ready status
     int maxWaitTime = 30; // Maximum 30 seconds to wait for image
     int waitCount = 0;
@@ -1649,6 +1942,15 @@ void AlpacaCCD::workerExposure(const std::atomic_bool &isAboutToQuit, float dura
             LOG_INFO("Image ready, downloading...");
             downloadImage();
             return;
+        }
+
+        // Report download progress every second, if the camera supports it
+        if (m_HasPercentCompleted && waitCount % 10 == 0)
+        {
+            if (sendAlpacaGET("/percentcompleted", response))
+                LOGF_DEBUG("Percent completed: %d%%", response["Value"].get<int>());
+            else
+                m_HasPercentCompleted = false;
         }
 
         usleep(100 * 1000); // Wait 100ms
@@ -1686,16 +1988,19 @@ void AlpacaCCD::updateCoolerStatus()
     }
 
     // Get CoolerPower
-    success = sendAlpacaGET("/coolerpower", response);
-    if (success)
+    if (m_HasCoolerPower)
     {
-        CoolerPowerNP[0].setValue(response["Value"].get<double>());
-        CoolerPowerNP.setState(IPS_OK);
-        CoolerPowerNP.apply();
-    }
-    else
-    {
-        LOG_WARN("Failed to get cooler power.");
+        success = sendAlpacaGET("/coolerpower", response);
+        if (success)
+        {
+            CoolerPowerNP[0].setValue(response["Value"].get<double>());
+            CoolerPowerNP.setState(IPS_OK);
+            CoolerPowerNP.apply();
+        }
+        else
+        {
+            LOG_WARN("Failed to get cooler power.");
+        }
     }
 }
 
@@ -1811,6 +2116,11 @@ bool AlpacaCCD::processImageBytesData(uint8_t* buffer, size_t buffer_size, const
         return false;
     }
 
+    // Copy source data before reallocating the frame buffer, since `buffer`
+    // points into the current PrimaryCCD frame buffer and setFrameBufferSize
+    // may realloc/free it.
+    std::vector<uint8_t> src_copy(buffer, buffer + buffer_size);
+
     // Convert ImageBytes data to INDI format (typically 16-bit)
     size_t indi_buffer_size = width * height * sizeof(uint16_t);
     PrimaryCCD.setFrameBufferSize(indi_buffer_size);
@@ -1832,14 +2142,14 @@ bool AlpacaCCD::processImageBytesData(uint8_t* buffer, size_t buffer_size, const
     {
         // 2D monochrome/Bayer image
         LOG_DEBUG("Converting 2D image data");
-        convertImageBytesToINDI2D(buffer, indi_buffer, width, height, metadata.TransmissionElementType);
+        convertImageBytesToINDI2D(src_copy.data(), indi_buffer, width, height, metadata.TransmissionElementType);
     }
     else if (metadata.Rank == 3)
     {
         // 3D color image - for now, just take the first plane or convert to grayscale
         // This is a simplified implementation; full color support would require more work
         LOGF_DEBUG("Converting 3D image data (averaging %d planes to grayscale)", planes);
-        convertImageBytesToINDI3D(buffer, indi_buffer, width, height, planes, metadata.TransmissionElementType);
+        convertImageBytesToINDI3D(src_copy.data(), indi_buffer, width, height, planes, metadata.TransmissionElementType);
     }
     else
     {
@@ -2015,11 +2325,11 @@ void AlpacaCCD::temperatureTimerTimeout()
 void AlpacaCCD::convertImageBytesToINDI2D(uint8_t* src_buffer, uint16_t* dst_buffer, uint32_t width, uint32_t height,
         int32_t transmission_type)
 {
-    // Convert ImageBytes 2D data to INDI 16-bit format
-    // ImageBytes uses row-major ordering as per ASCOM Alpaca API v10 section 8.8.1
-    // For 2D arrays: rightmost dimension (height) changes most quickly
-
-    size_t dst_index = 0;
+    // ASCOM ImageBytes stores 2D data in column-major order: the rightmost
+    // dimension (Dimension2 = height/rows) varies fastest, so each contiguous
+    // block of `height` elements is one column.
+    // FITS/INDI expects row-major order: each contiguous block of `width`
+    // elements is one row.  We transpose here: src[x*height+y] -> dst[y*width+x].
 
     switch (transmission_type)
     {
@@ -2030,8 +2340,7 @@ void AlpacaCCD::convertImageBytesToINDI2D(uint8_t* src_buffer, uint16_t* dst_buf
             {
                 for (uint32_t y = 0; y < height; y++)
                 {
-                    // Scale 8-bit to 16-bit
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(src[x * height + y]) << 8;
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(src[x * height + y]) << 8;
                 }
             }
             break;
@@ -2043,9 +2352,8 @@ void AlpacaCCD::convertImageBytesToINDI2D(uint8_t* src_buffer, uint16_t* dst_buf
             {
                 for (uint32_t y = 0; y < height; y++)
                 {
-                    // Convert signed to unsigned, handle negative values
                     int16_t val = src[x * height + y];
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(val + 32768);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(val + 32768);
                 }
             }
             break;
@@ -2057,8 +2365,7 @@ void AlpacaCCD::convertImageBytesToINDI2D(uint8_t* src_buffer, uint16_t* dst_buf
             {
                 for (uint32_t y = 0; y < height; y++)
                 {
-                    // Direct copy
-                    dst_buffer[dst_index++] = src[x * height + y];
+                    dst_buffer[y * width + x] = src[x * height + y];
                 }
             }
             break;
@@ -2070,9 +2377,8 @@ void AlpacaCCD::convertImageBytesToINDI2D(uint8_t* src_buffer, uint16_t* dst_buf
             {
                 for (uint32_t y = 0; y < height; y++)
                 {
-                    // Scale down from 32-bit to 16-bit
                     int32_t val = src[x * height + y];
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(val);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(val);
                 }
             }
             break;
@@ -2084,9 +2390,8 @@ void AlpacaCCD::convertImageBytesToINDI2D(uint8_t* src_buffer, uint16_t* dst_buf
             {
                 for (uint32_t y = 0; y < height; y++)
                 {
-                    // Scale down from 32-bit to 16-bit
                     uint32_t val = src[x * height + y];
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(val);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(val);
                 }
             }
             break;
@@ -2098,16 +2403,14 @@ void AlpacaCCD::convertImageBytesToINDI2D(uint8_t* src_buffer, uint16_t* dst_buf
             {
                 for (uint32_t y = 0; y < height; y++)
                 {
-                    // Convert float to 16-bit, assuming 0.0-1.0 range
                     float val = src[x * height + y];
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(val * 65535.0f);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(val * 65535.0f);
                 }
             }
             break;
         }
         default:
             LOGF_ERROR("Unsupported transmission type for 2D conversion: %d", transmission_type);
-            // Fill with zeros as fallback
             memset(dst_buffer, 0, width * height * sizeof(uint16_t));
             break;
     }
@@ -2117,14 +2420,8 @@ void AlpacaCCD::convertImageBytesToINDI3D(uint8_t* src_buffer, uint16_t* dst_buf
         uint32_t planes,
         int32_t transmission_type)
 {
-    // Convert ImageBytes 3D data to INDI 16-bit format
-    // ImageBytes uses row-major ordering as per ASCOM Alpaca API v10 section 8.8.1
-    // For 3D arrays: rightmost dimension (color plane) changes most quickly
-
-    // For now, we'll convert 3D color data to grayscale by averaging the planes
-    // A full color implementation would require more complex handling
-
-    size_t dst_index = 0;
+    // ASCOM ImageBytes 3D data: column-major with color plane as the fastest
+    // dimension.  Transpose to FITS row-major (grayscale average of planes).
 
     switch (transmission_type)
     {
@@ -2140,9 +2437,8 @@ void AlpacaCCD::convertImageBytesToINDI3D(uint8_t* src_buffer, uint16_t* dst_buf
                     {
                         sum += src[(x * height + y) * planes + p];
                     }
-                    // Average the planes and scale to 16-bit
                     uint16_t avg = static_cast<uint16_t>((sum / planes)) << 8;
-                    dst_buffer[dst_index++] = avg;
+                    dst_buffer[y * width + x] = avg;
                 }
             }
             break;
@@ -2159,9 +2455,8 @@ void AlpacaCCD::convertImageBytesToINDI3D(uint8_t* src_buffer, uint16_t* dst_buf
                     {
                         sum += src[(x * height + y) * planes + p];
                     }
-                    // Average and convert to unsigned
                     int16_t avg = static_cast<int16_t>(sum / planes);
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(avg + 32768);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(avg + 32768);
                 }
             }
             break;
@@ -2178,8 +2473,7 @@ void AlpacaCCD::convertImageBytesToINDI3D(uint8_t* src_buffer, uint16_t* dst_buf
                     {
                         sum += src[(x * height + y) * planes + p];
                     }
-                    // Average the planes
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(sum / planes);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(sum / planes);
                 }
             }
             break;
@@ -2196,9 +2490,8 @@ void AlpacaCCD::convertImageBytesToINDI3D(uint8_t* src_buffer, uint16_t* dst_buf
                     {
                         sum += src[(x * height + y) * planes + p];
                     }
-                    // Average and scale down
                     int32_t avg = static_cast<int32_t>(sum / planes);
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(avg >> 16);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(avg >> 16);
                 }
             }
             break;
@@ -2215,9 +2508,8 @@ void AlpacaCCD::convertImageBytesToINDI3D(uint8_t* src_buffer, uint16_t* dst_buf
                     {
                         sum += src[(x * height + y) * planes + p];
                     }
-                    // Average and scale down
                     uint32_t avg = static_cast<uint32_t>(sum / planes);
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(avg >> 16);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(avg >> 16);
                 }
             }
             break;
@@ -2234,16 +2526,14 @@ void AlpacaCCD::convertImageBytesToINDI3D(uint8_t* src_buffer, uint16_t* dst_buf
                     {
                         sum += src[(x * height + y) * planes + p];
                     }
-                    // Average and convert to 16-bit
                     float avg = sum / planes;
-                    dst_buffer[dst_index++] = static_cast<uint16_t>(avg * 65535.0f);
+                    dst_buffer[y * width + x] = static_cast<uint16_t>(avg * 65535.0f);
                 }
             }
             break;
         }
         default:
             LOGF_ERROR("Unsupported transmission type for 3D conversion: %d", transmission_type);
-            // Fill with zeros as fallback
             memset(dst_buffer, 0, width * height * sizeof(uint16_t));
             break;
     }
@@ -2290,10 +2580,38 @@ void AlpacaCCD::addFITSKeywords(INDI::CCDChip * targetChip, std::vector<INDI::FI
     // Gain and Offset (if supported by the camera and not already added by base class)
     if (m_HasGain)
     {
-        fitsKeywords.push_back({"GAIN", GainNP[0].getValue(), 3, "Camera Gain setting"});
+        if (m_GainIsList)
+        {
+            int index = GainSP.findOnSwitchIndex();
+            if (index != -1)
+                fitsKeywords.push_back({"GAIN", GainSP[index].getLabel(), "Camera Gain setting"});
+        }
+        else
+        {
+            fitsKeywords.push_back({"GAIN", GainNP[0].getValue(), 3, "Camera Gain setting"});
+        }
     }
     if (m_HasOffset)
     {
-        fitsKeywords.push_back({"OFFSET", OffsetNP[0].getValue(), 3, "Camera Offset setting"});
+        if (m_OffsetIsList)
+        {
+            int index = OffsetSP.findOnSwitchIndex();
+            if (index != -1)
+                fitsKeywords.push_back({"OFFSET", OffsetSP[index].getLabel(), "Camera Offset setting"});
+        }
+        else
+        {
+            fitsKeywords.push_back({"OFFSET", OffsetNP[0].getValue(), 3, "Camera Offset setting"});
+        }
+    }
+
+    // Electrons per ADU and full well capacity (if reported by the camera)
+    if (m_ElectronsPerADU > 0)
+    {
+        fitsKeywords.push_back({"EGAIN", m_ElectronsPerADU, 3, "Electrons per ADU"});
+    }
+    if (m_FullWellCapacity > 0)
+    {
+        fitsKeywords.push_back({"FULLWELL", m_FullWellCapacity, 3, "Full well capacity in electrons"});
     }
 }

--- a/drivers/ccd/indi_alpaca_ccd.h
+++ b/drivers/ccd/indi_alpaca_ccd.h
@@ -118,6 +118,8 @@ class AlpacaCCD : public INDI::CCD
         std::string m_Description, m_DriverInfo, m_DriverVersion, m_CameraName;
         double m_GainMin {0}, m_GainMax {0};
         uint8_t m_BayerOffsetX {0}, m_BayerOffsetY {0};
+        double m_ElectronsPerADU {0};
+        double m_FullWellCapacity {0};
 
         // Alpaca Communication
         std::unique_ptr<httplib::Client> httpClient; // Declared here
@@ -180,6 +182,18 @@ class AlpacaCCD : public INDI::CCD
         INDI::PropertyNumber OffsetNP {1}; // CCD_OFFSET
         INDI::PropertyNumber CoolerPowerNP {1}; // Cooler power percentage
 
+        // Gain/Offset as named presets (used instead of GainNP/OffsetNP when the device
+        // reports a non-empty Gains/Offsets list rather than a Min/Max numeric range)
+        INDI::PropertySwitch GainSP {0};
+        INDI::PropertySwitch OffsetSP {0};
+        bool m_GainIsList {false};
+        bool m_OffsetIsList {false};
+
+        // Fast readout mode (only defined if the device reports canfastreadout=true)
+        INDI::PropertySwitch FastReadoutSP {2};
+        enum { FAST_READOUT_ENABLE, FAST_READOUT_DISABLE };
+        bool m_HasFastReadout {false};
+
         INDI::PropertyText DeviceInfoTP {4}; // Description, DriverInfo, DriverVersion, Name
 
         INDI::PropertySwitch CoolerSP {2}; // Declared here
@@ -189,7 +203,16 @@ class AlpacaCCD : public INDI::CCD
         bool m_HasGain {false}; // Flag to track if device supports Gain
         bool m_HasOffset {false}; // Flag to track if device supports Offset
         bool m_CanPulseGuide {false}; // Flag to track if device supports pulse guiding
-        bool m_CanStopExposure {false}; // Flag to track if device supports stopping exposure
+        bool m_CanAbortExposure {false}; // Flag to track if device supports aborting (discarding) an exposure
+        bool m_CanStopExposure {false}; // Flag to track if device supports stopping (reading out) an exposure
+        bool m_CanAsymmetricBin {false}; // Flag to track if device supports different X/Y binning factors
+        bool m_HasCoolerPower {false}; // Flag to track if device can report cooler power
+        bool m_HasPercentCompleted {true};
+        bool m_HasLastExposureDuration {true};
+
+        // Pulse guiding state (tracks an in-progress /pulseguide command)
+        bool m_PulseGuiding {false};
+        INDI_EQ_AXIS m_PulseGuideAxis {AXIS_RA};
 
         // Temperature and cooler monitoring
         INDI::Timer mTimerTemperature;

--- a/drivers/filter_wheel/indi_alpaca_filterwheel.cpp
+++ b/drivers/filter_wheel/indi_alpaca_filterwheel.cpp
@@ -26,7 +26,7 @@ static std::unique_ptr<AlpacaFilterWheel> alpacaFilterWheel(new AlpacaFilterWhee
 
 AlpacaFilterWheel::AlpacaFilterWheel()
 {
-    setVersion(1, 0);
+    setVersion(1, 1);
 }
 
 const char *AlpacaFilterWheel::getDefaultName()
@@ -73,6 +73,14 @@ bool AlpacaFilterWheel::initProperties()
     addDebugControl();
 
     return true;
+}
+
+void AlpacaFilterWheel::ISGetProperties(const char *dev)
+{
+    INDI::FilterWheel::ISGetProperties(dev);
+
+    // Always define the server address so it can be configured before connecting
+    defineProperty(ServerAddressTP);
 }
 
 bool AlpacaFilterWheel::updateProperties()
@@ -185,20 +193,39 @@ bool AlpacaFilterWheel::setupFilterWheel()
     if (sendAlpacaGET("/names", response) && response.contains("Value"))
     {
         auto names = response["Value"];
-        if (names.is_array())
+        if (names.is_array() && !names.empty())
         {
-            // Resize filter name property
-            FilterNameTP.resize(names.size());
-            
-            // Set filter names
+            // Rebuild the filter name property with properly named/labeled widgets.
+            // A plain resize() leaves new widgets without a "name" attribute, which
+            // causes the receiving end to discard them as "defTextVector with no
+            // valid members".
+            FilterNameTP.resize(0);
+
             for (size_t i = 0; i < names.size(); i++)
             {
                 std::string name = names[i].get<std::string>();
-                FilterNameTP[i].setText(name.c_str());
+
+                char filterName[MAXINDINAME];
+                char filterLabel[MAXINDILABEL];
+                snprintf(filterName, MAXINDINAME, "FILTER_SLOT_NAME_%zu", i + 1);
+                snprintf(filterLabel, MAXINDILABEL, "Filter#%zu", i + 1);
+
+                INDI::WidgetText oneText;
+                oneText.fill(filterName, filterLabel, name.c_str());
+                FilterNameTP.push(std::move(oneText));
+
                 LOGF_INFO("Filter %zu: %s", i, name.c_str());
             }
 
-            FilterNameTP.apply();
+            FilterNameTP.fill(getDeviceName(), "FILTER_NAME", "Filter", FilterSlotNP.getGroupName(), IP_RW, 60, IPS_IDLE);
+            FilterNameTP.shrink_to_fit();
+
+            // Match the filter slot range to the number of filters reported
+            FilterSlotNP[0].setMax(static_cast<double>(names.size()));
+
+            if (isConnected())
+                FilterNameTP.apply();
+
             LOGF_INFO("Found %zu filters", names.size());
         }
     }
@@ -244,6 +271,7 @@ bool AlpacaFilterWheel::SelectFilter(int position)
     if (currentPos == targetPos)
     {
         LOGF_INFO("Already at position %d, no movement needed", targetPos);
+        SelectFilterDone(position);
         return true;
     }
 
@@ -270,6 +298,10 @@ bool AlpacaFilterWheel::SelectFilter(int position)
     }
 
     LOGF_INFO("Filter position set to %d", targetPos);
+
+    // Notify the client that the filter change has completed
+    SelectFilterDone(position);
+
     return true;
 }
 
@@ -290,6 +322,15 @@ int AlpacaFilterWheel::QueryFilter()
     }
 
     return -1;
+}
+
+bool AlpacaFilterWheel::saveConfigItems(FILE *fp)
+{
+    INDI::FilterWheel::saveConfigItems(fp);
+
+    ServerAddressTP.save(fp);
+
+    return true;
 }
 
 bool AlpacaFilterWheel::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)

--- a/drivers/filter_wheel/indi_alpaca_filterwheel.h
+++ b/drivers/filter_wheel/indi_alpaca_filterwheel.h
@@ -41,12 +41,15 @@ public:
 
     virtual const char *getDefaultName() override;
     virtual bool initProperties() override;
+    virtual void ISGetProperties(const char *dev) override;
     virtual bool updateProperties() override;
 
     virtual bool Connect() override;
     virtual bool Disconnect() override;
 
     virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+
+    virtual bool saveConfigItems(FILE *fp) override;
 
 protected:
     // FilterWheel interface

--- a/drivers/focuser/indi_alpaca_focuser.cpp
+++ b/drivers/focuser/indi_alpaca_focuser.cpp
@@ -64,6 +64,12 @@ bool AlpacaFocuser::initProperties()
     TemperatureNP[0].fill("TEMPERATURE", "Temperature (°C)", "%.2f", -50, 100, 0, 0);
     TemperatureNP.fill(getDeviceName(), "FOCUS_TEMPERATURE", "Temperature", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
+    // Temperature compensation switch (only defined if the device supports it)
+    TempCompSP[TEMP_COMP_ENABLE].fill("TEMP_COMP_ENABLE", "Enable", ISS_OFF);
+    TempCompSP[TEMP_COMP_DISABLE].fill("TEMP_COMP_DISABLE", "Disable", ISS_ON);
+    TempCompSP.fill(getDeviceName(), "FOCUS_TEMP_COMP", "Temp. Compensation", MAIN_CONTROL_TAB, IP_RW, ISR_1OFMANY, 60,
+                     IPS_IDLE);
+
     addDebugControl();
     setDefaultPollingPeriod(500); // Poll every 500ms
 
@@ -78,11 +84,15 @@ bool AlpacaFocuser::updateProperties()
     {
         defineProperty(DeviceInfoTP);
         defineProperty(TemperatureNP);
+
+        if (m_TempCompAvailable)
+            defineProperty(TempCompSP);
     }
     else
     {
         deleteProperty(DeviceInfoTP);
         deleteProperty(TemperatureNP);
+        deleteProperty(TempCompSP);
     }
 
     return true;
@@ -232,6 +242,21 @@ bool AlpacaFocuser::setupFocuser()
         }
     }
 
+    // Check if temperature compensation is available
+    if (sendAlpacaGET("/tempcompavailable", response) && response.contains("Value"))
+    {
+        m_TempCompAvailable = response["Value"].get<bool>();
+        LOGF_INFO("Temperature compensation available: %s", m_TempCompAvailable ? "yes" : "no");
+
+        if (m_TempCompAvailable && sendAlpacaGET("/tempcomp", response) && response.contains("Value"))
+        {
+            bool tempComp = response["Value"].get<bool>();
+            TempCompSP.reset();
+            TempCompSP[tempComp ? TEMP_COMP_ENABLE : TEMP_COMP_DISABLE].setState(ISS_ON);
+            TempCompSP.setState(IPS_OK);
+        }
+    }
+
     return true;
 }
 
@@ -312,6 +337,20 @@ void AlpacaFocuser::TimerHit()
         }
     }
 
+    // Update temperature compensation state
+    if (m_TempCompAvailable && sendAlpacaGET("/tempcomp", response) && response.contains("Value"))
+    {
+        bool tempComp = response["Value"].get<bool>();
+        int activeIndex = tempComp ? TEMP_COMP_ENABLE : TEMP_COMP_DISABLE;
+        if (TempCompSP[activeIndex].getState() != ISS_ON)
+        {
+            TempCompSP.reset();
+            TempCompSP[activeIndex].setState(ISS_ON);
+            TempCompSP.setState(IPS_OK);
+            TempCompSP.apply();
+        }
+    }
+
     // Check if moving
     if (m_Moving)
     {
@@ -380,6 +419,37 @@ int AlpacaFocuser::getPosition()
     }
 
     return -1;
+}
+
+bool AlpacaFocuser::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
+{
+    if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
+    {
+        if (TempCompSP.isNameMatch(name))
+        {
+            TempCompSP.update(states, names, n);
+
+            bool enable = TempCompSP[TEMP_COMP_ENABLE].getState() == ISS_ON;
+
+            nlohmann::json response;
+            std::string data = std::string("TempComp=") + (enable ? "true" : "false");
+
+            if (!sendAlpacaPUT("/tempcomp", data, response))
+            {
+                LOG_ERROR("Failed to set temperature compensation");
+                TempCompSP.setState(IPS_ALERT);
+                TempCompSP.apply();
+                return false;
+            }
+
+            LOGF_INFO("Temperature compensation %s", enable ? "enabled" : "disabled");
+            TempCompSP.setState(IPS_OK);
+            TempCompSP.apply();
+            return true;
+        }
+    }
+
+    return INDI::Focuser::ISNewSwitch(dev, name, states, names, n);
 }
 
 bool AlpacaFocuser::ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n)

--- a/drivers/focuser/indi_alpaca_focuser.h
+++ b/drivers/focuser/indi_alpaca_focuser.h
@@ -49,6 +49,7 @@ class AlpacaFocuser : public INDI::Focuser
         virtual bool Handshake() override;
 
         virtual bool ISNewText(const char *dev, const char *name, char *texts[], char *names[], int n) override;
+        virtual bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
 
     protected:
         // Focuser interface
@@ -63,6 +64,11 @@ class AlpacaFocuser : public INDI::Focuser
 
         // Temperature property
         INDI::PropertyNumber TemperatureNP {1};
+
+        // Temperature compensation switch (only defined if the device reports tempcompavailable=true)
+        INDI::PropertySwitch TempCompSP {2};
+        enum { TEMP_COMP_ENABLE, TEMP_COMP_DISABLE };
+        bool m_TempCompAvailable = false;
 
         // Alpaca communication
         std::unique_ptr<httplib::Client> m_AlpacaClient;

--- a/drivers/telescope/indi_alpaca_telescope.cpp
+++ b/drivers/telescope/indi_alpaca_telescope.cpp
@@ -41,7 +41,8 @@ alpacaTelescopeDriver::alpacaTelescopeDriver()
         TELESCOPE_CAN_GOTO |
         TELESCOPE_CAN_SYNC |
         TELESCOPE_CAN_ABORT |
-        TELESCOPE_CAN_PARK,
+        TELESCOPE_CAN_PARK |
+        TELESCOPE_HAS_TIME,
         4
     );
     setTelescopeConnection(CONNECTION_TCP);
@@ -103,8 +104,6 @@ bool alpacaTelescopeDriver::updateProperties()
             SetAxis1ParkDefault(-6.);
             SetAxis2ParkDefault(0.);
         }
-
-        sendTimeFromSystem();
     }
     else
     {
@@ -144,6 +143,11 @@ bool alpacaTelescopeDriver::Connect()
         httpClient.reset();
         return false;
     }
+
+    // Query device capabilities, location, time, and initial status now that the
+    // HTTP client is ready (Handshake() also defines TrackModeSP via AddTrackMode(),
+    // which must happen before updateProperties() is called)
+    Handshake();
 
     // Start the timer
     SetTimer(getCurrentPollingPeriod());
@@ -250,6 +254,18 @@ bool alpacaTelescopeDriver::Handshake()
         locationValid = false;
     }
 
+    // Site elevation is optional - default to 0 if the device doesn't report it
+    double elevation = 0.0;
+    if (sendAlpacaGET("/siteelevation", response) && response.contains("Value"))
+    {
+        elevation = response["Value"].get<double>();
+        LOGF_INFO("Site elevation from device: %.1fm", elevation);
+    }
+    else
+    {
+        LOG_WARN("Failed to get site elevation from device");
+    }
+
     // Update INDI location property if we got valid data
     if (locationValid)
     {
@@ -257,7 +273,7 @@ bool alpacaTelescopeDriver::Handshake()
         // Alpaca uses same convention
         LocationNP[LOCATION_LATITUDE].setValue(latitude);
         LocationNP[LOCATION_LONGITUDE].setValue(longitude);
-        LocationNP[LOCATION_ELEVATION].setValue(0); // Elevation not available from Alpaca
+        LocationNP[LOCATION_ELEVATION].setValue(elevation);
         LocationNP.setState(IPS_OK);
         LocationNP.apply();
 
@@ -267,6 +283,22 @@ bool alpacaTelescopeDriver::Handshake()
         m_cosLat = cos(latRad);
 
         LOGF_INFO("Site location set: Lat=%.6f° Long=%.6f°", latitude, longitude);
+    }
+
+    // Get UTC date/time from device
+    if (sendAlpacaGET("/utcdate", response) && response.contains("Value"))
+    {
+        std::string utcDate = response["Value"].get<std::string>();
+        TimeTP[UTC].setText(utcDate.c_str());
+        TimeTP[OFFSET].setText("0");
+        TimeTP.setState(IPS_OK);
+        TimeTP.apply();
+        LOGF_INFO("Device UTC date/time: %s", utcDate.c_str());
+    }
+    else
+    {
+        LOG_WARN("Failed to get UTC date/time from device, using system time");
+        sendTimeFromSystem();
     }
 
     // Query tracking capability
@@ -285,6 +317,83 @@ bool alpacaTelescopeDriver::Handshake()
     else
     {
         LOG_WARN("Failed to query tracking capability from device");
+    }
+
+    // Query whether the mount supports the non-blocking slewtotargetasync/slewtoaltazasync
+    // commands. If not, fall back to the blocking slewtotarget/slewtoaltaz commands.
+    if (sendAlpacaGET("/canslewasync", response) && response.contains("Value"))
+        m_CanSlewAsync = response["Value"].get<bool>();
+    else
+        m_CanSlewAsync = false;
+    LOGF_INFO("Telescope supports async slew: %s", m_CanSlewAsync ? "Yes" : "No");
+
+    // Query the list of supported tracking rates (Alpaca DriveRate enum: 0=Sidereal,
+    // 1=Lunar, 2=Solar, 3=King) and build the TrackModeSP property accordingly.
+    m_TrackModeAlpacaRates.clear();
+    TrackModeSP.resize(0);
+    if (sendAlpacaGET("/trackingrates", response) && response.contains("Value") && response["Value"].is_array())
+    {
+        static const struct { int rate; const char *name; const char *label; } alpacaRates[] =
+        {
+            {0, "TRACK_SIDEREAL", "Sidereal"},
+            {1, "TRACK_LUNAR", "Lunar"},
+            {2, "TRACK_SOLAR", "Solar"},
+            {3, "TRACK_KING", "King"},
+        };
+
+        for (const auto &entry : alpacaRates)
+        {
+            for (const auto &value : response["Value"])
+            {
+                if (value.get<int>() == entry.rate)
+                {
+                    AddTrackMode(entry.name, entry.label, entry.rate == 0);
+                    m_TrackModeAlpacaRates.push_back(entry.rate);
+                    break;
+                }
+            }
+        }
+    }
+
+    if (!m_TrackModeAlpacaRates.empty())
+    {
+        SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_HAS_TRACK_MODE, 4);
+        LOGF_INFO("Telescope supports %zu tracking rate(s)", m_TrackModeAlpacaRates.size());
+
+        // Sync the current tracking rate
+        if (sendAlpacaGET("/trackingrate", response) && response.contains("Value"))
+        {
+            int currentRate = response["Value"].get<int>();
+            for (size_t i = 0; i < m_TrackModeAlpacaRates.size(); i++)
+            {
+                if (m_TrackModeAlpacaRates[i] == currentRate)
+                {
+                    TrackModeSP.reset();
+                    TrackModeSP[i].setState(ISS_ON);
+                    break;
+                }
+            }
+        }
+    }
+    else
+    {
+        LOG_WARN("Failed to query supported tracking rates from device");
+    }
+
+    // Query support for custom (offset) tracking rates
+    m_CanSetRaRate = sendAlpacaGET("/cansetrightascensionrate", response) && response.contains("Value")
+                     && response["Value"].get<bool>();
+    m_CanSetDecRate = sendAlpacaGET("/cansetdeclinationrate", response) && response.contains("Value")
+                      && response["Value"].get<bool>();
+
+    if (m_CanSetRaRate && m_CanSetDecRate)
+    {
+        SetTelescopeCapability(GetTelescopeCapability() | TELESCOPE_HAS_TRACK_RATE, 4);
+        LOG_INFO("Telescope supports custom tracking rates - TELESCOPE_TRACK_RATE enabled");
+    }
+    else
+    {
+        LOG_INFO("Telescope does not support custom tracking rates");
     }
 
     // Get initial coordinates
@@ -345,6 +454,24 @@ bool alpacaTelescopeDriver::ReadScopeStatus()
     // Get tracking state
     if (sendAlpacaGET("/tracking", response) && response.contains("Value"))
         isTracking = response["Value"].get<bool>();
+
+    // Keep TrackModeSP in sync with the device's current tracking rate
+    if (HasTrackMode() && sendAlpacaGET("/trackingrate", response) && response.contains("Value"))
+    {
+        int currentRate = response["Value"].get<int>();
+        int currentIndex = TrackModeSP.findOnSwitchIndex();
+        for (size_t i = 0; i < m_TrackModeAlpacaRates.size(); i++)
+        {
+            if (m_TrackModeAlpacaRates[i] == currentRate && static_cast<int>(i) != currentIndex)
+            {
+                TrackModeSP.reset();
+                TrackModeSP[i].setState(ISS_ON);
+                TrackModeSP.setState(IPS_OK);
+                TrackModeSP.apply();
+                break;
+            }
+        }
+    }
 
     // Get park state
     if (sendAlpacaGET("/atpark", response) && response.contains("Value"))
@@ -411,16 +538,19 @@ bool alpacaTelescopeDriver::Goto(double ra, double dec)
         return false;
     }
 
-    // Step 3: Start slew to target
+    // Step 3: Start slew to target. Prefer the non-blocking /slewtotargetasync if the
+    // device supports it, since /slewtotarget blocks the HTTP request (and therefore
+    // this driver) until the slew completes.
     nlohmann::json emptyRequest;
-    if (!sendAlpacaPUT("/slewtotarget", emptyRequest, response))
+    const char *slewEndpoint = m_CanSlewAsync ? "/slewtotargetasync" : "/slewtotarget";
+    if (!sendAlpacaPUT(slewEndpoint, emptyRequest, response))
     {
         LOG_ERROR("Failed to send GoTo command");
         return false;
     }
 
     TrackState = SCOPE_SLEWING;
-    LOG_INFO("GoTo command sent - slewing to target");
+    LOGF_INFO("GoTo command sent (%s) - slewing to target", m_CanSlewAsync ? "async" : "sync");
     return true;
 }
 
@@ -571,9 +701,14 @@ bool alpacaTelescopeDriver::SetTrackEnabled(bool enabled)
 
 bool alpacaTelescopeDriver::SetTrackMode(uint8_t mode)
 {
+    if (mode >= m_TrackModeAlpacaRates.size())
+    {
+        LOG_ERROR("Invalid track mode index");
+        return false;
+    }
+
     nlohmann::json request, response;
-    // Mode: 0=Sidereal, 1=Lunar, 2=Solar
-    request["TrackingRate"] = static_cast<int>(mode);
+    request["TrackingRate"] = m_TrackModeAlpacaRates[mode];
 
     if (!sendAlpacaPUT("/trackingrate", request, response))
     {
@@ -581,7 +716,39 @@ bool alpacaTelescopeDriver::SetTrackMode(uint8_t mode)
         return false;
     }
 
-    LOG_INFO("Track mode set");
+    LOGF_INFO("Track mode set to %s", TrackModeSP[mode].getLabel());
+    return true;
+}
+
+bool alpacaTelescopeDriver::SetTrackRate(double raRate, double deRate)
+{
+    if (!m_CanSetRaRate || !m_CanSetDecRate)
+    {
+        LOG_WARN("Custom tracking rates are not supported by this telescope");
+        return false;
+    }
+
+    nlohmann::json request, response;
+
+    // Alpaca's RightAscensionRate is expressed in seconds of RA per sidereal second,
+    // while INDI's raRate is in arcseconds/second. 1 second of RA = 15 arcseconds, and
+    // the sidereal/solar second difference (~0.27%) is negligible for this offset.
+    request["RightAscensionRate"] = raRate / 15.0;
+    if (!sendAlpacaPUT("/rightascensionrate", request, response))
+    {
+        LOG_ERROR("Failed to set RA tracking rate");
+        return false;
+    }
+
+    request.clear();
+    request["DeclinationRate"] = deRate;
+    if (!sendAlpacaPUT("/declinationrate", request, response))
+    {
+        LOG_ERROR("Failed to set DEC tracking rate");
+        return false;
+    }
+
+    LOGF_INFO("Custom tracking rate set: RA=%.6f arcsec/s, DEC=%.6f arcsec/s", raRate, deRate);
     return true;
 }
 
@@ -697,6 +864,12 @@ bool alpacaTelescopeDriver::updateLocation(double latitude, double longitude, do
         return false;
     }
 
+    // Set elevation (not all Alpaca devices support this, so just warn on failure)
+    request.clear();
+    request["SiteElevation"] = elevation;
+    if (!sendAlpacaPUT("/siteelevation", request, response))
+        LOG_WARN("Failed to set site elevation on device");
+
     // Calculate and cache sin/cos for coordinate transformations
     double latRad = latitude * M_PI / 180.0;
     m_sinLat = sin(latRad);
@@ -706,6 +879,26 @@ bool alpacaTelescopeDriver::updateLocation(double latitude, double longitude, do
 
     // Call base class to update INDI properties
     return INDI::Telescope::updateLocation(latitude, longitude, elevation);
+}
+
+bool alpacaTelescopeDriver::updateTime(ln_date *utc, double utc_offset)
+{
+    INDI_UNUSED(utc_offset);
+
+    // Alpaca utcdate is always UTC, expressed as an ISO 8601 string
+    char isoDate[32];
+    snprintf(isoDate, sizeof(isoDate), "%04d-%02d-%02dT%02d:%02d:%06.3fZ",
+             utc->years, utc->months, utc->days, utc->hours, utc->minutes, utc->seconds);
+
+    nlohmann::json request, response;
+    request["UTCDate"] = isoDate;
+    if (!sendAlpacaPUT("/utcdate", request, response))
+    {
+        LOG_ERROR("Failed to set UTC date/time on device");
+        return false;
+    }
+
+    return true;
 }
 
 // Alpaca helper methods

--- a/drivers/telescope/indi_alpaca_telescope.h
+++ b/drivers/telescope/indi_alpaca_telescope.h
@@ -22,6 +22,7 @@
 
 #include <inditelescope.h>
 #include <memory>
+#include <vector>
 #include <httplib.h>
 
 #ifdef _USE_SYSTEM_JSONLIB
@@ -60,6 +61,7 @@ class alpacaTelescopeDriver : public INDI::Telescope
         // Tracking
         virtual bool SetTrackEnabled(bool enabled) override;
         virtual bool SetTrackMode(uint8_t mode) override;
+        virtual bool SetTrackRate(double raRate, double deRate) override;
 
         // Motion Control
         virtual bool MoveNS(INDI_DIR_NS dir, TelescopeMotionCommand command) override;
@@ -70,6 +72,9 @@ class alpacaTelescopeDriver : public INDI::Telescope
 
         // Site location
         virtual bool updateLocation(double latitude, double longitude, double elevation) override;
+
+        // Time
+        virtual bool updateTime(ln_date *utc, double utc_offset) override;
 
     private:
         // State tracking
@@ -84,6 +89,17 @@ class alpacaTelescopeDriver : public INDI::Telescope
         bool isSlewing{false};
         bool isTracking{false};
         double currentSlewRate{0.5};  // Current slew rate in deg/sec
+
+        // Async slew support: prefer /slewtotargetasync over the blocking /slewtotarget
+        bool m_CanSlewAsync{false};
+
+        // Track modes: maps an index in TrackModeSP to the corresponding Alpaca
+        // DriveRate value (0=Sidereal, 1=Lunar, 2=Solar, 3=King) reported by /trackingrates
+        std::vector<int> m_TrackModeAlpacaRates;
+
+        // Custom tracking rate support (TELESCOPE_HAS_TRACK_RATE)
+        bool m_CanSetRaRate{false};
+        bool m_CanSetDecRate{false};
 
         // used by GoTo and Park
         void StartSlew(double ra, double dec, TelescopeStatus status);


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Alpaca INDI drivers for filter wheel, focuser, CCD, and telescope devices. The main changes enhance device property handling, add support for new device capabilities, and improve the robustness of device configuration and state synchronization.

**Filter Wheel driver enhancements:**

* The filter wheel driver now properly rebuilds filter name properties with correct widget naming, ensuring compatibility with INDI clients. The filter slot range is also dynamically matched to the number of filters reported by the device, and configuration persistence is improved. [[1]](diffhunk://#diff-ea32d921cd3d234241227589c3d4e844ed8af05f731b0005edaf2a925ccb71afL188-R228) [[2]](diffhunk://#diff-ea32d921cd3d234241227589c3d4e844ed8af05f731b0005edaf2a925ccb71afR327-R335)
* The server address property is always defined and can be saved/loaded from configuration, improving device setup and usability. [[1]](diffhunk://#diff-ea32d921cd3d234241227589c3d4e844ed8af05f731b0005edaf2a925ccb71afR78-R85) [[2]](diffhunk://#diff-4b7c7c493bac60a8bd7a8afd4d75083ef0a51898fc004aa5b289eaf51809e73dR44-R53) [[3]](diffhunk://#diff-ea32d921cd3d234241227589c3d4e844ed8af05f731b0005edaf2a925ccb71afR327-R335)
* The driver version is updated to 1.1 in both code and XML. [[1]](diffhunk://#diff-ac5380c149d88c3704284cfad3ad8c01de8786bc182fa32dec1e4b7135c14107L751-R751) [[2]](diffhunk://#diff-ea32d921cd3d234241227589c3d4e844ed8af05f731b0005edaf2a925ccb71afL29-R29)

**Focuser driver enhancements:**

* Adds support for temperature compensation if the device reports it available, including a new switch property for enabling/disabling compensation, state synchronization, and handling user requests. [[1]](diffhunk://#diff-aa8447a2b447f6f3e2a150d1e55364a638cd6cc0f54c0976658bb3faaa73f64dR67-R72) [[2]](diffhunk://#diff-aa8447a2b447f6f3e2a150d1e55364a638cd6cc0f54c0976658bb3faaa73f64dR87-R95) [[3]](diffhunk://#diff-aa8447a2b447f6f3e2a150d1e55364a638cd6cc0f54c0976658bb3faaa73f64dR245-R259) [[4]](diffhunk://#diff-aa8447a2b447f6f3e2a150d1e55364a638cd6cc0f54c0976658bb3faaa73f64dR340-R353) [[5]](diffhunk://#diff-aa8447a2b447f6f3e2a150d1e55364a638cd6cc0f54c0976658bb3faaa73f64dR424-R454) [[6]](diffhunk://#diff-b78b07123ae3ffba61e2caffbe3ef3570457711eb5b58dce275da17125bc4f17R52) [[7]](diffhunk://#diff-b78b07123ae3ffba61e2caffbe3ef3570457711eb5b58dce275da17125bc4f17R68-R72)

**CCD driver improvements:**

* Adds new properties and flags for advanced features such as gain/offset preset lists, fast readout mode, asymmetric binning, and improved state tracking for pulse guiding and exposure control. [[1]](diffhunk://#diff-6cd72f552f7dc76c45ddae93352fae2ff6d17c2f175bc76a25b645283b10f4deR121-R122) [[2]](diffhunk://#diff-6cd72f552f7dc76c45ddae93352fae2ff6d17c2f175bc76a25b645283b10f4deR185-R196) [[3]](diffhunk://#diff-6cd72f552f7dc76c45ddae93352fae2ff6d17c2f175bc76a25b645283b10f4deL192-R215)
* Resolve image format issues

**Telescope driver improvements:**

* The telescope driver now queries and sets the site elevation and UTC date/time from the device (if available), and updates the INDI location and time properties accordingly. If the device does not provide these, system values are used as fallback. [[1]](diffhunk://#diff-6e9b10c941eb2860bf40c71c1e7bf171eb2520fe5dedc9d12eb8d9d5a6abe0f5R257-R276) [[2]](diffhunk://#diff-6e9b10c941eb2860bf40c71c1e7bf171eb2520fe5dedc9d12eb8d9d5a6abe0f5R288-R303)
* The driver now advertises `TELESCOPE_HAS_TIME` capability and ensures device handshake is performed upon connection. [[1]](diffhunk://#diff-6e9b10c941eb2860bf40c71c1e7bf171eb2520fe5dedc9d12eb8d9d5a6abe0f5L44-R45) [[2]](diffhunk://#diff-6e9b10c941eb2860bf40c71c1e7bf171eb2520fe5dedc9d12eb8d9d5a6abe0f5R147-R151)

These changes collectively improve device compatibility, user experience, and the overall robustness of the Alpaca INDI driver suite.