### PR TITLE
Wanderer ETA: Fix first-connect serial garbage

### DIFF
--- a/drivers/auxiliary/wanderer_eta.cpp
+++ b/drivers/auxiliary/wanderer_eta.cpp
@@ -422,14 +422,12 @@ bool WandererETA::ISNewSwitch(const char *dev, const char *name, ISState *states
             double pos3 = PositionReadNP[POINT_3].getValue();
 
             // Calculate new targets
-            double newPos1 = pos1 + offset;
-            double newPos2 = pos2 + offset;
-            double newPos3 = pos3 + offset;
+            double targets[3] = {pos1 + offset, pos2 + offset, pos3 + offset};
 
             // Validate all within range
-            if (newPos1 < 0.0 || newPos1 > 1.2 ||
-                newPos2 < 0.0 || newPos2 > 1.2 ||
-                newPos3 < 0.0 || newPos3 > 1.2)
+            if (targets[0] < 0.0 || targets[0] > 1.2 ||
+                targets[1] < 0.0 || targets[1] > 1.2 ||
+                targets[2] < 0.0 || targets[2] > 1.2)
             {
                 LOGF_ERROR("Offset %.3f mm would move one or more points out of range (0.000 - 1.200 mm). "
                            "Current positions: P1=%.3f, P2=%.3f, P3=%.3f",
@@ -441,56 +439,13 @@ bool WandererETA::ISNewSwitch(const char *dev, const char *name, ISState *states
             }
 
             LOGF_INFO("Applying backfocus offset %.3f mm to all points (P1: %.3f→%.3f, P2: %.3f→%.3f, P3: %.3f→%.3f)",
-                      offset, pos1, newPos1, pos2, newPos2, pos3, newPos3);
+                      offset, pos1, targets[0], pos2, targets[1], pos3, targets[2]);
 
-            bool success = true;
-            m_SendingCommand = true;
-            usleep(200000);
-            tcflush(PortFD, TCIOFLUSH);
-            usleep(100000);
-
-            double targets[3] = {newPos1, newPos2, newPos3};
-            for (int i = 0; i < 3; i++)
-            {
-                char cmd[32];
-                snprintf(cmd, sizeof(cmd), "%d%.3f\n", i + 1, targets[i]);
-
-                tcflush(PortFD, TCIOFLUSH);
-                usleep(100000);
-
-                int nbytes_written = 0, rc = -1;
-                if ((rc = tty_write_string(PortFD, cmd, &nbytes_written)) != TTY_OK)
-                {
-                    char errorMessage[MAXRBUF];
-                    tty_error_msg(rc, errorMessage, MAXRBUF);
-                    LOGF_ERROR("Serial write error on Point %d: %s", i + 1, errorMessage);
-                    success = false;
-                    break;
-                }
-                tcdrain(PortFD);
-
-                if (!waitForPosition(i, targets[i], 15000))
-                {
-                    LOGF_WARN("Point %d did not reach target %.3f within timeout", i + 1, targets[i]);
-                }
-            }
-
-            m_SendingCommand = false;
+            bool success = moveAllPoints(targets);
 
             if (success)
             {
-                // Update target properties to reflect new positions
-                Position1NP[0].setValue(newPos1);
-                Position1NP.setState(IPS_OK);
-                Position1NP.apply();
-                Position2NP[0].setValue(newPos2);
-                Position2NP.setState(IPS_OK);
-                Position2NP.apply();
-                Position3NP[0].setValue(newPos3);
-                Position3NP.setState(IPS_OK);
-                Position3NP.apply();
-
-                // Reset offset field to zero after successful application
+                updateAllTargets(targets);
                 BackfocusOffsetNP[0].setValue(0.0);
                 BackfocusOffsetNP.setState(IPS_OK);
                 BackfocusOffsetNP.apply();
@@ -504,53 +459,13 @@ bool WandererETA::ISNewSwitch(const char *dev, const char *name, ISState *states
 
         if (ZeroAllSP.isNameMatch(name))
         {
-            bool success = true;
+            double targets[3] = {0.0, 0.0, 0.0};
+            LOG_INFO("Moving all points to zero position");
 
-            m_SendingCommand = true;
-            usleep(200000);
-            tcflush(PortFD, TCIOFLUSH);
-            usleep(100000);
-
-            // Send zero command for each point with flush and wait
-            for (int i = 0; i < 3; i++)
-            {
-                char cmd[32];
-                snprintf(cmd, sizeof(cmd), "%d0.000\n", i + 1);
-
-                tcflush(PortFD, TCIOFLUSH);
-                usleep(100000);
-
-                int nbytes_written = 0, rc = -1;
-                if ((rc = tty_write_string(PortFD, cmd, &nbytes_written)) != TTY_OK)
-                {
-                    success = false;
-                    break;
-                }
-                tcdrain(PortFD);
-                LOGF_INFO("Zeroing Point %d", i + 1);
-
-                if (!waitForPosition(i, 0.0, 15000))
-                {
-                    LOGF_WARN("Point %d did not reach zero within timeout", i + 1);
-                }
-            }
-
-            m_SendingCommand = false;
+            bool success = moveAllPoints(targets);
 
             if (success)
-            {
-                LOG_INFO("Moving all points to zero position");
-                // Update targets to reflect zero
-                Position1NP[0].setValue(0.0);
-                Position1NP.setState(IPS_OK);
-                Position1NP.apply();
-                Position2NP[0].setValue(0.0);
-                Position2NP.setState(IPS_OK);
-                Position2NP.apply();
-                Position3NP[0].setValue(0.0);
-                Position3NP.setState(IPS_OK);
-                Position3NP.apply();
-            }
+                updateAllTargets(targets);
 
             ZeroAllSP.setState(success ? IPS_OK : IPS_ALERT);
             ZeroAllSP[ZERO_ALL].setState(ISS_OFF);
@@ -560,6 +475,63 @@ bool WandererETA::ISNewSwitch(const char *dev, const char *name, ISState *states
     }
 
     return INDI::DefaultDevice::ISNewSwitch(dev, name, states, names, n);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Move all 3 points to specified targets (shared logic for ZeroAll and ApplyOffset)
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+bool WandererETA::moveAllPoints(double targets[3])
+{
+    m_SendingCommand = true;
+    usleep(200000);
+    tcflush(PortFD, TCIOFLUSH);
+    usleep(100000);
+
+    bool success = true;
+    for (int i = 0; i < 3; i++)
+    {
+        char cmd[32];
+        snprintf(cmd, sizeof(cmd), "%d%.3f\n", i + 1, targets[i]);
+
+        tcflush(PortFD, TCIOFLUSH);
+        usleep(100000);
+
+        int nbytes_written = 0, rc = -1;
+        if ((rc = tty_write_string(PortFD, cmd, &nbytes_written)) != TTY_OK)
+        {
+            char errorMessage[MAXRBUF];
+            tty_error_msg(rc, errorMessage, MAXRBUF);
+            LOGF_ERROR("Serial write error on Point %d: %s", i + 1, errorMessage);
+            success = false;
+            break;
+        }
+        tcdrain(PortFD);
+        LOGF_INFO("Moving Point %d to %.3f mm", i + 1, targets[i]);
+
+        if (!waitForPosition(i, targets[i], 15000))
+        {
+            LOGF_WARN("Point %d did not reach target %.3f within timeout", i + 1, targets[i]);
+        }
+    }
+
+    m_SendingCommand = false;
+    return success;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// Update all 3 target position properties after a successful multi-point move
+////////////////////////////////////////////////////////////////////////////////////////////////////////
+void WandererETA::updateAllTargets(double targets[3])
+{
+    Position1NP[0].setValue(targets[0]);
+    Position1NP.setState(IPS_OK);
+    Position1NP.apply();
+    Position2NP[0].setValue(targets[1]);
+    Position2NP.setState(IPS_OK);
+    Position2NP.apply();
+    Position3NP[0].setValue(targets[2]);
+    Position3NP.setState(IPS_OK);
+    Position3NP.apply();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/drivers/auxiliary/wanderer_eta.cpp
+++ b/drivers/auxiliary/wanderer_eta.cpp
@@ -449,6 +449,8 @@ bool WandererETA::ISNewSwitch(const char *dev, const char *name, ISState *states
                 BackfocusOffsetNP[0].setValue(0.0);
                 BackfocusOffsetNP.setState(IPS_OK);
                 BackfocusOffsetNP.apply();
+                LOGF_INFO("Backfocus offset applied successfully. New positions: P1=%.3f, P2=%.3f, P3=%.3f",
+                          targets[0], targets[1], targets[2]);
             }
 
             ApplyOffsetSP.setState(success ? IPS_OK : IPS_ALERT);
@@ -465,7 +467,10 @@ bool WandererETA::ISNewSwitch(const char *dev, const char *name, ISState *states
             bool success = moveAllPoints(targets);
 
             if (success)
+            {
                 updateAllTargets(targets);
+                LOG_INFO("All points moved to zero position successfully");
+            }
 
             ZeroAllSP.setState(success ? IPS_OK : IPS_ALERT);
             ZeroAllSP[ZERO_ALL].setState(ISS_OFF);

--- a/drivers/auxiliary/wanderer_eta.cpp
+++ b/drivers/auxiliary/wanderer_eta.cpp
@@ -167,6 +167,37 @@ bool WandererETA::getData()
     {
         PortFD = serialConnection->getPortFD();
 
+        // On first read (handshake), flush stale serial buffer data.
+        // The ETA device streams status continuously (~every 2s); the first bytes after
+        // opening the port may contain garbage from power-on or prior session.
+        // After flushing, we need to wait long enough for a fresh complete status line.
+        if (m_FirstRead)
+        {
+            tcflush(PortFD, TCIOFLUSH);
+            m_FirstRead = false;
+
+            // Try up to 3 reads with 3s timeout each to get a valid status line.
+            // The device streams every ~2s, so worst case we wait one full cycle.
+            char firstBuffer[512] = {0};
+            int firstBytes = 0;
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                memset(firstBuffer, 0, sizeof(firstBuffer));
+                firstBytes = 0;
+                int firstRc = tty_read_section(PortFD, firstBuffer, '\n', 3, &firstBytes);
+                if (firstRc == TTY_OK && parseDeviceData(firstBuffer))
+                {
+                    LOG_INFO("Wanderer ETA M54 is online.");
+                    return true;
+                }
+                // If we got data but it didn't parse (partial/garbage), flush and retry
+                if (firstBytes > 0)
+                    tcflush(PortFD, TCIOFLUSH);
+            }
+            LOG_WARN("Handshake: could not get valid data after 3 attempts");
+            return false;
+        }
+
         char buffer[512] = {0};
         int nbytes_read = 0, rc = -1;
 
@@ -224,7 +255,11 @@ bool WandererETA::parseDeviceData(const char *data)
         // Validate device identifier
         if (tokens[0] != "WandererTilterM54")
         {
-            LOGF_WARN("Unknown device: %s (expected WandererTilterM54)", tokens[0].c_str());
+            // During handshake, garbage on first read is expected — suppress warning
+            if (m_Initializing)
+                LOGF_DEBUG("Handshake: skipping invalid data: %s", tokens[0].c_str());
+            else
+                LOGF_WARN("Unknown device: %s (expected WandererTilterM54)", tokens[0].c_str());
             return false;
         }
 

--- a/drivers/auxiliary/wanderer_eta.h
+++ b/drivers/auxiliary/wanderer_eta.h
@@ -102,6 +102,8 @@ class WandererETA : public INDI::DefaultDevice
         bool m_SendingCommand {false};
         bool m_Initializing {true};
         bool waitForPosition(int pointIndex, double target, int timeoutMs);
+        bool moveAllPoints(double targets[3]);
         void setPositionNP(int index, double values[], char *names[], int n, IPState state);
         void setPositionState(int index, IPState state);
+        void updateAllTargets(double targets[3]);
 };

--- a/drivers/auxiliary/wanderer_eta.h
+++ b/drivers/auxiliary/wanderer_eta.h
@@ -101,6 +101,7 @@ class WandererETA : public INDI::DefaultDevice
         std::timed_mutex serialPortMutex;
         bool m_SendingCommand {false};
         bool m_Initializing {true};
+        bool m_FirstRead {true};
         bool waitForPosition(int pointIndex, double target, int timeoutMs);
         bool moveAllPoints(double targets[3]);
         void setPositionNP(int index, double values[], char *names[], int n, IPState state);


### PR DESCRIPTION
## Summary

Fix the Wanderer ETA M54 driver failing to connect on first attempt due to stale/garbage bytes in the serial buffer after port open.

## Problem

On initial connection, the USB-serial buffer contains stale bytes from device power-on or a prior session. The first `tty_read_section()` in the handshake reads a line prefixed with garbage, causing `parseDeviceData()` to fail with "Unknown device" and the connection to time out. A manual disconnect + reconnect always worked because the garbage was consumed on the first (failed) attempt.

## Fix

- Flush the serial buffer (`tcflush TCIOFLUSH`) on the first `getData()` call (which serves as the handshake)
- Retry up to 3 times with 3-second timeout each to get a valid status line
- If a read returns data that doesn't parse (partial/garbage), flush again and retry
- Suppress the "Unknown device" warning during handshake retries (use DEBUG level) to avoid confusing users — warning only fires for invalid data after successful initialization

## Testing

- Tested on hardware: firmware 20251123, StellarMate OS 2.2.1
- Verified: clean first-connect after fresh reboot (no manual reconnect needed)
- Verified: no WARNING message visible to user during normal handshake
- Compared with other Wanderer drivers — they use command/response model so don't hit this issue. The ETA uses passive streaming which is susceptible to mid-stream port opening.