### PR TITLE
skywatcherAltAzMount: fix Alt-Az tracking direction reversal

### DIFF
--- a/drivers/telescope/skywatcherAPIMount.cpp
+++ b/drivers/telescope/skywatcherAPIMount.cpp
@@ -1615,8 +1615,8 @@ bool SkywatcherAPIMount::trackByRate(AXISID axis, double rate)
     if (AxesStatus[axis].FullStop && rate == 0)
         return true;
     // If rate is zero, or direction changed then we should stop.
-    else if (!AxesStatus[axis].FullStop && (rate == 0 || (AxesStatus[AXIS1].SlewingForward && rate < 0)
-                                            || (!AxesStatus[AXIS1].SlewingForward && rate > 0)))
+    else if (!AxesStatus[axis].FullStop && (rate == 0 || (AxesStatus[axis].SlewingForward && rate < 0)
+                                            || (!AxesStatus[axis].SlewingForward && rate > 0)))
     {
         SlowStop(axis);
         LOGF_DEBUG("Tracking -> %s direction change.", (axis == AXIS1 ? "Axis 1" : "Axis 2"));
@@ -1628,12 +1628,16 @@ bool SkywatcherAPIMount::trackByRate(AXISID axis, double rate)
                           AxisOneEncoderValuesN[MICROSTEPS_PER_ARCSEC].value : AxisTwoEncoderValuesN[MICROSTEPS_PER_ARCSEC].value)));
     auto clockRate = (StepperClockFrequency[axis] / std::max(1u, stepsPerSecond));
 
-    SetClockTicksPerMicrostep(axis, clockRate);
     if (AxesStatus[axis].FullStop)
     {
         LOGF_DEBUG("Tracking -> %s restart.", (axis == AXIS1 ? "Axis 1" : "Axis 2"));
         SetAxisMotionMode(axis, '1', Direction);
+        SetClockTicksPerMicrostep(axis, clockRate);
         StartAxisMotion(axis);
+    }
+    else
+    {
+        SetClockTicksPerMicrostep(axis, clockRate);
     }
 
     return true;


### PR DESCRIPTION
trackByRate() had two bugs preventing the altitude axis from tracking correctly whenever a direction reversal was needed:

1. The direction-change check compared AxesStatus[AXIS1] in both branches instead of AxesStatus[axis], so altitude's reversal decision was driven by azimuth's current direction rather than its own.

2. On restart after a stop, SetClockTicksPerMicrostep() (speed) was called before SetAxisMotionMode() (direction/mode). The mount firmware rejected this with a "Motor not stopped" error, even from a full standstill. The working manual-jog path (Slew() / PrepareForSlewing()) always sets motion mode before speed; reorder trackByRate()'s restart branch to match.

Without this fix, altitude would freeze whenever a reversal was needed and the tracking offset would grow unbounded. Tested on real hardware (AZ-EQ6, Wave 150i, and AZ-GTi) with both fixes applied: altitude and azimuth now track continuously with no errors, confirmed via encoder movement over several minutes and multiple GOTO targets. Tested on-sky tracking with Wave 150i.