### PR TITLE
indiccd: Add gradual warm-up state machine to INDI::CCD base class

### DIFF
--- a/drivers/ccd/ccd_simulator.cpp
+++ b/drivers/ccd/ccd_simulator.cpp
@@ -368,7 +368,7 @@ bool CCDSim::updateProperties()
     return true;
 }
 
-int CCDSim::SetTemperature(double temperature)
+int CCDSim::SetTemperature(double temperature, bool enableCooler)
 {
     TemperatureRequest = temperature;
     if (std::abs(temperature - TemperatureNP[0].getValue()) < 0.1)
@@ -377,11 +377,14 @@ int CCDSim::SetTemperature(double temperature)
         return 1;
     }
 
-    auto isCooling = TemperatureRequest < temperature;
-    CoolerSP[INDI_ENABLED].setState(isCooling ? ISS_ON : ISS_OFF);
-    CoolerSP[INDI_DISABLED].setState(isCooling ? ISS_OFF : ISS_ON);
-    CoolerSP.setState(isCooling ? IPS_BUSY : IPS_IDLE);
-    CoolerSP.apply();
+    if (enableCooler)
+    {
+        auto isCooling = TemperatureRequest < temperature;
+        CoolerSP[INDI_ENABLED].setState(isCooling ? ISS_ON : ISS_OFF);
+        CoolerSP[INDI_DISABLED].setState(isCooling ? ISS_OFF : ISS_ON);
+        CoolerSP.setState(isCooling ? IPS_BUSY : IPS_IDLE);
+        CoolerSP.apply();
+    }
     return 0;
 }
 

--- a/drivers/ccd/ccd_simulator.h
+++ b/drivers/ccd/ccd_simulator.h
@@ -112,7 +112,7 @@ class CCDSim : public INDI::CCD, public INDI::FilterInterface
         virtual bool saveConfigItems(FILE *fp) override;
         virtual void addFITSKeywords(INDI::CCDChip *targetChip, std::vector<INDI::FITSRecord> &fitsKeyword) override;
         virtual void activeDevicesUpdated() override;
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
         virtual bool UpdateCCDBin(int hor, int ver) override;
         virtual bool UpdateGuiderBin(int hor, int ver) override;

--- a/drivers/ccd/indi_alpaca_ccd.cpp
+++ b/drivers/ccd/indi_alpaca_ccd.cpp
@@ -968,7 +968,7 @@ bool AlpacaCCD::AbortExposure()
     return true;
 }
 
-int AlpacaCCD::SetTemperature(double temperature)
+int AlpacaCCD::SetTemperature(double temperature, bool enableCooler)
 {
     if (!isConnected())
     {
@@ -980,8 +980,8 @@ int AlpacaCCD::SetTemperature(double temperature)
     if (std::abs(temperature - m_CurrentTemperature) < TEMP_THRESHOLD)
         return 1;
 
-    // Activate cooler if not already on
-    if (CoolerSP[INDI_ENABLED].getState() != ISS_ON)
+    // Activate cooler if explicitly requested and not already on
+    if (enableCooler && CoolerSP[INDI_ENABLED].getState() != ISS_ON)
     {
         nlohmann::json response;
         nlohmann::json body = {{"CoolerOn", true}};

--- a/drivers/ccd/indi_alpaca_ccd.h
+++ b/drivers/ccd/indi_alpaca_ccd.h
@@ -71,7 +71,7 @@ class AlpacaCCD : public INDI::CCD
 
         virtual bool StartExposure(float duration) override;
         virtual bool AbortExposure() override;
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
         virtual bool UpdateCCDFrame(int x, int y, int w, int h) override;
         virtual bool UpdateCCDBin(int hor, int ver) override;
         virtual bool SetCaptureFormat(uint8_t index) override;

--- a/drivers/ccd/indi_seestar_ccd.cpp
+++ b/drivers/ccd/indi_seestar_ccd.cpp
@@ -110,10 +110,11 @@ bool SeestarCCD::updateProperties()
 ////////////////////////////////////////////////////////////////////////////////////////////
 ///
 ////////////////////////////////////////////////////////////////////////////////////////////
-int SeestarCCD::SetTemperature(double temperature)
+int SeestarCCD::SetTemperature(double temperature, bool enableCooler)
 {
     // Seestar doesn't have active cooling, so we don't allow temperature setting
     INDI_UNUSED(temperature);
+    INDI_UNUSED(enableCooler);
     return -1;
 }
 

--- a/drivers/ccd/indi_seestar_ccd.h
+++ b/drivers/ccd/indi_seestar_ccd.h
@@ -54,7 +54,7 @@ class SeestarCCD : public AlpacaCCD
         virtual bool updateProperties() override;
         
         // Disable cooler controls (Seestar doesn't have active cooling)
-        virtual int SetTemperature(double temperature) override;
+        virtual int SetTemperature(double temperature, bool enableCooler = false) override;
 
         /**
          * @brief Build Alpaca form data with Seestar-specific parameter ordering

--- a/examples/tutorial_three/simpleccd.cpp
+++ b/examples/tutorial_three/simpleccd.cpp
@@ -141,8 +141,9 @@ bool SimpleCCD::AbortExposure()
 /**************************************************************************************
 ** Client is asking us to set a new temperature
 ***************************************************************************************/
-int SimpleCCD::SetTemperature(double temperature)
+int SimpleCCD::SetTemperature(double temperature, bool enableCooler)
 {
+    INDI_UNUSED(enableCooler);
     TemperatureRequest = temperature;
 
     // 0 means it will take a while to change the temperature

--- a/examples/tutorial_three/simpleccd.h
+++ b/examples/tutorial_three/simpleccd.h
@@ -41,7 +41,7 @@ class SimpleCCD : public INDI::CCD
         // CCD specific functions
         bool StartExposure(float duration) override;
         bool AbortExposure() override;
-        int SetTemperature(double temperature) override;
+        int SetTemperature(double temperature, bool enableCooler = false) override;
         void TimerHit() override;
 
     private:

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -62,6 +62,15 @@
 const char * IMAGE_SETTINGS_TAB = "Image Settings";
 const char * IMAGE_INFO_TAB     = "Image Info";
 const char * GUIDE_HEAD_TAB     = "Guider Head";
+
+// Warm-up target when switching the cooler off. No new property: TECs need to reach a safe
+// temperature before power is cut; 30 °C is high enough to ensure the sensor is at or above
+// the dew point in virtually all observing conditions.
+static constexpr double WARMUP_TARGET_C    = 30.0;
+// Stability window: the reading must not change by more than this to count as "settled".
+static constexpr double WARMUP_STABLE_DELTA = 0.5;
+// How long (ms) the temperature must stay within WARMUP_STABLE_DELTA to be considered done.
+static constexpr int64_t WARMUP_STABLE_MS  = 60000;
 //const char * RAPIDGUIDE_TAB     = "Rapid Guide";
 
 
@@ -1409,6 +1418,10 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
                 TemperatureNP.apply();
                 return false;
             }
+
+            // An explicit temperature request cancels any cooler warm-up in progress.
+            if (m_CoolerWarmingUp)
+                m_CoolerWarmingUp = false;
 
             double nextTemperature = values[0];
             // If temperature ramp is enabled, find
@@ -2898,7 +2911,9 @@ bool CCD::saveConfigItems(FILE * fp)
         EncodeFormatSP.save(fp);
 
     if (HasCooler())
+    {
         TemperatureRampNP.save(fp);
+    }
 
     if (HasGuideHead())
     {
@@ -3149,6 +3164,134 @@ bool CCD::StopStreaming()
 /////////////////////////////////////////////////////////////////////////////////////////
 ///
 /////////////////////////////////////////////////////////////////////////////////////////
+bool CCD::SetCoolerEnabled(bool enable)
+{
+    INDI_UNUSED(enable);
+    LOG_ERROR("SetCoolerEnabled() is not implemented. Override it in the driver.");
+    return false;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////////
+void CCD::beginCoolerWarmup(double currentTemperature)
+{
+    // Save the user's actual target before we overwrite m_TargetTemperature with the ramp target.
+    m_SavedCoolingTarget = m_TargetTemperature;
+
+    if (TemperatureRampNP[RAMP_SLOPE].getValue() == 0 || currentTemperature >= WARMUP_TARGET_C)
+    {
+        // No ramp configured, or already warm — cut the cooler immediately.
+        // The driver should have set its CoolerSP to IPS_BUSY before calling us; SetCoolerEnabled
+        // will update it to IPS_IDLE.
+        SetCoolerEnabled(false);
+        return;
+    }
+
+    double nextTemperature = std::min(WARMUP_TARGET_C,
+                                      currentTemperature + TemperatureRampNP[RAMP_SLOPE].getValue());
+    int rc = SetTemperature(nextTemperature);
+    if (rc == -1)
+    {
+        LOG_ERROR("Failed to start cooler warm-up; turning cooler off immediately.");
+        SetCoolerEnabled(false);
+        return;
+    }
+
+    m_CoolerWarmingUp = true;
+    m_WarmupLastTemperature = currentTemperature;
+    m_WarmupStableTimer.start();
+
+    if (rc == 0)
+    {
+        m_TemperatureElapsedTimer.start();
+        m_TargetTemperature = WARMUP_TARGET_C;
+        m_TemperatureCheckTimer.start();
+        TemperatureNP.setState(IPS_BUSY);
+        TemperatureNP.apply();
+    }
+
+    LOGF_INFO("Cooler warming up to %.0f C...", WARMUP_TARGET_C);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////////
+void CCD::cancelCoolerWarmup()
+{
+    if (!m_CoolerWarmingUp)
+        return;
+
+    m_CoolerWarmingUp = false;
+    m_TemperatureCheckTimer.stop();
+
+    if (TemperatureNP.getState() == IPS_BUSY)
+    {
+        TemperatureNP.setState(IPS_OK);
+        TemperatureNP.apply();
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////////
+void CCD::resumeCoolingAfterWarmup()
+{
+    if (m_SavedCoolingTarget >= TemperatureNP[0].getValue())
+        return; // no saved target, or already cooler than the saved target — nothing to do
+
+    double nextTemperature = m_SavedCoolingTarget;
+    if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
+        nextTemperature = std::max(m_SavedCoolingTarget,
+                                   TemperatureNP[0].getValue() - TemperatureRampNP[RAMP_SLOPE].getValue());
+
+    int rc = SetTemperature(nextTemperature);
+    if (rc == 0)
+    {
+        if (TemperatureRampNP[RAMP_SLOPE].getValue() != 0)
+            m_TemperatureElapsedTimer.start();
+        m_TargetTemperature = m_SavedCoolingTarget;
+        m_TemperatureCheckTimer.start();
+        TemperatureNP.setState(IPS_BUSY);
+        TemperatureNP.apply();
+        LOGF_INFO("Resuming cooling to %.2f C.", m_SavedCoolingTarget);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////////
+void CCD::coolerWarmupTick(double currentTemperature)
+{
+    if (!m_CoolerWarmingUp)
+        return;
+
+    if (std::abs(currentTemperature - m_WarmupLastTemperature) > WARMUP_STABLE_DELTA)
+    {
+        m_WarmupLastTemperature = currentTemperature;
+        m_WarmupStableTimer.start();
+    }
+    else if (m_WarmupStableTimer.hasExpired(WARMUP_STABLE_MS))
+    {
+        m_CoolerWarmingUp = false;
+        m_TemperatureCheckTimer.stop();
+
+        if (TemperatureNP.getState() == IPS_BUSY)
+        {
+            TemperatureNP.setState(IPS_OK);
+            TemperatureNP.apply();
+        }
+
+        if (SetCoolerEnabled(false))
+            LOG_INFO("Cooler is now off, temperature has stabilized.");
+        else
+            LOG_ERROR("Failed to turn cooler off after warm-up.");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+///
+/////////////////////////////////////////////////////////////////////////////////////////
 void CCD::checkTemperatureTarget()
 {
     if (TemperatureNP.getState() == IPS_BUSY)
@@ -3158,6 +3301,16 @@ void CCD::checkTemperatureTarget()
             TemperatureNP.setState(IPS_OK);
             m_TemperatureCheckTimer.stop();
             TemperatureNP.apply();
+
+            // If this was a warm-up ramp, switch the cooler off now.
+            if (m_CoolerWarmingUp)
+            {
+                m_CoolerWarmingUp = false;
+                if (SetCoolerEnabled(false))
+                    LOG_INFO("Cooler is now off, ambient temperature reached.");
+                else
+                    LOG_ERROR("Failed to turn cooler off after warm-up.");
+            }
         }
         // If we are beyond a minute, check for next step
         else if (TemperatureRampNP[RAMP_SLOPE].getValue() > 0 && m_TemperatureElapsedTimer.elapsed() >= 60000)

--- a/libs/indibase/indiccd.cpp
+++ b/libs/indibase/indiccd.cpp
@@ -1438,7 +1438,7 @@ bool CCD::ISNewNumber(const char * dev, const char * name, double values[], char
                 }
             }
 
-            int rc = SetTemperature(nextTemperature);
+            int rc = SetTemperature(nextTemperature, true);
 
             if (rc == 0)
             {
@@ -1929,9 +1929,10 @@ bool CCD::ISNewBLOB(const char *dev, const char *name, int sizes[], int blobsize
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-int CCD::SetTemperature(double temperature)
+int CCD::SetTemperature(double temperature, bool enableCooler)
 {
     INDI_UNUSED(temperature);
+    INDI_UNUSED(enableCooler);
     DEBUGF(Logger::DBG_WARNING, "CCD::SetTemperature %4.2f -  Should never get here", temperature);
     return -1;
 }

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -278,7 +278,7 @@ class CCD : public DefaultDevice, GuiderInterface
          * value, change the state to OK.
          * \note This function is not implemented in CCD, it must be implemented in the child class
          */
-        virtual int SetTemperature(double temperature);
+        virtual int SetTemperature(double temperature, bool enableCooler = false);
 
         /**
          * @brief SetCoolerEnabled Turn the cooler on or off.

--- a/libs/indibase/indiccd.h
+++ b/libs/indibase/indiccd.h
@@ -281,6 +281,16 @@ class CCD : public DefaultDevice, GuiderInterface
         virtual int SetTemperature(double temperature);
 
         /**
+         * @brief SetCoolerEnabled Turn the cooler on or off.
+         * @param enable True to enable, false to disable.
+         * @return true if the hardware call succeeded, false otherwise.
+         * \note This function is not implemented in CCD, it must be implemented in the child class
+         *       if CCD_HAS_COOLER capability is set.  When called with enable=false at the end of
+         *       a warm-up sequence the driver should also update its own CoolerSP switch to IPS_IDLE.
+         */
+        virtual bool SetCoolerEnabled(bool enable);
+
+        /**
          * \brief Start exposing primary CCD chip
          * \param duration Duration in seconds
          * \return true if OK and exposure will take some time to complete, false on error.
@@ -530,6 +540,41 @@ class CCD : public DefaultDevice, GuiderInterface
         virtual void checkTemperatureTarget();
 
         /**
+         * @brief coolerWarmupTick Must be called by the driver's temperature polling loop to feed
+         *        the current temperature reading into the warm-up state machine. When the cooler is
+         *        not warming up this is a no-op. When warming up it checks whether the temperature
+         *        has been stable (changed less than WARMUP_STABLE_DELTA) for WARMUP_STABLE_MS and
+         *        finalises the warm-up by calling SetCoolerEnabled(false) once stable.
+         * @param currentTemperature Latest temperature reading in °C.
+         */
+        void coolerWarmupTick(double currentTemperature);
+
+        /**
+         * @brief beginCoolerWarmup Start a gradual warm-up ramp toward WARMUP_TARGET_C (30 °C).
+         *        Saves the current m_TargetTemperature so it can be restored if the cooler is
+         *        switched back on. The driver must set its own CoolerSP to IPS_BUSY before calling
+         *        this, and must override SetCoolerEnabled() to transition CoolerSP to IPS_IDLE
+         *        when the base class finally calls SetCoolerEnabled(false) on completion.
+         * @param currentTemperature Current sensor reading used to kick off the first ramp step.
+         */
+        void beginCoolerWarmup(double currentTemperature);
+
+        /**
+         * @brief cancelCoolerWarmup Abort an in-progress warm-up (e.g. because the cooler was
+         *        switched back on). Stops the temperature timer and clears the warming-up flag.
+         *        Does NOT touch the hardware or any property — the caller is responsible for that.
+         */
+        void cancelCoolerWarmup();
+
+        /**
+         * @brief resumeCoolingAfterWarmup If a valid cooling target was saved before the last
+         *        warm-up, this issues a new SetTemperature() ramp toward that target and sets
+         *        TemperatureNP to IPS_BUSY.  Call this after SetCoolerEnabled(true) succeeds when
+         *        the user re-enables the cooler.
+         */
+        void resumeCoolingAfterWarmup();
+
+        /**
          * @brief processFastExposure After an exposure is complete, check if fast
          * exposure was enabled. If it is, then immediately start the next exposure
          * if possible and decrement the counter.
@@ -599,6 +644,12 @@ class CCD : public DefaultDevice, GuiderInterface
         double m_TargetTemperature {0};
         INDI::Timer m_TemperatureCheckTimer;
         INDI::ElapsedTimer m_TemperatureElapsedTimer;
+
+        // Cooler warm-up state machine
+        bool m_CoolerWarmingUp {false};
+        double m_WarmupLastTemperature {0};
+        double m_SavedCoolingTarget {100.0}; // sentinel: no prior cooling target
+        INDI::ElapsedTimer m_WarmupStableTimer;
 
         // Threading
         std::mutex ccdBufferLock;


### PR DESCRIPTION
When a driver turns the cooler off and a temperature ramp slope is configured, the base class now ramps the sensor target toward 30 °C instead of cutting power immediately.  Completion is detected by temperature stability (< 0.5 °C change over 60 s) so it works correctly with unidirectional TECs that cannot actively heat.

CoolerSP stays in each driver.  The base class exposes three protected helper methods that drivers call from their own ISNewSwitch handler:

  beginCoolerWarmup(currentTemperature)
    Saves the user's cooling target (m_TargetTemperature), then either
    cuts the cooler immediately (no ramp, or already ≥ 30 °C) or starts
    a ramped ascent.  The driver must set its own CoolerSP to IPS_BUSY
    before calling this.

  cancelCoolerWarmup()
    Clears m_CoolerWarmingUp and stops the temperature timer.  Call
    when the user re-enables the cooler mid warm-up.

  resumeCoolingAfterWarmup()
    If a valid target was saved, issues a new SetTemperature() ramp
    toward it.  Call after SetCoolerEnabled(true) succeeds.

  coolerWarmupTick(currentTemperature)
    Must be called from the driver's polling loop.  No-op when not
    warming up; fires SetCoolerEnabled(false) once temperature is stable.

The driver's SetCoolerEnabled(false) override is responsible for transitioning its own CoolerSP to IPS_IDLE on completion.