### PR TITLE
Fix Pegasus PPBA adjustable output cannot be re-enabled (#2471)

### DIFF
--- a/drivers/power/pegasus_ppba.cpp
+++ b/drivers/power/pegasus_ppba.cpp
@@ -360,22 +360,31 @@ bool PegasusPPBA::ISNewSwitch(const char * dev, const char * name, ISState * sta
 
             AdjOutVoltSP.setState(IPS_ALERT);
             char cmd[PEGASUS_LEN] = {0}, res[PEGASUS_LEN] = {0};
-            // if switching from off to some voltage, we first need to turn on the port
-            if (previous_index == ADJOUT_OFF)
+            // On the PPBA, port 2's adjustable output tracks a voltage setpoint and an enable
+            // flag *independently*:
+            //   - "P2:<v>" (v = 3/5/8/9/12) sets the voltage but does NOT enable the output
+            //   - "P2:1" enables the output, "P2:0" disables it; neither changes the setpoint
+            // So to switch a voltage ON we set the voltage first, then enable (setting the
+            // voltage first avoids briefly emitting the previously stored voltage). To switch
+            // OFF we just disable with "P2:0". Enabling unconditionally (not only when coming
+            // from OFF) keeps the driver in sync even if the output was disabled behind our
+            // back. Verified against PPBADV_Gen2C firmware. See indilib/indi#2471.
+            bool ok = true;
+            if (target_index == ADJOUT_OFF)
             {
-                snprintf(cmd, PEGASUS_LEN, "P2:%d", 1);
-                if (!sendCommand(cmd, res))
-                {
-                    AdjOutVoltSP.reset();
-                    AdjOutVoltSP[previous_index].setState(ISS_ON);
-                    AdjOutVoltSP.setState(IPS_ALERT);
-                    AdjOutVoltSP.apply();
-                    return true;
-                }
+                ok = sendCommand("P2:0", res);
             }
-            snprintf(cmd, PEGASUS_LEN, "P2:%d", adjv);
-            if (sendCommand(cmd, res))
+            else
             {
+                snprintf(cmd, PEGASUS_LEN, "P2:%d", adjv);
+                ok = sendCommand(cmd, res);
+                if (ok)
+                    ok = sendCommand("P2:1", res);
+            }
+
+            if (ok)
+            {
+                AdjOutVoltSP.reset();
                 AdjOutVoltSP[target_index].setState(ISS_ON);
                 AdjOutVoltSP.setState(IPS_OK);
                 saveConfig(AdjOutVoltSP);
@@ -729,8 +738,12 @@ bool PegasusPPBA::getSensorData()
                 PI::PowerChannelsSP.apply();
         }
         // Adjustable Power Status
+        // Use the enable flag (PA_ADJ_STATUS) to decide on/off, not the voltage setpoint
+        // (PA_PWRADJ): the two can diverge (output disabled while a non-zero setpoint is
+        // still remembered), which otherwise makes the selector display a voltage while the
+        // output is physically off (see indilib/indi#2471).
         AdjOutVoltSP.reset();
-        if (std::stoi(result[PA_PWRADJ]) == 0)
+        if (std::stoi(result[PA_ADJ_STATUS]) == 0)
             AdjOutVoltSP[ADJOUT_OFF].setState(ISS_ON);
         else
         {


### PR DESCRIPTION
## Summary

Fixes #2471. On the Pegasus Pocket Powerbox Advance, the adjustable ("Adj") output could not be turned back on after being set to **Off** — the selector snapped back to Off (or showed a stale voltage) and the output stayed physically off.

## Root cause

Port 2's adjustable output tracks the **voltage setpoint** and the **enable flag** independently, and #2326 mishandled both:

- `P2:<v>` (v = 3/5/8/9/12) sets the voltage but does **not** enable the output.
- `P2:1` enables the output, `P2:0` disables it; neither changes the stored voltage.
- In the `PA` status reply, field 7 (`ADJ_STATUS`) is the enable flag and field 12 (`PWRADJ`) is the setpoint. `P2:0` clears `ADJ_STATUS` but leaves `PWRADJ` at the last voltage.

#2326 sent only a voltage (assuming it also enables) in some paths and, critically, read on/off back from `PWRADJ`. Because `PWRADJ` keeps the last voltage after a disable, the driver believed the output was still on, which corrupted the state and skipped the enable step on the next switch-on.

## Fix

- `ISNewSwitch`: set the voltage first, then send `P2:1` to enable (voltage-first avoids briefly emitting the previously stored voltage); OFF sends `P2:0`. Enable is issued for any non-zero target so the driver re-syncs even if the output was disabled externally.
- `getSensorData`: decide on/off from `ADJ_STATUS` instead of `PWRADJ`.

## Test setup

Verified on real hardware — **Pegasus Pocket Powerbox Advance Gen2** (USB `0403:6015`, `ID_MODEL=PPBADV_Gen2C`) on StellarMate (Arch Linux, x86_64), driver built from source.

Exercised the full cycle `OFF → 12V → OFF → 12V → 5V → OFF → 3V → 9V → OFF → 8V` through the driver, and cross-checked the raw `PA` reply over serial. `ADJ_STATUS`/`PWRADJ` matched the requested state at every step (e.g. 8V → `ADJ_STATUS=1, PWRADJ=8`; after `P2:0` → `ADJ_STATUS=0`).

> Note: the enable/voltage split and the `ADJ_STATUS`/`PWRADJ` field semantics were confirmed on a Gen2C unit. If older PPBA firmware reports these fields differently, that's worth confirming — feedback from the original reporter's unit would help.