### PR TITLE
Add pier side to PMC8 driver

### DIFF
--- a/drivers/telescope/pmc8.cpp
+++ b/drivers/telescope/pmc8.cpp
@@ -7,6 +7,7 @@
         Thomas Olson, Copyright (C) 2019
         Karl Rees, Copyright (C) 2019-2023
         Martin Ruiz, Copyright (C) 2023
+        Daniel Karnaukh, Copyright (C) 2026
 
     Based on IEQPro driver.
 
@@ -67,7 +68,7 @@ PMC8::PMC8() : GI(this)
 
     SetTelescopeCapability(TELESCOPE_CAN_PARK | TELESCOPE_CAN_SYNC | TELESCOPE_CAN_GOTO | TELESCOPE_CAN_ABORT |
                            TELESCOPE_HAS_TRACK_MODE | TELESCOPE_CAN_CONTROL_TRACK | TELESCOPE_HAS_TRACK_RATE |
-                           TELESCOPE_HAS_LOCATION,
+                           TELESCOPE_HAS_LOCATION | TELESCOPE_HAS_PIER_SIDE,
                            9);
 
     setVersion(PMC8_VERSION_MAJOR, PMC8_VERSION_MINOR);
@@ -619,10 +620,14 @@ bool PMC8::ReadScopeStatus()
             break;
     }
 
-    rc = get_pmc8_coords(PortFD, currentRA, currentDEC);
+    TelescopePierSide sop;
+    rc = get_pmc8_coords(PortFD, currentRA, currentDEC, sop);
 
     if (rc)
+    {
         NewRaDec(currentRA, currentDEC);
+        setPierSide(sop);
+    }
 
     return rc;
 }
@@ -1460,10 +1465,11 @@ void PMC8::mountSim()
             break;
 
         case SCOPE_PARKED:
+            TelescopePierSide unused;
             // setting system status to parked will automatically
             // set the simulated RA/DEC to park position so reread
             set_pmc8_sim_system_status(ST_PARKED);
-            get_pmc8_coords(PortFD, currentRA, currentDEC);
+            get_pmc8_coords(PortFD, currentRA, currentDEC, unused);
 
             break;
 

--- a/drivers/telescope/pmc8driver.cpp
+++ b/drivers/telescope/pmc8driver.cpp
@@ -6,6 +6,7 @@
         Thomas Olson, Copyright (C) 2019
         Karl Rees, Copyright (C) 2019-2023
         Martin Ruiz, Copyright (C) 2023
+        Daniel Karnaukh, Copyright (C) 2026
 
     Based on IEQPro driver.
 
@@ -344,8 +345,8 @@ bool check_pmc8_connection(int fd, PMC8_CONNECTION_TYPE connection)
             if (detect_pmc8(fd))
             {
                 DEBUGDEVICE(pmc8_device, INDI::Logger::DBG_WARNING, "Connected to PMC8 using a standard-configured FTDI cable."
-                                                                    "Your mount will reset and lose its position anytime you disconnect and reconnect."
-                                                                    "See http://indilib.org/devices/telescopes/explore-scientific-g11-pmc-eight/ ");
+                            "Your mount will reset and lose its position anytime you disconnect and reconnect."
+                            "See http://indilib.org/devices/telescopes/explore-scientific-g11-pmc-eight/ ");
                 return true;
             }
             usleep(PMC8_RETRY_DELAY);
@@ -2079,6 +2080,26 @@ INDI::Telescope::TelescopePierSide destSideOfPier(double ra, double dec)
     }
 }
 
+INDI::Telescope::TelescopePierSide currentSideOfPier(int decCounts)
+{
+    // Northern hemisphere
+    if (pmc8_east_dir)
+    {
+        if (decCounts > 0)
+            return INDI::Telescope::PIER_WEST;
+        else
+            return INDI::Telescope::PIER_EAST;
+    }
+    // Southern hemisphere
+    else
+    {
+        if (decCounts >= 0)
+            return INDI::Telescope::PIER_EAST;
+        else
+            return INDI::Telescope::PIER_WEST;
+    }
+}
+
 bool sync_pmc8(int fd, double ra, double dec)
 {
     bool rc;
@@ -2171,7 +2192,7 @@ bool set_pmc8_radec(int fd, double ra, double dec)
     return true;
 }
 
-bool get_pmc8_coords(int fd, double &ra, double &dec)
+bool get_pmc8_coords(int fd, double &ra, double &dec, INDI::Telescope::TelescopePierSide &sop)
 {
     int racounts, deccounts;
     bool rc;
@@ -2180,8 +2201,6 @@ bool get_pmc8_coords(int fd, double &ra, double &dec)
     {
         // sortof silly but convert simulated RA/DEC to counts so we can then convert
         // back to RA/DEC to test that conversion code
-        INDI::Telescope::TelescopePierSide sop;
-
         sop = destSideOfPier(simPMC8Data.ra, simPMC8Data.dec);
 
         rc = convert_ra_to_motor(simPMC8Data.ra, sop, &racounts);
@@ -2197,6 +2216,7 @@ bool get_pmc8_coords(int fd, double &ra, double &dec)
     else
     {
         rc = get_pmc8_position(fd, racounts, deccounts);
+        sop = currentSideOfPier(deccounts);
     }
 
     if (!rc)

--- a/drivers/telescope/pmc8driver.h
+++ b/drivers/telescope/pmc8driver.h
@@ -6,6 +6,7 @@
         Thomas Olson, Copyright (C) 2019
         Karl Rees, Copyright (C) 2019-2023
         Martin Ruiz, Copyright (C) 2023
+        Daniel Karnaukh, Copyright (C) 2026
 
     Based on IEQPro driver.
 
@@ -119,7 +120,7 @@ bool get_pmc8_status(int fd, PMC8Info *info);
 /** Get All firmware information in addition to mount model */
 bool get_pmc8_firmware(int fd, FirmwareInfo *info);
 /** Get RA/DEC */
-bool get_pmc8_coords(int fd, double &ra, double &dec);
+bool get_pmc8_coords(int fd, double &ra, double &dec, INDI::Telescope::TelescopePierSide &pierSide);
 bool get_pmc8_move_rate_axis(int fd, PMC8_AXIS axis, double &rate);
 bool get_pmc8_track_rate(int fd, double &rate);
 bool get_pmc8_tracking_data(int fd, double &rate, uint8_t &mode);
@@ -147,6 +148,7 @@ bool sync_pmc8(int fd, double ra, double dec);
 bool set_pmc8_radec(int fd, double ra, double dec);
 void set_pmc8_goto_resume(bool resume);
 INDI::Telescope::TelescopePierSide destSideOfPier(double ra, double dec);
+INDI::Telescope::TelescopePierSide currentSideOfPier(int decCounts);
 
 
 /**************************************************************************


### PR DESCRIPTION
The PMC8 INDI driver does not report pier side, even though [the ASCOM driver does](https://github.com/ExploreScientific/PMC-Eight-ASCOM-Driver-Source/blob/960eb2415d506c2a3c602993595e9fb6ac4b02cc/Driver.vb#L2157); this PR copies the logic from the ASCOM driver to the INDI driver. I have no prior INDI development experience so I'm not 100% sure I did it correctly, but from my testing with my own iEXOS-100 mount it seems to be working correctly.

Contributing guidelines say I need to update docs but I cannot seem to find the docs for this specific driver, help would be appreciated.