### PR TITLE
iEQ: clarify firmware labels, show N/A for absent hand controller

### DIFF
--- a/drivers/telescope/ieqpro.cpp
+++ b/drivers/telescope/ieqpro.cpp
@@ -43,7 +43,7 @@ static std::unique_ptr<IEQPro> scope(new IEQPro());
 
 IEQPro::IEQPro(): GI(this)
 {
-    setVersion(1, 10);
+    setVersion(1, 11);
 
     driver.reset(new Base());
 
@@ -73,11 +73,14 @@ bool IEQPro::initProperties()
     INDI::Telescope::initProperties();
 
     /* Firmware */
-    IUFillText(&FirmwareT[FW_MODEL], "Model", "", nullptr);
-    IUFillText(&FirmwareT[FW_BOARD], "Board", "", nullptr);
-    IUFillText(&FirmwareT[FW_CONTROLLER], "Controller", "", nullptr);
-    IUFillText(&FirmwareT[FW_RA], "RA", "", nullptr);
-    IUFillText(&FirmwareT[FW_DEC], "DEC", "", nullptr);
+    // Note: the second field of the ':FW1#' reply is the Go2Nova hand controller
+    // firmware, which is distinct from the main board firmware. Element names are
+    // kept for config back-compat; only the display labels are clarified.
+    IUFillText(&FirmwareT[FW_MODEL], "Model", "Model", nullptr);
+    IUFillText(&FirmwareT[FW_BOARD], "Board", "Main Board", nullptr);
+    IUFillText(&FirmwareT[FW_CONTROLLER], "Controller", "Hand Controller", nullptr);
+    IUFillText(&FirmwareT[FW_RA], "RA", "RA", nullptr);
+    IUFillText(&FirmwareT[FW_DEC], "DEC", "DEC", nullptr);
     IUFillTextVector(&FirmwareTP, FirmwareT, 5, getDeviceName(), "Firmware Info", "", MOUNTINFO_TAB, IP_RO, 0,
                      IPS_IDLE);
 
@@ -200,7 +203,12 @@ void IEQPro::getStartupData()
 
     IUSaveText(&FirmwareT[0], firmwareInfo.Model.c_str());
     IUSaveText(&FirmwareT[1], firmwareInfo.MainBoardFirmware.c_str());
-    IUSaveText(&FirmwareT[2], firmwareInfo.ControllerFirmware.c_str());
+    // The mount reports "xxxxxx" for the hand controller firmware when no Go2Nova
+    // hand controller is present in the serial path (e.g. connected directly to the
+    // mount's RS-232 port). Show "N/A" instead of the raw placeholder.
+    const bool controllerReported = !firmwareInfo.ControllerFirmware.empty() &&
+                                     firmwareInfo.ControllerFirmware.find_first_not_of('x') != std::string::npos;
+    IUSaveText(&FirmwareT[2], controllerReported ? firmwareInfo.ControllerFirmware.c_str() : "N/A");
     IUSaveText(&FirmwareT[3], firmwareInfo.RAFirmware.c_str());
     IUSaveText(&FirmwareT[4], firmwareInfo.DEFirmware.c_str());
 


### PR DESCRIPTION
## Summary
Cosmetic clean-up of the iEQ driver's (`indi_ieq_telescope`) firmware display on the Mount Info tab.

The tab shows four fields parsed from `:FW1#` (main board + hand controller) and `:FW2#` (RA + DEC). Two issues were confusing in practice:

1. The **Controller** field is the Go2Nova hand-controller firmware, distinct from the main board firmware — but the raw label "Controller" sits right next to the **Time Source: Controller** toggle and reads ambiguously.
2. When no hand controller is in the serial path (e.g. connected directly to the mount's RS-232 port), the mount returns `xxxxxx` for that field. The driver displayed it verbatim, which looks like a fault. (Confirmed on a CEM60: `:FW1#` → `211018xxxxxx#`.)

## Changes
- Give the firmware fields clear display **labels**: `Main Board`, `Hand Controller` (Model/RA/DEC kept). Element **names are unchanged**, so saved configs and clients that reference them by name are unaffected.
- Show `N/A` instead of the raw `xxxxxx` placeholder when the mount does not report a hand-controller firmware.

## Notes
- Cosmetic only — no protocol or functional change. The main-board firmware was already displayed correctly; this just makes the hand-controller field self-explanatory.
- Applies to the whole iEQ family (CEM40/GEM45/CEM60/...). Driver version 1.10 → 1.11.
- Verified it builds (`indi_ieq_telescope` target).