### PR TITLE
More build fixes for OpenBSD

### DIFF
--- a/indiserver/LocalDvrInfo.cpp
+++ b/indiserver/LocalDvrInfo.cpp
@@ -25,6 +25,7 @@
 
 #include "Fifo.hpp"
 #include <sys/socket.h>
+#include <sys/wait.h>
 #include <fcntl.h>
 #include <libgen.h>
 #include <unistd.h>

--- a/indiserver/RemoteDvrInfo.cpp
+++ b/indiserver/RemoteDvrInfo.cpp
@@ -23,6 +23,7 @@
 #include "CommandLineArgs.hpp"
 
 #include <cstdio>
+#include <sys/socket.h>
 #include <netinet/in.h>
 #include <netdb.h>
 

--- a/indiserver/TcpServer.cpp
+++ b/indiserver/TcpServer.cpp
@@ -22,6 +22,7 @@
 #include "ClInfo.hpp"
 #include "CommandLineArgs.hpp"
 
+#include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <fcntl.h>

--- a/libs/indicore/indicom.c
+++ b/libs/indicore/indicom.c
@@ -51,6 +51,7 @@
 #include <time.h>
 
 #if !defined(_WIN32) && !defined(__CYGWIN__)
+#include <sys/socket.h>
 #include <netinet/in.h>
 #endif
 


### PR DESCRIPTION
```
indiserver/LocalDvrInfo.cpp:305:13: error: use of undeclared identifier 'WIFEXITED'
  305 |         if (WIFEXITED(pidwatcher.rstatus))
      |             ^~~~~~~~~

indiserver/RemoteDvrInfo.cpp:119:33: error: use of undeclared identifier 'AF_INET'
  119 |     serv_addr.sin_family      = AF_INET;
      |                                 ^~~~~~~
indiserver/RemoteDvrInfo.cpp:122:26: error: use of undeclared identifier 'AF_INET'
  122 |     if ((sockfd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
      |                          ^~~~~~~

indiserver/TcpServer.cpp:57:23: error: use of undeclared identifier 'AF_INET'
   57 |     if ((sfd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
      |                       ^~~~~~~
indiserver/TcpServer.cpp:57:32: error: use of undeclared identifier 'SOCK_STREAM'
   57 |     if ((sfd = socket(AF_INET, SOCK_STREAM, 0)) < 0)
      |                                ^~~~~~~~~~~

libs/indicore/indicom.c:519:14: error: call to undeclared function 'socket'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
  519 |     new_fd = socket(AF_INET, SOCK_DGRAM, 0);
      |              ^
libs/indicore/indicom.c:519:21: error: use of undeclared identifier 'AF_INET'
  519 |     new_fd = socket(AF_INET, SOCK_DGRAM, 0);
      |                     ^~~~~~~
libs/indicore/indicom.c:519:30: error: use of undeclared identifier 'SOCK_DGRAM'
  519 |     new_fd = socket(AF_INET, SOCK_DGRAM, 0);
      |                              ^~~~~~~~~~
```