### PR TITLE
guide/ccd simulator: restore sub-pixel star placement in SkyRenderer

### DIFF
--- a/drivers/ccd/sky_renderer.cpp
+++ b/drivers/ccd/sky_renderer.cpp
@@ -82,12 +82,20 @@ int SkyRenderer::drawImageStar(INDI::CCDChip *chip, float mag, float x, float y,
     float const norm     = 1.0f / (sigma * std::sqrt(2.0f * float(M_PI)));
     float const inv2sig2 = 1.0f / (2.0f * sigma * sigma);
 
+    // Sub-pixel centering: keep the fractional part of the star position so the
+    // PSF is centred on the true (floating-point) location rather than snapped to
+    // the truncated integer pixel. Without this, sub-pixel drift is discarded and
+    // the measured centroid quantises to a lattice (see indilib/indi#2465).
+    float const fracX = x - static_cast<int>(x);
+    float const fracY = y - static_cast<int>(y);
+
     for (int sy = -boxsizey; sy <= boxsizey; sy++)
     {
         for (int sx = -boxsizey; sx <= boxsizey; sx++)
         {
-            float const dc2 = sx * sx * m_ImageScaleX * m_ImageScaleX
-                              + sy * sy * m_ImageScaleY * m_ImageScaleY;
+            float const ddx = m_ImageScaleX * (sx - fracX);
+            float const ddy = m_ImageScaleY * (sy - fracY);
+            float const dc2 = ddx * ddx + ddy * ddy;
             float const fa  = norm * std::exp(-dc2 * inv2sig2);
             int const fp = static_cast<int>(fa * totalFlux);
             if (fp > 0)

--- a/test/drivers/test_ccd_simulator.cpp
+++ b/test/drivers/test_ccd_simulator.cpp
@@ -338,6 +338,62 @@ TEST_F(SkyRendererTest, star_zero_beyond_render_box)
     }
 }
 
+// Regression guard for indilib/indi#2465: the PSF must be centred on the true
+// (sub-pixel) star position, not snapped to the truncated integer pixel. If the
+// fractional part of the coordinate is discarded, a sub-pixel shift produces no
+// change in the rendered centroid, which quantised guide-sim drift to a lattice
+// and broke calibration.
+TEST_F(SkyRendererTest, star_centroid_tracks_subpixel_shift)
+{
+    int const xres = 201;
+    int const yres = 201;
+
+    RenderConfig cfg;
+    cfg.maxVal        = 65000;
+    cfg.saturationMag = 0.0f;
+    cfg.limitingMag   = 20.0f;
+    cfg.seeing        = 3.0f;
+    renderer.setConfig(cfg);
+    renderer.setImageScale(1.0f, 1.0f);
+
+    // Flux-weighted X centroid of the whole frame.
+    auto centroidX = [this](int nx, int ny) -> double
+    {
+        uint16_t *buf = fb();
+        double sumWeighted = 0.0;
+        double sumFlux     = 0.0;
+        for (int y = 0; y < ny; y++)
+            for (int x = 0; x < nx; x++)
+            {
+                double const v = buf[y * nx + x];
+                sumWeighted += v * x;
+                sumFlux     += v;
+            }
+        return sumFlux > 0 ? sumWeighted / sumFlux : -1.0;
+    };
+
+    // Integer y keeps the comparison on the X axis only.
+    float const y = 100.0f;
+
+    setupChip(xres, yres);
+    renderer.drawImageStar(&chip, 6.0f, 100.3f, y, 1.0f);
+    double const cxLow = centroidX(xres, yres);
+
+    setupChip(xres, yres);
+    renderer.drawImageStar(&chip, 6.0f, 100.7f, y, 1.0f);
+    double const cxHigh = centroidX(xres, yres);
+
+    ASSERT_GT(cxLow, 0.0);
+    ASSERT_GT(cxHigh, 0.0);
+
+    // Each centroid should sit near its true sub-pixel position...
+    EXPECT_NEAR(cxLow, 100.3, 0.15);
+    EXPECT_NEAR(cxHigh, 100.7, 0.15);
+    // ...and, crucially, the 0.4 px shift must be reflected in the render.
+    // The pre-fix code snapped both to pixel 100, giving a zero difference.
+    EXPECT_GT(cxHigh - cxLow, 0.2);
+}
+
 TEST_F(SkyRendererTest, star_flux_scales_with_exposure)
 {
     int const xres = 33;


### PR DESCRIPTION
## Fix guide/CCD simulator sub-pixel star placement (Fixes #2465)

### Problem
The guide simulator produced a non-stochastic, lattice-like mount-drift
pattern, and guide calibration in simulator mode was unreliable. Bisected
by the reporter to #2412 (SkyRenderer extraction).

### Root cause
When `GuideSim::DrawImageStar` was refactored into
`SkyRenderer::drawImageStar`, the sub-pixel centering was dropped. The old
code offset the Gaussian by the fractional pixel position
(`pixelPartX/Y`); the new renderer centred a symmetric PSF on the truncated
integer pixel (`static_cast<int>(x/y)`) and discarded the fraction.

Because the guide sim is undersampled (PSF sigma < 1 px), the rendered
centroid stayed pinned to integer pixels: a smoothly drifting field didn't
move the star until the drift crossed a whole-pixel boundary, then it
jumped a full pixel. The guider's centroid quantised to a lattice, which
showed as the "silly" drift pattern and skewed the RA/Dec axis angles
measured during calibration.

### Fix
Restore the fractional offset (`fracX/fracY`) so the PSF is centred on the
true floating-point position. Single file, ~10 lines. Both guide and CCD
simulators share this renderer, so both are fixed.

### Testing
- `indi_simulator_guide` and `indi_simulator_ccd` build and link cleanly.
- No change to existing SkyRenderer unit tests (they draw at integer
  coordinates, where `fracX/fracY == 0`).
- Verified in Ekos on StellarMate: calibration completes, Mount Drift plot
  is stochastic again, ~0.25" total RMS, tight calibration bullseye.
