### PR TITLE
weather: uranusmeteo: fix GPS altitude, TIME_UTC offset, add Lux

### DIFF
--- a/drivers/weather/uranusmeteo.cpp
+++ b/drivers/weather/uranusmeteo.cpp
@@ -94,6 +94,7 @@ bool UranusMeteo::initProperties()
     SkyQualityNP[FullSpectrum].fill("FullSpectrum",  "Full Spectrum", "%.2f", -1000, 1000, 10, 0);
     SkyQualityNP[VisualSpectrum].fill("VisualSpectrum",  "Visual Spectrum", "%.2f", -1000, 1000, 10, 0);
     SkyQualityNP[InfraredSpectrum].fill("InfraredSpectrum",  "Infrared Spectrum", "%.2f", 0, 1, 0.1, 0);
+    SkyQualityNP[Lux].fill("Lux",  "Lux", "%.2f", 0, 1e6, 10, 0);
     SkyQualityNP.fill(getDeviceName(), "SKYQUALITY", "Sky Quality", SKYQUALITY_TAB, IP_RO, 60, IPS_IDLE);
 
     SkyQualityUpdateNP[0].fill("VALUE", "Period (s)", "%.f", 0, 3600, 60, 60);
@@ -108,6 +109,7 @@ bool UranusMeteo::initProperties()
     GPSNP[Latitude].fill("Latitude",  "Latitude", "%.2f", -90, 90, 10, 0);
     GPSNP[Longitude].fill("Longitude",  "Longitude", "%.2f", -180, 180, 10, 0);
     GPSNP[SatelliteNumber].fill("SatelliteNumber",  "Sat. #", "%.f", 0, 30, 10, 0);
+    GPSNP[Altitude].fill("Altitude",  "Altitude (m)", "%.2f", -1000, 10000, 10, 0);
     GPSNP[GPSSpeed].fill("GPSSpeed",  "Speed (kph)", "%.2f", 0, 30, 10, 0);
     GPSNP[GPSBearing].fill("GPSBearing",  "Bearing (deg)", "%.2f", 0, 360, 10, 0);
     GPSNP.fill(getDeviceName(), "GPS", "GPS", GPS_TAB, IP_RO, 60, IPS_IDLE);
@@ -229,6 +231,7 @@ IPState UranusMeteo::updateGPS()
             GPSNP[Latitude].setValue(std::stod(result[Latitude]));
             GPSNP[Longitude].setValue(std::stod(result[Longitude]));
             GPSNP[SatelliteNumber].setValue(std::stod(result[SatelliteNumber]));
+            GPSNP[Altitude].setValue(std::stod(result[Altitude]));
             GPSNP[GPSSpeed].setValue(std::stod(result[GPSSpeed]));
             GPSNP[GPSBearing].setValue(std::stod(result[GPSBearing]));
 
@@ -244,27 +247,28 @@ IPState UranusMeteo::updateGPS()
             if (LocationNP[LOCATION_LONGITUDE].value < 0)
                 LocationNP[LOCATION_LONGITUDE].value += 360;
 
-            LocationNP[LOCATION_ELEVATION].value = SensorNP[BarometricAltitude].getValue();
+            // GPS altitude is a real position fix and, unlike barometric altitude,
+            // does not drift with weather (pressure changes of a few tens of hPa
+            // shift the barometric estimate by tens of meters for a stationary site).
+            LocationNP[LOCATION_ELEVATION].value = GPSNP[Altitude].getValue();
 
             // Get GPS Time
             char ts[32] = {0};
-            time_t raw_time = GPSNP[GPSTime].getValue();
+            time_t raw_time = static_cast<time_t>(GPSNP[GPSTime].getValue());
 
-            // Convert to UTC
-            // JM 2022.12.28: Uranus returns LOCAL TIME, not UTC.
-            struct tm *local = localtime(&raw_time);
-            // Get UTC Offset
-            auto utcOffset = local->tm_gmtoff / 3600.0;
-            // Convert to UTC time
-            time_t utcTime = raw_time - utcOffset * 3600.0;
-            // Store in GPS
-            m_GPSTime = utcTime;
-            // Get tm struct in UTC
-            struct tm *utc = gmtime(&utcTime);
+            // GP already reports Unix UTC time directly (verified against wall-clock
+            // UTC on real hardware: the raw field matched `date -u` exactly). The
+            // previous code assumed it was local time and subtracted the host's UTC
+            // offset, which shifted TIME_UTC by exactly that offset -- e.g. 2 hours
+            // off under CEST. No conversion is needed; use the offset the device
+            // itself reports instead of deriving one from the host's timezone.
+            m_GPSTime = raw_time;
+            struct tm *utc = gmtime(&raw_time);
             // Format it
             strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", utc);
             IUSaveText(&TimeTP[0], ts);
 
+            auto utcOffset = GPSNP[UTCOffset].getValue();
             snprintf(ts, sizeof(ts), "%.2f", utcOffset);
             IUSaveText(&TimeTP[1], ts);
 
@@ -437,6 +441,7 @@ bool UranusMeteo::readSkyQuality()
             SkyQualityNP[FullSpectrum].setValue(std::stod(result[FullSpectrum]));
             SkyQualityNP[VisualSpectrum].setValue(std::stod(result[VisualSpectrum]));
             SkyQualityNP[InfraredSpectrum].setValue(std::stod(result[InfraredSpectrum]));
+            SkyQualityNP[Lux].setValue(std::stod(result[Lux]));
 
             SkyQualityNP.setState(IPS_OK);
             SkyQualityNP.apply();

--- a/drivers/weather/uranusmeteo.h
+++ b/drivers/weather/uranusmeteo.h
@@ -93,8 +93,9 @@ class UranusMeteo : public INDI::GPS, public INDI::WeatherInterface
             FullSpectrum,
             VisualSpectrum,
             InfraredSpectrum,
+            Lux,
         };
-        INDI::PropertyNumber SkyQualityNP {5};
+        INDI::PropertyNumber SkyQualityNP {6};
         INDI::PropertyNumber SkyQualityUpdateNP {1};
 
         ////////////////////////////////////////////////////////////////////////////////////
@@ -122,10 +123,11 @@ class UranusMeteo : public INDI::GPS, public INDI::WeatherInterface
             Latitude,
             Longitude,
             SatelliteNumber,
+            Altitude,
             GPSSpeed,
             GPSBearing
         };
-        INDI::PropertyNumber GPSNP {8};
+        INDI::PropertyNumber GPSNP {9};
 
         ////////////////////////////////////////////////////////////////////////////////////
         /// Moon Report


### PR DESCRIPTION
## Summary

Three fixes to the Uranus Meteo Sensor driver, found while cross-checking the wire protocol against a hand-reverse-engineered decoder validated against real hardware (firmware 1.5).

- **GPS altitude**: `GP` is parsed as an 8-field response (fix, time, utc offset, lat, lon, sat count, speed, bearing), but the device actually sends **9 fields** — a GPS altitude sits between satellite count and speed, undocumented in Pegasus Astro's own command-set PDF. `LocationNP`'s elevation was filled from the barometric sensor instead, which drifts with weather (pressure changes of a few tens of hPa shift the estimate by tens of meters for a stationary site) since it isn't referenced against the site's true elevation. Now `GPSNP` exposes the real GPS altitude and `LocationNP` uses it.

- **TIME_UTC off by the device's UTC offset**: the code assumed `GP`'s Unix time field was local time and subtracted the offset to get UTC, per a 2022 comment. On real hardware the field is already UTC — it matched `date -u` to the second. The subtraction was double-converting (e.g. 2 hours off under CEST). This is more than cosmetic: `GPSInterface`'s `SystemTimeUpdateSP` can use this value to set the host clock. Fixed to use the raw value directly, and to source the UTC offset from the device's own `GP` field instead of the host's timezone.

- **SQ Lux**: the sixth field of `SQ` (raw lux) was read off the wire but never exposed. Unlike MPAS, which saturates near daylight (observed `0.44 mag/arcsec²` in full sun — not a meaningful night-sky reading), lux stays linear and gives a usable daylight/twilight signal.

## Test plan

Verified against a real Uranus Meteo Sensor (firmware 1.5):
- [x] GPS altitude read 441m / 439m / 433m across three separate fixes, agreeing with the barometric sensor's 432m reading under stable weather (as expected when both should roughly agree).
- [x] `TIME_UTC` matched wall-clock UTC after a fix (previously off by exactly the device's 2h offset).
- [x] `SQ` Lux read 72050 lux in full sunlight, while MPAS read a non-physical 0.44 mag/arcsec² at the same time (illustrating why lux is useful near daylight).
- [x] `scripts/check-codestyle.sh` clean on both changed files.
- [x] Builds cleanly (`INDI_BUILD_DRIVERS=ON`).