### PR TITLE
Fix stack buffer overflow in lilxml error formatting (CVE-2026-71979)

### DIFF
--- a/drivers/auxiliary/joystick.cpp
+++ b/drivers/auxiliary/joystick.cpp
@@ -726,7 +726,7 @@ bool JoyStick::loadCalibrationData()
         return false; // file does not exist yet — normal on first use
 
     LilXML *lp = newLilXML();
-    static char errmsg[512];
+    static char errmsg[XML_ERROR_SIZE];
     XMLEle *root = readXMLFile(fp, lp, errmsg);
     fclose(fp);
     delLilXML(lp);
@@ -821,7 +821,7 @@ bool JoyStick::saveCalibrationData()
         if (fp)
         {
             LilXML *lp = newLilXML();
-            static char errmsg[512];
+            static char errmsg[XML_ERROR_SIZE];
             root = readXMLFile(fp, lp, errmsg);
             fclose(fp);
             delLilXML(lp);

--- a/indiserver/MsgQueue.cpp
+++ b/indiserver/MsgQueue.cpp
@@ -522,7 +522,7 @@ void MsgQueue::readFromFd()
     }
 
     /* process XML chunk */
-    char err[1024];
+    char err[XML_ERROR_SIZE];
     XMLEle **nodes = parseXMLChunk(lp, buf, nr, err);
     if (!nodes)
     {

--- a/libs/indibase/defaultdevice.cpp
+++ b/libs/indibase/defaultdevice.cpp
@@ -256,7 +256,7 @@ int DefaultDevicePrivate::loadINDINicknamesXML(const char *devicename)
     XMLEle *NickXmlRoot = nullptr;
     XMLEle *devicexml = nullptr;
     XMLEle *nickxml = nullptr;
-    static char errmsg[512];
+    static char errmsg[XML_ERROR_SIZE];
     memset(errmsg, 0, sizeof(errmsg)); // Clear anything from prior run
     FILE *fp = fopen(filename.c_str(), "r");
     if (fp)
@@ -343,7 +343,7 @@ int DefaultDevicePrivate::saveINDINicknamesXML(const char *devicename)
     XMLEle *NickXmlRoot = nullptr;
     XMLEle *devicexml = nullptr;
     XMLEle *nickxml = nullptr;
-    static char errmsg[512];
+    static char errmsg[XML_ERROR_SIZE];
     memset(errmsg, 0, sizeof(errmsg)); // Clear anything from prior run
     FILE *fp = fopen(filename.c_str(), "r+");
     if (fp)

--- a/libs/indibase/indidome.cpp
+++ b/libs/indibase/indidome.cpp
@@ -1801,7 +1801,7 @@ const char * Dome::LoadParkXML()
     wordexp_t wexp;
     FILE * fp;
     LilXML * lp;
-    static char errmsg[512];
+    static char errmsg[XML_ERROR_SIZE];
 
     XMLEle * parkxml;
     XMLAtt * ap;

--- a/libs/indibase/inditelescope.cpp
+++ b/libs/indibase/inditelescope.cpp
@@ -2067,7 +2067,7 @@ const char *Telescope::LoadParkXML()
     wordexp_t wexp;
     FILE *fp = nullptr;
     LilXML *lp = nullptr;
-    static char errmsg[512];
+    static char errmsg[XML_ERROR_SIZE];
 
     XMLEle *parkxml = nullptr;
     XMLAtt *ap = nullptr;
@@ -2212,7 +2212,7 @@ bool Telescope::PurgeParkData()
     wordexp_t wexp;
     FILE *fp = nullptr;
     LilXML *lp = nullptr;
-    static char errmsg[512];
+    static char errmsg[XML_ERROR_SIZE];
 
     XMLEle *parkxml = nullptr;
     XMLAtt *ap = nullptr;

--- a/libs/indicore/lilxml.cpp
+++ b/libs/indicore/lilxml.cpp
@@ -299,7 +299,7 @@ XMLEle **parseXMLChunk(LilXML *lp, char *buf, int size, char ynot[])
         /* EOF? */
         if (newc == 0)
         {
-            sprintf(ynot, "Line %d: early XML EOF", lp->ln);
+            snprintf(ynot, XML_ERROR_SIZE, "Line %d: early XML EOF", lp->ln);
             initParser(lp);
             curr++;
             continue;
@@ -393,7 +393,7 @@ XMLEle *readXMLEle(LilXML *lp, int newc, char ynot[])
     /* EOF? */
     if (newc == 0)
     {
-        sprintf(ynot, "Line %d: early XML EOF", lp->ln);
+        snprintf(ynot, XML_ERROR_SIZE, "Line %d: early XML EOF", lp->ln);
         initParser(lp);
         return (NULL);
     }
@@ -479,7 +479,7 @@ XMLEle *parseXML(char buf[], char ynot[])
 XMLEle *cloneXMLEle(XMLEle *ep)
 {
     char *buf;
-    char ynot[1024];
+    char ynot[XML_ERROR_SIZE];
     XMLEle *newep;
 
     buf = (char*)(*mymalloc)(sprlXMLEle(ep, 0) + 1);
@@ -1083,7 +1083,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
             }
             else if (!isspace(c))
             {
-                sprintf(ynot, "Line %d: Bogus tag char %c", lp->ln, c);
+                snprintf(ynot, XML_ERROR_SIZE, "Line %d: Bogus tag char %c", lp->ln, c);
                 return (-1);
             }
             break;
@@ -1112,7 +1112,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
             }
             else if (!isspace(c))
             {
-                sprintf(ynot, "Line %d: Bogus leading attr name char: %c", lp->ln, c);
+                snprintf(ynot, XML_ERROR_SIZE, "Line %d: Bogus leading attr name char: %c", lp->ln, c);
                 return (-1);
             }
             break;
@@ -1127,7 +1127,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
             }
             else
             {
-                sprintf(ynot, "Line %d: Bogus char %c before >", lp->ln, c);
+                snprintf(ynot, XML_ERROR_SIZE, "Line %d: Bogus char %c before >", lp->ln, c);
                 return (-1);
             }
             break;
@@ -1139,7 +1139,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
                 lp->cs = LOOK4ATTRV;
             else
             {
-                sprintf(ynot, "Line %d: Bogus attr name char: %c", lp->ln, c);
+                snprintf(ynot, XML_ERROR_SIZE, "Line %d: Bogus attr name char: %c", lp->ln, c);
                 return (-1);
             }
             break;
@@ -1152,7 +1152,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
             }
             else if (!(isspace(c) || c == '='))
             {
-                sprintf(ynot, "Line %d: No value for attribute %s", lp->ln, lp->ce->at[lp->ce->nat - 1]->name.s);
+                snprintf(ynot, XML_ERROR_SIZE, "Line %d: No value for attribute %s", lp->ln, lp->ce->at[lp->ce->nat - 1]->name.s);
                 return (-1);
             }
             break;
@@ -1266,7 +1266,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
             }
             else if (!isspace(c))
             {
-                sprintf(ynot, "Line %d: Bogus preend tag char %c", lp->ln, c);
+                snprintf(ynot, XML_ERROR_SIZE, "Line %d: Bogus preend tag char %c", lp->ln, c);
                 return (-1);
             }
             break;
@@ -1278,7 +1278,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
             {
                 if (strcmp(lp->ce->tag.s, lp->endtag.s))
                 {
-                    sprintf(ynot, "Line %d: closing tag %s does not match %s", lp->ln, lp->endtag.s, lp->ce->tag.s);
+                    snprintf(ynot, XML_ERROR_SIZE, "Line %d: closing tag %s does not match %s", lp->ln, lp->endtag.s, lp->ce->tag.s);
                     return (-1);
                 }
                 else if (lp->ce->pe)
@@ -1291,7 +1291,7 @@ static int oneXMLchar(LilXML *lp, int c, char ynot[])
             }
             else if (!isspace(c))
             {
-                sprintf(ynot, "Line %d: Bogus end tag char %c", lp->ln, c);
+                snprintf(ynot, XML_ERROR_SIZE, "Line %d: Bogus end tag char %c", lp->ln, c);
                 return (-1);
             }
             break;
@@ -1473,7 +1473,7 @@ static void *moremem(void *old, size_t n)
 int main(int ac, char *av[])
 {
     LilXML *lp = newLilXML();
-    char ynot[1024];
+    char ynot[XML_ERROR_SIZE];
     XMLEle *root;
 
     root = readXMLFile(stdin, lp, ynot);

--- a/libs/indicore/lilxml.h
+++ b/libs/indicore/lilxml.h
@@ -66,6 +66,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110 - 1301  USA
 
 #include <stdio.h>
 
+/* size every caller must allocate for the errmsg[]/ynot[] buffer passed to
+ * parseXMLChunk(), readXMLEle(), readXMLFile() and parseXML(). Error text
+ * is always truncated to fit this size, no matter how long the offending
+ * XML token is. */
+#define XML_ERROR_SIZE 1024
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/obsolete/skywatcherAltAzSimple.cpp
+++ b/obsolete/skywatcherAltAzSimple.cpp
@@ -530,7 +530,7 @@ void SkywatcherAltAzSimple::UpdateScopeConfigSwitch()
     XMLEle *CurrentXmlNode = nullptr;
     XMLAtt *Ap             = nullptr;
     bool DeviceFound       = false;
-    char ErrMsg[512];
+    char ErrMsg[XML_ERROR_SIZE];
 
     RootXmlNode = readXMLFile(FilePtr, XmlHandle, ErrMsg);
     delLilXML(XmlHandle);


### PR DESCRIPTION
## Summary
Fixes the unauthenticated remote stack buffer overflow reported in #2472 (CVE-2026-71979).

`oneXMLchar()` in `libs/indicore/lilxml.cpp` formats parser diagnostics (e.g. "closing tag X does not match Y") with `sprintf()` into a fixed 1024-byte caller-supplied buffer. The tag/attribute names interpolated into that message are read from the client via `growString()`, which has no upper bound. A single ~1.2KB TCP packet with a mismatched closing tag (`<AAAA...>x</BBBB...>`) writes far past the 1024-byte stack buffer and crashes `indiserver`. Since INDI has no authentication, any host that can reach TCP/7624 can trigger this with one packet.

- Bound all 10 `sprintf(ynot, ...)` call sites in `lilxml.cpp` to `snprintf(ynot, XML_ERROR_SIZE, ...)`.
- Added `XML_ERROR_SIZE` (1024) to `lilxml.h`, documenting the buffer-size contract every caller of `parseXMLChunk()`/`readXMLEle()`/`readXMLFile()`/`parseXML()` must honor.
- Audited every call site in the tree and found several (`defaultdevice.cpp`, `indidome.cpp`, `inditelescope.cpp`, `joystick.cpp`, `obsolete/skywatcherAltAzSimple.cpp`) passing 512-byte buffers — smaller than what the library can write. Bumped these to `XML_ERROR_SIZE` too, since they're exploitable the same way via a local config/park-data file with an oversized tag name.

This only touches the parser's error-reporting path (already-malformed XML that aborts the parse) — it does not affect BLOB transfer or any well-formed-XML parsing path, which use separate `memcpy`-based routines unrelated to `ynot`/`sprintf`.

## Test plan
- Reproduced the overflow with an ASan-instrumented standalone harness against `lilxml.cpp` at the pre-fix commit: `AddressSanitizer: stack-buffer-overflow ... WRITE of size 1237 ... in oneXMLchar lilxml.cpp:1281`, matching the report's own trace.
- Re-ran the same harness against the patched `lilxml.cpp`: no overflow, error message safely truncated to fit the buffer.
- Ran the reporter's exact PoC packet against a live `indiserver -v /bin/cat`: pre-fix, corrupted state under ASan; post-fix, connection is cleanly reset and the server keeps running.
- Built `indicore`, `indibase`/`indidriver`, `indi_joystick`, and `indiserver` targets clean with no new warnings.

Reported by Fatullayev Asadbek.