### PR TITLE
    Fix -Wformat errors: format specifier type mismatches breaking Powerpc builds

### DIFF
--- a/libs/fpack/fpackutil.c
+++ b/libs/fpack/fpackutil.c
@@ -20,6 +20,7 @@
 #include <fitsio.h>
 #include <fitsio2.h>
 #include "fpack.h"
+#include <inttypes.h>
 
 /* these filename buffer are used to delete temporary files */
 /* in case the program is aborted */
@@ -245,14 +246,9 @@ int fp_list (int argc, char *argv[], fpstate fpvar)
 
         snprintf (msg, SZ_STR,"# %s (", infits); fp_msg (msg);
 
-#if defined(_MSC_VER)
-        /* Microsoft Visual C++ 6.0 uses '%I64d' syntax  for 8-byte integers */
-        snprintf(msg, SZ_STR,"%I64d bytes)\n", sizell); fp_msg (msg);
-#elif (USE_LL_SUFFIX == 1)
-        snprintf(msg, SZ_STR,"%lld bytes)\n", sizell); fp_msg (msg);
-#else
-        snprintf(msg, SZ_STR,"%ld bytes)\n", sizell); fp_msg (msg);
-#endif
+	snprintf(msg, SZ_STR, "%" PRId64 " bytes)\n", (int64_t) sizell);
+        fp_msg (msg);
+
         fp_info_hdu (infptr);
 
         fits_close_file (infptr, &stat);
@@ -1879,15 +1875,10 @@ int fp_test (char *infits, char *outfits, char *outfits2, fpstate fpvar)
 
             fits_get_num_rowsll(inputfptr, &nrows, &stat);
             fits_get_num_cols(inputfptr, &ncols, &stat);
-#if defined(_MSC_VER)
-            /* Microsoft Visual C++ 6.0 uses '%I64d' syntax  for 8-byte integers */
-            printf("\n File: %s, HDU %d,  %d cols X %I64d rows\n", infits, extnum, ncols, nrows);
-#elif (USE_LL_SUFFIX == 1)
-            printf("\n File: %s, HDU %d,  %d cols X %lld rows\n", infits, extnum, ncols, nrows);
-#else
-            printf("\n File: %s, HDU %d,  %d cols X %ld rows\n", infits, extnum, ncols, nrows);
-#endif
-            fp_test_table(inputfptr, outfptr, outfptr2, fpvar, &stat);
+            
+	    printf("\n File: %s, HDU %d,  %d cols X %" PRId64 " rows\n",
+                                 infits, extnum, ncols, (int64_t)nrows);
+	    fp_test_table(inputfptr, outfptr, outfptr2, fpvar, &stat);
 
         } else {
             fits_copy_hdu (inputfptr, outfptr, 0, &stat);

--- a/libs/fpack/fpackutil.c
+++ b/libs/fpack/fpackutil.c
@@ -1875,9 +1875,6 @@ int fp_test (char *infits, char *outfits, char *outfits2, fpstate fpvar)
 
             fits_get_num_rowsll(inputfptr, &nrows, &stat);
             fits_get_num_cols(inputfptr, &ncols, &stat);
-            
-	    printf("\n File: %s, HDU %d,  %d cols X %" PRId64 " rows\n",
-                                 infits, extnum, ncols, (int64_t)nrows);
 	    fp_test_table(inputfptr, outfptr, outfptr2, fpvar, &stat);
 
         } else {

--- a/libs/indibase/webcam/v4l2_base.cpp
+++ b/libs/indibase/webcam/v4l2_base.cpp
@@ -45,6 +45,7 @@
 #include <ctime>
 #include <cmath>
 #include <sys/time.h>
+#include <inttypes.h>
 
 #ifdef __linux__
 #include <asm/types.h> /* for videodev2.h */
@@ -2117,7 +2118,7 @@ void V4L2_Base::enumerate_menu()
             {
                 char menuname[19];
                 menuname[18] = '\0';
-                snprintf(menuname, 19, "0x%016llX", querymenu.value);
+                snprintf(menuname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
                 cerr << "  " << menuname << endl;
             }
 #endif
@@ -2303,7 +2304,7 @@ void V4L2_Base::queryControls(INumberVectorProperty * nvp, unsigned int * nnumbe
                         }
                         if (queryctrl.type == V4L2_CTRL_TYPE_INTEGER_MENU)
                         {
-                            snprintf(sname, 19, "0x%016llX", querymenu.value);
+                            snprintf(sname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
                             sname[31] = '\0';
                         }
 #else
@@ -2458,7 +2459,7 @@ void V4L2_Base::queryControls(INumberVectorProperty * nvp, unsigned int * nnumbe
                         }
                         if (queryctrl.type == V4L2_CTRL_TYPE_INTEGER_MENU)
                         {
-                            snprintf(sname, 19, "0x%016llX", querymenu.value);
+                            snprintf(sname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
                             sname[31] = '\0';
                         }
 #else
@@ -2918,7 +2919,7 @@ bool V4L2_Base::queryExtControls(INumberVectorProperty * nvp, unsigned int * nnu
                     }
                     if (queryctrl.type == V4L2_CTRL_TYPE_INTEGER_MENU)
                     {
-                        snprintf(sname, 19, "0x%016llX", querymenu.value);
+                        snprintf(sname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
                         sname[31] = '\0';
                     }
 #else

--- a/libs/indibase/webcam/v4l2_base.cpp
+++ b/libs/indibase/webcam/v4l2_base.cpp
@@ -2118,7 +2118,7 @@ void V4L2_Base::enumerate_menu()
             {
                 char menuname[19];
                 menuname[18] = '\0';
-                snprintf(menuname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
+                snprintf(menuname, 19, "0x%016" PRIX64, static_cast<int64_t>(querymenu.value));
                 cerr << "  " << menuname << endl;
             }
 #endif
@@ -2304,7 +2304,7 @@ void V4L2_Base::queryControls(INumberVectorProperty * nvp, unsigned int * nnumbe
                         }
                         if (queryctrl.type == V4L2_CTRL_TYPE_INTEGER_MENU)
                         {
-                            snprintf(sname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
+                            snprintf(sname, 19, "0x%016" PRIX64, static_cast<int64_t>(querymenu.value));
                             sname[31] = '\0';
                         }
 #else
@@ -2459,7 +2459,7 @@ void V4L2_Base::queryControls(INumberVectorProperty * nvp, unsigned int * nnumbe
                         }
                         if (queryctrl.type == V4L2_CTRL_TYPE_INTEGER_MENU)
                         {
-                            snprintf(sname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
+                            snprintf(sname, 19, "0x%016" PRIX64, static_cast<int64_t>(querymenu.value));
                             sname[31] = '\0';
                         }
 #else
@@ -2919,7 +2919,7 @@ bool V4L2_Base::queryExtControls(INumberVectorProperty * nvp, unsigned int * nnu
                     }
                     if (queryctrl.type == V4L2_CTRL_TYPE_INTEGER_MENU)
                     {
-                        snprintf(sname, 19, "0x%016" PRIX64, (int64_t)querymenu.value);
+                        snprintf(sname, 19, "0x%016" PRIX64, static_cast<int64_t>(querymenu.value));
                         sname[31] = '\0';
                     }
 #else


### PR DESCRIPTION
Using casts like **(long long)x** fixes the immediate warning, but only at that specific place in the code. Using <inttypes.h> is a more robust solution because it matches the actual type rather than assuming what it is. 

Macros like **PRId64, PRIu64, PRIx64** that are defined in **<inttypes.h>** automatically expand to the correct format specifier for the target architecture (%ld, %lld, I64d, etc.), so you don't have to worry about choosing between **%ld** and **%lld** on ppc64le or any other architecture in the future.