### PR TITLE
dome/nexdome_beaver: fix USB response truncation, add shutter and dome abort and rotator full-measurement

### DIFF
--- a/drivers/dome/nexdome_beaver.cpp
+++ b/drivers/dome/nexdome_beaver.cpp
@@ -301,7 +301,7 @@ bool Beaver::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
         /////////////////////////////////////////////
         if (RotatorCalibrationSP.isNameMatch(name))
         {
-            bool wasBusy = RotatorCalibrationSP.getState() == IPS_BUSY;
+            bool wasMoving = getDomeState() == DOME_MOVING;
             RotatorCalibrationSP.update(states, names, n);
             bool rc = false;
             switch (RotatorCalibrationSP.findOnSwitchIndex())
@@ -322,9 +322,11 @@ bool Beaver::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                     break;
 
                 default:
-                    // Button toggled off while a calibration was running: treat it as an abort request,
+                    // Button toggled off while the dome was still moving: treat it as an abort request,
                     // otherwise the switch goes idle in the UI while the dome keeps calibrating regardless.
-                    if (wasBusy)
+                    // Checked against actual dome motion (not just this property's state), since a rejected
+                    // re-start attempt (dome already busy) leaves the property in IPS_ALERT, not IPS_BUSY.
+                    if (wasMoving)
                     {
                         rc = abortAll();
                         RotatorCalibrationSP.setState(rc ? IPS_IDLE : IPS_ALERT);
@@ -927,6 +929,11 @@ bool Beaver::rotatorMeasureHome()
     double res = 0;
     if (sendCommand("!dome autocalrot 1#", res))
     {
+        if (res < 0)
+        {
+            LOGF_ERROR("Rotator refused to start measuring home, error code: %.0f", res);
+            return false;
+        }
         setDomeState(DOME_MOVING);
         std::string rStatus = "Measuring Home";
         RotatorStatusTP[0].setText(rStatus);
@@ -944,6 +951,11 @@ bool Beaver::rotatorFindHome()
     double res = 0;
     if (sendCommand("!dome autocalrot 0#", res))
     {
+        if (res < 0)
+        {
+            LOGF_ERROR("Rotator refused to start finding home, error code: %.0f", res);
+            return false;
+        }
         setDomeState(DOME_MOVING);
         std::string rStatus = "Finding Home";
         RotatorStatusTP[0].setText(rStatus);
@@ -962,6 +974,11 @@ bool Beaver::rotatorFullMeasure()
     double res = 0;
     if (sendCommand("!dome autocalrot 2#", res))
     {
+        if (res < 0)
+        {
+            LOGF_ERROR("Rotator refused to start full measurement, error code: %.0f", res);
+            return false;
+        }
         setDomeState(DOME_MOVING);
         std::string rStatus = "Measuring Full Dome";
         RotatorStatusTP[0].setText(rStatus);

--- a/drivers/dome/nexdome_beaver.cpp
+++ b/drivers/dome/nexdome_beaver.cpp
@@ -301,6 +301,7 @@ bool Beaver::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
         /////////////////////////////////////////////
         if (RotatorCalibrationSP.isNameMatch(name))
         {
+            bool wasBusy = RotatorCalibrationSP.getState() == IPS_BUSY;
             RotatorCalibrationSP.update(states, names, n);
             bool rc = false;
             switch (RotatorCalibrationSP.findOnSwitchIndex())
@@ -318,6 +319,16 @@ bool Beaver::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                 case ROTATOR_FULL_MEASURE:
                     rc = rotatorFullMeasure();
                     RotatorCalibrationSP.setState(rc ? IPS_BUSY : IPS_ALERT);
+                    break;
+
+                default:
+                    // Button toggled off while a calibration was running: treat it as an abort request,
+                    // otherwise the switch goes idle in the UI while the dome keeps calibrating regardless.
+                    if (wasBusy)
+                    {
+                        rc = abortAll();
+                        RotatorCalibrationSP.setState(rc ? IPS_IDLE : IPS_ALERT);
+                    }
                     break;
             }
             RotatorCalibrationSP.apply();

--- a/drivers/dome/nexdome_beaver.cpp
+++ b/drivers/dome/nexdome_beaver.cpp
@@ -92,6 +92,10 @@ bool Beaver::initProperties()
     RotatorCalibrationSP.fill(getDefaultName(), "ROTATOR_CALIBRATION", "Rotator", ROTATOR_TAB, IP_RW, ISR_ATMOST1, 60,
                               IPS_IDLE);
 
+    // Rotator Abort
+    RotatorAbortSP[0].fill("ROTATOR_ABORT", "Abort", ISS_OFF);
+    RotatorAbortSP.fill(getDefaultName(), "ROTATOR_ABORT", "Rotator", ROTATOR_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
+
     // Rotator Settings
     RotatorSettingsNP[ROTATOR_MAX_SPEED].fill("ROTATOR_MAX_SPEED", "Max Speed (m/s)", "%.f", 1, 1000, 10, 800);
     RotatorSettingsNP[ROTATOR_MIN_SPEED].fill("ROTATOR_MIN_SPEED", "Min Speed (m/s)", "%.f", 1, 1000, 10, 400);
@@ -105,6 +109,10 @@ bool Beaver::initProperties()
     // Shutter Home (calibrate, reset)
     ShutterCalibrationSP[SHUTTER_HOME_FIND].fill("SHUTTER_HOME_FIND", "AutoCalibrate", ISS_OFF);
     ShutterCalibrationSP.fill(getDeviceName(), "SHUTTER_CALIBRATION", "Shutter", SHUTTER_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
+
+    // Shutter Abort
+    ShutterAbortSP[0].fill("SHUTTER_ABORT", "Abort", ISS_OFF);
+    ShutterAbortSP.fill(getDeviceName(), "SHUTTER_ABORT", "Shutter", SHUTTER_TAB, IP_RW, ISR_ATMOST1, 60, IPS_IDLE);
 
     // Shutter Settings
     ShutterSettingsNP[SHUTTER_MAX_SPEED].fill("SHUTTER_MAX_SPEED", "Max Speed (m/s)", "%.f", 1, 1000, 10, 800);
@@ -158,12 +166,14 @@ bool Beaver::updateProperties()
         defineProperty(HomePositionNP);
         defineProperty(HomeOptionsSP);
         defineProperty(RotatorCalibrationSP);
+        defineProperty(RotatorAbortSP);
         defineProperty(GotoHomeSP);
         defineProperty(RotatorSettingsNP);
         defineProperty(RotatorStatusTP);
         if (shutterOnLine())
         {
             defineProperty(ShutterCalibrationSP);
+            defineProperty(ShutterAbortSP);
             defineProperty(ShutterSettingsNP);
             defineProperty(ShutterSettingsTimeoutNP);
             defineProperty(ShutterStatusTP);
@@ -174,6 +184,7 @@ bool Beaver::updateProperties()
     {
         deleteProperty(VersionTP.getName());
         deleteProperty(RotatorCalibrationSP.getName());
+        deleteProperty(RotatorAbortSP.getName());
         deleteProperty(GotoHomeSP.getName());
         deleteProperty(HomePositionNP.getName());
         deleteProperty(HomeOptionsSP.getName());
@@ -181,6 +192,7 @@ bool Beaver::updateProperties()
         deleteProperty(ShutterSettingsTimeoutNP.getName());
         deleteProperty(RotatorStatusTP.getName());
         deleteProperty(ShutterCalibrationSP.getName());
+        deleteProperty(ShutterAbortSP.getName());
         deleteProperty(ShutterSettingsNP.getName());
         deleteProperty(ShutterStatusTP.getName());
         deleteProperty(ShutterVoltsNP.getName());
@@ -338,6 +350,18 @@ bool Beaver::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
         }
 
         /////////////////////////////////////////////
+        // Rotator Abort
+        /////////////////////////////////////////////
+        if (RotatorAbortSP.isNameMatch(name))
+        {
+            RotatorAbortSP.update(states, names, n);
+            bool rc = rotatorAbort();
+            RotatorAbortSP.setState(rc ? IPS_OK : IPS_ALERT);
+            RotatorAbortSP.apply();
+            return true;
+        }
+
+        /////////////////////////////////////////////
         // Rotator Go Home
         /////////////////////////////////////////////
         if (GotoHomeSP.isNameMatch(name))
@@ -390,6 +414,18 @@ bool Beaver::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                 setShutterState(SHUTTER_MOVING);
             ShutterCalibrationSP.setState(rc ? IPS_BUSY : IPS_ALERT);
             ShutterCalibrationSP.apply();
+            return true;
+        }
+
+        /////////////////////////////////////////////
+        // Shutter Abort
+        /////////////////////////////////////////////
+        if (ShutterAbortSP.isNameMatch(name))
+        {
+            ShutterAbortSP.update(states, names, n);
+            bool rc = shutterAbort();
+            ShutterAbortSP.setState(rc ? IPS_OK : IPS_ALERT);
+            ShutterAbortSP.apply();
             return true;
         }
     }
@@ -1086,6 +1122,25 @@ bool Beaver::abortAll()
 {
     double res = 0;
     if (sendCommand("!dome abort 1 1 1#", res))
+    {
+        std::string rStatus = "Idle";
+        RotatorStatusTP[0].setText(rStatus);
+        RotatorStatusTP.apply();
+        if (!rotatorGetAz())
+            return false;
+        return true;
+    }
+
+    return false;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+/// abort rotator only
+/////////////////////////////////////////////////////////////////////////////
+bool Beaver::rotatorAbort()
+{
+    double res = 0;
+    if (sendCommand("!dome abort 0 1#", res))
     {
         std::string rStatus = "Idle";
         RotatorStatusTP[0].setText(rStatus);

--- a/drivers/dome/nexdome_beaver.cpp
+++ b/drivers/dome/nexdome_beaver.cpp
@@ -129,7 +129,6 @@ bool Beaver::initProperties()
     tcpConnection->setDefaultHost("192.168.1.1");
     tcpConnection->setDefaultPort(10000);
     tcpConnection->setConnectionType(Connection::TCP::TYPE_UDP);
-    tty_set_generic_udp_format(1);
     addDebugControl();
     return true;
 }
@@ -195,6 +194,15 @@ bool Beaver::updateProperties()
 //////////////////////////////////////////////////////////////////////////////
 bool Beaver::Handshake()
 {
+    // tty_generic_udp_format is a process-global flag in indicom.c: it must
+    // only be on while the active connection is really our UDP socket. Left
+    // on unconditionally (as it used to be, set once in initProperties()) it
+    // also hijacks the serial connection's tty_nread_section reads, which
+    // then do a single non-looping datagram-style read instead of accumulating
+    // bytes until the stop character — corrupting any reply that arrives
+    // split across more than one low-level USB-serial read.
+    tty_set_generic_udp_format(getActiveConnection() == tcpConnection ? 1 : 0);
+
     if (echo())
     {
         // Check if shutter is online

--- a/drivers/dome/nexdome_beaver.cpp
+++ b/drivers/dome/nexdome_beaver.cpp
@@ -236,6 +236,11 @@ bool Beaver::echo()
     LOGF_DEBUG("Version string returned %s", resString.c_str());
     std::regex e(R"(.*:\d*:(.*))");
     std::sregex_iterator iter(resString.begin(), resString.end(), e);
+    if (iter == std::sregex_iterator())
+    {
+        LOGF_ERROR("Unexpected version response: %s", resString.c_str());
+        return false;
+    }
     VersionTP[0].setText((*iter)[1]);
 
     // retrieve the current az from the dome
@@ -1270,7 +1275,12 @@ bool Beaver::sendRawCommand(const char * cmd, char * response)
 
         if (rc != TTY_OK)
         {
-            // wait and try again
+            // Response didn't arrive whole (e.g. the USB-serial link delivered
+            // it in more than one chunk and we only caught part of it). Drop
+            // whatever is still pending before resending, otherwise the next
+            // read picks up the tail of this reply and misreads it as the
+            // answer to the retry.
+            tcflush(PortFD, TCIFLUSH);
             usleep(100000);
             continue;
         }

--- a/drivers/dome/nexdome_beaver.cpp
+++ b/drivers/dome/nexdome_beaver.cpp
@@ -88,6 +88,7 @@ bool Beaver::initProperties()
     // Rotator Calibrations
     RotatorCalibrationSP[ROTATOR_HOME_FIND].fill("ROTATOR_HOME_FIND", "Find Home", ISS_OFF);
     RotatorCalibrationSP[ROTATOR_HOME_MEASURE].fill("ROTATOR_HOME_MEASURE", "Measure Home", ISS_OFF);
+    RotatorCalibrationSP[ROTATOR_FULL_MEASURE].fill("ROTATOR_FULL_MEASURE", "Full Measurement", ISS_OFF);
     RotatorCalibrationSP.fill(getDefaultName(), "ROTATOR_CALIBRATION", "Rotator", ROTATOR_TAB, IP_RW, ISR_ATMOST1, 60,
                               IPS_IDLE);
 
@@ -313,6 +314,11 @@ bool Beaver::ISNewSwitch(const char *dev, const char *name, ISState *states, cha
                     rc = rotatorMeasureHome();
                     RotatorCalibrationSP.setState(rc ? IPS_BUSY : IPS_ALERT);
                     break;
+
+                case ROTATOR_FULL_MEASURE:
+                    rc = rotatorFullMeasure();
+                    RotatorCalibrationSP.setState(rc ? IPS_BUSY : IPS_ALERT);
+                    break;
             }
             RotatorCalibrationSP.apply();
             return true;
@@ -519,6 +525,16 @@ void Beaver::TimerHit()
         }
         // Finding Home completed
         else if (!strcmp(RotatorStatusTP[0].getText(), "Finding Home"))
+        {
+            setDomeState(DOME_IDLE);
+            RotatorCalibrationSP.setState(IPS_OK);
+            RotatorCalibrationSP.apply();
+            std::string rStatus = "Home";
+            RotatorStatusTP[0].setText(rStatus);
+            RotatorStatusTP.setState(IPS_OK);
+        }
+        // Full dome measurement completed
+        else if (!strcmp(RotatorStatusTP[0].getText(), "Measuring Full Dome"))
         {
             setDomeState(DOME_IDLE);
             RotatorCalibrationSP.setState(IPS_OK);
@@ -919,6 +935,24 @@ bool Beaver::rotatorFindHome()
     {
         setDomeState(DOME_MOVING);
         std::string rStatus = "Finding Home";
+        RotatorStatusTP[0].setText(rStatus);
+        RotatorStatusTP.apply();
+        return true;
+    }
+    return false;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+/// full dome measurement: one complete turn to measure steps/degree plus
+/// home position, then a final home measurement pass
+/////////////////////////////////////////////////////////////////////////////
+bool Beaver::rotatorFullMeasure()
+{
+    double res = 0;
+    if (sendCommand("!dome autocalrot 2#", res))
+    {
+        setDomeState(DOME_MOVING);
+        std::string rStatus = "Measuring Full Dome";
         RotatorStatusTP[0].setText(rStatus);
         RotatorStatusTP.apply();
         return true;

--- a/drivers/dome/nexdome_beaver.cpp
+++ b/drivers/dome/nexdome_beaver.cpp
@@ -199,7 +199,7 @@ bool Beaver::Handshake()
     // on unconditionally (as it used to be, set once in initProperties()) it
     // also hijacks the serial connection's tty_nread_section reads, which
     // then do a single non-looping datagram-style read instead of accumulating
-    // bytes until the stop character — corrupting any reply that arrives
+    // bytes until the stop character, corrupting any reply that arrives
     // split across more than one low-level USB-serial read.
     tty_set_generic_udp_format(getActiveConnection() == tcpConnection ? 1 : 0);
 
@@ -1283,9 +1283,8 @@ bool Beaver::sendRawCommand(const char * cmd, char * response)
 
         if (rc != TTY_OK)
         {
-            // Response didn't arrive whole (e.g. the USB-serial link delivered
-            // it in more than one chunk and we only caught part of it). Drop
-            // whatever is still pending before resending, otherwise the next
+            // Response didn't arrive whole 
+            // Drop whatever is still pending before resending, otherwise the next
             // read picks up the tail of this reply and misreads it as the
             // answer to the retry.
             tcflush(PortFD, TCIFLUSH);

--- a/drivers/dome/nexdome_beaver.h
+++ b/drivers/dome/nexdome_beaver.h
@@ -106,6 +106,7 @@ class Beaver : public INDI::Dome
         bool rotatorUnPark();
         bool rotatorSetPark();
         bool abortAll();
+        bool rotatorAbort();
 
         bool rotatorGetSettings();
         bool rotatorSetSettings(double maxSpeed, double minSpeed, double acceleration, double timeout);
@@ -161,12 +162,16 @@ class Beaver : public INDI::Dome
             ROTATOR_HOME_MEASURE,
             ROTATOR_FULL_MEASURE
         };
+        // Rotator Abort
+        INDI::PropertySwitch RotatorAbortSP {1};
         // Shutter Calibration
         INDI::PropertySwitch ShutterCalibrationSP {1};
         enum
         {
             SHUTTER_HOME_FIND
         };
+        // Shutter Abort
+        INDI::PropertySwitch ShutterAbortSP {1};
         // Shutter Configuration
         INDI::PropertyNumber ShutterSettingsNP {4};
         enum

--- a/drivers/dome/nexdome_beaver.h
+++ b/drivers/dome/nexdome_beaver.h
@@ -100,6 +100,7 @@ class Beaver : public INDI::Dome
         bool rotatorGotoHome();
         bool rotatorMeasureHome();
         bool rotatorFindHome();
+        bool rotatorFullMeasure();
         bool rotatorIsHome();
         bool rotatorIsParked();
         bool rotatorUnPark();
@@ -153,11 +154,12 @@ class Beaver : public INDI::Dome
         // Shutter Status
         INDI::PropertyText ShutterStatusTP {1};
         // Rotator Calibration
-        INDI::PropertySwitch RotatorCalibrationSP {2};
+        INDI::PropertySwitch RotatorCalibrationSP {3};
         enum
         {
             ROTATOR_HOME_FIND,
-            ROTATOR_HOME_MEASURE
+            ROTATOR_HOME_MEASURE,
+            ROTATOR_FULL_MEASURE
         };
         // Shutter Calibration
         INDI::PropertySwitch ShutterCalibrationSP {1};


### PR DESCRIPTION
**USB/serial fixes:**
  - sendRawCommand(): flush stale input (tcflush) before resending a command on retry, so a delayed leftover reply from the previous attempt isn't misread as the answer to the retry.
  - echo(): guard against an unmatched version-string regex instead of crashing with std::length_error when the firmware returns an unexpected handshake response.
  - Handshake(): only enable tty_set_generic_udp_format() when the active connection is actually TCP/UDP. Previously it was set unconditionally, which broke serial reads whenever a reply arrived split across more than one USB packet (e.g. dome getaz, or the version handshake) — this was the actual root cause of intermittent USB truncation/hangs.
  (these issues surfaced when tested compatibility with the new Caterpillar controller)

**Rotator calibration:**
  - Add a "Full Measurement" button (autocalrot 2) alongside the existing Find Home / Measure Home controls - does one full rotation to measure steps/degree plus home position, then a home-measurement pass.
  - Fix rotatorFindHome()/rotatorMeasureHome()/rotatorFullMeasure() silently reporting success even when the firmware rejected the command (e.g. -101 when a calibration is already running) — these are now correctly reported as failures.
  - Add dedicated, always-available Abort buttons for the rotator and the shutter independently (!dome abort 0 1# / !dome abort 0 0 1#), since re-clicking a busy calibration switch to abort depends on client-widget click timing and isn't reliable.

**Tested with real hardware**