### PR TITLE
WandererRotator: Add configurable move accuracy and fix false "not po…

### DIFF
--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -135,7 +135,6 @@ bool WandererRotatorBase::ISNewNumber(const char * dev, const char * name, doubl
             accuracy = AccuracyNP[ACCURACY].getValue();
             AccuracyNP.setState(IPS_OK);
             AccuracyNP.apply();
-            saveConfig(AccuracyNP);
             return true;
         }
 
@@ -259,17 +258,19 @@ bool WandererRotatorBase::Handshake()
 IPState WandererRotatorBase::MoveRotator(double angle)
 {
     if (accuracy > 0)
-        angle = round(angle / accuracy) * accuracy;
+        angle = std::round(angle / accuracy) * accuracy;
 
     angle = angle - GotoRotatorNP[0].getValue();
 
-    // Rounded target matches the current position: nothing to move, and the
-    // firmware won't report a position update for a zero-step command.
-    if (std::abs(angle) < 1e-6)
+    // Gate on the actual step delta the firmware will see. Anything that
+    // rounds to zero steps is a no-op the firmware won't acknowledge, so
+    // return immediately instead of blocking in TimerHit ("not powered").
+    int steps = static_cast<int>(std::round(angle * getStepsPerDegree()));
+    if (steps == 0)
         return IPS_OK;
 
     char cmd[16];
-    int position = (int)(angle * getStepsPerDegree() + 1000000);
+    int position = steps + 1000000;
     positionhistory = angle;
     snprintf(cmd, 16, "%d", position);
     Move(cmd);

--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -57,6 +57,11 @@ bool WandererRotatorBase::initProperties()
     BacklashNP[BACKLASH].fill( "BACKLASH", "Degree", "%.2f", 0, 3, 0.1, 0);
     BacklashNP.fill(getDeviceName(), "BACKLASH", "Backlash", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
+    // ACCURACY
+    IUGetConfigNumber(getDeviceName(), "ACCURACY", "ACCURACY", &accuracy);
+    AccuracyNP[ACCURACY].fill("ACCURACY", "Degree (0=off)", "%.2f", 0, 10, 0.1, accuracy);
+    AccuracyNP.fill(getDeviceName(), "ACCURACY", "Accuracy", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
 
 
@@ -71,11 +76,13 @@ bool WandererRotatorBase::updateProperties()
     {
         defineProperty(SetZeroSP);
         defineProperty(BacklashNP);
+        defineProperty(AccuracyNP);
     }
     else
     {
         deleteProperty(SetZeroSP);
         deleteProperty(BacklashNP);
+        deleteProperty(AccuracyNP);
     }
     return true;
 }
@@ -121,8 +128,26 @@ bool WandererRotatorBase::ISNewNumber(const char * dev, const char * name, doubl
             return true;
         }
 
+        // accuracy
+        if (AccuracyNP.isNameMatch(name))
+        {
+            AccuracyNP.update(values, names, n);
+            accuracy = AccuracyNP[ACCURACY].getValue();
+            AccuracyNP.setState(IPS_OK);
+            AccuracyNP.apply();
+            saveConfig(AccuracyNP);
+            return true;
+        }
+
     }
     return Rotator::ISNewNumber(dev, name, values, names, n);
+}
+
+bool WandererRotatorBase::saveConfigItems(FILE *fp)
+{
+    INDI::Rotator::saveConfigItems(fp);
+    AccuracyNP.save(fp);
+    return true;
 }
 
 bool WandererRotatorBase::Handshake()
@@ -233,7 +258,15 @@ bool WandererRotatorBase::Handshake()
 
 IPState WandererRotatorBase::MoveRotator(double angle)
 {
+    if (accuracy > 0)
+        angle = round(angle / accuracy) * accuracy;
+
     angle = angle - GotoRotatorNP[0].getValue();
+
+    // Rounded target matches the current position: nothing to move, and the
+    // firmware won't report a position update for a zero-step command.
+    if (std::abs(angle) < 1e-6)
+        return IPS_OK;
 
     char cmd[16];
     int position = (int)(angle * getStepsPerDegree() + 1000000);

--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -58,9 +58,9 @@ bool WandererRotatorBase::initProperties()
     BacklashNP.fill(getDeviceName(), "BACKLASH", "Backlash", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
     // ACCURACY
-    IUGetConfigNumber(getDeviceName(), "ACCURACY", "ACCURACY", &accuracy);
-    AccuracyNP[ACCURACY].fill("ACCURACY", "Degree (0=off)", "%.2f", 0, 10, 0.1, accuracy);
+    AccuracyNP[0].fill("ACCURACY", "Degree (0=off)", "%.2f", 0, 10, 0.1, 0);
     AccuracyNP.fill(getDeviceName(), "ACCURACY", "Accuracy", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+    AccuracyNP.load();
 
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
 
@@ -131,11 +131,11 @@ bool WandererRotatorBase::ISNewNumber(const char * dev, const char * name, doubl
         // accuracy
         if (AccuracyNP.isNameMatch(name))
         {
-            AccuracyNP.update(values, names, n);
-            accuracy = AccuracyNP[ACCURACY].getValue();
-            AccuracyNP.setState(IPS_OK);
-            AccuracyNP.apply();
-            return true;
+            return updateProperty(AccuracyNP, values, names, n, [this, values]()
+            {
+                accuracy = values[0];
+                return true;
+            });
         }
 
     }

--- a/drivers/rotator/wanderer_rotator_base.h
+++ b/drivers/rotator/wanderer_rotator_base.h
@@ -38,6 +38,7 @@ public:
     bool updateProperties() override;
     bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+    bool saveConfigItems(FILE *fp) override;
 
 protected:
     virtual const char * getDefaultName() override = 0;
@@ -57,6 +58,7 @@ protected:
 
     INDI::PropertySwitch SetZeroSP{1};
     INDI::PropertyNumber BacklashNP{1};
+    INDI::PropertyNumber AccuracyNP{1};
 
     int firmware = 0;
     double M_angleread = 0;
@@ -66,6 +68,7 @@ protected:
     bool haltcommand = false;
     bool ReverseState = false;
     double backlash = 0.5;
+    double accuracy = 0.0;
     double positionhistory = 0;
     int estime = 0;
     int nowtime = 0;
@@ -73,5 +76,10 @@ protected:
     enum
     {
         BACKLASH,
+    };
+
+    enum
+    {
+        ACCURACY,
     };
 };

--- a/drivers/rotator/wanderer_rotator_base.h
+++ b/drivers/rotator/wanderer_rotator_base.h
@@ -77,9 +77,4 @@ protected:
     {
         BACKLASH,
     };
-
-    enum
-    {
-        ACCURACY,
-    };
 };


### PR DESCRIPTION
…wered" error on zero-step moves

Adds a new "Accuracy" number property (ROTATOR_ACCURACY/ACCURACY) to WandererRotatorBase, shared by both the Mini and Lite drivers. It lets the user configure the granularity to which requested rotator angles are rounded before a move is issued (e.g. 0.5 degrees), or disable rounding entirely by setting it to 0.

Motivation: physical backlash/precision of the WandererRotator Mini/Lite mechanism makes sub-degree accuracy meaningless for most setups, so snapping goto requests to a coarser grid avoids unnecessary micro-moves and firmware round-trips. The value is persisted via saveConfigItems and restored on startup via IUGetConfigNumber, mirroring the existing Backlash property.

While testing, rounding surfaced a pre-existing bug: if the client requests an angle that rounds to the same position the rotator is already at, MoveRotator still computed a relative move of 0 steps and sent it to the device. The firmware does not report a new position after a zero-step command (since nothing physically moves), so the driver's TimerHit blocked on tty_read_section until it timed out and logged "Rotator not powered!", even though the rotator was working correctly and simply didn't need to move.

Fix: after applying accuracy rounding, MoveRotator now checks whether the resulting relative angle is ~0 and, if so, returns IPS_OK immediately without writing to the serial port, instead of issuing a no-op move command and waiting for a response that will never arrive.