### PR TITLE
WandererRotator: fix handshake parse bugs and abs()-on-double hazards (on top of #2448)

### DIFF
--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -180,7 +180,7 @@ bool WandererRotatorBase::Handshake()
         {
             char errorMessage[MAXRBUF];
             tty_error_msg(rc, errorMessage, MAXRBUF);
-            LOGF_INFO("No data received, the device may not be WandererRotator, please check the serial port!", "Updated");
+            LOG_INFO("No data received, the device may not be WandererRotator, please check the serial port!");
             LOGF_ERROR("Device read error: %s", errorMessage);
             return false;
         }
@@ -203,7 +203,7 @@ bool WandererRotatorBase::Handshake()
     if(firmware < getMinimumCompatibleFirmwareVersion())
     {
         LOG_ERROR("The firmware is outdated, please upgrade to the latest firmware!");
-        LOGF_ERROR("The current firmware is %s.", firmware);
+        LOGF_ERROR("The current firmware is %d.", firmware);
         return false;
     }
 
@@ -214,7 +214,7 @@ bool WandererRotatorBase::Handshake()
     M_angle[nbytes_read_M_angle - 1] = '\0';
     M_angleread = std::strtod(M_angle, NULL);
 
-    if(abs(M_angleread) > 400000)
+    if(std::fabs(M_angleread) > 400000)
     {
         rc = sendCommand("1500002");
         LOG_WARN("Virtual Mechanical Angle is too large, it is now set to zero!");
@@ -225,7 +225,7 @@ bool WandererRotatorBase::Handshake()
         M_angle[nbytes_read_M_angle - 1] = '\0';
         M_angleread = std::strtod(M_angle, NULL);
     }
-    GotoRotatorNP[0].setValue(abs(M_angleread / 1000));
+    GotoRotatorNP[0].setValue(std::fabs(M_angleread / 1000));
     //backlash/////////////////////////////////////////////////////////////////////
     char M_backlash[64] = {0};
     int nbytes_read_M_backlash = 0;
@@ -240,7 +240,7 @@ bool WandererRotatorBase::Handshake()
     char M_reverse[64] = {0};
     int nbytes_read_M_reverse = 0;
     tty_read_section(PortFD, M_reverse, 'A', 5, &nbytes_read_M_reverse);
-    M_reverse[nbytes_read_M_angle - 1] = '\0';
+    M_reverse[nbytes_read_M_reverse - 1] = '\0';
     M_reverseread = std::strtod(M_reverse, NULL);
     if(M_reverseread == 0)
     {
@@ -360,7 +360,7 @@ void WandererRotatorBase::TimerHit()
 
         if(nowtime < estime && haltcommand == false)
         {
-            GotoRotatorNP[0].setValue(GotoRotatorNP[0].getValue() + 1 * positionhistory / abs(positionhistory));
+            GotoRotatorNP[0].setValue(GotoRotatorNP[0].getValue() + std::copysign(1.0, positionhistory));
             GotoRotatorNP.apply();
             nowtime = nowtime + 240;
             SetTimer(240);
@@ -386,7 +386,7 @@ void WandererRotatorBase::TimerHit()
 
             M_angle[nbytes_read_M_angle - 1] = '\0';
             M_angleread = std::strtod(M_angle, NULL);
-            GotoRotatorNP[0].setValue(abs(M_angleread / 1000));
+            GotoRotatorNP[0].setValue(std::fabs(M_angleread / 1000));
             GotoRotatorNP.setState(IPS_OK);
             GotoRotatorNP.apply();
             haltcommand = false;

--- a/drivers/rotator/wanderer_rotator_base.cpp
+++ b/drivers/rotator/wanderer_rotator_base.cpp
@@ -57,6 +57,11 @@ bool WandererRotatorBase::initProperties()
     BacklashNP[BACKLASH].fill( "BACKLASH", "Degree", "%.2f", 0, 3, 0.1, 0);
     BacklashNP.fill(getDeviceName(), "BACKLASH", "Backlash", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
 
+    // ACCURACY
+    IUGetConfigNumber(getDeviceName(), "ACCURACY", "ACCURACY", &accuracy);
+    AccuracyNP[ACCURACY].fill("ACCURACY", "Degree (0=off)", "%.2f", 0, 10, 0.1, accuracy);
+    AccuracyNP.fill(getDeviceName(), "ACCURACY", "Accuracy", MAIN_CONTROL_TAB, IP_RW, 60, IPS_IDLE);
+
     serialConnection->setDefaultBaudRate(Connection::Serial::B_19200);
 
 
@@ -71,11 +76,13 @@ bool WandererRotatorBase::updateProperties()
     {
         defineProperty(SetZeroSP);
         defineProperty(BacklashNP);
+        defineProperty(AccuracyNP);
     }
     else
     {
         deleteProperty(SetZeroSP);
         deleteProperty(BacklashNP);
+        deleteProperty(AccuracyNP);
     }
     return true;
 }
@@ -121,8 +128,26 @@ bool WandererRotatorBase::ISNewNumber(const char * dev, const char * name, doubl
             return true;
         }
 
+        // accuracy
+        if (AccuracyNP.isNameMatch(name))
+        {
+            AccuracyNP.update(values, names, n);
+            accuracy = AccuracyNP[ACCURACY].getValue();
+            AccuracyNP.setState(IPS_OK);
+            AccuracyNP.apply();
+            saveConfig(AccuracyNP);
+            return true;
+        }
+
     }
     return Rotator::ISNewNumber(dev, name, values, names, n);
+}
+
+bool WandererRotatorBase::saveConfigItems(FILE *fp)
+{
+    INDI::Rotator::saveConfigItems(fp);
+    AccuracyNP.save(fp);
+    return true;
 }
 
 bool WandererRotatorBase::Handshake()
@@ -233,7 +258,15 @@ bool WandererRotatorBase::Handshake()
 
 IPState WandererRotatorBase::MoveRotator(double angle)
 {
+    if (accuracy > 0)
+        angle = round(angle / accuracy) * accuracy;
+
     angle = angle - GotoRotatorNP[0].getValue();
+
+    // Rounded target matches the current position: nothing to move, and the
+    // firmware won't report a position update for a zero-step command.
+    if (std::abs(angle) < 1e-6)
+        return IPS_OK;
 
     char cmd[16];
     int position = (int)(angle * getStepsPerDegree() + 1000000);

--- a/drivers/rotator/wanderer_rotator_base.h
+++ b/drivers/rotator/wanderer_rotator_base.h
@@ -38,6 +38,7 @@ public:
     bool updateProperties() override;
     bool ISNewSwitch(const char *dev, const char *name, ISState *states, char *names[], int n) override;
     bool ISNewNumber(const char *dev, const char *name, double values[], char *names[], int n) override;
+    bool saveConfigItems(FILE *fp) override;
 
 protected:
     virtual const char * getDefaultName() override = 0;
@@ -57,6 +58,7 @@ protected:
 
     INDI::PropertySwitch SetZeroSP{1};
     INDI::PropertyNumber BacklashNP{1};
+    INDI::PropertyNumber AccuracyNP{1};
 
     int firmware = 0;
     double M_angleread = 0;
@@ -66,6 +68,7 @@ protected:
     bool haltcommand = false;
     bool ReverseState = false;
     double backlash = 0.5;
+    double accuracy = 0.0;
     double positionhistory = 0;
     int estime = 0;
     int nowtime = 0;
@@ -73,5 +76,10 @@ protected:
     enum
     {
         BACKLASH,
+    };
+
+    enum
+    {
+        ACCURACY,
     };
 };


### PR DESCRIPTION
## Stacked on #2448

This PR is built **on top of #2448** (`WandererRotator: Add configurable move accuracy …`). The first commit here is that PR's commit; the diff will reduce to just the fix commit once #2448 is merged. Please merge #2448 first, or merge this after rebasing onto master once #2448 lands.

The fixes below are pre-existing bugs, independent of the accuracy feature, but they are stacked here because #2448's sub-degree accuracy makes bug 3 (below) considerably more likely to trigger in practice.

---

## Fixes (this PR's own commit)

Three pre-existing bugs in `WandererRotatorBase`:

### 1. Reverse-flag buffer mis-terminated in `Handshake()`
The reverse-flag response buffer was null-terminated using the **angle** response length (`nbytes_read_M_angle`) instead of its own length (`nbytes_read_M_reverse`). If the two replies differ in length, the reverse state is parsed from a mis-terminated buffer. Same class of bug as the backlash-read fix in #2195.

### 2. `%s` format specifier used for an `int`
On the outdated-firmware path, the firmware version (an `int`) was logged with `%s`, reinterpreting the integer as a `char*` → garbage read / potential crash on the exact path meant to give the user a clear message. Changed to `%d`. Also removed a stray extra argument passed to a non-format `LOG_INFO` on the "no data received" path.

### 3. `abs()` on doubles truncates position / divides by zero
Rotator angles were passed through the C integer `abs()` (unqualified), which truncates sub-degree positions to whole degrees and, in `TimerHit`'s sign term `positionhistory / abs(positionhistory)`, divides by zero for any sub-1° move. Switched the position reads to `std::fabs()` and the sign term to `std::copysign(1.0, positionhistory)`.

**This is why the fix is stacked here:** #2448 lets users request sub-degree accuracy (e.g. 0.5°), which makes the divide-by-zero in bug 3 reachable through normal use.

---

7-line change, single file (`drivers/rotator/wanderer_rotator_base.cpp`), syntax-checked against the repo headers with #2448 applied.
