### PR TITLE
Publish Pinefeat CEF firmware version as a property

### DIFF
--- a/drivers/focuser/pinefeat_cef.cpp
+++ b/drivers/focuser/pinefeat_cef.cpp
@@ -84,6 +84,9 @@ bool PinefeatCEF::initProperties()
     FocusDistanceTP[0].fill("FOCUS_DISTANCE", "meter", nullptr);
     FocusDistanceTP.fill(getDeviceName(), "FOCUS_DISTANCE", "Focus Distance", MAIN_CONTROL_TAB, IP_RO, 60, IPS_IDLE);
 
+    FirmwareTP[0].fill("FIRMWARE_VERSION", "Version", "Unknown");
+    FirmwareTP.fill(getDeviceName(), "FIRMWARE_VERSION", "Firmware", INFO_TAB, IP_RO, 0, IPS_IDLE);
+
     serialConnection->setDefaultBaudRate(Connection::Serial::B_115200);
 
     setDefaultPollingPeriod(50);
@@ -97,6 +100,7 @@ bool PinefeatCEF::updateProperties()
 
     if (isConnected())
     {
+        defineProperty(FirmwareTP);
         defineProperty(FocusDistanceTP);
         defineProperty(CalibrateSP);
         defineProperty(ApertureRangeTP);
@@ -117,6 +121,7 @@ bool PinefeatCEF::updateProperties()
     }
     else
     {
+        deleteProperty(FirmwareTP);
         deleteProperty(FocusDistanceTP);
         deleteProperty(CalibrateSP);
         deleteProperty(ApertureRangeTP);
@@ -183,8 +188,11 @@ bool PinefeatCEF::readFirmwareVersion()
     int major, minor;
     if (sscanf(res, "%d.%d", &major, &minor) == 2)
     {
-        setVersion(major, minor);
+        firmwareMinor = minor;
     }
+
+    FirmwareTP[0].setText(res);
+    FirmwareTP.setState(IPS_OK);
 
     LOGF_INFO("Detected firmware version %s.", res);
 
@@ -210,7 +218,7 @@ bool PinefeatCEF::readFocusPosition(int32_t &pos)
 
 bool PinefeatCEF::readFocusMaxPosition(int32_t &pos)
 {
-    if (getMinorVersion() < 3)
+    if (firmwareMinor < 3)
     {
         return true;
     }

--- a/drivers/focuser/pinefeat_cef.cpp
+++ b/drivers/focuser/pinefeat_cef.cpp
@@ -34,7 +34,7 @@ static std::unique_ptr<PinefeatCEF> pinefeatCEF(new PinefeatCEF());
 
 PinefeatCEF::PinefeatCEF()
 {
-    setVersion(1, 0);
+    setVersion(1, 1);
 
     FI::SetCapability(FOCUSER_CAN_ABS_MOVE | FOCUSER_CAN_REL_MOVE | FOCUSER_HAS_VARIABLE_SPEED);
 

--- a/drivers/focuser/pinefeat_cef.h
+++ b/drivers/focuser/pinefeat_cef.h
@@ -78,6 +78,8 @@ class PinefeatCEF : public INDI::Focuser
 
         INDI::PropertyText FocusDistanceTP {1};
 
+        INDI::PropertyText FirmwareTP {1};
+
         // CEF Buffer Size
         static const uint8_t CEF_BUF { 16 };
 
@@ -88,4 +90,6 @@ class PinefeatCEF : public INDI::Focuser
         static const uint8_t CEF_TIMEOUT { 3 };
 
         std::chrono::steady_clock::time_point lastUpdate;
+
+        uint16_t firmwareMinor {0};
 };


### PR DESCRIPTION
This PR...

- Adds a new read-only FIRMWARE_VERSION.FIRMWARE_VERSION property on the info tab for the @pinefeat CEF focuser.
  - Populated by the response to the serial `v` command, which is currently only printed as a log message.
- Separates the driver version itself (as set by `setVersion(x, y)`) from the device firmware version.
  - The version set/provided by `setVersion()` is intended to be the driver version (used by DRIVER_INFO) but the previous version of this code was storing the firmware version here (and not even ever actually publishing it as a property).
- Adds a dedicated firmwareMinor member and keeps the existing check for the `r` command / maximum focus-position support.
- Bumps the *driver* version from 1.0 to 1.1 to reflect the new property and changes above.