### PR TITLE
Make wanderer rotator much more robust

### DIFF
--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -290,7 +290,17 @@ bool WandererRotatorBase::Handshake()
     this->reader.start(PortFD);
 
     if (!send_handshake())
-        return false;
+    {
+        /* For some reason, when this is the first time attempting to
+         * communicate to the wanderer rotator after connecting the USB, it does
+         * not respond to the first query immediately after connection.  We will
+         * attempt to send the handshake one more time after having waited for
+         * the handshake response to timeout.  If this does not work, there must
+         * be a real issue.
+         */
+        if (!send_handshake())
+            return false;
+    }
 
     //Device Model//////////////////////////////////////////////////////////////
     LOGF_INFO("Connected to device %s", this->getRotatorHandshakeName());

--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -59,7 +59,6 @@ bool WandererRotatorBase::initProperties()
 
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
 
-
     return true;
 }
 
@@ -82,7 +81,6 @@ bool WandererRotatorBase::updateProperties()
 
 bool WandererRotatorBase::ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n)
 {
-
     if (dev && !strcmp(dev, getDeviceName()))
     {
         if (SetZeroSP.isNameMatch(name))
@@ -105,15 +103,13 @@ bool WandererRotatorBase::ISNewNumber(const char * dev, const char * name, doubl
         // backlash
         if (BacklashNP.isNameMatch(name))
         {
-            bool rc1 = false;
             BacklashNP.update(values, names, n);
             backlash = BacklashNP[BACKLASH].value;
 
             char cmd[16];
             snprintf(cmd, 16, "%d", (int)(backlash * 10 + 1600000));
-            rc1 = sendCommand(cmd);
 
-            BacklashNP.setState( (rc1) ? IPS_OK : IPS_ALERT);
+            BacklashNP.setState(sendCommand(cmd) ? IPS_OK : IPS_ALERT);
             if (BacklashNP.getState() == IPS_OK)
                 BacklashNP.update(values, names, n);
             BacklashNP.apply();
@@ -132,23 +128,17 @@ bool WandererRotatorBase::Handshake()
     int nbytes_read_name = 0, nbytes_written = 0, rc = -1;
     char name[64] = {0};
 
-    if ((rc = tty_write_string(PortFD, "1500001", &nbytes_written)) != TTY_OK)
+    if (!sendCommand("1500001"))
     {
-        char errorMessage[MAXRBUF];
-        tty_error_msg(rc, errorMessage, MAXRBUF);
-        LOGF_ERROR("Serial write error: %s", errorMessage);
         return false;
     }
 
-    //Device Model//////////////////////////////////////////////////////////////////////////////////////////////////////
+    //Device Model//////////////////////////////////////////////////////////////
     if ((rc = tty_read_section(PortFD, name, 'A', 3, &nbytes_read_name)) != TTY_OK)
     {
         tcflush(PortFD, TCIOFLUSH);
-        if ((rc = tty_write_string(PortFD, "1500001", &nbytes_written)) != TTY_OK)
+        if (!sendCommand("1500001"))
         {
-            char errorMessage[MAXRBUF];
-            tty_error_msg(rc, errorMessage, MAXRBUF);
-            LOGF_ERROR("Serial write error: %s", errorMessage);
             return false;
         }
         if ((rc = tty_read_section(PortFD, name, 'A', 3, &nbytes_read_name)) != TTY_OK)
@@ -177,8 +167,8 @@ bool WandererRotatorBase::Handshake()
     firmware = std::atoi(version);
     if(firmware < getMinimumCompatibleFirmwareVersion())
     {
-        LOG_ERROR("The firmware is outdated, please upgrade to the latest firmware!");
-        LOGF_ERROR("The current firmware is %s.", firmware);
+        LOG_ERROR("Firmware is outdated, please upgrade to latest firmware!");
+        LOGF_ERROR("Current firmware is %s.", firmware);
         return false;
     }
 
@@ -254,11 +244,8 @@ bool WandererRotatorBase::AbortRotator()
         haltcommand = true;
         int nbytes_written = 0, rc = -1;
         tcflush(PortFD, TCIOFLUSH);
-        if ((rc = tty_write_string(PortFD, "Stop", &nbytes_written)) != TTY_OK)
+        if (!sendCommand("Stop"))
         {
-            char errorMessage[MAXRBUF];
-            tty_error_msg(rc, errorMessage, MAXRBUF);
-            LOGF_ERROR("Serial write error: %s", errorMessage);
             return false;
         }
         SetTimer(100);
@@ -294,9 +281,8 @@ bool WandererRotatorBase::ReverseRotator(bool enabled)
     {
         char cmd[16];
         snprintf(cmd, 16, "%d", 1700001);
-        if (sendCommand(cmd) != true)
+        if (!sendCommand(cmd))
         {
-            LOG_ERROR("Serial write error.");
             return false;
         }
         ReverseState = true;
@@ -306,9 +292,8 @@ bool WandererRotatorBase::ReverseRotator(bool enabled)
     {
         char cmd[16];
         snprintf(cmd, 16, "%d", 1700000);
-        if (sendCommand(cmd) != true)
+        if (!sendCommand(cmd))
         {
-            LOG_ERROR("Serial write error.");
             return false;
         }
         ReverseState = false;
@@ -321,10 +306,8 @@ bool WandererRotatorBase::ReverseRotator(bool enabled)
 
 void WandererRotatorBase::TimerHit()
 {
-
     if (GotoRotatorNP.getState() == IPS_BUSY || haltcommand == true)
     {
-
         if(nowtime < estime && haltcommand == false)
         {
             GotoRotatorNP[0].setValue(GotoRotatorNP[0].getValue() + 1 * positionhistory / abs(positionhistory));
@@ -360,22 +343,16 @@ void WandererRotatorBase::TimerHit()
         }
     }
 
-
     SetTimer(2000);
 }
-
-
 
 bool WandererRotatorBase::Move(const char *cmd)
 {
     initangle = GotoRotatorNP[0].getValue();
     int nbytes_written = 0, rc = -1;
     LOGF_DEBUG("CMD <%s>", cmd);
-    if ((rc = tty_write_string(PortFD, cmd, &nbytes_written)) != TTY_OK)
+    if (!sendCommand(cmd))
     {
-        char errorMessage[MAXRBUF];
-        tty_error_msg(rc, errorMessage, MAXRBUF);
-        LOGF_ERROR("Serial write error: %s", errorMessage);
         return false;
     }
     SetTimer(2000);
@@ -384,13 +361,13 @@ bool WandererRotatorBase::Move(const char *cmd)
     return true;
 }
 
-
 bool WandererRotatorBase::sendCommand(std::string command)
 {
     int nbytes_written = 0, rc = -1;
     std::string command_termination = "\n";
     LOGF_DEBUG("CMD: %s", command.c_str());
-    if ((rc = tty_write_string(PortFD, (command + command_termination).c_str(), &nbytes_written)) != TTY_OK)
+    if ((rc = tty_write_string(PortFD, (command + command_termination).c_str(),
+                               &nbytes_written)) != TTY_OK)
     {
         char errorMessage[MAXRBUF];
         tty_error_msg(rc, errorMessage, MAXRBUF);
@@ -399,5 +376,3 @@ bool WandererRotatorBase::sendCommand(std::string command)
     }
     return true;
 }
-
-

--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -313,7 +313,7 @@ bool WandererRotatorBase::Handshake()
             return false;
         }
     }
-    GotoRotatorNP[0].setValue(this->reader.angle().second);
+    GotoRotatorNP[0].setValue(range360(this->reader.angle().second));
     //backlash//////////////////////////////////////////////////////////////////
     BacklashNP[0].setValue(this->reader.backlash().second);
     BacklashNP.setState(IPS_OK);
@@ -386,7 +386,7 @@ WandererRotatorBase::move(double abs_angle)
         this->state = State::MOVING;
         this->tracking.t0 = t0.value();
         this->tracking.angle_0 = current_angle;
-        this->tracking.angle_f = abs_angle;
+        this->tracking.angle_f = current_angle + delta;
     }
     return t0;
 }
@@ -446,7 +446,7 @@ void WandererRotatorBase::TimerHit()
         } else if (this->state == State::HALTED) {
             /* Query the position of the motor and update INDI. */
             send_handshake();
-            GotoRotatorNP[0].setValue(this->reader.angle().second);
+            GotoRotatorNP[0].setValue(range360(this->reader.angle().second));
             GotoRotatorNP.setState(IPS_OK);
             GotoRotatorNP.apply();
         } else if (this->state == State::MOVING) {
@@ -457,7 +457,7 @@ void WandererRotatorBase::TimerHit()
                  * that the only way this would have happened is that the motion
                  * was interrupted or stopped. */
                 this->state = State::HALTED;
-                GotoRotatorNP[0].setValue(current.second);
+                GotoRotatorNP[0].setValue(range360(current.second));
                 GotoRotatorNP.setState(IPS_OK);
                 GotoRotatorNP.apply();
             } else {
@@ -475,7 +475,7 @@ void WandererRotatorBase::TimerHit()
                 else
                     angle =std::clamp(angle, tracking.angle_0,tracking.angle_f);
 
-                GotoRotatorNP[0].setValue(angle);
+                GotoRotatorNP[0].setValue(range360(angle));
                 GotoRotatorNP.setState(IPS_BUSY);
                 GotoRotatorNP.apply();
             }

--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -32,30 +32,185 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <sstream>
-#include <iostream>
+#include <regex>
+#include <chrono>
+#include <algorithm>
 
+using namespace std::literals;
 
+void WandererReader::init()
+{
+    std::string name = wanderer->getRotatorHandshakeName();
+    this->patterns["handshake"] =
+        // {name}A{firmware}A{θ}A{backlash}A{reversed}A\r\n
+        name + "A([0-9]{8})A([-+]?[0-9]+)A([^A]+)A([01])A\r\n";
 
-WandererRotatorBase::WandererRotatorBase()
+    // {Δθ}A{θ}A\r\n
+    this->patterns["movement"] = "([^A]+)A([-+]?[0-9]+)A\r\n";
+    this->patterns["volterr"] = "NP\r\n";
+}
+
+WandererReader::~WandererReader()
+{
+    this->stop();
+}
+
+const char * WandererReader::getDeviceName() const {
+    return this->wanderer->getDeviceName();
+}
+
+bool WandererReader::start(int fd)
+{
+    if (this->read_thread.joinable())
+        return false;
+
+    this->failures = 0;
+    this->timeouts = 0;
+    this->stop_requested = false;
+
+    this->read_thread = std::thread([this, fd](){
+        char buf[256]; // some large-enough buffer for all conceivable inputs
+        int totbytes = 0;
+        this->did_stop = false;
+        while (!this->stop_requested) {
+            int nbytes = 0;
+            memset(buf, 0, sizeof(buf));
+            int rc = tty_nread_section(fd, buf + totbytes,
+                                       sizeof(buf) - 1 - totbytes, '\n', 3,
+                                       &nbytes);
+            const auto now = std::chrono::system_clock::now();
+
+            totbytes += nbytes;
+
+            if (nbytes == 0) {
+                if (rc != TTY_TIME_OUT) {
+                    LOG_ERROR("Received zero bytes but didn't time out!?!");
+                    this->stop_requested = true;
+                }
+                ++this->timeouts;
+                continue;
+            } else if (rc != TTY_OK) {
+                char errorMessage[MAXRBUF];
+                tty_error_msg(rc, errorMessage, MAXRBUF);
+                LOGF_ERROR("Device read error: %s", errorMessage);
+                ++this->failures;
+                if (this->failures > MAX_FAILURES)
+                    break;
+                continue;
+            } else if (buf[totbytes-1] != '\n') {
+                if (rc != TTY_TIME_OUT)
+                    LOG_ERROR(
+                      "Didn't time out but didn't read until endline char");
+                continue;
+            }
+
+            buf[totbytes] = '\0'; // ensure this thing is null terminated
+            totbytes = 0; // reset this for next while-loop iteration
+            std::string sbuf = buf;
+
+            /* we have a full line with a possibly valid message--parse it. */
+            bool valid = false;
+            for (const auto & pat : this->patterns) {
+                std::smatch matches;
+
+                if (!std::regex_match(sbuf, matches, pat.second))
+                    // does not match--go on to test other regular expressions
+                    continue;
+
+                //thread-safety:
+                std::lock_guard<std::recursive_mutex> lock(this->mutex);
+                valid = true;
+                // regex matched one of the expected messages, figure out which
+                if (pat.first == "handshake") {
+                    this->_firmware   = {now, std::stoi(matches[1].str())};
+                    this->_angle      = {now, std::stoi(matches[2].str())*1e-3};
+                    this->_backlash   = {now, std::stof(matches[3].str())};
+                    this->_reversed   = {now, std::stoi(matches[4].str())};
+                } else if (pat.first == "movement") {
+                    this->_completed  = {now, std::stof(matches[1].str())};
+                    this->_angle      = {now, std::stoi(matches[2].str())*1e-3};
+                } else if (pat.first == "volterr") {
+                    this->_voltage_error = {now, true};
+                } else {
+                    LOGF_ERROR(
+                      "Unimplemented (%s).  This code should never be reached.",
+                      pat.first);
+                }
+                this->cv.notify_all();
+
+                // no need to keep trying other patterns, so break out of "for".
+                break;
+            }
+
+            if (!valid)
+                LOGF_ERROR("Invalid message read from serial: \"%s\"", buf);
+        }
+
+        this->did_stop = true;
+    });
+    return true;
+}
+
+void WandererReader::stop()
+{
+    if (!this->read_thread.joinable())
+        return;
+
+    this->stop_requested = true;
+    this->read_thread.join();
+    // ensure that our thread object is no longer joinable.
+    this->read_thread = std::thread();
+}
+
+bool WandererReader::updated_since(
+  const unsigned int updates, const std::chrono::system_clock::time_point & t0)
+{
+    std::lock_guard<std::recursive_mutex> lock(this->mutex);
+    int recent = 0;
+    if (t0 < this->_firmware.first)
+        recent |= UPDATES::FIRMWARE;
+    if (t0 < this->_angle.first)
+        recent |= UPDATES::ANGLE;
+    if (t0 < this->_backlash.first)
+        recent |= UPDATES::BACKLASH;
+    if (t0 < this->_reversed.first)
+        recent |= UPDATES::REVERSED;
+    if (t0 < this->_completed.first)
+        recent |= UPDATES::COMPLETED;
+    if (t0 < this->_voltage_error.first)
+        recent |= UPDATES::VOLTERR;
+
+    if (updates == 0)
+        return recent != 0;
+    return (recent & updates) == updates;
+}
+
+WandererRotatorBase::WandererRotatorBase() : reader(this)
 {
     setVersion(1, 0);
-
 }
+
 bool WandererRotatorBase::initProperties()
 {
-
+    this->reader.init(); // delayed init to allow for vptr to be correct first
     INDI::Rotator::initProperties();
 
     SetCapability(ROTATOR_CAN_REVERSE | ROTATOR_CAN_ABORT | ROTATOR_CAN_HOME);
 
+    addPollPeriodControl();
     addAuxControls();
     // Calibrate
     SetZeroSP[0].fill("Set_Zero", "Mechanical Zero", ISS_OFF);
     SetZeroSP.fill(getDeviceName(), "Set_Zero", "Set Current As", MAIN_CONTROL_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // BACKLASH
-    BacklashNP[BACKLASH].fill( "BACKLASH", "Degree", "%.2f", 0, 3, 0.1, 0);
+    BacklashNP[0].fill( "BACKLASH", "Degree", "%.2f", 0, 3, 0.1, 0);
     BacklashNP.fill(getDeviceName(), "BACKLASH", "Backlash", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
+    EstimatedSpeedNP[0].fill("SPEED", "Speed [°/s]", "%.2f", 0, 5, 0.1, 3.0);
+    EstimatedSpeedNP.fill(getDeviceName(), "ESTIMATED", "Estimated",
+                          OPTIONS_TAB, IP_RW, 60, IPS_IDLE);
+    EstimatedSpeedNP.load();
 
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
 
@@ -70,11 +225,13 @@ bool WandererRotatorBase::updateProperties()
     {
         defineProperty(SetZeroSP);
         defineProperty(BacklashNP);
+        defineProperty(EstimatedSpeedNP);
     }
     else
     {
         deleteProperty(SetZeroSP);
         deleteProperty(BacklashNP);
+        deleteProperty(EstimatedSpeedNP);
     }
     return true;
 }
@@ -85,7 +242,7 @@ bool WandererRotatorBase::ISNewSwitch(const char *dev, const char *name, ISState
     {
         if (SetZeroSP.isNameMatch(name))
         {
-            SetZeroSP.setState(sendCommand("1500002") ? IPS_OK : IPS_ALERT);
+            SetZeroSP.setState(send_zero_cmd(true) ? IPS_OK : IPS_ALERT);
             SetZeroSP.apply();
             GotoRotatorNP[0].setValue(0);
             GotoRotatorNP.apply();
@@ -104,19 +261,23 @@ bool WandererRotatorBase::ISNewNumber(const char * dev, const char * name, doubl
         if (BacklashNP.isNameMatch(name))
         {
             BacklashNP.update(values, names, n);
-            backlash = BacklashNP[BACKLASH].value;
+            double backlash = BacklashNP[0].getValue();
 
             char cmd[16];
-            snprintf(cmd, 16, "%d", (int)(backlash * 10 + 1600000));
+            snprintf(cmd, 16, "%d", static_cast<int>(backlash * 10 + 1600000));
 
             BacklashNP.setState(sendCommand(cmd) ? IPS_OK : IPS_ALERT);
-            if (BacklashNP.getState() == IPS_OK)
-                BacklashNP.update(values, names, n);
             BacklashNP.apply();
             LOG_INFO("Backlash Set");
             return true;
         }
-
+        else if (EstimatedSpeedNP.isNameMatch(name))
+        {
+            EstimatedSpeedNP.update(values, names, n);
+            EstimatedSpeedNP.setState(IPS_OK);
+            EstimatedSpeedNP.apply();
+            return true;
+        }
     }
     return Rotator::ISNewNumber(dev, name, values, names, n);
 }
@@ -125,132 +286,124 @@ bool WandererRotatorBase::Handshake()
 {
     PortFD = serialConnection->getPortFD();
     tcflush(PortFD, TCIOFLUSH);
-    int nbytes_read_name = 0, nbytes_written = 0, rc = -1;
-    char name[64] = {0};
+    this->reader.stop();
+    this->reader.start(PortFD);
 
-    if (!sendCommand("1500001"))
-    {
+    if (!send_handshake())
         return false;
-    }
 
     //Device Model//////////////////////////////////////////////////////////////
-    if ((rc = tty_read_section(PortFD, name, 'A', 3, &nbytes_read_name)) != TTY_OK)
-    {
-        tcflush(PortFD, TCIOFLUSH);
-        if (!sendCommand("1500001"))
-        {
-            return false;
-        }
-        if ((rc = tty_read_section(PortFD, name, 'A', 3, &nbytes_read_name)) != TTY_OK)
-        {
-            char errorMessage[MAXRBUF];
-            tty_error_msg(rc, errorMessage, MAXRBUF);
-            LOGF_INFO("No data received, the device may not be WandererRotator, please check the serial port!", "Updated");
-            LOGF_ERROR("Device read error: %s", errorMessage);
-            return false;
-        }
-    }
-    name[nbytes_read_name - 1] = '\0';
-    if(strcmp(name, getRotatorHandshakeName()) != 0)
-    {
-        LOGF_ERROR("The device is not %s", getDefaultName());
-        LOGF_INFO("The device is %s.", name);
-        return false;
-    }
-    // Frimware version/////////////////////////////////////////////////////////////////////////////////////////////
-    int nbytes_read_version = 0;
-    char version[64] = {0};
-    tty_read_section(PortFD, version, 'A', 5, &nbytes_read_version);
+    LOGF_INFO("Connected to device %s", this->getRotatorHandshakeName());
 
-    version[nbytes_read_version - 1] = '\0';
-    LOGF_INFO("Firmware Version:%s", version);
-    firmware = std::atoi(version);
-    if(firmware < getMinimumCompatibleFirmwareVersion())
+    // Firmware version/////////////////////////////////////////////////////////
+    if(this->reader.firmware().second < getMinimumCompatibleFirmwareVersion())
     {
         LOG_ERROR("Firmware is outdated, please upgrade to latest firmware!");
-        LOGF_ERROR("Current firmware is %s.", firmware);
+        LOGF_ERROR("Current firmware is %s.", this->reader.firmware().second);
         return false;
     }
 
-    // Angle//////////////////////////////////////////////////////////////////////////////////////////
-    char M_angle[64] = {0};
-    int nbytes_read_M_angle = 0;
-    tty_read_section(PortFD, M_angle, 'A', 5, &nbytes_read_M_angle);
-    M_angle[nbytes_read_M_angle - 1] = '\0';
-    M_angleread = std::strtod(M_angle, NULL);
-
-    if(abs(M_angleread) > 400000)
+    // Angle////////////////////////////////////////////////////////////////////
+    if(abs(this->reader.angle().second) > 400)
     {
-        rc = sendCommand("1500002");
-        LOG_WARN("Virtual Mechanical Angle is too large, it is now set to zero!");
-        rc = sendCommand("1500001");
-        rc = tty_read_section(PortFD, M_angle, 'A', 5, &nbytes_read_M_angle);
-        rc = tty_read_section(PortFD, M_angle, 'A', 5, &nbytes_read_M_angle);
-        rc = tty_read_section(PortFD, M_angle, 'A', 5, &nbytes_read_M_angle);
-        M_angle[nbytes_read_M_angle - 1] = '\0';
-        M_angleread = std::strtod(M_angle, NULL);
+        LOG_WARN("Virtual Mechanical Angle > 400°, setting to zero!");
+        if (!send_zero_cmd(true))
+        {
+            LOG_ERROR("Could not redo handshake after zeroing virtual offset");
+            return false;
+        }
     }
-    GotoRotatorNP[0].setValue(abs(M_angleread / 1000));
-    //backlash/////////////////////////////////////////////////////////////////////
-    char M_backlash[64] = {0};
-    int nbytes_read_M_backlash = 0;
-    tty_read_section(PortFD, M_backlash, 'A', 5, &nbytes_read_M_backlash);
-    M_backlash[nbytes_read_M_backlash - 1] = '\0';
-    M_backlashread = std::strtod(M_backlash, NULL);
-
-    BacklashNP[BACKLASH].setValue(M_backlashread);
+    GotoRotatorNP[0].setValue(this->reader.angle().second);
+    //backlash//////////////////////////////////////////////////////////////////
+    BacklashNP[0].setValue(this->reader.backlash().second);
     BacklashNP.setState(IPS_OK);
     BacklashNP.apply();
-    //reverse/////////////////////////////////////////////////////////////////////
-    char M_reverse[64] = {0};
-    int nbytes_read_M_reverse = 0;
-    tty_read_section(PortFD, M_reverse, 'A', 5, &nbytes_read_M_reverse);
-    M_reverse[nbytes_read_M_angle - 1] = '\0';
-    M_reverseread = std::strtod(M_reverse, NULL);
-    if(M_reverseread == 0)
+    //reverse///////////////////////////////////////////////////////////////////
+    ReverseRotatorSP.reset();
+    // sync software settings to hardware settings:
+    if(this->reader.reversed().second)
     {
-        ReverseRotator(false);
+        ReverseRotatorSP[DefaultDevice::INDI_ENABLED].setState(ISS_ON);
     }
     else
     {
-        ReverseRotator(true);
+        ReverseRotatorSP[DefaultDevice::INDI_DISABLED].setState(ISS_ON);
     }
+    ReverseRotatorSP.apply();
 
-    tcflush(PortFD, TCIOFLUSH);
+    this->state = State::HALTED;
     return true;
 }
 
+bool WandererRotatorBase::Disconnect()
+{
+    this->reader.stop();
+    return this->INDI::Rotator::Disconnect();
+}
 
 IPState WandererRotatorBase::MoveRotator(double angle)
 {
-    angle = angle - GotoRotatorNP[0].getValue();
-
-    char cmd[16];
-    int position = (int)(angle * getStepsPerDegree() + 1000000);
-    positionhistory = angle;
-    snprintf(cmd, 16, "%d", position);
-    Move(cmd);
-
-    return IPS_BUSY;
+    if (this->move(angle))
+        return IPS_BUSY;
+    return IPS_ALERT;
 }
 
+std::optional<std::chrono::system_clock::time_point>
+WandererRotatorBase::move(double abs_angle)
+{
+    typedef WandererReader::UPDATES UP;
+    if (this->state == State::MOVING)
+    {
+        /* rotator is already moving; abort and wait for position. */
+        this->reader.wait_for(5s, UP::ANGLE, this->stop());
+    }
+
+    double current_angle = this->reader.angle().second;
+    /* move in shortest direction. */
+    double delta = range180(abs_angle - current_angle);
+    int steps = static_cast<int>(std::round(delta * getStepsPerDegree()));
+
+    if (steps == 0)
+      return std::chrono::system_clock::now();
+
+    /* Create the command.  The +1000000 is an undocumented offset in the
+     * commands for movement.  The 20240226 serial protocol documentation shows
+     * that one can use commands centered around zero instead of centered around
+     * 1000000.  Perhaps we continue using this offset because it still does
+     * work for the Mini v1/v2 and because of the other rotators that are
+     * supported.  Documentation for the serial protocols of the other rotators
+     * do not seem to be available online.
+     */
+    char cmd[16];
+    snprintf(cmd, 16, "%d", steps + 1000000);
+    auto t0 = sendCommand(cmd);
+    if (t0) {
+        /* Get "tracking" info ready to present predicted rotation angles while
+         * motion is active since the Wanderer rotators do not have a way to
+         * query the current position or motion progress without interrupting
+         * the motion.
+         */
+        this->state = State::MOVING;
+        this->tracking.t0 = t0.value();
+        this->tracking.angle_0 = current_angle;
+        this->tracking.angle_f = abs_angle;
+    }
+    return t0;
+}
+
+std::optional<std::chrono::system_clock::time_point> WandererRotatorBase::stop()
+{
+    tcflush(PortFD, TCOFLUSH);
+    LOG_DEBUG("CMD Stop");
+    auto t0 = sendCommand("Stop", "");
+    if (t0)
+        this->state = State::HALTED;
+    return t0;
+}
 
 bool WandererRotatorBase::AbortRotator()
 {
-
-
-    if (GotoRotatorNP.getState() == IPS_BUSY)
-    {
-        haltcommand = true;
-        int nbytes_written = 0, rc = -1;
-        tcflush(PortFD, TCIOFLUSH);
-        if (!sendCommand("Stop"))
-        {
-            return false;
-        }
-        SetTimer(100);
-    }
-    return true;
+    return this->stop().has_value();
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -259,16 +412,11 @@ bool WandererRotatorBase::AbortRotator()
 ///
 IPState WandererRotatorBase::HomeRotator()
 {
-    if(GotoRotatorNP[0].getValue() != 0)
+    if (this->reader.angle().second != 0)
     {
-        double angle = -1 * GotoRotatorNP[0].getValue();
-        positionhistory = angle;
-        char cmd[16];
-        int position = (int)(angle * getStepsPerDegree() + 1000000);
-        snprintf(cmd, 16, "%d", position);
-        GotoRotatorNP.setState(IPS_BUSY);
-        Move(cmd);
         LOG_INFO("Moving to zero...");
+        if (!this->move(0))
+            return IPS_ALERT;
     }
     return IPS_OK;
 }
@@ -276,103 +424,117 @@ IPState WandererRotatorBase::HomeRotator()
 
 bool WandererRotatorBase::ReverseRotator(bool enabled)
 {
-
-    if (enabled)
-    {
-        char cmd[16];
-        snprintf(cmd, 16, "%d", 1700001);
-        if (!sendCommand(cmd))
-        {
-            return false;
-        }
-        ReverseState = true;
-        return true;
-    }
-    else
-    {
-        char cmd[16];
-        snprintf(cmd, 16, "%d", 1700000);
-        if (!sendCommand(cmd))
-        {
-            return false;
-        }
-        ReverseState = false;
-        return true;
-    }
-    return false;
+    auto t0 = sendCommand(enabled ? "1700001" : "1700000");
+    if (!t0 || !send_handshake())
+        return false;
+    return this->reader.reversed().second == enabled;
 }
-
 
 
 void WandererRotatorBase::TimerHit()
 {
-    if (GotoRotatorNP.getState() == IPS_BUSY || haltcommand == true)
+    if (isConnected())
     {
-        if(nowtime < estime && haltcommand == false)
+        if (this->reader.stopped())
         {
-            GotoRotatorNP[0].setValue(GotoRotatorNP[0].getValue() + 1 * positionhistory / abs(positionhistory));
+            /* send alert back to user and give up on TimerHit.  Only remedy may
+             * be for user to disconnect and reconnect.
+             */
+            GotoRotatorNP.setState(IPS_ALERT);
             GotoRotatorNP.apply();
-            nowtime = nowtime + 240;
-            SetTimer(240);
             return;
-        }
-        else
-        {
-            int rc = -1;
-            estime = 0;
-            nowtime = 0;
-            char M_angle[64] = {0};
-            int nbytes_read_M_angle = 0;
-            rc = tty_read_section(PortFD, M_angle, 'A', 5, &nbytes_read_M_angle);
-            if(rc != TTY_OK)
-            {
-                LOG_ERROR("Rotator not powered!");
-                GotoRotatorNP[0].setValue(initangle);
-                GotoRotatorNP.apply();
-                haltcommand = false;
-                return;
-            }
-            tty_read_section(PortFD, M_angle, 'A', 5, &nbytes_read_M_angle);
-
-            M_angle[nbytes_read_M_angle - 1] = '\0';
-            M_angleread = std::strtod(M_angle, NULL);
-            GotoRotatorNP[0].setValue(abs(M_angleread / 1000));
+        } else if (this->state == State::HALTED) {
+            /* Query the position of the motor and update INDI. */
+            send_handshake();
+            GotoRotatorNP[0].setValue(this->reader.angle().second);
             GotoRotatorNP.setState(IPS_OK);
             GotoRotatorNP.apply();
-            haltcommand = false;
+        } else if (this->state == State::MOVING) {
+            auto current = this->reader.angle();
+
+            if (tracking.t0 < current.first) {
+                /* We have a measurement after we started motion.  We assume
+                 * that the only way this would have happened is that the motion
+                 * was interrupted or stopped. */
+                this->state = State::HALTED;
+                GotoRotatorNP[0].setValue(current.second);
+                GotoRotatorNP.setState(IPS_OK);
+                GotoRotatorNP.apply();
+            } else {
+
+                double m = EstimatedSpeedNP[0].getValue();
+                auto dt = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now() - tracking.t0
+                ).count() * 1e-9;
+
+                auto sgn = std::copysign(1, tracking.angle_f -tracking.angle_0);
+                double angle = tracking.angle_0 + sgn * m * dt;
+
+                if (sgn < 0)
+                    angle =std::clamp(angle, tracking.angle_f,tracking.angle_0);
+                else
+                    angle =std::clamp(angle, tracking.angle_0,tracking.angle_f);
+
+                GotoRotatorNP[0].setValue(angle);
+                GotoRotatorNP.setState(IPS_BUSY);
+                GotoRotatorNP.apply();
+            }
+        } else {
+            LOG_ERROR("Invalid state should not be seen");
         }
-    }
 
-    SetTimer(2000);
+        SetTimer(getCurrentPollingPeriod());
+    }
 }
 
-bool WandererRotatorBase::Move(const char *cmd)
+
+std::optional<std::chrono::system_clock::time_point>
+WandererRotatorBase::send_zero_cmd(bool requery)
 {
-    initangle = GotoRotatorNP[0].getValue();
-    int nbytes_written = 0, rc = -1;
-    LOGF_DEBUG("CMD <%s>", cmd);
-    if (!sendCommand(cmd))
+    auto t0 = sendCommand("1500002");
+    if (!t0)
+        return {};
+
+    if (requery && !send_handshake(true))
     {
-        return false;
+        return {};
     }
-    SetTimer(2000);
-    nowtime = 0;
-    estime = abs((std::atoi(cmd) - 1000000) / getStepsPerDegree() * 240);
-    return true;
+    return t0;
 }
 
-bool WandererRotatorBase::sendCommand(std::string command)
+std::optional<std::chrono::system_clock::time_point>
+WandererRotatorBase::send_handshake(bool wait)
+{
+    typedef WandererReader::UPDATES UP;
+    auto t0 = sendCommand("1500001");
+    if (!t0 || (wait && !this->reader.wait_for(3s, UP::HANDSHAKE, t0)))
+    {
+        return {};
+    }
+    return t0;
+}
+
+std::optional<std::chrono::system_clock::time_point>
+WandererRotatorBase::sendCommand(std::string command,
+                                 const std::string & termination)
 {
     int nbytes_written = 0, rc = -1;
-    std::string command_termination = "\n";
     LOGF_DEBUG("CMD: %s", command.c_str());
-    if ((rc = tty_write_string(PortFD, (command + command_termination).c_str(),
+    auto t0 = std::chrono::system_clock::now();
+    if ((rc = tty_write_string(PortFD, (command + termination).c_str(),
                                &nbytes_written)) != TTY_OK)
     {
         char errorMessage[MAXRBUF];
         tty_error_msg(rc, errorMessage, MAXRBUF);
         LOGF_ERROR("Serial write error: %s", errorMessage);
-        return false;
+        return {};
     }
+    return t0;
+}
+
+bool WandererRotatorBase::saveConfigItems(FILE *fp)
+{
+    INDI::Rotator::saveConfigItems(fp);
+    EstimatedSpeedNP.save(fp);
     return true;
 }

--- a/drivers/rotator/wanderer_rotator_base.h
+++ b/drivers/rotator/wanderer_rotator_base.h
@@ -28,16 +28,161 @@
 #include "indirotator.h"
 #include "indirotatorinterface.h"
 #include "indipropertyswitch.h"
+#include <condition_variable>
+#include <optional>
+#include <thread>
+#include <atomic>
+#include <string>
+#include <chrono>
+#include <mutex>
+#include <regex>
+#include <map>
+
+class WandererRotatorBase;
+
+/** Simple class to continuously read and parse the serial stream from the
+ * rotator (in a separate thread). */
+class WandererReader {
+public:
+    static const unsigned int MAX_FAILURES = 10;
+    struct UPDATES {
+        enum VALUES {
+            FIRMWARE  = 1,
+            ANGLE     = 2,
+            BACKLASH  = 4,
+            REVERSED  = 8,
+            HANDSHAKE = FIRMWARE | ANGLE | BACKLASH | REVERSED,
+            COMPLETED = 16,
+            VOLTERR   = 32,
+            ANY       = 0,
+            ALL       = FIRMWARE | ANGLE | BACKLASH | REVERSED | COMPLETED
+                      | VOLTERR,
+        };
+    };
+
+    WandererReader(WandererRotatorBase * wanderer) : wanderer(wanderer) { }
+    ~WandererReader();
+
+    /** Initialize reader patterns.
+     * Call to this should be delayed to something like
+     * Wanderer...::initProperties to allow for wanderer vptr to be correct
+     * first.
+     */
+    void init();
+
+    bool start(int fd);
+    void stop();
+    bool stopped() { return this->did_stop; }
+    const char * getDeviceName() const;
+
+    auto firmware() {
+        std::lock_guard<std::recursive_mutex> lock(this->mutex);
+        return this->_firmware;
+    }
+    auto angle() {
+        std::lock_guard<std::recursive_mutex> lock(this->mutex);
+        return this->_angle;
+    }
+    auto backlash() {
+        std::lock_guard<std::recursive_mutex> lock(this->mutex);
+        return this->_backlash;
+    }
+    auto reversed() {
+        std::lock_guard<std::recursive_mutex> lock(this->mutex);
+        return this->_reversed;
+    }
+    auto completed() {
+        std::lock_guard<std::recursive_mutex> lock(this->mutex);
+        return this->_completed;
+    }
+    auto voltage_error() {
+        std::lock_guard<std::recursive_mutex> lock(this->mutex);
+        return this->_voltage_error;
+    }
+    bool pop_voltage_error() {
+        std::lock_guard<std::recursive_mutex> lock(this->mutex);
+        bool retval = this->_voltage_error.second;
+        this->_voltage_error.second = false;
+        return retval;
+    }
+
+    /** Check if *all* updates requested have occurred since the given time.
+     * If `updates` is given as zero, then this function returns if *any* item
+     * was updated since the given time.
+     */
+    bool updated_since(const unsigned int updates,
+                       const std::chrono::system_clock::time_point &);
+
+    void wait(const unsigned int updates = UPDATES::ANY,
+              std::optional<std::chrono::system_clock::time_point> t0 = {}) {
+        if (!t0)
+            t0 = {std::chrono::system_clock::now()};
+        std::unique_lock<std::recursive_mutex> lock(this->mutex);
+        this->cv.wait(lock, [this, updates, t0](){
+            return this->updated_since(updates, t0.value());
+        });
+    }
+
+    template< class Rep, class Period >
+    bool wait_for(const std::chrono::duration<Rep, Period> & dt,
+                  const unsigned int updates = UPDATES::ANY,
+                  std::optional<std::chrono::system_clock::time_point> t0 = {}) {
+        if (!t0)
+            t0 = {std::chrono::system_clock::now()};
+        std::unique_lock<std::recursive_mutex> lock(this->mutex);
+        return this->cv.wait_for(lock, dt, [this, t0, updates](){
+            return this->updated_since(updates, t0.value());
+        });
+    }
+
+protected:
+    /** Pointer back to parent rotator instance. */
+    WandererRotatorBase * wanderer;
+
+    /** Map of regex expressions for various message types. */
+    std::map<std::string, std::regex> patterns;
+
+    /** Firmware taken from last valid handshake. */
+    std::pair<std::chrono::system_clock::time_point, int> _firmware;
+
+    /** Mechanical angle from last relevant message. */
+    std::pair<std::chrono::system_clock::time_point, double> _angle;
+
+    /** Backlash angle from last valid handshake. */
+    std::pair<std::chrono::system_clock::time_point, float> _backlash;
+
+    /** Reversed from last valid handshake. */
+    std::pair<std::chrono::system_clock::time_point, bool> _reversed;
+
+    /** Completed angle, in degrees from last relevant message. */
+    std::pair<std::chrono::system_clock::time_point, float> _completed;
+
+    /** Voltage error.  The single-page "datasheet" indicates that this is
+     * asserted when the power voltage goes below 11V.
+     */
+    std::pair<std::chrono::system_clock::time_point, bool> _voltage_error;
+
+    /** Simple mutux to keep things thread-safe. */
+    std::recursive_mutex mutex;
+    std::condition_variable_any cv;
+    std::thread read_thread;
+    std::atomic<bool> stop_requested = true;
+    std::atomic<bool> did_stop = true;
+    std::atomic<unsigned int> timeouts = 0;
+    std::atomic<unsigned int> failures = 0;
+};
 
 class WandererRotatorBase : public INDI::Rotator
 {
 public:
     WandererRotatorBase();
 
-    bool initProperties() override;
-    bool updateProperties() override;
-    bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
-    bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+    virtual bool initProperties() override;
+    virtual bool updateProperties() override;
+    virtual bool ISNewSwitch(const char *dev, const char *name,
+                             ISState *states, char *names[], int n) override;
+    virtual bool ISNewNumber(const char *dev, const char *name,
+                             double values[], char *names[], int n) override;
 
 protected:
     virtual const char * getDefaultName() override = 0;
@@ -45,33 +190,61 @@ protected:
     virtual int getMinimumCompatibleFirmwareVersion() = 0;
     virtual int getStepsPerDegree() = 0;
 
-    IPState MoveRotator(double angle) override;
-    IPState HomeRotator() override;
-    bool ReverseRotator(bool enabled) override;
-    bool AbortRotator() override;
-    void TimerHit() override;
+    virtual IPState MoveRotator(double angle) override;
+    virtual IPState HomeRotator() override;
+    virtual bool ReverseRotator(bool enabled) override;
+    virtual bool AbortRotator() override;
+    virtual void TimerHit() override;
+    virtual bool Handshake() override;
+    virtual bool Disconnect() override;
+    virtual bool saveConfigItems(FILE *fp) override;
 
-    bool Handshake() override;
-    bool sendCommand(std::string command);
-    bool Move(const char *cmd);
+    /** Send command to zero virtual origin for mechanical angle.
+     * @return system_clock time if successful and empty optional otherwise.
+     */
+    std::optional<std::chrono::system_clock::time_point>
+    send_zero_cmd(bool requery=true);
+
+    /** Send basic handshake command and optionally (default yes) wait for a
+     * response.
+     * @return system_clock time if successful and empty optional otherwise.
+     */
+    std::optional<std::chrono::system_clock::time_point>
+    send_handshake(bool wait=true);
+    std::optional<std::chrono::system_clock::time_point> stop();
+    std::optional<std::chrono::system_clock::time_point> move(double abs_angle);
+
+    /** Send a serial command to the rotator.
+     * @return If successful, returns system_clock time immediately before the
+     *         serial command.
+     *         If not successful, returns an empty std::optional<...>
+     */
+    std::optional<std::chrono::system_clock::time_point>
+    sendCommand(std::string command, const std::string & termination="\n");
 
     INDI::PropertySwitch SetZeroSP{1};
     INDI::PropertyNumber BacklashNP{1};
+    /** Estimated speed.  Used to predict where the rotator is because the
+     * Wanderer firmware has no way of querying the current position without
+     * halting the motion.
+     */
+    INDI::PropertyNumber EstimatedSpeedNP{1};
 
-    int firmware = 0;
-    double M_angleread = 0;
-    double M_backlashread = 0;
-    double M_reverseread = 0;
-    double initangle = 0;
-    bool haltcommand = false;
-    bool ReverseState = false;
-    double backlash = 0.5;
-    double positionhistory = 0;
-    int estime = 0;
-    int nowtime = 0;
+    WandererReader reader;
 
-    enum
+    /** information for estimating position tracking. */
+    struct {
+        std::chrono::system_clock::time_point t0;
+        double angle_0 = 0;
+        double angle_f = 0;
+    } tracking;
+
+    /** States for a software state machine for the wanderer. */
+    enum class State
     {
-        BACKLASH,
-    };
+        MOVING,
+        HALTED,
+    } state;
+
+    friend WandererReader;
 };


### PR DESCRIPTION
These patches improve the stability and robustness of the wanderer rotators, such that serial comms do not get confused anymore.  This patch also ensures that the rotator follows commanded angles, even if these change during the middle of a move operation.