### PR TITLE
CCD Simulator: Add tilt simulation for Aberration Inspector testing

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -160,6 +160,12 @@ bool CCDSim::initProperties()
     FocusSimulationNP.fill(getDeviceName(), "SIM_FOCUSING", "Focus Simulation",
                            SIMULATOR_TAB, IP_RW, 60, IPS_IDLE);
 
+    // Simulate sensor tilt (extra defocus in arcsec at sensor edge)
+    TiltSimulationNP[SIM_TILT_LR].fill("SIM_TILT_LR", "Left-Right (arcsec)", "%4.2f", 0, 20, 0.5, 0);
+    TiltSimulationNP[SIM_TILT_TB].fill("SIM_TILT_TB", "Top-Bottom (arcsec)", "%4.2f", 0, 20, 0.5, 0);
+    TiltSimulationNP.fill(getDeviceName(), "SIM_TILT", "Tilt Simulation",
+                          SIMULATOR_TAB, IP_RW, 60, IPS_IDLE);
+
     // Periodic Error
     EqPENP[AXIS_RA].fill("RA_PE", "RA (hh:mm:ss)", "%010.6m", 0, 24, 0, 0);
     EqPENP[AXIS_DE].fill("DEC_PE", "DEC (dd:mm:ss)", "%010.6m", -90, 90, 0, 0);
@@ -270,6 +276,7 @@ void CCDSim::ISGetProperties(const char * dev)
     defineProperty(SimulatorSettingsNP);
     defineProperty(EqPENP);
     defineProperty(FocusSimulationNP);
+    defineProperty(TiltSimulationNP);
     defineProperty(SimTestsSP);
 }
 
@@ -593,6 +600,8 @@ int CCDSim::DrawCcdFrame(INDI::CCDChip * targetChip)
         cfg.limitingMag   = m_LimitingMag;
         cfg.saturationMag = m_SaturationMag;
         cfg.seeing        = m_Seeing;
+        cfg.tiltLR        = TiltSimulationNP[SIM_TILT_LR].getValue();
+        cfg.tiltTB        = TiltSimulationNP[SIM_TILT_TB].getValue();
         // Sky glow: 30% boost for realistic light-frame backgrounds; flat frames use diffuser daylight level
         cfg.skyGlow = isLight ? m_SkyGlow * 1.3f : m_SkyGlow / 10.0f;
         m_Renderer.setConfig(cfg);
@@ -766,6 +775,12 @@ bool CCDSim::ISNewNumber(const char * dev, const char * name, double values[], c
             FocusSimulationNP.update(values, names, n);
             FocusSimulationNP.setState(IPS_OK);
             FocusSimulationNP.apply();
+        }
+        else if (TiltSimulationNP.isNameMatch(name))
+        {
+            TiltSimulationNP.update(values, names, n);
+            TiltSimulationNP.setState(IPS_OK);
+            TiltSimulationNP.apply();
         }
     }
 
@@ -1057,6 +1072,9 @@ bool CCDSim::saveConfigItems(FILE * fp)
 
     // Focus simulation
     FocusSimulationNP.save(fp);
+
+    // Tilt simulation
+    TiltSimulationNP.save(fp);
 
     return true;
 }

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -234,6 +234,13 @@ class CCDSim : public INDI::CCD, public INDI::FilterInterface
             SIM_SEEING
         };
 
+        INDI::PropertyNumber TiltSimulationNP {2};
+        enum
+        {
+            SIM_TILT_LR,
+            SIM_TILT_TB
+        };
+
         INDI::PropertyNumber EqPENP {2};
 
         INDI::PropertySwitch CoolerSP {2};

--- a/drivers/ccd/sky_renderer.cpp
+++ b/drivers/ccd/sky_renderer.cpp
@@ -56,9 +56,29 @@ int SkyRenderer::drawImageStar(INDI::CCDChip *chip, float mag, float x, float y,
 
     float const totalFlux = static_cast<float>(flux(mag) * exp_s);
 
-    int const boxsizey = static_cast<int>(3.0f * m_Cfg.seeing / m_ImageScaleY) + 1;
+    // Compute position-dependent seeing to simulate sensor tilt.
+    // Instead of a global seeing, compute per-star seeing by shifting the
+    // effective focus position based on star location on the sensor.
+    // This causes each tile's V-curve minimum to land at a different focuser
+    // position — which is exactly what the Aberration Inspector detects as tilt.
+    float effectiveSeeing = m_Cfg.seeing;
+    if (m_Cfg.tiltLR != 0.0f || m_Cfg.tiltTB != 0.0f)
+    {
+        float const cx = chip->getXRes() / 2.0f;
+        float const cy = chip->getYRes() / 2.0f;
+        float const dx = (x - cx) / cx;  // normalized [-1, +1]
+        float const dy = (y - cy) / cy;
+        // tiltLR/tiltTB in arcsec: directly added to seeing at that position.
+        // This shifts where the V-curve minimum occurs for edge tiles vs center.
+        float const tiltOffset = m_Cfg.tiltLR * dx + m_Cfg.tiltTB * dy;
+        effectiveSeeing += tiltOffset;
+        if (effectiveSeeing < 0.5f)
+            effectiveSeeing = 0.5f;  // Floor to prevent degenerate PSF
+    }
 
-    float const sigma    = m_Cfg.seeing / (2.0f * std::sqrt(2.0f * std::log(2.0f)));
+    int const boxsizey = static_cast<int>(3.0f * effectiveSeeing / m_ImageScaleY) + 1;
+
+    float const sigma    = effectiveSeeing / (2.0f * std::sqrt(2.0f * std::log(2.0f)));
     float const norm     = 1.0f / (sigma * std::sqrt(2.0f * float(M_PI)));
     float const inv2sig2 = 1.0f / (2.0f * sigma * sigma);
 

--- a/drivers/ccd/sky_renderer.h
+++ b/drivers/ccd/sky_renderer.h
@@ -10,6 +10,8 @@ struct RenderConfig
     float saturationMag = 2.0f;     // magnitude that saturates in 1 s
     float seeing        = 3.5f;     // atmospheric FWHM (arcsec)
     float skyGlow       = 19.5f;    // sky background brightness (magnitudes)
+    float tiltLR        = 0.0f;     // Left-to-Right tilt: extra defocus (arcsec) at sensor edge
+    float tiltTB        = 0.0f;     // Top-to-Bottom tilt: extra defocus (arcsec) at sensor edge
 };
 
 // SkyRenderer renders a synthetic sky scene into an INDI::CCDChip frame buffer.


### PR DESCRIPTION
## Summary

Adds configurable sensor tilt to the CCD Simulator that produces position-dependent FWHM variation across the field. This enables testing the Aberration Inspector tilt detection and correction workflows (including tilt plate integrations like Wanderer ETA) without real hardware.

## New Properties (Simulator Config tab)

- **SIM_TILT_LR** (Left-Right): extra seeing at sensor edge (arcsec)
- **SIM_TILT_TB** (Top-Bottom): extra seeing at sensor edge (arcsec)

Default 0/0 — no behavior change for existing users.

## How It Works

The tilt is modeled as a linear defocus plane: one edge gets sharper stars (smaller FWHM) while the opposite edge gets blurrier (larger FWHM). During autofocus, this causes different tiles to find their V-curve minimum at different focuser positions — exactly what the Aberration Inspector detects as sensor tilt.

## Recommended Test Settings

- **Tilt values**: LR=0.2, TB=0.4 arcsec for realistic results
- **CFZ Step Size**: Set to 0.5 μm/step for simulator testing (lower values = smaller corrections)
- **Focus Mechanics**: Walk=Fixed Steps, Initial Step=5000, Number Steps=11, Max Travel=100000
- **Mask**: Mosaic Mask 25%, Spacer 5 px

With these settings, the Aberration Inspector reports ~15μm total tilt with tilt plate corrections of 0.1-0.7mm — well within the Wanderer ETA M54 travel range (0-1.2mm).

## Testing

Tested on StellarMate with Aberration Inspector mosaic mask + Wanderer ETA M54 Apply to ETA integration. Sequential point moves confirmed working (P1→0.615, P2→0.000, P3→0.132 mm).

Config is persisted via Save Configuration.