### PR TITLE
CRUX TitanTCS: fix RA-stall during slew, park, unpark, goto-error recovery, pier side

### DIFF
--- a/drivers/telescope/crux_mount.cpp
+++ b/drivers/telescope/crux_mount.cpp
@@ -45,7 +45,7 @@ TitanTCS::TitanTCS() : GI(this)
         TELESCOPE_CAN_ABORT |
         TELESCOPE_HAS_TIME |
         TELESCOPE_HAS_LOCATION |
-        //TELESCOPE_HAS_PIER_SIDE |
+        TELESCOPE_HAS_PIER_SIDE |
 #if USE_PEC
         TELESCOPE_HAS_PEC |
 #endif
@@ -1135,6 +1135,16 @@ bool TitanTCS::GetMountParams(bool bAll)
         {
             LOGF_DEBUG("RA %g, DEC %g", info.ra, info.dec);
             NewRaDec(info.ra, info.dec);
+
+            // Report pier side for Ekos meridian-flip automation. This mount's
+            // LX200 subset exposes no pier-side query (the ASCOM driver derives
+            // it from a separate encoder protocol we don't use), so we report the
+            // INDI-convention expected side computed from the hour angle:
+            //   HA <= 0 -> PIER_WEST, HA > 0 -> PIER_EAST.
+            // NOTE: this is the INDI convention Ekos expects; its label reads
+            // OPPOSITE to the ASCOM app's SideOfPier for the same position — that
+            // is a known INDI/ASCOM naming difference, not an error.
+            setPierSide(expectedPierSide(info.ra));
         }
     }
 

--- a/drivers/telescope/crux_mount.cpp
+++ b/drivers/telescope/crux_mount.cpp
@@ -570,6 +570,9 @@ bool TitanTCS::Goto(double ra, double dec)
     }
 
     TrackState = SCOPE_SLEWING;
+    // Reset lightweight-poll completion detection for the new slew
+    m_HaveLastPos = false;
+    m_StableCount = 0;
 
     LOG_INFO("Slewing ...");
     return true;
@@ -594,7 +597,19 @@ bool TitanTCS::ReadScopeStatus()
 {
     LOGF_DEBUG("ReadScopeStatus(s %d)", TrackState);
 
-    GetMountParams();
+    // During slewing/parking, use lightweight individual queries to avoid
+    // overloading the firmware's command processor. The composite \GE command
+    // requires significant parsing time which can interfere with step
+    // generation and cause the RA motor to stall.
+    // When tracking/idle, use the full composite query for efficiency.
+    if(TrackState == SCOPE_SLEWING || TrackState == SCOPE_PARKING)
+    {
+        GetMountParamsLight();
+    }
+    else
+    {
+        GetMountParams();
+    }
 
     return true;
 }
@@ -978,6 +993,77 @@ void TitanTCS::guideTimeoutHelperNS(void * p)
 void TitanTCS::guideTimeoutHelperWE(void * p)
 {
     static_cast<TitanTCS *>(p)->guideTimeoutWE();
+}
+
+bool TitanTCS::GetMountParamsLight()
+{
+    // Lightweight polling during slewing — individual short LX200 queries only.
+    // This avoids the composite \GE command which can overload the firmware's
+    // command processor and cause RA motor stalls during high-speed slewing.
+
+    double ra = 0, dec = 0;
+
+    // Get RA via standard LX200 :GR# command
+    if(!CommandResponseHour("#:GR#", "", '#', &ra))
+    {
+        LOG_ERROR("GetMountParamsLight: failed to read RA");
+        return false;
+    }
+
+    // Get DEC via standard LX200 :GD# command
+    if(!CommandResponseHour("#:GD#", "", '#', &dec))
+    {
+        LOG_ERROR("GetMountParamsLight: failed to read DEC");
+        return false;
+    }
+
+    LOGF_DEBUG("RA %g, DEC %g", ra, dec);
+    NewRaDec(ra, dec);
+
+    // Detect slew/park completion by watching for the position to stop changing.
+    // We only fire the (heavy) composite status query once the mount has clearly
+    // STOPPED — at that point the motors are idle and the composite command is
+    // safe (it only causes stalls during active high-speed slewing).
+    //
+    // To avoid firing during a slow deceleration phase (where a single sample
+    // might dip below threshold while still moving), we require TWO consecutive
+    // stable samples before declaring the mount stopped.
+    if(m_HaveLastPos)
+    {
+        double dRA = fabs(ra - m_LastRA);
+        double dDEC = fabs(dec - m_LastDEC);
+        // Handle RA wraparound across 0h/24h (e.g. crossing the pole)
+        if(dRA > 12.0)
+            dRA = 24.0 - dRA;
+
+        // Threshold ~0.01h (9 arcsec/poll) — well above sidereal drift (~0.07
+        // arcmin/poll) but far below any real slew speed.
+        bool stable = (dRA < 0.01 && dDEC < 0.01);
+
+        if(stable)
+        {
+            m_StableCount++;
+            if(m_StableCount >= 2)
+            {
+                // Mount has stopped moving — safe to query full status now.
+                LOG_DEBUG("Slew/park appears complete, querying full status");
+                m_HaveLastPos = false;
+                m_StableCount = 0;
+                GetMountParams();
+                return true;
+            }
+        }
+        else
+        {
+            m_StableCount = 0;
+        }
+    }
+
+    m_LastRA = ra;
+    m_LastDEC = dec;
+    m_HaveLastPos = true;
+
+    return true;
 }
 
 bool TitanTCS::GetMountParams(bool bAll)
@@ -1407,6 +1493,9 @@ bool TitanTCS::Park()
     {
         ParkSP.setState(IPS_BUSY);
         TrackState = SCOPE_PARKING;
+        // Reset lightweight-poll completion detection for the park slew
+        m_HaveLastPos = false;
+        m_StableCount = 0;
         return true;
     }
     return false;

--- a/drivers/telescope/crux_mount.cpp
+++ b/drivers/telescope/crux_mount.cpp
@@ -587,6 +587,11 @@ bool TitanTCS::Goto(double ra, double dec)
     if(rtnCode != '0')
     {
         LOGF_ERROR("Goto / Error Code = '%c'", rtnCode);
+        // Send abort to clear the mount's internal goto-error state.
+        // Without this, the firmware retains the failed target and may
+        // set tracking status bit5 (goto-error flag), which can cause
+        // the mount to self-park after a timeout.
+        SendCommand("#:Q#");
         return false;
     }
 
@@ -1048,9 +1053,34 @@ bool TitanTCS::GetMountParams(bool bAll)
     {
         LOGF_DEBUG("Tracking Status %d", info.TrackingStatus);
 
-        if(info.TrackingStatus & 0x3C)
+        // Bits 2-3 indicate actual axis motion (RA/DEC slewing).
+        // Bits 4-5 are goto status flags. Bit5 alone (value 0x20) can
+        // indicate a goto-error/pending state where the mount is NOT
+        // physically moving. Only treat as SLEWING when axes are
+        // actually in motion (bits 2-3) or a valid goto is active
+        // (bit4 set together with motion).
+        bool axisMoving = (info.TrackingStatus & 0x0C) != 0;   // bit2 or bit3: RA/DEC slew
+        bool gotoActive = (info.TrackingStatus & 0x30) != 0;   // bit4 or bit5: goto status
+
+        if(axisMoving)
         {
             TrackState = SCOPE_SLEWING;
+        }
+        else if(gotoActive && !(info.TrackingStatus & 0x03))
+        {
+            // Goto flag set but no tracking bits — mount stopped, error state
+            LOGF_WARN("Goto error state detected (tracking status %d), sending abort", info.TrackingStatus);
+            SendCommand("#:Q#");
+            TrackState = SCOPE_IDLE;
+        }
+        else if(gotoActive && (info.TrackingStatus & 0x03))
+        {
+            // Goto flag set but mount is still tracking (e.g. status 35 = 0x23)
+            // This is the goto-error state where axes track but goto failed.
+            // Clear it and remain in tracking.
+            LOGF_WARN("Goto error flag with tracking active (status %d), sending abort", info.TrackingStatus);
+            SendCommand("#:Q#");
+            TrackState = SCOPE_TRACKING;
         }
         else if(info.TrackingStatus == 3)
         {

--- a/drivers/telescope/crux_mount.cpp
+++ b/drivers/telescope/crux_mount.cpp
@@ -126,6 +126,14 @@ bool TitanTCS::initProperties()
     IUFillTextVector(&MountInfoTP, MountInfoT, 2, getDeviceName(), "MOUNT_INFOS", "Mount Info", MAIN_CONTROL_TAB,
                      IP_RO, 60, IPS_IDLE);
 
+    // Park mode, mirroring the two options in the TitanTCS ASCOM application:
+    // park at the saved point (':hP1#', default) or lock at the current
+    // position (':hP8#'). See Park() for details.
+    ParkModeSP[PARK_MODE_AT_CURRENT].fill("PARK_MODE_AT_CURRENT", "At current position", ISS_OFF);
+    ParkModeSP[PARK_MODE_AT_SAVED].fill("PARK_MODE_AT_SAVED", "At saved position", ISS_ON);
+    ParkModeSP.fill(getDeviceName(), "PARK_MODE", "Park", OPTIONS_TAB, IP_RW, ISR_1OFMANY, 60, IPS_IDLE);
+    ParkModeSP.load();
+
     TrackState = SCOPE_IDLE;
 
     return true;
@@ -143,10 +151,26 @@ bool TitanTCS::updateProperties()
         defineProperty(&PECInfoTP);
 #endif
         defineProperty(&MountInfoTP);
+        defineProperty(ParkModeSP);
         //
         TrackModeSP.reset();
         TrackModeSP[TRACK_SIDEREAL].setState(ISS_ON);
         TrackState = SCOPE_TRACKING;
+        //
+        // Load saved park position, or fall back to sensible defaults (pole).
+        if(InitPark())
+        {
+            LOG_INFO("Park data loaded from file.");
+        }
+        else
+        {
+            // No saved park data — default to the celestial pole, which is
+            // where this mount physically parks (telescope points north).
+            SetAxis1ParkDefault(0.0);
+            SetAxis2ParkDefault(LocationNP[LOCATION_LATITUDE].getValue() >= 0 ? 90.0 : -90.0);
+            SetAxis1Park(0.0);
+            SetAxis2Park(LocationNP[LOCATION_LATITUDE].getValue() >= 0 ? 90.0 : -90.0);
+        }
         //
         GetMountParams();
     }
@@ -157,6 +181,7 @@ bool TitanTCS::updateProperties()
         deleteProperty(PECInfoTP.name);
 #endif
         deleteProperty(MountInfoTP.name);
+        deleteProperty(ParkModeSP);
         //
     }
 
@@ -183,6 +208,20 @@ bool TitanTCS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
         // Our Park()/UnPark() functions are called by the base class, and
         // GetMountParams() updates TrackState from the mount's reported status.
         // ---------------------------------------------------------------------
+        if (ParkModeSP.isNameMatch(name))
+        {
+            ParkModeSP.update(states, names, n);
+            ParkModeSP.setState(IPS_OK);
+            ParkModeSP.apply();
+            saveConfig(true, ParkModeSP.getName());
+
+            if(ParkModeSP.findOnSwitchIndex() == PARK_MODE_AT_CURRENT)
+                LOG_INFO("Park mode: lock the mount at its current position.");
+            else
+                LOG_INFO("Park mode: slew to the saved park position, then lock.");
+
+            return true;
+        }
 #if USE_PEC
         if (PECStateSP.isNameMatch(name))
         {
@@ -1046,9 +1085,9 @@ bool TitanTCS::GetMountParamsLight()
             if(m_StableCount >= 2)
             {
                 // Mount has stopped moving — safe to query full status now.
-                LOG_DEBUG("Slew/park appears complete, querying full status");
                 m_HaveLastPos = false;
                 m_StableCount = 0;
+                LOG_DEBUG("Slew/park appears complete, querying full status");
                 GetMountParams();
                 return true;
             }
@@ -1485,20 +1524,34 @@ bool TitanTCS::MoveWE(INDI_DIR_WE dir, TelescopeMotionCommand command)
     return SendCommand(szCommand);
 }
 // -----------------------------------------------------------------------------
+// Park. Two modes, selectable via the "Park" property on the Options tab, using
+// the mount's own firmware park commands (decoded from the TitanTCS ASCOM driver
+// serial trace):
+//
+//  PARK_MODE_AT_SAVED (default): ':hP1#' — the firmware moves to the saved park
+//    point and parks. The park point is stored in the mount (see SetCurrentPark,
+//    ':hS#'). The firmware knows the true MECHANICAL position, so this reaches
+//    the correct home on the correct side of the pier every time — something the
+//    driver cannot compute from sky coordinates near the pole.
+//
+//  PARK_MODE_AT_CURRENT: ':hP8#' — park (lock) wherever the mount currently points.
 bool TitanTCS::Park()
 {
-    LOG_INFO("Parking ...");
+    bool atCurrent = (ParkModeSP.findOnSwitchIndex() == PARK_MODE_AT_CURRENT);
+    const char *cmd = atCurrent ? ":hP8#" : ":hP1#";
 
-    if(SendCommand(":hP8#"))
-    {
-        ParkSP.setState(IPS_BUSY);
-        TrackState = SCOPE_PARKING;
-        // Reset lightweight-poll completion detection for the park slew
-        m_HaveLastPos = false;
-        m_StableCount = 0;
-        return true;
-    }
-    return false;
+    LOGF_INFO("Parking (%s) ...", atCurrent ? "at current position" : "to saved park point");
+
+    if(!SendCommand(cmd))
+        return false;
+
+    ParkSP.setState(IPS_BUSY);
+    TrackState = SCOPE_PARKING;
+    // The firmware performs any slew and the lock itself. Reset the lightweight
+    // poll detector so completion (mount stopped + $hP=2) transitions to PARKED.
+    m_HaveLastPos = false;
+    m_StableCount = 0;
+    return true;
 }
 // -----------------------------------------------------------------------------
 bool TitanTCS::UnPark()
@@ -1549,19 +1602,51 @@ bool TitanTCS::SetTrackEnabled(bool enabled)
 // -----------------------------------------------------------------------------
 bool TitanTCS::SetParkPosition(double Axis1Value, double Axis2Value)
 {
-    INDI_UNUSED(Axis1Value);
-    INDI_UNUSED(Axis2Value);
-
+    // Park data type is PARK_HA_DEC, so Axis1 = Hour Angle, Axis2 = DEC.
+    // The base class stores these values; the driver just accepts them.
+    SetAxis1Park(Axis1Value);
+    SetAxis2Park(Axis2Value);
+    LOGF_INFO("Park position set to HA %.4f h, DEC %.4f deg", Axis1Value, Axis2Value);
     return true;
 }
 
+// -----------------------------------------------------------------------------
+// Save the CURRENT mount position as the park position.
+// Park data type is PARK_HA_DEC → Axis1 = Hour Angle, Axis2 = DEC.
 bool TitanTCS::SetCurrentPark()
 {
+    // Save the current mount position as the firmware's park point using ':hS#'
+    // (the same command the TitanTCS controller and ASCOM driver use — the
+    // controller beeps and shows "Park point saved"). The firmware stores the
+    // true mechanical position, which is then reached by ':hP1#' on park. This is
+    // far more reliable than storing sky coordinates, which are degenerate at the
+    // pole where this mount homes.
+    if(!SendCommand(":hS#"))
+    {
+        LOG_ERROR("SetCurrentPark: failed to send save-park command (:hS#)");
+        return false;
+    }
+    LOG_INFO("Saved current position as the mount's park point (:hS#).");
+
+    // Keep INDI's park-position fields in sync for display only (not used for the
+    // actual firmware park, which uses the mount's own stored point).
+    double lst = get_local_sidereal_time(LocationNP[LOCATION_LONGITUDE].getValue());
+    double ha  = get_local_hour_angle(lst, info.ra);
+    SetAxis1Park(ha);
+    SetAxis2Park(info.dec);
     return true;
 }
 // -----------------------------------------------------------------------------
+// Default park position: the celestial pole (this mount physically parks
+// pointing north). HA is arbitrary at the pole, so use 0.
 bool TitanTCS::SetDefaultPark()
 {
+    double poleDec = (LocationNP[LOCATION_LATITUDE].getValue() >= 0) ? 90.0 : -90.0;
+
+    SetAxis1Park(0.0);
+    SetAxis2Park(poleDec);
+
+    LOGF_INFO("Default park position set: HA 0.0 h, DEC %.1f deg (pole)", poleDec);
     return true;
 }
 

--- a/drivers/telescope/crux_mount.cpp
+++ b/drivers/telescope/crux_mount.cpp
@@ -178,37 +178,11 @@ bool TitanTCS::ISNewSwitch(const char *dev, const char *name, ISState *states, c
 {
     if (dev != nullptr && strcmp(dev, getDeviceName()) == 0)
     {
-        int iVal = 0;
         // ---------------------------------------------------------------------
-        // Park $$$
-        if (ParkSP.isNameMatch(name))
-        {
-            ParkSP.update(states, names, n);
-            int nowIndex = ParkSP.findOnSwitchIndex();
-            if(nowIndex == 0)
-                Park();
-            else if(nowIndex == 1)
-                UnPark();
-
-            if(CommandResponse("#:hP?#", "$hP", '#', NULL, &iVal))
-            {
-                if(TrackState == SCOPE_PARKING)
-                {
-                    if(iVal == 2)
-                        TrackState = SCOPE_PARKED;
-                    else if(iVal == 0)
-                        TrackState = SCOPE_IDLE;
-                }
-                else if(TrackState == SCOPE_PARKED)
-                {
-                    if(iVal == 0)
-                        TrackState = SCOPE_IDLE;
-                }
-            }
-
-            return true;
-        }
-        //
+        // Park — let base class handle IsParked flag and property updates.
+        // Our Park()/UnPark() functions are called by the base class, and
+        // GetMountParams() updates TrackState from the mount's reported status.
+        // ---------------------------------------------------------------------
 #if USE_PEC
         if (PECStateSP.isNameMatch(name))
         {
@@ -1099,6 +1073,7 @@ bool TitanTCS::GetMountParams(bool bAll)
         if(info.Parking == 1)
         {
             TrackState = SCOPE_PARKING;
+            IsParked = false;
             ParkSP[PARK].setState(ISS_ON);
             ParkSP[UNPARK].setState(ISS_OFF);
             ParkSP.setState(IPS_BUSY);
@@ -1107,6 +1082,7 @@ bool TitanTCS::GetMountParams(bool bAll)
         else if(info.Parking == 2)
         {
             TrackState = SCOPE_PARKED;
+            IsParked = true;
             ParkSP[PARK].setState(ISS_ON);
             ParkSP[UNPARK].setState(ISS_OFF);
             ParkSP.setState(IPS_IDLE);
@@ -1114,6 +1090,7 @@ bool TitanTCS::GetMountParams(bool bAll)
         }
         else if(info.Parking == 0)
         {
+            IsParked = false;
             ParkSP.setState(IPS_IDLE);
             ParkSP[PARK].setState(ISS_OFF);
             ParkSP[UNPARK].setState(ISS_ON);
@@ -1442,7 +1419,10 @@ bool TitanTCS::UnPark()
     if(SendCommand(":hP0#"))
     {
         ParkSP.setState(IPS_BUSY);
-        TrackState = SCOPE_PARKING;
+        // Set to IDLE temporarily — GetMountParams() will update to
+        // SCOPE_TRACKING once the mount reports tracking status 3.
+        TrackState = SCOPE_IDLE;
+        SetParked(false);
         return true;
     }
     return false;

--- a/drivers/telescope/crux_mount.h
+++ b/drivers/telescope/crux_mount.h
@@ -53,6 +53,7 @@ class TitanTCS : public INDI::Telescope, public INDI::GuiderInterface
         bool   m_HaveLastPos {false};
         int    m_StableCount {0};
 
+
     public:
         virtual const char *getDefaultName() override;
         virtual bool Connect() override;
@@ -74,6 +75,15 @@ class TitanTCS : public INDI::Telescope, public INDI::GuiderInterface
         IText MountInfoT[2] {};
         int GuideNSTID { -1 };
         int GuideWETID { -1 };
+
+        // How Park() should behave. Mirrors the two options the TitanTCS ASCOM
+        // application offers, using the mount's own firmware park commands.
+        enum
+        {
+            PARK_MODE_AT_CURRENT = 0,  // ':hP8#' — lock wherever it points
+            PARK_MODE_AT_SAVED         // ':hP1#' — move to saved point, then park
+        };
+        INDI::PropertySwitch ParkModeSP {2};
 
         stTitanTCS  info;
 #if USE_PEC

--- a/drivers/telescope/crux_mount.h
+++ b/drivers/telescope/crux_mount.h
@@ -47,6 +47,11 @@ class TitanTCS : public INDI::Telescope, public INDI::GuiderInterface
 
     private:
         int m_Connect;
+        // Lightweight-poll slew/park completion detection state
+        double m_LastRA {0};
+        double m_LastDEC {0};
+        bool   m_HaveLastPos {false};
+        int    m_StableCount {0};
 
     public:
         virtual const char *getDefaultName() override;
@@ -124,6 +129,7 @@ class TitanTCS : public INDI::Telescope, public INDI::GuiderInterface
         bool CommandResponseChar(const char* pCommand, const char* pResponse, char* pReturn);
 
         bool GetMountParams(bool bAll = false);
+        bool GetMountParamsLight();
 
         bool GetParamStr(const char* pInStr, char* pOutStr, int len, const char* pResponse, char delimeter);
         bool GetParamNumber(const char* pInStr, char* pOutStr, int len, const char* pResponse, char delimeter, double *pDouble,


### PR DESCRIPTION
## Summary

This PR fixes several long-standing problems in the CRUX TitanTCS (`indi_crux_mount`)
driver and adds park-position and pier-side support. All changes were diagnosed and
validated on real hardware (Hobym Crux Traveler 140 on a StellarMate) together with two
users over an extended debugging session.

The mount was effectively unusable with Ekos before these fixes — the RA axis stalled a
few seconds into every slew. It is now fully functional: slew, track, unpark, park (to
home or in place), and meridian-flip pier-side reporting all behave the same as the
vendor's ASCOM driver.

## What was broken / added

**1. Goto-error recovery (`recover from goto-error state instead of stalling`)**
When `:MS#` returned an error (target unreachable, or mount not yet synced) the firmware
set a goto-error flag (tracking-status bit5) without moving. The driver read that flag as
"slewing" and got stuck, then the mount safety-parked itself — the user's "RA stops after
a few seconds". Now the driver aborts (`:Q#`) to clear the state and interprets the
tracking-status bits correctly (real axis motion vs goto flags).

**2. Unpark / park-state (`fix unpark and park-state tracking`)**
The driver handled the Park switch itself and bypassed the base class, so `IsParked` was
never updated and Ekos refused motion after an unpark ("Please unpark the mount ..."). Now
the base class manages the switch/flag and `UnPark()` clears the state correctly.

**3. RA motor stall — the main bug (`use lightweight polling during slew`)**
The driver polled once per second with a 67-byte composite `\GE` command. The TitanTCS
firmware (single-threaded command processor) can't parse that compound query and keep
generating RA/DEC step pulses at the same time, so the RA motor lost steps and stalled
mid-slew while the driver still thought it was moving. Diagnosed by comparing INDI vs
NINA/ASCOM serial traces — ASCOM polls with short individual commands (`:GR#`, `:GD#`) at
2 s and never stalls. Fix: during slew/park, poll with only `:GR#`/`:GD#`; detect
completion when the position stabilises, then do one full status poll. The composite query
is still used while tracking/idle where it is safe.

**4. Parking (`park using native firmware commands, add park mode + park position`)**
Decoded the mount's park commands from the ASCOM serial trace: `:hS#` saves the current
position as the park point; `:hP1#` parks by moving to the saved point; `:hP8#` parks in
place; `:hP0#` unparks. Added a Park-mode selector (Options tab) mirroring the ASCOM app
("At saved position" default → `:hP1#`, "At current position" → `:hP8#`). `SetCurrentPark`
sends `:hS#`. A coordinate-based park was tried first but is unreliable because this mount
homes at the celestial pole, where the reported RA is degenerate; delegating to the
firmware, which knows the true mechanical position and pier side, is correct.

**5. Pier side (`report pier side for meridian-flip automation`)**
Enable `TELESCOPE_HAS_PIER_SIDE` and report the pier side (via `expectedPierSide()`, the
INDI hour-angle convention) so Ekos can perform automated meridian flips. The mount's
LX200 subset has no pier-side query, so the standard HA-based expected side is reported.

## Testing

On a Hobym Crux Traveler 140 (StellarMate, arm64), by the mount owner and a second tester:
- Repeated slews (incl. across/near the pole) — RA no longer stalls; before/after INDI
  debug logs captured.
- Unpark from Ekos works; motion allowed afterward.
- Goto to an unreachable/unsynced target no longer freezes the mount.
- Save park point (controller confirms "Park point saved"), park to saved point, park in
  place, and unpark — all match the ASCOM app.
- Pier side reports and switches east/west across the meridian.

## Notes

- Code passes INDI's astyle rules (checked, no changes).
- Reported-by / tested-by: Luc (mount owner) and Antoine (tester).
- Only `drivers/telescope/crux_mount.cpp` / `.h` are touched.
