### PR TITLE
Fix build with new gcc: add missing include

### DIFF
--- a/libs/indibase/webcam/v4l2_base.h
+++ b/libs/indibase/webcam/v4l2_base.h
@@ -37,6 +37,7 @@
 #include <stdio.h>
 #include <cstdlib>
 #include <map>
+#include <string>
 
 #include <dirent.h>
 #ifdef __OpenBSD__


### PR DESCRIPTION
std::string is used in v4l2_base.h without being included