### PR TITLE
FilterInterface: Fix filter name count when wheel size changes

### DIFF
--- a/libs/indibase/indifilterinterface.cpp
+++ b/libs/indibase/indifilterinterface.cpp
@@ -48,6 +48,47 @@ bool FilterInterface::updateProperties()
 {
     if (m_defaultDevice->isConnected())
     {
+        // Reconcile filter name count with hardware slot count.
+        // Handles both wheel upgrades (5→7) and downgrades (7→5).
+        int maxSlots = static_cast<int>(FilterSlotNP[0].getMax());
+        int nameCount = static_cast<int>(FilterNameTP.size());
+        if (nameCount > 0 && nameCount < maxSlots)
+        {
+            // Wheel got larger — extend with default names
+            char filterName[MAXINDINAME];
+            char filterLabel[MAXINDILABEL];
+            for (int i = nameCount; i < maxSlots; i++)
+            {
+                snprintf(filterName, MAXINDINAME, "FILTER_SLOT_NAME_%d", i + 1);
+                snprintf(filterLabel, MAXINDILABEL, "Filter#%d", i + 1);
+
+                INDI::WidgetText oneWidget;
+                oneWidget.fill(filterName, filterLabel, filterLabel);
+                FilterNameTP.push(std::move(oneWidget));
+            }
+            FilterNameTP.shrink_to_fit();
+
+            DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_SESSION,
+                         "Filter wheel has %d slots but only %d names were saved. "
+                         "Added default names for slots %d-%d.",
+                         maxSlots, nameCount, nameCount + 1, maxSlots);
+
+            m_defaultDevice->saveConfig();
+        }
+        else if (nameCount > maxSlots)
+        {
+            // Wheel got smaller — trim excess names
+            FilterNameTP.resize(maxSlots);
+            FilterNameTP.shrink_to_fit();
+
+            DEBUGFDEVICE(m_defaultDevice->getDeviceName(), Logger::DBG_SESSION,
+                         "Filter wheel has %d slots but %d names were saved. "
+                         "Trimmed to %d.",
+                         maxSlots, nameCount, maxSlots);
+
+            m_defaultDevice->saveConfig();
+        }
+
         // Define the Filter Slot and name properties
         m_defaultDevice->defineProperty(FilterSlotNP);
         if (FilterNameTP.size() == 0)


### PR DESCRIPTION
## Problem

When a user replaces their filter wheel with one that has a different number of positions (e.g. 5-slot to 7-slot or 7-slot to 5-slot), the UI shows the wrong number of filters despite the driver correctly detecting the new wheel size.

**Root cause**: `loadFilterNames()` runs during `initProperties()` (before connect) and loads the saved config which contains the old filter names. It also clamps `FilterSlotNP` max to the saved count. The driver `Connect()` correctly updates max from hardware, but `FilterNameTP` is never reconciled — so clients receive a mismatched filter name count.

## Fix

In `updateProperties()`, after connect and before defining properties to clients, reconcile `FilterNameTP` with `FilterSlotNP` max:

- **Wheel got larger** (5→7): Extend `FilterNameTP` with default `Filter#N` labels for the new positions
- **Wheel got smaller** (7→5): Trim excess names from `FilterNameTP`
- **Both cases**: Persist the corrected names via `SetFilterNames()` so the config file is updated

## Impact

- **Affected users** (wheel size changed): Filter names auto-reconciled with hardware, config file auto-corrected on first connect.
- **All other users** (no change): The size check evaluates false (nameCount == maxSlots), zero code executed, zero behavior change.

## Testing

Verified with Filter Simulator on StellarMate (Arch, x64):

1. Connected filter sim (8 slots), saved config → config has 8 names
2. Manually edited `~/.indi/Filter Simulator_config.xml` to only 5 names (simulating a wheel swap from 5→8)
3. **Without fix**: INDI Control Panel shows only 5 filters ✗
4. **With fix**: INDI Control Panel shows 8 filters (5 original + 3 default `Filter#6/7/8`) ✓
5. Config file auto-updated with all 8 names after reconnect ✓

## Reported by

DaveAOP on StellarMate Discord — new ZWO EFW USB-C (7-position) replacing old 5-position wheel. Driver log shows "Detected 7-position filter wheel" but INDI Control Panel and KStars only show 5 filter names.

## Workaround (for users on current INDI)

Delete `~/.indi/<device_name>_config.xml` and reconnect — driver will regenerate default names for all slots.