### PR TITLE
iEQ: mark Home operation complete when mount reaches home

### DIFF
--- a/drivers/telescope/ieqpro.cpp
+++ b/drivers/telescope/ieqpro.cpp
@@ -43,7 +43,7 @@ static std::unique_ptr<IEQPro> scope(new IEQPro());
 
 IEQPro::IEQPro(): GI(this)
 {
-    setVersion(1, 9);
+    setVersion(1, 10);
 
     driver.reset(new Base());
 
@@ -386,10 +386,28 @@ bool IEQPro::ReadScopeStatus()
                 TrackState    = SCOPE_PARKED;
                 if (!isParked())
                     SetParked(true);
+                // If a Home operation was in progress, mark it complete.
+                if (HomeSP.getState() == IPS_BUSY)
+                {
+                    HomeSP.reset();
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
+                    LOG_INFO("Mount arrived at home position.");
+                }
                 break;
             case ST_HOME:
                 TrackModeSP.setState(IPS_IDLE);
                 TrackState    = SCOPE_IDLE;
+                // The mount reports ST_HOME once it settles on the home switch.
+                // Clear the Home property only if a Home operation was actually
+                // requested (it is BUSY); the mount also reports ST_HOME at rest.
+                if (HomeSP.getState() == IPS_BUSY)
+                {
+                    HomeSP.reset();
+                    HomeSP.setState(IPS_OK);
+                    HomeSP.apply();
+                    LOG_INFO("Mount arrived at home position.");
+                }
                 break;
             case ST_SLEWING:
             case ST_MERIDIAN_FLIPPING:


### PR DESCRIPTION
## Summary
The iEQ driver (`indi_ieq_telescope`, used by the CEM60 and the rest of the older-protocol iOptron line) set the Home property to `IPS_BUSY` when a Find/Go Home was requested but never cleared it. When the mount finished homing and reported `ST_HOME` (or `ST_PARKED`) in its `:GLS#` status word, `ReadScopeStatus()` updated the tracking state but left the Home property stuck at `IPS_BUSY` — so the control-panel indicator never turned green even though the mount had physically completed the operation.

## Root cause
In `IEQPro::ReadScopeStatus()`, the `ST_HOME` / `ST_PARKED` cases updated `TrackState` but never reset `HomeSP`. There is no other code path that clears it, so the Home switch stays BUSY indefinitely after a successful home.

## Fix
Reset `HomeSP` to `IPS_OK` on `ST_HOME` / `ST_PARKED`, gated on it being `IPS_BUSY` (the mount also reports `ST_HOME` while at rest / at startup, so the guard prevents a spurious completion signal). This mirrors the existing behaviour already present in the `ioptronv3` driver, making the two iOptron drivers consistent.

## Testing
Confirmed against a real CEM60. Debug log shows `:MSH#` followed by a short `ST_SLEWING` window, then the status returns to `ST_HOME` while the old driver left the property BUSY. With the patch, both **Home Find** and **Home Go** turn the indicator green on arrival and log `Mount arrived at home position.`; verified over a couple of hours of operation.

## Scope / risk
The added block only runs when a Home operation is in progress (`HomeSP == IPS_BUSY`), which only happens on explicit user action; it is a no-op otherwise and does not touch slew/track/park/goto handling. Affects all homing-capable ieqpro mounts (CEM40, GEM45, CEM60, ...).