### PR TITLE
Harden buffer bounds when composing strings from parsed XML attributes

### DIFF
--- a/drivers/agent/agent_imager.cpp
+++ b/drivers/agent/agent_imager.cpp
@@ -183,8 +183,8 @@ void Imager::initiateDownload()
     if (group == 0 || image == 0)
         return;
 
-    sprintf(name, IMAGE_NAME, ImageNameTP[IMAGE_FOLDER].getText(), ImageNameTP[IMAGE_NAME_PREFIX].getText(), group, image,
-            format);
+    snprintf(name, sizeof(name), IMAGE_NAME, ImageNameTP[IMAGE_FOLDER].getText(), ImageNameTP[IMAGE_NAME_PREFIX].getText(), group, image,
+             format);
     file.open(name, std::ios::in | std::ios::binary | std::ios::ate);
     DownloadNP[GROUP].setValue(0);
     DownloadNP[IMAGE].setValue(0);
@@ -535,8 +535,8 @@ void Imager::updateProperty(INDI::Property property)
                 std::ofstream file;
 
                 snprintf(format, sizeof(format), "%s", bp.getFormat());
-                sprintf(name, IMAGE_NAME, ImageNameTP[IMAGE_FOLDER].getText(), ImageNameTP[IMAGE_NAME_PREFIX].getText(), group, image,
-                        format);
+                snprintf(name, sizeof(name), IMAGE_NAME, ImageNameTP[IMAGE_FOLDER].getText(), ImageNameTP[IMAGE_NAME_PREFIX].getText(), group, image,
+                         format);
                 file.open(name, std::ios::out | std::ios::binary | std::ios::trunc);
                 file.write(static_cast<char *>(bp.getBlob()), bp.getBlobLen());
                 file.close();
@@ -609,8 +609,8 @@ void Imager::updateProperty(INDI::Property property)
         char name[128] = {0};
 
         snprintf(format, sizeof(format), "%s", strrchr(propertyText[0].getText(), '.'));
-        sprintf(name, IMAGE_NAME, ImageNameTP[IMAGE_FOLDER].getText(), ImageNameTP[IMAGE_NAME_PREFIX].getText(), group, image,
-                format);
+        snprintf(name, sizeof(name), IMAGE_NAME, ImageNameTP[IMAGE_FOLDER].getText(), ImageNameTP[IMAGE_NAME_PREFIX].getText(), group, image,
+                 format);
         rename(propertyText[0].getText(), name);
         LOGF_DEBUG("Group %d of %d, image %d of %d, saved to %s", group, maxGroup, image,
                    maxImage, name);

--- a/libs/indibase/indidriver.c
+++ b/libs/indibase/indidriver.c
@@ -478,7 +478,7 @@ int dispatch(XMLEle *root, char msg[])
         return (0);
     }
 
-    sprintf(msg, "Unknown command: %s", rtag);
+    snprintf(msg, MAXRBUF, "Unknown command: %s", rtag);
     return (1);
 }
 

--- a/libs/indicore/indidevapi.c
+++ b/libs/indicore/indidevapi.c
@@ -772,7 +772,7 @@ int crackDN(XMLEle *root, char **dev, char **name, char msg[])
     ap = findXMLAtt(root, "device");
     if (!ap)
     {
-        sprintf(msg, "%s requires 'device' attribute", tagXMLEle(root));
+        snprintf(msg, MAXRBUF, "%s requires 'device' attribute", tagXMLEle(root));
         return (-1);
     }
     *dev = valuXMLAtt(ap);
@@ -780,7 +780,7 @@ int crackDN(XMLEle *root, char **dev, char **name, char msg[])
     ap = findXMLAtt(root, "name");
     if (!ap)
     {
-        sprintf(msg, "%s requires 'name' attribute", tagXMLEle(root));
+        snprintf(msg, MAXRBUF, "%s requires 'name' attribute", tagXMLEle(root));
         return (-1);
     }
     *name = valuXMLAtt(ap);

--- a/tools/evalINDI.c
+++ b/tools/evalINDI.c
@@ -375,7 +375,7 @@ static int setOp(XMLEle *root)
             char *et = tagXMLEle(ep);
             if (!strcmp(et, "defNumber") || !strcmp(et, "oneNumber"))
             {
-                sprintf(prop, "%s.%s.%s", d, n, findXMLAttValu(ep, "name"));
+                snprintf(prop, sizeof(prop), "%s.%s.%s", d, n, findXMLAttValu(ep, "name"));
                 v = atof(pcdataXMLEle(ep));
                 if (setOperand(prop, v) == 0)
                 {
@@ -394,7 +394,7 @@ static int setOp(XMLEle *root)
 
             if (!strcmp(et, "defSwitch") || !strcmp(et, "oneSwitch"))
             {
-                sprintf(prop, "%s.%s.%s", d, n, findXMLAttValu(ep, "name"));
+                snprintf(prop, sizeof(prop), "%s.%s.%s", d, n, findXMLAttValu(ep, "name"));
                 v = (double)!strncmp(pcdataXMLEle(ep), "On", 2);
                 if (setOperand(prop, v) == 0)
                 {
@@ -412,7 +412,7 @@ static int setOp(XMLEle *root)
             char *et = tagXMLEle(ep);
             if (!strcmp(et, "defLight") || !strcmp(et, "oneLight"))
             {
-                sprintf(prop, "%s.%s.%s", d, n, findXMLAttValu(ep, "name"));
+                snprintf(prop, sizeof(prop), "%s.%s.%s", d, n, findXMLAttValu(ep, "name"));
                 v = (double)pstatestr(pcdataXMLEle(ep));
                 if (setOperand(prop, v) == 0)
                 {
@@ -428,7 +428,7 @@ static int setOp(XMLEle *root)
     t = (char *)findXMLAttValu(root, "state");
     if (t[0])
     {
-        sprintf(prop, "%s.%s._STATE", d, n);
+        snprintf(prop, sizeof(prop), "%s.%s._STATE", d, n);
         v = (double)pstatestr(t);
         if (setOperand(prop, v) == 0)
         {
@@ -440,7 +440,7 @@ static int setOp(XMLEle *root)
     t = (char *)findXMLAttValu(root, "timestamp");
     if (t[0])
     {
-        sprintf(prop, "%s.%s._TS", d, n);
+        snprintf(prop, sizeof(prop), "%s.%s._TS", d, n);
         v = (double)timestampINDI(t);
         if (setOperand(prop, v) == 0)
         {

--- a/tools/getINDIproperty.c
+++ b/tools/getINDIproperty.c
@@ -588,7 +588,9 @@ static void oneBLOB(XMLEle *root, char *dev, char *nam, char *enam, char *p, int
     }
 
     /* rig up a file name from property name */
-    i = sprintf(fn, "%s.%s.%s%s", dev, nam, enam, format);
+    i = snprintf(fn, sizeof(fn), "%s.%s.%s%s", dev, nam, enam, format);
+    if (i >= (int)sizeof(fn))
+        i = sizeof(fn) - 1;
     if (isz)
         fn[i - 2] = '\0'; /* chop off .z */
 


### PR DESCRIPTION
Several `sprintf()` calls composed file names or diagnostic messages from device/property/tag strings parsed out of INDI XML, without bounding the write to the destination stack buffer. Switches these to `snprintf()` bounded by the actual buffer size, matching the pattern already used elsewhere in these files:

- `tools/getINDIproperty.c`: `oneBLOB()`
- `tools/evalINDI.c`: `setOp()`
- `drivers/agent/agent_imager.cpp`: `initiateDownload()` and its BLOB/`CCD_FILE_PATH` handlers
- `libs/indibase/indidriver.c`: `dispatch()`
- `libs/indicore/indidevapi.c`: `crackDN()`

Verified each affected target (`indi_getprop`, `indi_eval`, `indiserver`, `indi_imager_agent`) still builds cleanly.

Reported by zx (Jace) — GitHub: @manus-use